### PR TITLE
Allow server Services to expose DNS before Pod is ready

### DIFF
--- a/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/src/main/java/oracle/kubernetes/operator/Main.java
@@ -42,6 +42,7 @@ import oracle.kubernetes.operator.helpers.ClientHolder;
 import oracle.kubernetes.operator.helpers.ConfigMapHelper;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo.ServerStartupInfo;
+import oracle.kubernetes.operator.helpers.HealthCheckHelper.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.HealthCheckHelper;
 import oracle.kubernetes.operator.helpers.IngressHelper;
 import oracle.kubernetes.operator.helpers.PodHelper;
@@ -86,6 +87,7 @@ public class Main {
   private static Thread livenessThread = null;
   private static Map<String, DomainWatcher> domainWatchers = new HashMap<>();
   private static Map<String, PodWatcher> podWatchers = new HashMap<>();
+  private static KubernetesVersion version = null;
   
   private static final Engine engine = new Engine("operator");
 
@@ -147,6 +149,7 @@ public class Main {
   
         try {
           HealthCheckHelper healthCheck = new HealthCheckHelper(client, namespace, targetNamespaces);
+          version = healthCheck.performK8sVersionCheck();
           healthCheck.performNonSecurityChecks();
           healthCheck.performSecurityChecks(serviceAccountName);
         } catch (ApiException e) {
@@ -442,7 +445,7 @@ public class Main {
     Fiber f = engine.createFiber();
     Packet p = new Packet();
     
-    p.getComponents().put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(info));
+    p.getComponents().put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(info, version));
     p.put(ProcessingConstants.PRINCIPAL, principal);
     
     if (explicitRestartAdmin) {

--- a/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
@@ -220,6 +220,10 @@ public class HealthCheckHelper {
     }
   }
 
+  /**
+   * Major and minor version of Kubernetes API Server
+   * 
+   */
   public static class KubernetesVersion {
     public final int major;
     public final int minor;

--- a/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -77,13 +77,10 @@ public class ServiceHelper {
       V1ServiceSpec serviceSpec = new V1ServiceSpec();
       serviceSpec.setType(nodePort == null ? "ClusterIP" : "NodePort");
       
-      // Use Headless
-      /*
       Map<String, String> selector = new HashMap<>();
       selector.put(LabelConstants.DOMAINUID_LABEL, weblogicDomainUID);
       selector.put(LabelConstants.SERVERNAME_LABEL, serverName);
       serviceSpec.setSelector(selector);
-      */
       
       List<V1ServicePort> ports = new ArrayList<>();
       V1ServicePort servicePort = new V1ServicePort();

--- a/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -50,6 +50,9 @@ public class ServiceHelper {
       
       Domain dom = info.getDomain();
       V1ObjectMeta meta = dom.getMetadata();
+      
+      meta.putAnnotationsItem("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
+      
       DomainSpec spec = dom.getSpec();
       String namespace = meta.getNamespace();
 
@@ -73,10 +76,15 @@ public class ServiceHelper {
 
       V1ServiceSpec serviceSpec = new V1ServiceSpec();
       serviceSpec.setType(nodePort == null ? "ClusterIP" : "NodePort");
+      
+      // Use Headless
+      /*
       Map<String, String> selector = new HashMap<>();
       selector.put(LabelConstants.DOMAINUID_LABEL, weblogicDomainUID);
       selector.put(LabelConstants.SERVERNAME_LABEL, serverName);
       serviceSpec.setSelector(selector);
+      */
+      
       List<V1ServicePort> ports = new ArrayList<>();
       V1ServicePort servicePort = new V1ServicePort();
       servicePort.setPort(port);

--- a/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -49,10 +49,9 @@ public class ServiceHelper {
       String serverName = (String) packet.get(ProcessingConstants.SERVER_NAME);
       Integer port = (Integer) packet.get(ProcessingConstants.PORT);
       Integer nodePort = (Integer) packet.get(ProcessingConstants.NODE_PORT);
-      
+
       Domain dom = info.getDomain();
       V1ObjectMeta meta = dom.getMetadata();
-      
       DomainSpec spec = dom.getSpec();
       String namespace = meta.getNamespace();
 
@@ -74,19 +73,19 @@ public class ServiceHelper {
 
       AnnotationHelper.annotateWithDomain(metadata, dom);
       metadata.putAnnotationsItem("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
-      
+
       V1ServiceSpec serviceSpec = new V1ServiceSpec();
       serviceSpec.setType(nodePort == null ? "ClusterIP" : "NodePort");
-  
+
       Map<String, String> selector = new HashMap<>();
       selector.put(LabelConstants.DOMAINUID_LABEL, weblogicDomainUID);
       selector.put(LabelConstants.SERVERNAME_LABEL, serverName);
       serviceSpec.setSelector(selector);
-  
+
       if (version != null && (version.major > 1 || (version.major == 1 && version.minor >= 8))) {
         serviceSpec.setPublishNotReadyAddresses(Boolean.TRUE);
       }
-      
+
       List<V1ServicePort> ports = new ArrayList<>();
       V1ServicePort servicePort = new V1ServicePort();
       servicePort.setPort(port);

--- a/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -53,8 +53,6 @@ public class ServiceHelper {
       Domain dom = info.getDomain();
       V1ObjectMeta meta = dom.getMetadata();
       
-      meta.putAnnotationsItem("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
-      
       DomainSpec spec = dom.getSpec();
       String namespace = meta.getNamespace();
 
@@ -75,7 +73,8 @@ public class ServiceHelper {
       service.setMetadata(metadata);
 
       AnnotationHelper.annotateWithDomain(metadata, dom);
-
+      metadata.putAnnotationsItem("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
+      
       V1ServiceSpec serviceSpec = new V1ServiceSpec();
       serviceSpec.setType(nodePort == null ? "ClusterIP" : "NodePort");
   

--- a/src/main/java/oracle/kubernetes/operator/logging/LoggingFormatter.java
+++ b/src/main/java/oracle/kubernetes/operator/logging/LoggingFormatter.java
@@ -110,7 +110,7 @@ public class LoggingFormatter extends Formatter {
     map.put(SOURCE_METHOD, sourceMethodName);
     map.put(TIME_IN_MILLIS, rawTime);
     // if message or throwable have new lines in them, we need to replace with JSON newline control character \n
-    map.put(MESSAGE, message.replaceAll("\n", "\\\n"));
+    map.put(MESSAGE, message != null ? message.replaceAll("\n", "\\\n") : "");
     map.put(EXCEPTION, throwable.replaceAll("\n", "\\\n"));
     map.put(RESPONSE_CODE, code);
     map.put(RESPONSE_HEADERS, headers);


### PR DESCRIPTION
Part of the delay in starting WebLogic servers is that the servers can no locate other servers via DNS if the other servers reside in Pods that aren't yet Ready.  This is because the default behavior is for Services to not expose endpoints that aren't yet ready.

There is an annotation for <= 1.7 and a Service field for 1.8+.