### PR TITLE
Integration test 1

### DIFF
--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -11,16 +11,21 @@
 # -----------------
 #
 # This script runs a series of acceptance tests and archives the results
-# into tar.gz files upon completion.
+# into tar.gz files upon completion.  It currently runs in three modes,
+# "Wercker", "Jenkins", and "standalone" Oracle Linux, where the mode
+# is controlled by the WERCKER and JENKINS environment variables described
+# below.  A standalone run filters out verbose lines from the console output
+# while redirecting full output to the file /tmp/test_suite.out
 #
 # To cleanup after a run, see "cleanup.sh".
 #
-# The test has three levels of logging output, output that begins with:
+# The test has three levels of logging output. Output that begins with:
 #
 #     "##TEST_INFO" is very concise (one line per test (either PASS or FAIL).
 #     "[timestamp]" is concise.
 #     "+" is verbose.
 #     Anything else is semi-verbose.
+#
 #
 # This script accepts optional env var overrides:
 #
@@ -32,6 +37,9 @@
 #                  used for persistent volumes.
 #                  See "Directory Configuration and Structure" below for
 #                  defaults and a detailed description of test directies.
+#
+#   QUICKTEST      When set to "true", limits testing to a subset of
+#                  of the tests.
 #
 #   WERCKER        Set to true if invoking from Wercker, set
 #                  to false or "" if running stand-alone or from Jenkins.
@@ -371,6 +379,8 @@ trap ctrl_c INT
 
 function ctrl_c() {
     declare_new_test_from_trap 1 run_aborted_with_ctrl_c
+    # disable the trap:
+    trap - INT
     fail "Trapped CTRL-C"
 }
 
@@ -1449,6 +1459,8 @@ EOF
     # like local, it uses the t3 channel...
     run_wlst_script $1 hybrid ${pyfile_con} 
   else
+    # TODO The following has a dependency on java and WebLogic being in the path/classpath.
+    #      We should run on 'hybrid' mode instead if java and WebLogic aren't already setup.
     run_wlst_script $1 local ${pyfile_con} 
   fi
 
@@ -1469,6 +1481,11 @@ function run_wlst_script {
   if [ "$#" -lt 3 ] ; then
     fail "requires at least 3 parameters: domainKey local|remote|hybrid local_pyfile optionalarg1 optionalarg2 ..."
   fi 
+
+  # TODO It seems possible to obtain user/pass from the secret via WLST verbs.  This
+  #      would be better than passing it to the WLST command-line in plain-text.  See
+  #      read-domain-secret.py in domain-job-template for an example of how this is done
+  #      for WLST that runs from within a pod...
 
   local DOM_KEY="$1"
   local NAMESPACE="`dom_get $1 NAMESPACE`"
@@ -2352,8 +2369,9 @@ function test_suite_init {
 }
 
 #
-# TODO:  Make output less verbose -- suppress REST output, etc.  Move output to file and/or
-#        only report output on a failure and/or prefix output with a "+".
+# TODO:  Make output less verbose -- suppress REST, archive, and job output, etc.  In general, move
+#        move verbose output to file and/or  only report output on a failure and/or prefix output
+#        with a "+".   Also, suppress output in the pod readiness loops to only once every 30 seconds.
 #
 
 function test_suite {

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -2433,19 +2433,18 @@ function test_suite {
     # create first domain in default namespace and verify it
     test_domain_creation domain1 
 
+    # test shutting down and restarting a domain 
+    test_domain_lifecycle domain1 
+
+    # test shutting down and restarting the operator for the given domain
+    test_operator_lifecycle domain1
+
+    # test scaling domain1 cluster from 2 to 3 servers and back down to 2
+    test_cluster_scale domain1 
+    
     # if QUICKTEST is true skip the rest of the tests
     if [ ! "${QUICKTEST:-false}" = "true" ]; then
    
-      # test shutting down and restarting a domain 
-      test_domain_lifecycle domain1 
-
-      # test shutting down and restarting the operator for the given domain
-      test_operator_lifecycle domain1
-
-      # TODO move test_cluster_scale to QUICKTEST once we speedup mgd server boots
-      # test scaling domain1 cluster from 2 to 3 servers and back down to 2
-      test_cluster_scale domain1 
-    
       # create another domain in the default namespace and verify it
       test_domain_creation domain2 
     

--- a/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
@@ -28,6 +28,18 @@ public class AnnotationHelper {
     }
   }
 
+
+  /**
+   * Marks metadata with annotations that let Prometheus know how to retrieve metrics from
+   * the wls-exporter web-app.  The specified httpPort should be the listen port of the wl server
+   * running in the pod.
+   */
+  public static void annotateForPrometheus(V1ObjectMeta meta, int httpPort) {
+     meta.putAnnotationsItem("prometheus.io/port", "" + httpPort); // should be the ListenPort of the server in the pod
+     meta.putAnnotationsItem("prometheus.io/path", "/wls-exporter/metrics");
+     meta.putAnnotationsItem("prometheus.io/scrape", "true");
+  }
+
   /**
    * Check the metadata object for the presence of an annotation matching the domain and resource version.l
    * @param meta The metadata object

--- a/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -105,6 +105,7 @@ public class PodHelper {
       adminPod.setMetadata(metadata);
       
       AnnotationHelper.annotateWithDomain(metadata, dom);
+      AnnotationHelper.annotateForPrometheus(metadata, spec.getAsPort());
 
       Map<String, String> labels = new HashMap<>();
       labels.put(LabelConstants.DOMAINUID_LABEL, weblogicDomainUID);
@@ -438,6 +439,7 @@ public class PodHelper {
       pod.setMetadata(metadata);
 
       AnnotationHelper.annotateWithDomain(metadata, dom);
+      AnnotationHelper.annotateForPrometheus(metadata, scan.getListenPort());
 
       Map<String, String> labels = new HashMap<>();
       labels.put(LabelConstants.DOMAINUID_LABEL, weblogicDomainUID);


### PR DESCRIPTION
Expand integration test 'QUICKTEST' mode to include domain lifecycle, operator lifecycle, and domain scaling tests.     This should only be checked in once the tests are stabilized.   This change is branched off of pending push 'Issue-27'.