### PR TITLE
Fix an intermittent problem when scale down multiple times back to back, and typos in wercker.yml

### DIFF
--- a/src/main/java/oracle/kubernetes/operator/work/Fiber.java
+++ b/src/main/java/oracle/kubernetes/operator/work/Fiber.java
@@ -231,6 +231,10 @@ public final class Fiber implements Runnable, Future<Void>, ComponentRegistry {
       } finally {
         lock.unlock();
       }
+    } else if (status.get() == CANCELLED) {
+      if (--suspendedCount == 0) {
+        completionCheck();
+      }
     }
   }
   

--- a/src/main/java/oracle/kubernetes/operator/work/Fiber.java
+++ b/src/main/java/oracle/kubernetes/operator/work/Fiber.java
@@ -232,8 +232,13 @@ public final class Fiber implements Runnable, Future<Void>, ComponentRegistry {
         lock.unlock();
       }
     } else if (status.get() == CANCELLED) {
-      if (--suspendedCount == 0) {
-        completionCheck();
+      lock.lock();
+      try {
+        if (--suspendedCount == 0) {
+          completionCheck();
+        }
+      } finally {
+        lock.unlock();
       }
     }
   }

--- a/wercker.yml
+++ b/wercker.yml
@@ -146,7 +146,7 @@ integration-test:
       kubectl create secret docker-registry quay-io -n weblogic-operator-2 --docker-server=quay.io --docker-username=$QUAY_USERNAME --docker-password=$QUAY_PASSWORD --docker-email=$QUAY_EMAIL
 
       export IMAGE_NAME_OPERATOR="quay.io/markxnelson/weblogic-kubernetes-operator"
-      export IMAGE_TAG_OPERATOR="${WERCKER_GIT_BRANCH//[_/]/-}"
+      export IMAGE_TAG_OPERATOR="${WERCKER_GIT_BRANCH//[_\/]/-}"
       if [ "$IMAGE_TAG_OPERATOR" = "master" ]; then
         export IMAGE_TAG_OPERATOR="latest"
       fi

--- a/wercker.yml
+++ b/wercker.yml
@@ -43,7 +43,7 @@ build:
       mkdir /operator
       cp -R src/main/scripts/* /operator/
       cp target/weblogic-kubernetes-operator-0.1.0-alpha-SNAPSHOT.jar /operator/weblogic-kubernetes-operator.jar
-      export IMAGE_TAG_OPERATOR="${WERCKER_GIT_BRANCH//[_/]/-}"
+      export IMAGE_TAG_OPERATOR="${WERCKER_GIT_BRANCH//[_\/]/-}"
       if [ "$IMAGE_TAG_OPERATOR" = "master" ]; then
         export IMAGE_TAG_OPERATOR="latest"
       fi


### PR DESCRIPTION
Fix an intermittent issue in scale down. 

Problem: When two scale down operations come together, the first is cancelled, and the second one is suspended waiting for the cancelation of the first one forever.

Cause:  Fiber's resume method only handles NOT_COMPLETED state, but a cancelled fiber is in CANCALLED state.

Solution: Add code to handle CANCELLED state in resume.

In addition, fix string substitutions in wercker.yml to correctly handle "/" in branch names.