### PR TITLE
Store artifacts from integration-test so they can be easily downloaded

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -163,6 +163,9 @@ integration-test:
       # clean up
       yum clean all
 
+      # store the artifacts so we can download them easily 
+      tar czvf ${WERCKER_REPORT_ARTIFACTS_DIR}/integration-test-data.tar.gz /pipeline/output/*
+
 # This pipeline runs quality checks 
 quality:
   steps:


### PR DESCRIPTION
This PR "saves" the artifacts created during the integration-test phase, i.e. `/pipeline/output/k8s-dir` so that is can be easily downloaded from the wercker web interface. 

After the integration-test pipeline has run, you can obtain the artifacts by clicking on the "Download artifacts" button under the "Run integration tests" heading - see the image below: 

<img width="936" alt="image" src="https://user-images.githubusercontent.com/6345393/36823835-1dab88f8-1ccd-11e8-9a13-86d6338cb64e.png">
