### PR TITLE
Use WatchBuilder to create Watch objects

### DIFF
--- a/src/main/java/oracle/kubernetes/operator/DomainWatcher.java
+++ b/src/main/java/oracle/kubernetes/operator/DomainWatcher.java
@@ -3,17 +3,17 @@
 
 package oracle.kubernetes.operator;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.domain.model.oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.operator.helpers.ClientHelper;
 import oracle.kubernetes.operator.helpers.ClientHolder;
+import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.watcher.Watcher;
 import oracle.kubernetes.operator.watcher.Watching;
 import oracle.kubernetes.operator.watcher.WatchingEventDestination;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class handles Domain watching. It receives domain events and sends
@@ -73,14 +73,9 @@ public class DomainWatcher implements Runnable {
        */
       @Override
       public Watch<Domain> initiateWatch(Object context, String resourceVersion) throws ApiException {
-        return Watch.createWatch(client.getApiClient(),
-            client.callBuilder().with($ -> {
-              $.resourceVersion = resourceVersion;
-              $.timeoutSeconds = 30;
-              $.watch = true;
-            }).listDomainCall(ns),
-            new TypeToken<Watch.Response<Domain>>() {
-            }.getType());
+        return new WatchBuilder(client)
+                  .withResourceVersion(resourceVersion)
+                .createDomainsInNamespaceWatch(ns);
       }
 
       @Override

--- a/src/main/java/oracle/kubernetes/operator/IngressWatcher.java
+++ b/src/main/java/oracle/kubernetes/operator/IngressWatcher.java
@@ -3,19 +3,19 @@
 
 package oracle.kubernetes.operator;
 
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1beta1Ingress;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.helpers.ClientHelper;
 import oracle.kubernetes.operator.helpers.ClientHolder;
+import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.watcher.Watcher;
 import oracle.kubernetes.operator.watcher.Watching;
 import oracle.kubernetes.operator.watcher.WatchingEventDestination;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class handles Ingress watching. It receives Ingress change events and sends
@@ -75,15 +75,10 @@ public class IngressWatcher implements Runnable {
        */
       @Override
       public Watch<V1beta1Ingress> initiateWatch(Object context, String resourceVersion) throws ApiException {
-        return Watch.createWatch(client.getApiClient(),
-            client.callBuilder().with($ -> {
-              $.resourceVersion = resourceVersion;
-              $.labelSelector = LabelConstants.DOMAINUID_LABEL; // Any Ingress with a domainUID label
-              $.timeoutSeconds = 30;
-              $.watch = true;
-            }).listIngressCall(ns),
-            new TypeToken<Watch.Response<V1beta1Ingress>>() {
-            }.getType());
+        return new WatchBuilder(client)
+                  .withResourceVersion(resourceVersion)
+                  .withLabelSelector(LabelConstants.DOMAINUID_LABEL) // Any Ingress with a domainUID label
+                .createIngressWatch(ns);
       }
 
       @Override

--- a/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -2,14 +2,6 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 package oracle.kubernetes.operator;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.gson.reflect.TypeToken;
-
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
@@ -23,12 +15,19 @@ import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.watcher.Watcher;
 import oracle.kubernetes.operator.watcher.Watching;
 import oracle.kubernetes.operator.watcher.WatchingEventDestination;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Watches for Pods to become Ready or leave Ready state
@@ -49,7 +48,6 @@ public class PodWatcher implements Runnable {
    * Factory for PodWatcher
    * @param ns Namespace
    * @param initialResourceVersion Initial resource version or empty string
-   * @param destination Callback for watch events
    * @param isStopping Stop signal
    * @return Pod watcher for the namespace
    */
@@ -101,15 +99,10 @@ public class PodWatcher implements Runnable {
        */
       @Override
       public Watch<V1Pod> initiateWatch(Object context, String resourceVersion) throws ApiException {
-        return Watch.createWatch(client.getApiClient(),
-            client.callBuilder().with($ -> {
-              $.resourceVersion = resourceVersion;
-              $.labelSelector = LabelConstants.DOMAINUID_LABEL; // Any Pod with a domainUID label
-              $.timeoutSeconds = 30;
-              $.watch = true;
-            }).listPodCall(ns),
-            new TypeToken<Watch.Response<V1Pod>>() {
-            }.getType());
+        return new WatchBuilder(client)
+                  .withResourceVersion(resourceVersion)
+                  .withLabelSelector(LabelConstants.DOMAINUID_LABEL)  // Any Pod with a domainUID label
+                .createPodWatch(ns);
       }
 
       @Override

--- a/src/main/java/oracle/kubernetes/operator/ServiceWatcher.java
+++ b/src/main/java/oracle/kubernetes/operator/ServiceWatcher.java
@@ -3,20 +3,19 @@
 
 package oracle.kubernetes.operator;
 
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ObjectMeta;
-import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.helpers.ClientHelper;
 import oracle.kubernetes.operator.helpers.ClientHolder;
+import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.watcher.Watcher;
 import oracle.kubernetes.operator.watcher.Watching;
 import oracle.kubernetes.operator.watcher.WatchingEventDestination;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class handles Service watching. It service change events and sends
@@ -76,15 +75,10 @@ public class ServiceWatcher implements Runnable {
        */
       @Override
       public Watch<V1Service> initiateWatch(Object context, String resourceVersion) throws ApiException {
-        return Watch.createWatch(client.getApiClient(),
-            client.callBuilder().with($ -> {
-              $.resourceVersion = resourceVersion;
-              $.labelSelector = LabelConstants.DOMAINUID_LABEL; // Any Service with a domainUID label
-              $.timeoutSeconds = 30;
-              $.watch = true;
-            }).listServiceCall(ns),
-            new TypeToken<Watch.Response<V1Service>>() {
-            }.getType());
+        return new WatchBuilder(client)
+                  .withResourceVersion(resourceVersion)
+                  .withLabelSelector(LabelConstants.DOMAINUID_LABEL)   // Any Service with a domainUID label
+                .createServiceWatch(ns);
       }
 
       @Override

--- a/src/main/java/oracle/kubernetes/operator/builders/CallParams.java
+++ b/src/main/java/oracle/kubernetes/operator/builders/CallParams.java
@@ -1,0 +1,91 @@
+package oracle.kubernetes.operator.builders;
+
+import io.kubernetes.client.ProgressRequestBody;
+import io.kubernetes.client.ProgressResponseBody;
+
+public class CallParams {
+    private static final int DEFAULT_LIMIT = 500;
+    private static final int DEFAULT_TIMEOUT = 30;
+
+    private Boolean includeUninitialized;
+    private Integer limit = CallParams.DEFAULT_LIMIT;
+    private Integer timeoutSeconds = CallParams.DEFAULT_TIMEOUT;
+    private String fieldSelector;
+    private String labelSelector;
+    private String pretty;
+    private String resourceVersion;
+    private ProgressResponseBody.ProgressListener progressListener;
+    private ProgressRequestBody.ProgressRequestListener progressRequestListener;
+
+    public Boolean getIncludeUninitialized() {
+        return includeUninitialized;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public Integer getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public String getFieldSelector() {
+        return fieldSelector;
+    }
+
+    public String getLabelSelector() {
+        return labelSelector;
+    }
+
+    public String getPretty() {
+        return pretty;
+    }
+
+    public String getResourceVersion() {
+        return resourceVersion;
+    }
+
+    public ProgressResponseBody.ProgressListener getProgressListener() {
+        return progressListener;
+    }
+
+    public ProgressRequestBody.ProgressRequestListener getProgressRequestListener() {
+        return progressRequestListener;
+    }
+
+    void setIncludeUninitialized(Boolean includeUninitialized) {
+        this.includeUninitialized = includeUninitialized;
+    }
+
+    void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+
+    void setTimeoutSeconds(Integer timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    void setFieldSelector(String fieldSelector) {
+        this.fieldSelector = fieldSelector;
+    }
+
+    void setLabelSelector(String labelSelector) {
+        this.labelSelector = labelSelector;
+    }
+
+    void setPretty(String pretty) {
+        this.pretty = pretty;
+    }
+
+    void setResourceVersion(String resourceVersion) {
+        this.resourceVersion = resourceVersion;
+    }
+
+    void setProgressListener(ProgressResponseBody.ProgressListener progressListener) {
+        this.progressListener = progressListener;
+    }
+
+    void setProgressRequestListener(ProgressRequestBody.ProgressRequestListener progressRequestListener) {
+        this.progressRequestListener = progressRequestListener;
+    }
+}

--- a/src/main/java/oracle/kubernetes/operator/builders/UncheckedApiException.java
+++ b/src/main/java/oracle/kubernetes/operator/builders/UncheckedApiException.java
@@ -1,0 +1,20 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+package oracle.kubernetes.operator.builders;
+
+import io.kubernetes.client.ApiException;
+
+/**
+ * An exception used to bypass functional programming incompatability with checked exceptions. This is thrown
+ * by a function object and the underlying ApiException is then rethrown by the caller of the function object.
+ */
+class UncheckedApiException extends RuntimeException {
+    UncheckedApiException(ApiException e) {
+        super(e);
+    }
+
+    @Override
+    public synchronized ApiException getCause() {
+        return (ApiException) super.getCause();
+    }
+}

--- a/src/main/java/oracle/kubernetes/operator/builders/WatchBuilder.java
+++ b/src/main/java/oracle/kubernetes/operator/builders/WatchBuilder.java
@@ -1,0 +1,320 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+package oracle.kubernetes.operator.builders;
+
+import com.squareup.okhttp.Call;
+import io.kubernetes.client.ApiClient;
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.ProgressRequestBody;
+import io.kubernetes.client.ProgressResponseBody;
+import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1beta1Ingress;
+import io.kubernetes.client.util.Watch;
+import oracle.kubernetes.operator.domain.model.oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.operator.helpers.ClientHolder;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.function.BiFunction;
+
+@SuppressWarnings("unused")
+public class WatchBuilder {
+
+    private static final String START_LIST = "";
+    private static final boolean WATCH = true;
+    private static WatchFactory FACTORY = new WatchFactoryImpl();
+    private ClientHolder clientHolder;
+
+    private CallParams callParams = new CallParams();
+
+    public interface WatchFactory {
+        <T> Watch<T> createWatch(ClientHolder clientHolder, CallParams callParams, Class<?> responseBodyType, BiFunction<ClientHolder, CallParams, Call> function) throws ApiException;
+    }
+
+    public WatchBuilder(ClientHolder clientHolder) {
+        this.clientHolder = clientHolder;
+    }
+
+    /**
+     * Creates a web hook object to track changes to the namespaces.
+     * @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public Watch<V1Namespace> createNamespaceWatch() throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, V1Namespace.class, WatchBuilder::listNamespaceCall);
+    }
+
+    private ApiClient getApiClient() {
+        return clientHolder.getApiClient();
+    }
+
+    private static Call listNamespaceCall(ClientHolder clientHolder, CallParams callParams) {
+        try {
+            return clientHolder.getCoreApiClient().listNamespaceCall(
+                        callParams.getPretty(), START_LIST, callParams.getFieldSelector(),
+                        callParams.getIncludeUninitialized(), callParams.getLabelSelector(), callParams.getLimit(),
+                        callParams.getResourceVersion(), callParams.getTimeoutSeconds(), WATCH,
+                        callParams.getProgressListener(), callParams.getProgressRequestListener());
+        } catch (ApiException e) {
+            throw new UncheckedApiException(e);
+        }
+    }
+
+    private static <T> Type getType(Class<?> responseBodyType) {
+        return new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] {responseBodyType};
+            }
+
+            @Override
+            public Type getRawType() {
+                return Watch.Response.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return Watch.class;
+            }
+        };
+    }
+
+    /**
+     * Creates a web hook object to track service calls
+     * @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public Watch<V1Service> createServiceWatch(String namespace) throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, V1Service.class, new ListNamespacedServiceCall(namespace));
+    }
+
+    private class ListNamespacedServiceCall implements BiFunction<ClientHolder, CallParams, Call> {
+        private String namespace;
+
+        ListNamespacedServiceCall(String namespace) {
+            this.namespace = namespace;
+        }
+
+        @Override
+        public Call apply(ClientHolder clientHolder, CallParams callParams) {
+            try {
+                return clientHolder.getCoreApiClient().listNamespacedServiceCall(namespace,
+                              callParams.getPretty(), START_LIST,
+                              callParams.getFieldSelector(), callParams.getIncludeUninitialized(), callParams.getLabelSelector(),
+                              callParams.getLimit(), callParams.getResourceVersion(), callParams.getTimeoutSeconds(), WATCH, null, null);
+            } catch (ApiException e) {
+                throw new UncheckedApiException(e);
+            }
+        }
+    }
+
+    /**
+     * Creates a web hook object to track pods
+     * @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public Watch<V1Pod> createPodWatch(String namespace) throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, V1Pod.class, new ListPodCall(namespace));
+    }
+
+    private class ListPodCall implements BiFunction<ClientHolder, CallParams, Call> {
+        private String namespace;
+
+        ListPodCall(String namespace) {
+            this.namespace = namespace;
+        }
+
+        @Override
+        public Call apply(ClientHolder clientHolder, CallParams callParams) {
+            try {
+                return clientHolder.getCoreApiClient().listNamespacedPodCall(namespace, callParams.getPretty(),
+                            START_LIST, callParams.getFieldSelector(), callParams.getIncludeUninitialized(),
+                            callParams.getLabelSelector(), callParams.getLimit(), callParams.getResourceVersion(),
+                            callParams.getTimeoutSeconds(), WATCH, null, null);
+            } catch (ApiException e) {
+                throw new UncheckedApiException(e);
+            }
+        }
+    }
+
+    /**
+     * Creates a web hook object to track changes to the cluster ingress
+     * @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public Watch<V1beta1Ingress> createIngressWatch(String namespace) throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, V1beta1Ingress.class, new ListIngressCall(namespace));
+    }
+
+    private class ListIngressCall implements BiFunction<ClientHolder, CallParams, Call> {
+        private String namespace;
+
+        ListIngressCall(String namespace) {
+            this.namespace = namespace;
+        }
+
+        @Override
+        public Call apply(ClientHolder clientHolder, CallParams callParams) {
+            try {
+                return clientHolder.getExtensionsV1beta1ApiClient().listNamespacedIngressCall(namespace,
+                            callParams.getPretty(), START_LIST, callParams.getFieldSelector(),
+                            callParams.getIncludeUninitialized(), callParams.getLabelSelector(), callParams.getLimit(),
+                            callParams.getResourceVersion(), callParams.getTimeoutSeconds(), WATCH, null, null);
+            } catch (ApiException e) {
+                throw new UncheckedApiException(e);
+            }
+        }
+    }
+
+    /**
+     * Creates a web hook object to track changes to weblogic domains in all namespaces
+     * @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public Watch<Domain> createDomainsInAllNamespacesWatch() throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, Domain.class, WatchBuilder::listDomainsForAllNamespacesCall);
+    }
+
+    private static Call listDomainsForAllNamespacesCall(ClientHolder clientHolder, CallParams callParams) {
+        try {
+            return clientHolder.getWeblogicApiClient().listWebLogicOracleV1DomainForAllNamespacesCall(START_LIST,
+                        callParams.getFieldSelector(), callParams.getIncludeUninitialized(), callParams.getLabelSelector(),
+                        callParams.getLimit(), callParams.getPretty(), callParams.getResourceVersion(),
+                        callParams.getTimeoutSeconds(), WATCH, callParams.getProgressListener(), callParams.getProgressRequestListener());
+        } catch (ApiException e) {
+            throw new UncheckedApiException(e);
+        }
+    }
+
+    /**
+     * Creates a web hook object to track changes to weblogic domains in one namespaces
+     * @param namespace the namespace in which to track domains
+     * @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public Watch<Domain> createDomainsInNamespaceWatch(String namespace) throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, Domain.class, new ListDomainsInNamespaceCall(namespace));
+    }
+
+    private class ListDomainsInNamespaceCall implements BiFunction<ClientHolder, CallParams, Call> {
+        private String namespace;
+
+        ListDomainsInNamespaceCall(String namespace) {
+            this.namespace = namespace;
+        }
+
+        @Override
+        public Call apply(ClientHolder clientHolder, CallParams callParams) {
+            try {
+                return clientHolder.getWeblogicApiClient().listWebLogicOracleV1NamespacedDomainCall(namespace,
+                            callParams.getPretty(), START_LIST, callParams.getFieldSelector(),
+                            callParams.getIncludeUninitialized(), callParams.getLabelSelector(), callParams.getLimit(),
+                            callParams.getResourceVersion(), callParams.getTimeoutSeconds(), WATCH, null, null);
+            } catch (ApiException e) {
+                throw new UncheckedApiException(e);
+            }
+        }
+    }
+
+    /**
+     * Creates a web hook object to track changes to custom objects
+     * @param namespace the namespace in which to track custom objects.
+     * @param responseBodyType the type of objects returned in the events
+     * @param group the custom resource group name
+     * @param version the custom resource version
+     * @param plural the custom resource plural name    @return the active web hook
+     * @throws ApiException if there is an error on the call that sets up the web hook.
+     */
+    public <T> Watch<T> createCustomObjectWatch(String namespace, Class<?> responseBodyType, String group, String version, String plural) throws ApiException {
+        return FACTORY.createWatch(clientHolder, callParams, responseBodyType, new ListCustomObjectsInNamespaceCall(namespace, group, version, plural));
+    }
+
+    private class ListCustomObjectsInNamespaceCall implements BiFunction<ClientHolder, CallParams, Call> {
+        private String namespace;
+        private String group;
+        private String version;
+        private String plural;
+
+        ListCustomObjectsInNamespaceCall(String namespace, String group, String version, String plural) {
+            this.namespace = namespace;
+            this.group = group;
+            this.version = version;
+            this.plural = plural;
+        }
+
+        @Override
+        public Call apply(ClientHolder clientHolder, CallParams callParams) {
+            try {
+                return clientHolder.getCustomObjectsApiClient().listNamespacedCustomObjectCall(
+                            group, version, namespace, plural,
+                            callParams.getPretty(), callParams.getLabelSelector(), callParams.getResourceVersion(),
+                            WATCH, null, null);
+            } catch (ApiException e) {
+                throw new UncheckedApiException(e);
+            }
+        }
+    }
+
+    /**
+     * Sets a value for the fieldSelector parameter for the call that will set up this watch. Defaults to null.
+     * @param fieldSelector the desired value
+     * @return the updated builder
+     */
+    public WatchBuilder withFieldSelector(String fieldSelector) {
+        callParams.setFieldSelector(fieldSelector);
+        return this;
+    }
+
+    public WatchBuilder withIncludeUninitialized(Boolean includeUninitialized) {
+        callParams.setIncludeUninitialized(includeUninitialized);
+        return this;
+    }
+
+    public WatchBuilder withLabelSelector(String labelSelector) {
+        callParams.setLabelSelector(labelSelector);
+        return this;
+    }
+
+    public WatchBuilder withLimit(Integer limit) {
+        callParams.setLimit(limit);
+        return this;
+    }
+
+    public WatchBuilder withPrettyPrinting() {
+        callParams.setPretty("true");
+        return this;
+    }
+
+    public WatchBuilder withResourceVersion(String resourceVersion) {
+        callParams.setResourceVersion(resourceVersion);
+        return this;
+    }
+
+    public WatchBuilder withTimeoutSeconds(Integer timeoutSeconds) {
+        callParams.setTimeoutSeconds(timeoutSeconds);
+        return this;
+    }
+
+    public WatchBuilder withProgressListener(ProgressResponseBody.ProgressListener progressListener) {
+        callParams.setProgressListener(progressListener);
+        return this;
+    }
+
+    public WatchBuilder withProgressRequestListener(ProgressRequestBody.ProgressRequestListener progressRequestListener) {
+        callParams.setProgressRequestListener(progressRequestListener);
+        return this;
+    }
+
+    static class WatchFactoryImpl implements WatchFactory {
+        @Override
+        public <T> Watch<T> createWatch(ClientHolder clientHolder, CallParams callParams, Class<?> responseBodyType, BiFunction<ClientHolder, CallParams, Call> function) throws ApiException {
+            try {
+                return Watch.createWatch(clientHolder.getApiClient(), function.apply(clientHolder, callParams), getType(responseBodyType));
+            } catch (UncheckedApiException e) {
+                throw e.getCause();
+            }
+        }
+    }
+}

--- a/src/test/java/oracle/kubernetes/TestUtils.java
+++ b/src/test/java/oracle/kubernetes/TestUtils.java
@@ -1,3 +1,5 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 package oracle.kubernetes;
 
 import org.apache.commons.exec.CommandLine;
@@ -24,21 +26,35 @@ public class TestUtils {
     return kubernetesStatus;
   }
 
-    private static Boolean checkKubernetes() {
-      PrintStream savedOut = System.out;
-      System.setOut(new PrintStream(new ByteArrayOutputStream()));
-      try {
-        CommandLine cmdLine = CommandLine.parse("kubectl cluster-info");
-        DefaultExecutor executor = new DefaultExecutor();
-        executor.execute(cmdLine);
-        return true;
-      } catch (IOException e) {
-        return false;
-      } finally {
-        System.setOut(savedOut);
-      }
+  private static Boolean checkKubernetes() {
+    PrintStream savedOut = System.out;
+    System.setOut(new PrintStream(new ByteArrayOutputStream()));
+    try {
+      CommandLine cmdLine = CommandLine.parse("kubectl cluster-info");
+      DefaultExecutor executor = new DefaultExecutor();
+      executor.execute(cmdLine);
+      return true;
+    } catch (IOException e) {
+      return false;
+    } finally {
+      System.setOut(savedOut);
     }
+  }
 
+  /**
+   * Returns true if the current system is running Linux
+   * @return a boolean indicating the operating system match
+   */
+  public static boolean isLinux() {
+    return System.getProperty("os.name").toLowerCase().contains("linux");
+  }
+
+  /**
+   * Removes the console handlers from the specified logger, in order to silence them during a test.
+   *
+   * @param logger a logger to silence
+   * @return a collection of the removed handlers
+   */
   public static List<Handler> removeConsoleHandlers(Logger logger) {
     List<Handler> savedHandlers = new ArrayList<>();
     for (Handler handler : logger.getHandlers()) {
@@ -51,6 +67,12 @@ public class TestUtils {
     return savedHandlers;
   }
 
+  /**
+   * Restores the silenced logger handlers.
+   *
+   * @param logger a logger to restore
+   * @param savedHandlers the handlers to restore
+   */
   public static void restoreConsoleHandlers(Logger logger, List<Handler> savedHandlers) {
     for (Handler handler : savedHandlers) {
       logger.addHandler(handler);

--- a/src/test/java/oracle/kubernetes/custom/CustomObjectApisTest.java
+++ b/src/test/java/oracle/kubernetes/custom/CustomObjectApisTest.java
@@ -1,8 +1,7 @@
-// Copyright 2017, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2017-2018, Oracle Corporation and/or its affiliates.  All rights reserved.
 
 package oracle.kubernetes.custom;
 
-import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1DeleteOptions;
 import io.kubernetes.client.models.V1ObjectMeta;
@@ -12,7 +11,7 @@ import io.kubernetes.client.models.V1beta1CustomResourceDefinitionNames;
 import io.kubernetes.client.models.V1beta1CustomResourceDefinitionSpec;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watch.Response;
-import oracle.kubernetes.TestUtils;
+import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.helpers.ClientHelper;
 import oracle.kubernetes.operator.helpers.ClientHolder;
 import oracle.kubernetes.operator.logging.LoggingFacade;
@@ -22,7 +21,6 @@ import oracle.kubernetes.operator.watcher.Watcher;
 import oracle.kubernetes.operator.watcher.Watching;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -33,10 +31,14 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Handler;
 
+import static oracle.kubernetes.TestUtils.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Test CustomResourceDefinitions and custom objects
  */
-@Ignore("Ignore - sometimes runs indefinitely")
 public class CustomObjectApisTest {
 
   // Parameters for custom resources
@@ -54,16 +56,17 @@ public class CustomObjectApisTest {
 
   @Before
   public void setUp() throws Exception {
-    savedHandlers = TestUtils.removeConsoleHandlers(LOGGER.getUnderlyingLogger());
+    savedHandlers = removeConsoleHandlers(LOGGER.getUnderlyingLogger());
   }
 
   @After
   public void tearDown() throws Exception {
-    TestUtils.restoreConsoleHandlers(LOGGER.getUnderlyingLogger(), savedHandlers);
+    restoreConsoleHandlers(LOGGER.getUnderlyingLogger(), savedHandlers);
   }
 
   @Test
   public void testCustomResourceWatches() throws Exception {
+    assumeTrue(isKubernetesAvailable());
 
     ClientHolder client = ClientHelper.getInstance().take();
     try {
@@ -156,29 +159,18 @@ public class CustomObjectApisTest {
     Watching<TestDomain> w = new Watching<TestDomain>() {
 
       @Override
-      public Watch initiateWatch(Object context, String resourceVersion) throws ApiException {
+      public Watch<TestDomain> initiateWatch(Object context, String resourceVersion) throws ApiException {
 
         // resourceVersion is passed for each watch creation interation
         // to skip previous watch events in the resource history. It
         // must be passed each time a watch is created.
 
-        return Watch.createWatch(
-            client.getApiClient()
-            , client.getCustomObjectsApiClient().listNamespacedCustomObjectCall(
-                GROUP                 // group
-                , VERSION               // version
-                , NAMESPACE             // namespace
-                , PLURAL                // plural
-                , "true"                // pretty
-                , ""                    // labelSelector
-                , resourceVersion       // resourceVersion
-                , Boolean.TRUE          // watch is true
-                , null                  // progressListener
-                , null                  // progressRequestListener
-            )
-            , new TypeToken<Watch.Response<TestDomain>>() {
-            }.getType()
-        );
+        //noinspection unchecked
+        return new WatchBuilder(client)
+                    .withResourceVersion(resourceVersion)
+                    .withLabelSelector("")
+                    .withPrettyPrinting()
+                .createCustomObjectWatch(NAMESPACE, TestDomain.class, GROUP, VERSION, PLURAL);
       }
 
       private void formatTheObject(String type, Object object) {
@@ -207,18 +199,18 @@ public class CustomObjectApisTest {
       }
     };
     
-    return new Watcher<TestDomain>(w);
+    return new Watcher<>(w);
   }
 
   /**
    * Just wait for the watch operator to complete or terminate after
-   * a total of 5 minutes.
+   * a total of 3 seconds.
    *
    * @param watcher
    */
   private void waitForFinished(ClientHolder client, Watcher watcher) throws InterruptedException {
 
-    while (!finished.get() && timeoutLoop < 300) {
+    while (!finished.get() && timeoutLoop < 30) {
 
       switch (timeoutLoop) {
         case 3:
@@ -240,12 +232,11 @@ public class CustomObjectApisTest {
           break;
       }
 
-      Thread.sleep(1000); // sleep for a second and check
+      Thread.sleep(100); // sleep for a second and check
       timeoutLoop++;
     }
-    if (!finished.get()) {
-      LOGGER.info("Test timed out due to inactivity");
-    }
+
+    assertThat(finished.get(), is(true));
   }
 
   /**

--- a/src/test/java/oracle/kubernetes/operator/WatchTest.java
+++ b/src/test/java/oracle/kubernetes/operator/WatchTest.java
@@ -1,9 +1,8 @@
-// Copyright 2017, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2017-2018, Oracle Corporation and/or its affiliates.  All rights reserved.
 
 package oracle.kubernetes.operator;
 
 
-import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.models.V1Namespace;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.TestUtils;
@@ -12,13 +11,13 @@ import oracle.kubernetes.operator.helpers.CRDHelper;
 import oracle.kubernetes.operator.helpers.ClientHelper;
 import oracle.kubernetes.operator.helpers.ClientHolder;
 import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.builders.WatchBuilder;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.concurrent.NotThreadSafe;
-
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
@@ -45,23 +44,8 @@ public class WatchTest {
 
     ClientHolder client = ClientHelper.getInstance().take();
 
-      @SuppressWarnings("unused")
-      Watch<V1Namespace> watch = Watch.createWatch(
-          client.getApiClient(),
-          client.getCoreApiClient().listNamespaceCall(null,
-              null,
-              null,
-              null,
-              null,
-              5,
-              null,
-              60,
-              Boolean.TRUE,
-              null,
-              null),
-          new TypeToken<Watch.Response<V1Namespace>>() {
-          }.getType());
-
+    @SuppressWarnings("unused")
+    Watch<V1Namespace> watch = new WatchBuilder(client).createNamespaceWatch();
   }
 
 
@@ -71,23 +55,9 @@ public class WatchTest {
 
     ClientHolder client = ClientHelper.getInstance().take();
     CRDHelper.checkAndCreateCustomResourceDefinition(client);
-    
-      @SuppressWarnings("unused")
-      Watch<Domain> watch = Watch.createWatch(
-          client.getApiClient(),
-          client.getWeblogicApiClient().listWebLogicOracleV1DomainForAllNamespacesCall(null,
-              null,
-              null,
-              null,
-              5,
-              null,
-              null,
-              60,
-              Boolean.TRUE,
-              null,
-              null),
-          new TypeToken<Watch.Response<Domain>>() {
-          }.getType());
+
+    @SuppressWarnings("unused")
+    Watch<Domain> watch = new WatchBuilder(client).createDomainsInAllNamespacesWatch();
 
   }
 


### PR DESCRIPTION
Uses the builder pattern at the Watch level rather than the Call level, in preparation for providing unit test alternatives