### PR TITLE
Add persistent volume configuration to support NFS

### DIFF
--- a/kubernetes/create-domain-job-inputs.yaml
+++ b/kubernetes/create-domain-job-inputs.yaml
@@ -36,6 +36,13 @@ managedServerNameBase: managed-server
 # Port number for each managed server
 managedServerPort: 8001
 
+# Persistent volume type, the value must be hostPath or nfs.
+# If using nfs, nfsServer must be specified.
+persistenceType: hostPath
+
+# NFS server name or ip
+nfsServer: nfsServer
+
 # Physical path of the persistent volume storage
 persistencePath: /scratch/k8s_dir/persistentVolume001
 

--- a/kubernetes/internal/persistent-volume-template.yaml
+++ b/kubernetes/internal/persistent-volume-template.yaml
@@ -14,5 +14,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  hostPath:
+  %HOST_PATH_PREFIX%hostPath:
+  %NFS_PREFIX%nfs:
+    %NFS_PREFIX%server: %NFS_SERVER%
     path: "%PERSISTENT_VOLUME_PATH%"


### PR DESCRIPTION
The fix contains following content:
1. Add NFS related configuration in kubernetes/internal/persistent-volume-template.yaml
2. Add two configurable parameters (persistenceType and nfsServer) in kubernetes/create-domain-job-inputs.yaml
3. Update kubernetes/create-domain-job.sh
3.1 Validate the two input parameters. The value of persistenceType must be hostPath or nfs. If using nfs, nfsServer must be specified.
3.2 Generate the correct persistent volume yam file based on input parameters.
4. Fix a typo.  validatePersistenVolumeName --> validatePersistentVolumeName

Jenkins passed http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator/86/