### PR TITLE
Unit test and run-time fix

### DIFF
--- a/kubernetes/create-weblogic-domain.sh
+++ b/kubernetes/create-weblogic-domain.sh
@@ -15,7 +15,7 @@
 #
 
 script="${BASH_SOURCE[0]}"
-scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+scriptDir="$( cd "$(dirname "${script}")" > /dev/null 2>&1 ; pwd -P)"
 internalDir="${scriptDir}/internal"
 
 # This is the script that the customers use to create a domain.

--- a/kubernetes/create-weblogic-operator.sh
+++ b/kubernetes/create-weblogic-operator.sh
@@ -3,7 +3,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 script="${BASH_SOURCE[0]}"
-scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+scriptDir="$( cd "$(dirname "${script}")" > /dev/null 2>&1 ; pwd -P)"
 internalDir="${scriptDir}/internal"
 
 # This is the script that the customers use to create an operator.

--- a/src/test/scripts/unit-test-create-weblogic-domain.sh
+++ b/src/test/scripts/unit-test-create-weblogic-domain.sh
@@ -8,7 +8,7 @@
 # create domain script that generates the yaml files.
 
 script="${BASH_SOURCE[0]}"
-scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+scriptDir="$( cd "$(dirname "${script}")" > /dev/null 2>&1 ; pwd -P)"
 kubernetesDir="${scriptDir}/../../../kubernetes"
 internalDir="${kubernetesDir}/internal"
 

--- a/src/test/scripts/unit-test-create-weblogic-operator.sh
+++ b/src/test/scripts/unit-test-create-weblogic-operator.sh
@@ -12,7 +12,7 @@
 # used to actually run the operator.
 
 script="${BASH_SOURCE[0]}"
-scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+scriptDir="$( cd "$(dirname "${script}")" > /dev/null 2>&1 ; pwd -P)"
 kubernetesDir="${scriptDir}/../../../kubernetes"
 internalDir="${kubernetesDir}/internal"
 

--- a/src/test/scripts/unit-test-generate-weblogic-operator-cert.sh
+++ b/src/test/scripts/unit-test-generate-weblogic-operator-cert.sh
@@ -18,7 +18,8 @@ if [ ! $# -eq 1 ]; then
   exit 1
 fi
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 ; pwd -P)"
+
 
 CERT_DIR="${script_dir}/weblogic-operator-cert"
 OP_PREFIX="weblogic-operator"


### PR DESCRIPTION
Fix unit test and runtime script problem parsing 'cd' stdout that occurs on some linux boxes.
Unit tests now pass.
Local integration testing in progress (see also pending Wercker results).