### PR TITLE
Restore per-managed server service lifetime

### DIFF
--- a/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/src/main/java/oracle/kubernetes/operator/Main.java
@@ -1037,9 +1037,7 @@ public class Main {
         p.put(ProcessingConstants.SERVER_NAME, ssi.serverConfig.getName());
         p.put(ProcessingConstants.PORT, ssi.serverConfig.getListenPort());
         ServerStartup ss = ssi.serverStartup;
-        if (ss != null) {
-          p.put(ProcessingConstants.NODE_PORT, ss.getNodePort());
-        }
+        p.put(ProcessingConstants.NODE_PORT, ss != null ? ss.getNodePort() : null);
         
         startDetails.add(new StepAndPacket(bringManagedServerUp(ssi, null), p));
       }

--- a/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -162,6 +162,56 @@ public class ServiceHelper {
   }
   
   /**
+   * Factory for {@link Step} that deletes per-managed server service
+   * @param sko Server Kubernetes Objects
+   * @param next Next processing step
+   * @return Step for deleting per-managed server service
+   */
+  public static Step deleteServiceStep(ServerKubernetesObjects sko, Step next) {
+    return new DeleteServiceStep(sko, next);
+  }
+
+  private static class DeleteServiceStep extends Step {
+    private final ServerKubernetesObjects sko;
+
+    public DeleteServiceStep(ServerKubernetesObjects sko, Step next) {
+      super(next);
+      this.sko = sko;
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
+      
+      Domain dom = info.getDomain();
+      V1ObjectMeta meta = dom.getMetadata();
+      String namespace = meta.getNamespace();
+      
+      // Set service to null so that watcher doesn't try to recreate service
+      V1Service oldService = sko.getService().getAndSet(null);
+      if (oldService != null) {
+        return doNext(CallBuilder.create().deleteServiceAsync(oldService.getMetadata().getName(), namespace, new ResponseStep<V1Status>(next) {
+          @Override
+          public NextAction onFailure(Packet packet, ApiException e, int statusCode,
+              Map<String, List<String>> responseHeaders) {
+            if (statusCode == CallBuilder.NOT_FOUND) {
+              return onSuccess(packet, null, statusCode, responseHeaders);
+            }
+            return super.onFailure(packet, e, statusCode, responseHeaders);
+          }
+  
+          @Override
+          public NextAction onSuccess(Packet packet, V1Status result, int statusCode,
+              Map<String, List<String>> responseHeaders) {
+            return doNext(next, packet);
+          }
+        }), packet);
+      }
+      return doNext(packet);
+    }
+  }
+
+  /**
    * Create asynchronous step for internal cluster service
    * @param next Next processing step
    * @return Step for internal service creation


### PR DESCRIPTION
Earlier, we changed the lifetime of Services created by the operator.  Part of that change was correct, but unfortunately, part of it wasn't.

We are preserving the change to create a per-cluster Service and having this Service as the only backend of the cluster's Ingress.

However, this PR restores the original lifetime of the per-managed server Services to match that of the per-managed server Pod.  The ongoing work with dynamic clusters demonstrated that its better to delete the Services as Pods are deleted so that DNS lookups fail.  The WebLogic clustering subsystem more quickly identifies shutdown servers if their DNS lookups fail than if the DNS lookup is successful but the node manager is unavailable.