### PR TITLE
Int test leasing 2

### DIFF
--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -109,11 +109,17 @@ function genericDelete {
       resfile_yes="$TMP_DIR/kinv_filtered_yesnamespace.out.tmp"
 
       # leftover namespaced artifacts
-      kubectl get $1 --show-labels=true --all-namespaces=true 2>&1 | egrep -e "($3)" | awk '{ print $1 " " $2 }' | sort > $resfile_yes 2>&1
+      kubectl get $1 \
+          -o=jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.kind}{"/"}{.metadata.name}{"\n"}{end}' \
+          --all-namespaces=true 2>&1 \
+          | egrep -e "($3)" | sort > $resfile_yes 2>&1
       artcount_yes="`cat $resfile_yes | wc -l`"
 
       # leftover non-namespaced artifacts
-      kubectl get $2 --show-labels=true --all-namespaces=true 2>&1 | egrep -e "($3)" | awk '{ print $1 }' | sort > $resfile_no 2>&1
+      kubectl get $2 \
+          -o=jsonpath='{range .items[*]}{.kind}{"/"}{.metadata.name}{"\n"}{end}' \
+          --all-namespaces=true 2>&1 \
+          | egrep -e "($3)" | sort > $resfile_no 2>&1
       artcount_no="`cat $resfile_no | wc -l`"
 
       artcount_total=$((artcount_yes + artcount_no))

--- a/src/integration-tests/bash/lease.sh
+++ b/src/integration-tests/bash/lease.sh
@@ -6,6 +6,8 @@
 # Main:   See 'function main' below.
 #
 
+set -x
+
 function usage {
 cat << EOF
  

--- a/src/integration-tests/bash/lease.sh
+++ b/src/integration-tests/bash/lease.sh
@@ -299,7 +299,7 @@ function makeLocalLeaseAndReplaceRemote {
   local tempcf=${LOCAL_ROOT}/tempcf.yaml
 
   # next, try replace remote lease with the candidate lease
-  kubectl create configmap ${CONFIGMAP_NAME} --from-file ${LOCAL_ROOT}/${LOCAL_FILE} -o yaml -n default --dry-run > tempcf.yaml
+  kubectl create configmap ${CONFIGMAP_NAME} --from-file ${LOCAL_ROOT}/${LOCAL_FILE} -o yaml -n default --dry-run > $tempcf
   if [ $? -ne 0 ]; then
     traceError "failed - could not generate config map yaml"
     return 1

--- a/src/integration-tests/bash/lease.sh
+++ b/src/integration-tests/bash/lease.sh
@@ -6,8 +6,6 @@
 # Main:   See 'function main' below.
 #
 
-set -x
-
 function usage {
 cat << EOF
  
@@ -305,7 +303,7 @@ function makeLocalLeaseAndReplaceRemote {
     return 1
   fi
 
-  kubectl replace -f $tempcf
+  kubectl replace -f $tempcf --validate=false
   if [ $? -ne 0 ]; then
     traceError "failed - could not get replace remote lease"
     return 1

--- a/src/integration-tests/bash/lease.sh
+++ b/src/integration-tests/bash/lease.sh
@@ -289,7 +289,7 @@ EOF
 
 function makeLocalLeaseAndReplaceRemote {
 # TODO remote set +x/-x
-  set +x
+  set -x
   makeLocalLease
   if [ $? -ne 0 ]; then
     traceError "failed - could not generate a new local lease"
@@ -319,7 +319,7 @@ function makeLocalLeaseAndReplaceRemote {
     traceError "failed - replaced remote lease, but we somehow lost a race or can no longer communicate with kubernetes"
     return 1
   fi
-  set -x
+  set +x
 }
 
 function getRemoteLease {

--- a/wercker.yml
+++ b/wercker.yml
@@ -141,6 +141,7 @@ integration-test:
       #   - finally, run.sh will periodically try renew the lease as it runs (using $LEASE_ID)
       #   - if run.sh fails when it tries to renew the lease (as something else took it, etc), it will exit early
       #   - when run.sh exits, it will try release the lease if it's still the owner...
+      set -x
       export LEASE_ID="${WERCKER_STEP_ID}-pid$$"
       echo @@
       echo @@ "Obtaining lease!"
@@ -154,10 +155,10 @@ integration-test:
       echo @@ "Current lease owner (if any):"
       $WERCKER_SOURCE_DIR/src/integration-tests/bash/lease.sh -s 
       echo @@
-      set -x
       echo @@ "About to try obtain lease:"
       $WERCKER_SOURCE_DIR/src/integration-tests/bash/lease.sh -o "$LEASE_ID" -t $((100 * 60))
       echo @@
+      set +x
 
       # create pull secrets
       echo @@ "Creating pull secrets"

--- a/wercker.yml
+++ b/wercker.yml
@@ -141,7 +141,6 @@ integration-test:
       #   - finally, run.sh will periodically try renew the lease as it runs (using $LEASE_ID)
       #   - if run.sh fails when it tries to renew the lease (as something else took it, etc), it will exit early
       #   - when run.sh exits, it will try release the lease if it's still the owner...
-      set -x
       export LEASE_ID="${WERCKER_STEP_ID}-pid$$"
       echo @@
       echo @@ "Obtaining lease!"
@@ -158,7 +157,6 @@ integration-test:
       echo @@ "About to try obtain lease:"
       $WERCKER_SOURCE_DIR/src/integration-tests/bash/lease.sh -o "$LEASE_ID" -t $((100 * 60))
       echo @@
-      set +x
 
       # create pull secrets
       echo @@ "Creating pull secrets"

--- a/wercker.yml
+++ b/wercker.yml
@@ -154,6 +154,7 @@ integration-test:
       echo @@ "Current lease owner (if any):"
       $WERCKER_SOURCE_DIR/src/integration-tests/bash/lease.sh -s 
       echo @@
+      set -x
       echo @@ "About to try obtain lease:"
       $WERCKER_SOURCE_DIR/src/integration-tests/bash/lease.sh -o "$LEASE_ID" -t $((100 * 60))
       echo @@


### PR DESCRIPTION
**Test status:   Passes locally and Wercker.**

I think I traced down the problem with ‘lease.sh’ and a new problem with ‘cleanup.sh’ which was revealed after fixing lease.sh.   In both cases, it looks like kubectl client behavior changed.    

For example, I see failed runs on Wercker with version 1.10 client and passing runs with a 1.9 client.  

In lease.sh, a ‘kubectl replace -f’ stopped working with config-maps (it apparently has stricter usage requirements now), and in cleanup.sh the default output format of a ‘kubectl get’ appears to have changed.    

Fixes:

- Modify lease.sh to use 'k create' and  'k delete' pattern instead of 'k replace' pattern for config maps.   
- To use jsonpath instead of 'awk' when in k get queries for abandoned resources.  For some reason, awk has stopped working reliably on wercker.

Additional change:

- Enhanced cleanup.sh to release lease if cleanup itself fails and leasing is enabled.  This is because Wercker fails if cleanup fails, so a failed cleanup should release the lease right away.   Otherwise other Wercker runs need to wait 10 minutes for the lease to timeout...
