### PR TITLE
Experiment / WIP: Create a headless node manager for pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@
 FROM store/oracle/serverjre:8
 
 RUN mkdir /operator
+RUN mkdir /operator/bin
 RUN mkdir /operator/lib
 ENV PATH=$PATH:/operator
 
 COPY src/scripts/* /operator/
 COPY operator/target/weblogic-kubernetes-operator-0.1.0.jar /operator/weblogic-kubernetes-operator.jar
+COPY nodemanager/target/headless-nodemanager-0.1.0.jar /operator/bin/headless-nodemanager.jar
 COPY operator/target/lib/*.jar /operator/lib/
 
 HEALTHCHECK --interval=1m --timeout=10s \

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -172,10 +172,10 @@ data:
     #!/bin/bash
     
     # Base64 decode binary support files
-    mkdir /weblogic-operator/bin
+    mkdir -p /tmp/weblogic-operator/bin
     shopt -s nullglob
     for f in /weblogic-operator/scripts/*.base64; do
-      cat "$f" | base64 > "/weblogic-operator/bin/$(basename "$f" .base64)"
+      cat "$f" | base64 > "/tmp/weblogic-operator/bin/$(basename "$f" .base64)"
     done
 
     # Check for stale state file and remove if found"
@@ -184,9 +184,9 @@ data:
       rm ${stateFile}
     fi
 
-    if [ -f /weblogic-operator/bin/headless-nodemanager.jar ]; then
+    if [ -f /tmp/weblogic-operator/bin/headless-nodemanager.jar ]; then
       echo "Start the nodemanager"
-      PRE_CLASSPATH=/weblogic-operator/bin/headless-nodemanager.jar
+      PRE_CLASSPATH=/tmp/weblogic-operator/bin/headless-nodemanager.jar
       . ${nmdir}/startNodeManager.sh &
 
     else

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -175,7 +175,7 @@ data:
     mkdir -p /tmp/weblogic-operator/bin
     shopt -s nullglob
     for f in /weblogic-operator/scripts/*.base64; do
-      cat "$f" | base64 > "/tmp/weblogic-operator/bin/$(basename "$f" .base64)"
+      cat "$f" | base64 --decode > /tmp/weblogic-operator/bin/$(basename "$f" .base64)
     done
 
     # Check for stale state file and remove if found"

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -185,8 +185,8 @@ data:
     fi
 
     if [ -f /tmp/weblogic-operator/bin/headless-nodemanager.jar ]; then
-      echo "Start the nodemanager"
-      PRE_CLASSPATH=/tmp/weblogic-operator/bin/headless-nodemanager.jar
+      echo "Start the headless nodemanager and server instance"
+      export PRE_CLASSPATH=/tmp/weblogic-operator/bin/headless-nodemanager.jar
       . ${nmdir}/startNodeManager.sh &
 
     else

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -175,7 +175,7 @@ data:
     mkdir -p /tmp/weblogic-operator/bin
     shopt -s nullglob
     for f in /weblogic-operator/scripts/*.base64; do
-      cat "\$f" | base64 --decode > /tmp/weblogic-operator/bin/$(basename "\$f" .base64)
+      cat "\$f" | base64 --decode > /tmp/weblogic-operator/bin/\$(basename "\$f" .base64)
     done
 
     # Check for stale state file and remove if found"

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -170,6 +170,13 @@ data:
       # The script and 'EOF' on the following lines must not be indented!
       cat << EOF > ${scriptFile}
     #!/bin/bash
+    
+    # Base64 decode binary support files
+    mkdir /weblogic-operator/bin
+    shopt -s nullglob
+    for f in /weblogic-operator/scripts/*.base64; do
+      cat "$f" | base64 > "/weblogic-operator/bin/$(basename "$f" .base64)"
+    done
 
     # Check for stale state file and remove if found"
     if [ -f ${stateFile} ]; then
@@ -177,26 +184,33 @@ data:
       rm ${stateFile}
     fi
 
-    echo "Start the nodemanager"
-    . ${nmdir}/startNodeManager.sh &
+    if [ -f /weblogic-operator/bin/headless-nodemanager.jar ]; then
+      echo "Start the nodemanager"
+      PRE_CLASSPATH=/weblogic-operator/bin/headless-nodemanager.jar
+      . ${nmdir}/startNodeManager.sh &
 
-    echo "Allow the nodemanager some time to start before attempting to connect"
-    sleep 15
-    echo "Finished waiting for the nodemanager to start"
-
-    echo "Update JVM arguments"
-    if [ $# -eq 3 ]
-    then
-      echo "Update JVM arguments for admin server"
-      echo "Arguments=\${USER_MEM_ARGS} -XX\:+UnlockExperimentalVMOptions -XX\:+UseCGroupMemoryLimitForHeap \${JAVA_OPTIONS}" >> ${startProp}
     else
-      echo "Update JVM arguments for managed server"
-      wlst.sh ${argsFile} $1 $2 ${startProp}
+      echo "Start the nodemanager"
+      . ${nmdir}/startNodeManager.sh &
+
+      echo "Allow the nodemanager some time to start before attempting to connect"
+      sleep 15
+      echo "Finished waiting for the nodemanager to start"
+
+      echo "Update JVM arguments"
+      if [ $# -eq 3 ]
+      then
+        echo "Update JVM arguments for admin server"
+        echo "Arguments=\${USER_MEM_ARGS} -XX\:+UnlockExperimentalVMOptions -XX\:+UseCGroupMemoryLimitForHeap \${JAVA_OPTIONS}" >> ${startProp}
+      else
+        echo "Update JVM arguments for managed server"
+        wlst.sh ${argsFile} $1 $2 ${startProp}
+      fi
+
+      echo "Start the server"
+      wlst.sh -skipWLSModuleScanning ${pyFile}
     fi
-
-    echo "Start the server"
-    wlst.sh -skipWLSModuleScanning ${pyFile}
-
+    
     echo "Wait indefinitely so that the Kubernetes pod does not exit and try to restart"
     while true; do sleep 60; done
     EOF

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -175,7 +175,7 @@ data:
     mkdir -p /tmp/weblogic-operator/bin
     shopt -s nullglob
     for f in /weblogic-operator/scripts/*.base64; do
-      cat "$f" | base64 --decode > /tmp/weblogic-operator/bin/$(basename "$f" .base64)
+      cat "\$f" | base64 --decode > /tmp/weblogic-operator/bin/$(basename "\$f" .base64)
     done
 
     # Check for stale state file and remove if found"

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -147,6 +147,9 @@ data:
       sed -i -e "s:NodeManagerHome=.*:NodeManagerHome=${nmdir}:g" ${prop}
       sed -i -e "s:ListenAddress=.*:ListenAddress=$1-$2:g" ${prop}
       sed -i -e "s:LogFile=.*:LogFile=/shared/logs/nodemanager-$2.log:g" ${prop}
+      
+      # Edit the nodemanager properties file to make the listener impl pluggable
+      echo "RestEnabled=true" >> ${prop}
 
     }
 

--- a/nodemanager/pom.xml
+++ b/nodemanager/pom.xml
@@ -1,0 +1,82 @@
+<!-- Copyright 2017, Oracle Corporation. All Rights Reserved. -->
+<!-- This is unreleased proprietary source code of Oracle Corporation -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>oracle.kubernetes</groupId>
+    <artifactId>operator-parent</artifactId>
+    <version>0.1.0</version>
+  </parent>
+
+    <groupId>oracle.kubernetes</groupId>
+    <artifactId>headless-nodemanager</artifactId>
+    <version>0.1.0</version>
+
+    <description>Oracle Weblogic Server Headless Node Manager</description>
+    <name>headless-nodemanager</name>
+    <packaging>jar</packaging>
+
+    <url>https://oracle.github.io/weblogic-kubernetes-operator</url>
+    <inceptionYear>2017</inceptionYear>
+    <licenses>
+      <license>
+        <name>The Universal Permissive License (UPL), Version 1.0</name>
+        <url>https://github.com/oracle/weblogic-kubernetes-operator/blob/master/LICENSE</url>
+      </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Title>${project.artifactId}</Implementation-Title>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Implementation-Build>${git.branch}.${git.shortRevision}</Implementation-Build>
+                            <Implementation-DisplayVersion>${project.displayVersion}</Implementation-DisplayVersion>
+                            <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                            <Specification-Title>${project.artifactId}</Specification-Title>
+                            <Built-By>Oracle</Built-By>
+                        </manifestEntries>
+                    </archive>
+                    <excludes>
+                        <exclude>weblogic/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+        
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <surefireArgLine></surefireArgLine>
+                <failsafeArgLine></failsafeArgLine>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/nodemanager/src/main/java/oracle/weblogic/nodemanager/HeadlessServer.java
+++ b/nodemanager/src/main/java/oracle/weblogic/nodemanager/HeadlessServer.java
@@ -3,10 +3,13 @@
 
 package oracle.weblogic.nodemanager;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintWriter;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import weblogic.nodemanager.server.InternalNMCommandHandler;
@@ -22,42 +25,79 @@ public class HeadlessServer implements Server {
 
   @Override
   public void start(NMServer nmServer) throws IOException {
+    nmLog.entering(HeadlessServer.class.toString(), "start");
+
     // Log start Message
     nmLog.info("Headless Node Manager for WebLogic on Kubernetes Started");
     
     String domainName = System.getenv("DOMAIN_NAME");
     String serverName = System.getenv("SERVER_NAME");
 
-    PipedInputStream pipeIn = new PipedInputStream();
-    PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
+    PipedInputStream inputPipeIn = new PipedInputStream();
+    PipedOutputStream inputPipeOut = new PipedOutputStream(inputPipeIn);
 
-    InternalNMCommandHandler handler = new InternalNMCommandHandler(nmServer, System.out, pipeIn);
+    PipedInputStream outputPipeIn = new PipedInputStream();
+    PipedOutputStream outputPipeOut = new PipedOutputStream(inputPipeIn);
+
+    InternalNMCommandHandler handler = new InternalNMCommandHandler(nmServer, outputPipeOut, inputPipeIn);
     
     Thread in = new Thread(() -> {
-      try (PrintWriter pw = new PrintWriter(pipeOut)) {
+      nmLog.entering(HeadlessServer.class.toString(), "inputReader");
+      
+      try (PrintWriter pw = new PrintWriter(inputPipeOut)) {
+        nmLog.info("Injecting command DOMAIN " + domainName);
         pw.write("DOMAIN ");
         pw.write(domainName);
         pw.flush();
         handler.runCommand();
 
+        nmLog.info("Injecting command SERVER " + serverName);
         pw.write("SERVER ");
         pw.write(serverName);
         pw.flush();
         handler.runCommand();
 
+        nmLog.info("Injecting command START");
         pw.write("START");
         pw.flush();
         handler.runCommand();
-}
+        
+        nmLog.info("Injecting command DONE");
+        pw.write("DONE");
+        pw.flush();
+        handler.runCommand();
+      } finally {
+        nmLog.exiting(HeadlessServer.class.toString(), "inputReader");
+      }
     });
     in.setDaemon(true);
     in.start();
+    
+    Thread out = new Thread(() -> {
+      nmLog.entering(HeadlessServer.class.toString(), "outputReader");
+      
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(outputPipeIn))) {
+        String line = null;
+        while ((line = br.readLine()) != null) {
+          nmLog.info("Command result: " + line);
+        }
+       
+      } catch (IOException io) {
+        nmLog.log(Level.SEVERE, "Exception reading command response", io);
+      } finally {
+        nmLog.exiting(HeadlessServer.class.toString(), "outputReader");
+      }
+    }) ;
+    out.setDaemon(true);
+    out.start();
     
     // Block this thread forever
     try {
       Thread.currentThread().join();
     } catch (InterruptedException e) {
     }
+    
+    nmLog.exiting(HeadlessServer.class.toString(), "start");
   }
 
   @Override

--- a/nodemanager/src/main/java/oracle/weblogic/nodemanager/HeadlessServer.java
+++ b/nodemanager/src/main/java/oracle/weblogic/nodemanager/HeadlessServer.java
@@ -37,7 +37,7 @@ public class HeadlessServer implements Server {
     PipedOutputStream inputPipeOut = new PipedOutputStream(inputPipeIn);
 
     PipedInputStream outputPipeIn = new PipedInputStream();
-    PipedOutputStream outputPipeOut = new PipedOutputStream(inputPipeIn);
+    PipedOutputStream outputPipeOut = new PipedOutputStream(outputPipeIn);
 
     InternalNMCommandHandler handler = new InternalNMCommandHandler(nmServer, outputPipeOut, inputPipeIn);
     

--- a/nodemanager/src/main/java/oracle/weblogic/nodemanager/HeadlessServer.java
+++ b/nodemanager/src/main/java/oracle/weblogic/nodemanager/HeadlessServer.java
@@ -1,0 +1,67 @@
+// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.nodemanager;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintWriter;
+import java.util.logging.Logger;
+
+import weblogic.nodemanager.server.InternalNMCommandHandler;
+import weblogic.nodemanager.server.NMServer;
+import weblogic.nodemanager.server.Server;
+
+public class HeadlessServer implements Server {
+  public static final Logger nmLog = Logger.getLogger("weblogic.nodemanager");
+
+  @Override
+  public void init(NMServer nmServer) throws IOException {
+  }
+
+  @Override
+  public void start(NMServer nmServer) throws IOException {
+    // Log start Message
+    nmLog.info("Headless Node Manager for WebLogic on Kubernetes Started");
+    
+    String domainName = System.getenv("DOMAIN_NAME");
+    String serverName = System.getenv("SERVER_NAME");
+
+    PipedInputStream pipeIn = new PipedInputStream();
+    PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
+
+    InternalNMCommandHandler handler = new InternalNMCommandHandler(nmServer, System.out, pipeIn);
+    
+    Thread in = new Thread(() -> {
+      try (PrintWriter pw = new PrintWriter(pipeOut)) {
+        pw.write("DOMAIN ");
+        pw.write(domainName);
+        pw.flush();
+        handler.runCommand();
+
+        pw.write("SERVER ");
+        pw.write(serverName);
+        pw.flush();
+        handler.runCommand();
+
+        pw.write("START");
+        pw.flush();
+        handler.runCommand();
+}
+    });
+    in.setDaemon(true);
+    in.start();
+    
+    // Block this thread forever
+    try {
+      Thread.currentThread().join();
+    } catch (InterruptedException e) {
+    }
+  }
+
+  @Override
+  public String supportedMode() {
+    return "REST";
+  }
+}

--- a/nodemanager/src/main/java/weblogic/nodemanager/common/NMWriter.java
+++ b/nodemanager/src/main/java/weblogic/nodemanager/common/NMWriter.java
@@ -1,0 +1,17 @@
+// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package weblogic.nodemanager.common;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class NMWriter {
+
+  public NMWriter(OutputStream outputStream) {
+  }
+
+  public void writeLine(String line) throws IOException {
+  }
+
+}

--- a/nodemanager/src/main/java/weblogic/nodemanager/server/InternalNMCommandHandler.java
+++ b/nodemanager/src/main/java/weblogic/nodemanager/server/InternalNMCommandHandler.java
@@ -1,0 +1,20 @@
+// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package weblogic.nodemanager.server;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class InternalNMCommandHandler {
+
+  public InternalNMCommandHandler(NMServer nmServer, OutputStream grizzlyOut,
+      InputStream grizzlyIn) {
+  }
+
+  public void processRequests() {
+  }
+
+  public void runCommand() {
+  }
+}

--- a/nodemanager/src/main/java/weblogic/nodemanager/server/NMServer.java
+++ b/nodemanager/src/main/java/weblogic/nodemanager/server/NMServer.java
@@ -1,0 +1,8 @@
+// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package weblogic.nodemanager.server;
+
+public class NMServer {
+
+}

--- a/nodemanager/src/main/java/weblogic/nodemanager/server/Server.java
+++ b/nodemanager/src/main/java/weblogic/nodemanager/server/Server.java
@@ -1,0 +1,15 @@
+// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package weblogic.nodemanager.server;
+
+import java.io.IOException;
+
+public interface Server {
+  
+  public void init(NMServer nmServer) throws IOException;
+  
+  public void start(NMServer nmServer) throws IOException;
+
+  public String supportedMode();
+}

--- a/nodemanager/src/main/resources/META-INF/services/weblogic.nodemanager.server.Server
+++ b/nodemanager/src/main/resources/META-INF/services/weblogic.nodemanager.server.Server
@@ -1,0 +1,1 @@
+oracle.weblogic.nodemanager.HeadlessServer

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -3,6 +3,11 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +138,12 @@ public class ConfigMapHelper {
           "cat ${STATEFILE} | cut -f 1 -d ':'\n" +
           "exit 0");
 
+      try {
+        data.put("headless-nodemanager.jar.base64", toBase64("/operator/bin/headless-nodemanager.jar"));
+      } catch (IOException e1) {
+        return doTerminate(e1, packet);
+      }
+      
       cm.setData(data);
       
       CallBuilderFactory factory = ContainerResolver.getInstance().getContainer().getSPI(CallBuilderFactory.class);
@@ -201,4 +212,9 @@ public class ConfigMapHelper {
     }
   }
 
+  private static String toBase64(String fileName) throws IOException {
+    File file = new File(fileName);
+    byte[] encoded = Base64.getEncoder().encode(Files.readAllBytes(file.toPath()));
+    return new String(encoded, StandardCharsets.UTF_8);
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,9 @@
 
   <modules>
     <module>model</module>
-    <module>operator</module>
     <module>swagger</module>
+    <module>operator</module>
+    <module>nodemanager</module>
   </modules>
 
   <scm>

--- a/wercker.yml
+++ b/wercker.yml
@@ -41,9 +41,11 @@ build:
     name: Copy built-artifacts into the image
     code: |
       mkdir /operator
+      mkdir /operator/bin
       mkdir /operator/lib
       cp -R src/scripts/* /operator/
       cp operator/target/weblogic-kubernetes-operator-0.1.0.jar /operator/weblogic-kubernetes-operator.jar
+      cp nodemanager/target/headless-nodemanager-0.1.0.jar /operator/bin/headless-nodemanager.jar
       cp operator/target/lib/*.jar /operator/lib/
       export IMAGE_TAG_OPERATOR="${WERCKER_GIT_BRANCH//[_\/]/-}"
       if [ "$IMAGE_TAG_OPERATOR" = "master" ]; then


### PR DESCRIPTION
1. Created a headless node manager Server type
2. Build the jar and include in the operator's image
3. Put the base64 bytes of this jar into cm injected into pods
4. On Pod startServer.sh, Base64 decode jar
5. Headless node manager injects commands to start server instance

This means that we don't need to wait for the node manager to start before injecting commands

This is an experiment / work-in-progress.  I know that the scripts skip the current WLST call to get per-server startup arguments.
