### PR TITLE
Replace the domainUID="" label on the per-domain operator config map with an operatorName="<operatornamespace>" label

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -169,10 +169,7 @@ public class Main {
 
   private static void begin() {
     // read the operator configuration
-    String namespace = System.getenv("OPERATOR_NAMESPACE");
-    if (namespace == null) {
-      namespace = "default";
-    }
+    String namespace = getOperatorNamespace();
 
     Collection<String> targetNamespaces = getTargetNamespaces(namespace);
 
@@ -245,7 +242,7 @@ public class Main {
           }
         });
 
-        Step initialize = ConfigMapHelper.createScriptConfigMapStep(ns,
+        Step initialize = ConfigMapHelper.createScriptConfigMapStep(namespace, ns,
             new ConfigMapAfterStep(ns, callBuilderFactory.create().with($ -> {
               $.labelSelector = LabelConstants.DOMAINUID_LABEL + "," + LabelConstants.CREATEDBYOPERATOR_LABEL;
             }).listPodAsync(ns, new ResponseStep<V1PodList>(callBuilderFactory.create().with($ -> {
@@ -1791,7 +1788,7 @@ public class Main {
       switch (item.type) {
       case "MODIFIED":
       case "DELETED":
-        engine.createFiber().start(ConfigMapHelper.createScriptConfigMapStep(c.getMetadata().getNamespace(), null),
+        engine.createFiber().start(ConfigMapHelper.createScriptConfigMapStep(getOperatorNamespace(), c.getMetadata().getNamespace(), null),
             new Packet(), new CompletionCallback() {
               @Override
               public void onCompletion(Packet packet) {
@@ -1918,5 +1915,13 @@ public class Main {
 
     LOGGER.exiting();
     return validatedChannels;
+  }
+
+  private static String getOperatorNamespace() {
+    String namespace = System.getenv("OPERATOR_NAMESPACE");
+    if (namespace == null) {
+      namespace = "default";
+    }
+    return namespace;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -29,28 +29,31 @@ public class ConfigMapHelper {
   
   /**
    * Factory for {@link Step} that creates config map containing scripts
-   * @param namespace Namespace
+   * @param operatorNamespace the operator's namespace
+   * @param domainNamespace the domain's namespace
    * @param next Next processing step
    * @return Step for creating config map containing scripts
    */
-  public static Step createScriptConfigMapStep(String namespace, Step next) {
-    return new ScriptConfigMapStep(namespace, next);
+  public static Step createScriptConfigMapStep(String operatorNamespace, String domainNamespace, Step next) {
+    return new ScriptConfigMapStep(operatorNamespace, domainNamespace, next);
   }
 
   // Make this public so that it can be unit tested
   public static class ScriptConfigMapStep extends Step {
-    private final String namespace;
+    private final String operatorNamespace;
+    private final String domainNamespace;
     
-    public ScriptConfigMapStep(String namespace, Step next) {
+    public ScriptConfigMapStep(String operatorNamespace, String domainNamespace, Step next) {
       super(next);
-      this.namespace = namespace;
+      this.operatorNamespace = operatorNamespace;
+      this.domainNamespace = domainNamespace;
     }
 
     @Override
     public NextAction apply(Packet packet) {
       V1ConfigMap cm = computeDomainConfigMap();
       CallBuilderFactory factory = ContainerResolver.getInstance().getContainer().getSPI(CallBuilderFactory.class);
-      Step read = factory.create().readConfigMapAsync(cm.getMetadata().getName(), namespace, new ResponseStep<V1ConfigMap>(next) {
+      Step read = factory.create().readConfigMapAsync(cm.getMetadata().getName(), domainNamespace, new ResponseStep<V1ConfigMap>(next) {
         @Override
         public NextAction onFailure(Packet packet, ApiException e, int statusCode,
             Map<String, List<String>> responseHeaders) {
@@ -64,7 +67,7 @@ public class ConfigMapHelper {
         public NextAction onSuccess(Packet packet, V1ConfigMap result, int statusCode,
             Map<String, List<String>> responseHeaders) {
           if (result == null) {
-            Step create = factory.create().createConfigMapAsync(namespace, cm, new ResponseStep<V1ConfigMap>(next) {
+            Step create = factory.create().createConfigMapAsync(domainNamespace, cm, new ResponseStep<V1ConfigMap>(next) {
               @Override
               public NextAction onFailure(Packet packet, ApiException e, int statusCode,
                   Map<String, List<String>> responseHeaders) {
@@ -75,7 +78,7 @@ public class ConfigMapHelper {
               public NextAction onSuccess(Packet packet, V1ConfigMap result, int statusCode,
                   Map<String, List<String>> responseHeaders) {
                 
-                LOGGER.info(MessageKeys.CM_CREATED, namespace);
+                LOGGER.info(MessageKeys.CM_CREATED, domainNamespace);
                 packet.put(ProcessingConstants.SCRIPT_CONFIG_MAP, result);
                 return doNext(packet);
               }
@@ -83,7 +86,7 @@ public class ConfigMapHelper {
             return doNext(create, packet);
           } else if (AnnotationHelper.checkFormatAnnotation(result.getMetadata()) && result.getData().entrySet().containsAll(cm.getData().entrySet())) {
             // existing config map has correct data
-            LOGGER.fine(MessageKeys.CM_EXISTS, namespace);
+            LOGGER.fine(MessageKeys.CM_EXISTS, domainNamespace);
             packet.put(ProcessingConstants.SCRIPT_CONFIG_MAP, result);
             return doNext(packet);
           } else {
@@ -91,7 +94,7 @@ public class ConfigMapHelper {
             Map<String, String> updated = result.getData();
             updated.putAll(cm.getData());
             cm.setData(updated);
-            Step replace = factory.create().replaceConfigMapAsync(cm.getMetadata().getName(), namespace, cm, new ResponseStep<V1ConfigMap>(next) {
+            Step replace = factory.create().replaceConfigMapAsync(cm.getMetadata().getName(), domainNamespace, cm, new ResponseStep<V1ConfigMap>(next) {
               @Override
               public NextAction onFailure(Packet packet, ApiException e, int statusCode,
                   Map<String, List<String>> responseHeaders) {
@@ -101,7 +104,7 @@ public class ConfigMapHelper {
               @Override
               public NextAction onSuccess(Packet packet, V1ConfigMap result, int statusCode,
                   Map<String, List<String>> responseHeaders) {
-                LOGGER.info(MessageKeys.CM_REPLACED, namespace);
+                LOGGER.info(MessageKeys.CM_REPLACED, domainNamespace);
                 packet.put(ProcessingConstants.SCRIPT_CONFIG_MAP, result);
                 return doNext(packet);
               }
@@ -123,17 +126,12 @@ public class ConfigMapHelper {
 
       V1ObjectMeta metadata = new V1ObjectMeta();
       metadata.setName(name);
-      metadata.setNamespace(namespace);
+      metadata.setNamespace(domainNamespace);
       
       AnnotationHelper.annotateWithFormat(metadata);
       
       Map<String, String> labels = new HashMap<>();
-      // This config map is a singleton that is shared by all the domains
-      // We need to add a domain uid label so that it can be located as
-      // related to the operator.  However, we don't have a specific domain uid
-      // to set as the value.  So, just set it to an empty string.  That way,
-      // someone seleting on just the weblogic.domainUID label will find it.
-      labels.put(LabelConstants.DOMAINUID_LABEL, "");
+      labels.put(LabelConstants.OPERATORNAME_LABEL, operatorNamespace);
       labels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
       metadata.setLabels(labels);
 

--- a/operator/src/test/java/oracle/kubernetes/operator/create/ConfigMapHelperConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/create/ConfigMapHelperConfigTest.java
@@ -19,7 +19,8 @@ import org.junit.Test;
  */
 public class ConfigMapHelperConfigTest {
 
-  private static final String NAMESPACE = "test-namespace";
+  private static final String OPERATOR_NAMESPACE = "test-operator-namespace";
+  private static final String DOMAIN_NAMESPACE = "test-domain-namespace";
   private static final String PROPERTY_LIVENESS_PROBE_SH = "livenessProbe.sh";
   private static final String PROPERTY_READINESS_PROBE_SH = "readinessProbe.sh";
   private static final String PROPERTY_READ_STATE_SH = "readState.sh";
@@ -45,8 +46,8 @@ public class ConfigMapHelperConfigTest {
       newConfigMap()
         .metadata(newObjectMeta()
           .name(DOMAIN_CONFIG_MAP_NAME)
-          .namespace(NAMESPACE)
-          .putLabelsItem(DOMAINUID_LABEL, "")
+          .namespace(DOMAIN_NAMESPACE)
+          .putLabelsItem(OPERATORNAME_LABEL, OPERATOR_NAMESPACE)
           .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true")
           .putAnnotationsItem(FORMAT_ANNOTATION, FORMAT_VERSION))
         .putDataItem(PROPERTY_LIVENESS_PROBE_SH, "")
@@ -60,7 +61,7 @@ public class ConfigMapHelperConfigTest {
 
   private static class TestScriptConfigMapStep extends ConfigMapHelper.ScriptConfigMapStep {
     public TestScriptConfigMapStep() {
-      super(NAMESPACE, null);
+      super(OPERATOR_NAMESPACE, DOMAIN_NAMESPACE, null);
     }
     @Override public V1ConfigMap computeDomainConfigMap() {
       return super.computeDomainConfigMap();


### PR DESCRIPTION
The delete script for removing all domains does it by looking for kubernetes artifacts with a domainUID tag.  Currently, the operator creates a config map per domain namespace containing scripts that should be shared by all domains in that namespace, and tags it with a domainUID="" label.

This causes the delete script for removing all domains to remove this config map too, and, the next time the operator needs to create a domain in that namespace, it has to recreate the config map for the scripts in that namespace.

To prevent this, change the label on the config map from 'domainUid=""' to 'operatorName="<operatorNamespace>"' - that is, tag it as operator related instead of domain related.

Note: eventually we should add a script to remove the operator.  That script can use the
operatorLabel to find and delete these config maps (as well as the other operator-related
k8s artifacts).