### PR TITLE
fix checksum error in build

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -32,8 +32,8 @@ build:
   - script:
     name: Install pre-reqs
     code: |
-      yum -y install tar gzip
-  - java/maven:
+      yum -y install tar gzip procps
+  - wercker/maven:
     goals: clean install
     version: 3.5.2
     cache_repo: true


### PR DESCRIPTION
pick up new version of the maven step which has fix for apache's change from md5 to sha1 checksums