### PR TITLE
feature/managed-coh

### DIFF
--- a/kubernetes/create-weblogic-domain-inputs.yaml
+++ b/kubernetes/create-weblogic-domain-inputs.yaml
@@ -96,3 +96,7 @@ loadBalancerDashboardPort: 30315
 
 #Java Option for Weblogic Server
 javaOptions: -Dweblogic.StdoutDebugEnabled=false
+
+# Option to enable coherence on managed servers
+# The following line must be uncommented and updated with desired cluster name to enable coherence.
+#coherenceClusterName: Cluster-0

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -449,6 +449,28 @@ data:
     readDomain(domain_path)
     cd('/')
     cmo.setProductionModeEnabled(%PRODUCTION_MODE_ENABLED%)
+
+    # Enabled Coherence if COHERENCE_CLUSTER_NAME is specified by user
+    coherenceClusterName='%COHERENCE_CLUSTER_NAME%'
+    if not (coherenceClusterName is None):
+      create(coherenceClusterName, 'CoherenceClusterSystemResource')
+      servers=''
+      for index in range(0, number_of_ms):
+        server='%MANAGED_SERVER_NAME_BASE%%s' % (index+1)
+        cd('/Servers/%s' % server)
+        set('CoherenceClusterSystemResource', coherenceClusterName)
+        if index is 0:
+          servers=str(server)
+        else:
+          servers=str(servers + "," + server)
+
+      cd('/')
+      create('CacheTier', 'Cluster')
+      assign('Server', servers, 'Cluster', 'CacheTier')
+      assign('Cluster', 'CacheTier', 'CoherenceClusterSystemResource', coherenceClusterName)
+      cd('/CoherenceClusterSystemResource/%s' % coherenceClusterName)
+      set('Target', 'CacheTier')
+
     updateDomain()
     closeDomain()
     print 'Domain Updated'

--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -366,7 +366,6 @@ function initialize {
   failIfValidationErrors
 }
 
-
 #
 # Function to generate the yaml files for creating a domain
 #
@@ -442,6 +441,7 @@ function createYamlFiles {
   sed -i -e "s:%T3_CHANNEL_PORT%:${t3ChannelPort}:g" ${jobOutput}
   sed -i -e "s:%T3_PUBLIC_ADDRESS%:${t3PublicAddress}:g" ${jobOutput}
   sed -i -e "s:%CLUSTER_NAME%:${clusterName}:g" ${jobOutput}
+  sed -i -e "s:%COHERENCE_CLUSTER_NAME%:${coherenceClusterName:-None}:g" ${jobOutput}
 
   # Generate the yaml to create the domain custom resource
   echo Generating ${dcrOutput}


### PR DESCRIPTION
Provide an option shown below to the domain input file for enabling coherence on managed servers.

# Option to enable coherence on managed servers
# The following line must be uncommented and updated with desired cluster name to enable coherence.
#coherenceClusterName: Cluster-0