### PR TITLE
simplify operator script maintenance

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -3,9 +3,21 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ConfigMap;
@@ -25,282 +37,7 @@ import oracle.kubernetes.operator.work.Step;
 public class ConfigMapHelper {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
-  private static final String START_SERVER_SHELL_SCRIPT = "#!/bin/bash\n" +
-          "\n" +
-          "domain_uid=$1\n" +
-          "server_name=$2\n" +
-          "domain_name=$3\n" +
-          "as_name=$4\n" +
-          "as_port=$5\n" +
-          "as_hostname=$1-$4\n" +
-          "\n" +
-          "echo \"debug arguments are $1 $2 $3 $4 $5\"\n" +
-          "\n" +
-          "nmProp=\"/u01/nodemanager/nodemanager.properties\"\n" +
-          "\n" +
-          "# TODO: parameterize shared home and domain name\n" +
-          "export DOMAIN_HOME=/shared/domain/$domain_name\n" +
-          "\n" +
-          "#\n" +
-          "# Create a folder\n" +
-          "# $1 - path of folder to create\n" +
-          "function createFolder {\n" +
-          "  mkdir -m 777 -p $1\n" +
-          "  if [ ! -d $1 ]; then\n" +
-          "    fail \"Unable to create folder $1\"\n" +
-          "  fi\n" +
-          "}\n" +
-          "\n" +
-          "# Function to create server specific scripts and properties (e.g startup.properties, etc)\n" +
-          "# $1 - Domain UID\n" +
-          "# $2 - Server Name\n" +
-          "# $3 - Domain Name\n" +
-          "# $4 - Admin Server Hostname (only passed for managed servers)\n" +
-          "# $5 - Admin Server port (only passed for managed servers)\n" +
-          "function createServerScriptsProperties() {\n" +
-          "\n" +
-          "  # Create nodemanager home for the server\n" +
-          "  srvr_nmdir=/u01/nodemanager\n" +
-          "  createFolder ${srvr_nmdir}\n" +
-          "  cp /shared/domain/$3/nodemanager/nodemanager.domains ${srvr_nmdir}\n" +
-          "  cp /shared/domain/$3/bin/startNodeManager.sh ${srvr_nmdir}\n" +
-          "\n" +
-          "  # Edit the start nodemanager script to use the home for the server\n" +
-          "  sed -i -e \"s:/shared/domain/$3/nodemanager:/u01/nodemanager:g\" ${srvr_nmdir}/startNodeManager.sh\n" +
-          "\n" +
-          "  # Create startup.properties file\n" +
-          "  datadir=${DOMAIN_HOME}/servers/$2/data/nodemanager\n" +
-          "  nmdir=${DOMAIN_HOME}/nodemgr_home\n" +
-          "  stateFile=${datadir}/$2.state\n" +
-          "  startProp=${datadir}/startup.properties\n" +
-          "  if [ -f \"$startProp\" ]; then\n" +
-          "    echo \"startup.properties already exists\"\n" +
-          "    return 0\n" +
-          "  fi\n" +
-          "\n" +
-          "  createFolder ${datadir}\n" +
-          "  echo \"# Server startup properties\" > ${startProp}\n" +
-          "  echo \"AutoRestart=true\" >> ${startProp}\n" +
-          "  if [ -n \"$4\" ]; then\n" +
-          "    echo \"AdminURL=http\\://$4\\:$5\" >> ${startProp}\n" +
-          "  fi\n" +
-          "  echo \"RestartMax=2\" >> ${startProp}\n" +
-          "  echo \"RotateLogOnStartup=false\" >> ${startProp}\n" +
-          "  echo \"RotationType=bySize\" >> ${startProp}\n" +
-          "  echo \"RotationTimeStart=00\\:00\" >> ${startProp}\n" +
-          "  echo \"RotatedFileCount=100\" >> ${startProp}\n" +
-          "  echo \"RestartDelaySeconds=0\" >> ${startProp}\n" +
-          "  echo \"FileSizeKB=5000\" >> ${startProp}\n" +
-          "  echo \"FileTimeSpanFactor=3600000\" >> ${startProp}\n" +
-          "  echo \"RestartInterval=3600\" >> ${startProp}\n" +
-          "  echo \"NumberOfFilesLimited=true\" >> ${startProp}\n" +
-          "  echo \"FileTimeSpan=24\" >> ${startProp}\n" +
-          "  echo \"NMHostName=$1-$2\" >> ${startProp}\n" +
-          "}\n" +
-          "\n" +
-          "# Check for stale state file and remove if found\"\n" +
-          "if [ -f \"$stateFile\" ]; then\n" +
-          "  echo \"Removing stale file $stateFile\"\n" +
-          "  rm ${stateFile}\n" +
-          "fi\n" +
-          "\n" +
-          "# Create nodemanager home directory that is local to the k8s node\n" +
-          "mkdir -p /u01/nodemanager\n" +
-          "cp ${DOMAIN_HOME}/nodemanager/* /u01/nodemanager/\n" +
-          "\n" +
-          "# Edit the nodemanager properties file to use the home for the server\n" +
-          "sed -i -e \"s:DomainsFile=.*:DomainsFile=/u01/nodemanager/nodemanager.domains:g\" /u01/nodemanager/nodemanager.properties\n" +
-          "sed -i -e \"s:NodeManagerHome=.*:NodeManagerHome=/u01/nodemanager:g\" /u01/nodemanager/nodemanager.properties\n" +
-          "sed -i -e \"s:ListenAddress=.*:ListenAddress=$1-$2:g\" /u01/nodemanager/nodemanager.properties\n" +
-          "sed -i -e \"s:LogFile=.*:LogFile=/shared/logs/nodemanager-$2.log:g\" /u01/nodemanager/nodemanager.properties\n" +
-          "\n" +
-          "export JAVA_PROPERTIES=\"-DLogFile=/shared/logs/nodemanager-$server_name.log -DNodeManagerHome=/u01/nodemanager\"\n" +
-          "export NODEMGR_HOME=\"/u01/nodemanager\"\n" +
-          "\n" +
-          "\n" +
-          "# Create startup.properties\n" +
-          "echo \"Create startup.properties\"\n" +
-          "if [ -n \"$4\" ]; then\n" +
-          "  echo \"this is managed server\"\n" +
-          "  createServerScriptsProperties $domain_uid $server_name $domain_name $as_hostname $as_port\n" +
-          "else\n" +
-          "  echo \"this is admin server\"\n" +
-          "  createServerScriptsProperties $domain_uid $server_name $domain_name\n" +
-          "fi\n" +
-          "\n" +
-          "echo \"Start the nodemanager\"\n" +
-          ". ${NODEMGR_HOME}/startNodeManager.sh &\n" +
-          "\n" +
-          "echo \"Allow the nodemanager some time to start before attempting to connect\"\n" +
-          "sleep 15\n" +
-          "echo \"Finished waiting for the nodemanager to start\"\n" +
-          "\n" +
-          "echo \"Update JVM arguments\"\n" +
-          "echo \"Arguments=${USER_MEM_ARGS} -XX\\:+UnlockExperimentalVMOptions -XX\\:+UseCGroupMemoryLimitForHeap ${JAVA_OPTIONS}\" >> ${startProp}\n" +
-          "\n" +
-          "admin_server_t3_url=\n" +
-          "if [ -n \"$4\" ]; then\n" +
-          "  admin_server_t3_url=t3://$domain_uid-$as_name:$as_port\n" +
-          "fi\n" +
-          "\n" +
-          "echo \"Start the server\"\n" +
-          "wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/start-server.py $domain_uid $server_name $domain_name $admin_server_t3_url\n" +
-          "\n" +
-          "echo \"Wait indefinitely so that the Kubernetes pod does not exit and try to restart\"\n" +
-          "while true; do sleep 60; done\n";
-
-  private static final String START_SERVER_PYTHON_SCRIPT = "import sys;\n" +
-          "#\n" +
-          "# +++ Start of common code for reading domain secrets\n" +
-          "\n" +
-          "# Read username secret\n" +
-          "file = open('/weblogic-operator/secrets/username', 'r')\n" +
-          "admin_username = file.read()\n" +
-          "file.close()\n" +
-          "\n" +
-          "# Read password secret\n" +
-          "file = open('/weblogic-operator/secrets/password', 'r')\n" +
-          "admin_password = file.read()\n" +
-          "file.close()\n" +
-          "\n" +
-          "# +++ End of common code for reading domain secrets\n" +
-          "#\n" +
-          "domain_uid = sys.argv[1]\n" +
-          "server_name = sys.argv[2]\n" +
-          "domain_name = sys.argv[3]\n" +
-          "if (len(sys.argv) == 5):\n" +
-          "  admin_server_url = sys.argv[4]\n" +
-          "else:\n" +
-          "  admin_server_url = None\n" +
-          "\n" +
-          "domain_path='/shared/domain/%s' % domain_name\n" +
-          "\n" +
-          "print 'admin username is %s' % admin_username\n" +
-          "print 'domain path is %s' % domain_path\n" +
-          "print 'server name is %s' % server_name\n" +
-          "print 'admin server url is %s' % admin_server_url\n" +
-          "\n" +
-          "# Encrypt the admin username and password\n" +
-          "adminUsernameEncrypted=encrypt(admin_username, domain_path)\n" +
-          "adminPasswordEncrypted=encrypt(admin_password, domain_path)\n" +
-          "\n" +
-          "print 'Create boot.properties files for this server'\n" +
-          "\n" +
-          "# Define the folder path\n" +
-          "secdir='%s/servers/%s/security' % (domain_path, server_name)\n" +
-          "\n" +
-          "# Create the security folder (if it does not already exist)\n" +
-          "try:\n" +
-          "  os.makedirs(secdir)\n" +
-          "except OSError:\n" +
-          "  if not os.path.isdir(secdir):\n" +
-          "    raise\n" +
-          "\n" +
-          "print 'writing boot.properties to %s/servers/%s/security/boot.properties' % (domain_path, server_name)\n" +
-          "\n" +
-          "bpFile=open('%s/servers/%s/security/boot.properties' % (domain_path, server_name), 'w+')\n" +
-          "bpFile.write(\"username=%s\\n\" % adminUsernameEncrypted)\n" +
-          "bpFile.write(\"password=%s\\n\" % adminPasswordEncrypted)\n" +
-          "bpFile.close()\n" +
-          "\n" +
-          "service_name = domain_uid + \"-\" + server_name\n" +
-          "\n" +
-    /* Commented out as we are not configuring machines for servers
-          "# Update node manager listen address\n" +
-          "if admin_server_url is not None:\n" +
-          "  connect(admin_username, admin_password, admin_server_url)\n" +
-          "  serverConfig()\n" +
-          "  server=cmo.lookupServer(server_name)\n" +
-          "  machineName=server.getMachine().getName()\n" +
-          "  print 'Name of machine assigned to server %s is %s' % (server_name, machineName)\n" +
-          "\n" +
-          "  if machineName is not None:\n" +
-          "    print 'Updating listen address of machine %s' % machineName\n" +
-          "    try:\n" +
-          "      edit()\n" +
-          "      startEdit(120000, 120000, 'true')\n" +
-          "      cd('/')\n" +
-          "      machine=cmo.lookupMachine(machineName)\n" +
-          "      print 'Machine is %s' % machine\n" +
-          "      nm=machine.getNodeManager()\n" +
-          "      nm.setListenAddress(service_name)\n" +
-          "      nm.setNMType('Plain')\n" +
-          "      save()\n" +
-          "      activate()\n" +
-          "      print 'Updated listen address of machine %s to %s' % (machineName, service_name)\n" +
-          "    except:\n" +
-          "      cancelEdit('y')\n" +
-          "  disconnect()\n" +
-          "\n" +
-     */
-          "# Connect to nodemanager and start server\n" +
-          "try:\n" +
-          "  nmConnect(admin_username, admin_password, service_name,  '5556', domain_name, domain_path, 'plain')\n" +
-          "  nmStart(server_name)\n" +
-          "  nmDisconnect()\n" +
-          "except WLSTException, e:\n" +
-          "  nmDisconnect()\n" +
-          "  print e\n" +
-          "\n" +
-          "# Exit WLST\n" +
-          "exit()\n";
-
-  private static final String STOP_SERVER_SHELL_SCRIPT = "#!/bin/bash\n" +
-          "\n" +
-          "echo \"Stop the server\"\n" +
-          "\n" +
-          "wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/stop-server.py $1 $2 $3\n" +
-          "\n" +
-          "# Return status of 2 means failed to stop a server through the NodeManager.\n" +
-          "# Look to see if there is a server process that can be killed.\n" +
-          "if [ $? -eq 2 ]; then\n" +
-          "  pid=$(jps -v | grep '[D]weblogic.Name=$2' | awk '{print $1}')\n" +
-          "  if [ ! -z $pid ]; then\n" +
-          "    echo \"Killing the server process $pid\"\n" +
-          "    kill -15 $pid\n" +
-          "  fi\n" +
-          "fi\n" +
-          "\n";
-
-  private static final String STOP_SERVER_PYTHON_SCRIPT = "#\n" +
-          "# +++ Start of common code for reading domain secrets\n" +
-          "\n" +
-          "# Read username secret\n" +
-          "file = open('/weblogic-operator/secrets/username', 'r')\n" +
-          "admin_username = file.read()\n" +
-          "file.close()\n" +
-          "\n" +
-          "# Read password secret\n" +
-          "file = open('/weblogic-operator/secrets/password', 'r')\n" +
-          "admin_password = file.read()\n" +
-          "file.close()\n" +
-          "\n" +
-          "# +++ End of common code for reading domain secrets\n" +
-          "#\n" +
-          "domain_uid = sys.argv[1]\n" +
-          "server_name = sys.argv[2]\n" +
-          "domain_name = sys.argv[3]\n" +
-          "\n" +
-          "service_name = domain_uid + \"-\" + server_name\n" +
-          "domain_path='/shared/domain/%s' % domain_name\n" +
-          "\n" +
-          "# Connect to nodemanager and stop server\n" +
-          "try:\n" +
-          "  nmConnect(admin_username, admin_password, service_name,  '5556', domain_name, domain_path, 'plain')\n" +
-          "except:\n" +
-          "  print('Failed to connect to the NodeManager')\n" +
-          "  exit(exitcode=2)\n" +
-          "\n" +
-          "# Kill the server\n" +
-          "try:\n" +
-          "  nmKill(server_name)\n" +
-          "except:\n" +
-          "  print('Connected to the NodeManager, but failed to stop the server')\n" +
-          "  exit(exitcode=2)\n" +
-          "\n" +
-          "# Exit WLST\n" +
-          "nmDisconnect()\n" +
-          "exit()\n";
+  private static final String SCRIPT_LOCATION = "/scripts";
 
   private ConfigMapHelper() {}
   
@@ -413,89 +150,47 @@ public class ConfigMapHelper {
       metadata.setLabels(labels);
 
       cm.setMetadata(metadata);
-
-      Map<String, String> data = new HashMap<>();
-      
-      data.put("livenessProbe.sh", 
-          "#!/bin/bash\n" + 
-          "# Kubernetes periodically calls this liveness probe script to determine whether\n" + 
-          "# the pod should be restarted. The script checks a WebLogic Server state file which\n" + 
-          "# is updated by the node manager.\n" + 
-          "DN=${DOMAIN_NAME:-$1}\n" +
-          "SN=${SERVER_NAME:-$2}\n" +
-          "STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state\n" + 
-          "if [ `jps -l | grep -c \" weblogic.NodeManager\"` -eq 0 ]; then\n" + 
-          "  echo \"Error: WebLogic NodeManager process not found.\"\n" +
-          "  exit 1\n" + 
-          "fi\n" + 
-          "if [ -f ${STATEFILE} ] && [ `grep -c \"" + WebLogicConstants.FAILED_NOT_RESTARTABLE_STATE + "\" ${STATEFILE}` -eq 1 ]; then\n" + 
-          "  echo \"Error: WebLogic Server state is " + WebLogicConstants.FAILED_NOT_RESTARTABLE_STATE + ".\"\n" +
-          "  exit 1\n" + 
-          "fi\n" + 
-          "exit 0");
-      
-      data.put("readinessProbe.sh", 
-          "#!/bin/bash\n" + 
-          "\n" + 
-          "# Kubernetes periodically calls this readiness probe script to determine whether\n" + 
-          "# the pod should be included in load balancing. The script checks a WebLogic Server state\n" + 
-          "# file which is updated by the node manager.\n" + 
-          "\n" + 
-          "DN=${DOMAIN_NAME:-$1}\n" +
-          "SN=${SERVER_NAME:-$2}\n" +
-          "STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state\n" + 
-          "\n" + 
-          "if [ `jps -l | grep -c \" weblogic.NodeManager\"` -eq 0 ]; then\n" + 
-          "  echo \"Error: WebLogic NodeManager process not found.\"\n" +
-          "  exit 1\n" + 
-          "fi\n" + 
-          "\n" + 
-          "if [ ! -f ${STATEFILE} ]; then\n" + 
-          "  echo \"Error: WebLogic Server state file not found.\"\n" +
-          "  exit 2\n" + 
-          "fi\n" + 
-          "\n" + 
-          "state=$(cat ${STATEFILE} | cut -f 1 -d ':')\n" +
-          "if [ \"$state\" != \"" + WebLogicConstants.RUNNING_STATE + "\" ]; then\n" +
-          "  echo \"" + WebLogicConstants.READINESS_PROBE_NOT_READY_STATE + "${state}\"\n" +
-          "  exit 3\n" + 
-          "fi\n" + 
-          "exit 0");
-
-      data.put("startServer.sh", START_SERVER_SHELL_SCRIPT);
-
-      data.put("start-server.py", START_SERVER_PYTHON_SCRIPT);
-
-      data.put("stopServer.sh", STOP_SERVER_SHELL_SCRIPT);
-
-      data.put("stop-server.py", STOP_SERVER_PYTHON_SCRIPT);
-
-      data.put("readState.sh", 
-          "#!/bin/bash\n" + 
-          "\n" + 
-          "# Reads the current state of a server. The script checks a WebLogic Server state\n" + 
-          "# file which is updated by the node manager.\n" + 
-          "\n" + 
-          "DN=${DOMAIN_NAME:-$1}\n" +
-          "SN=${SERVER_NAME:-$2}\n" +
-          "STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state\n" + 
-          "\n" + 
-          "if [ `jps -l | grep -c \" weblogic.NodeManager\"` -eq 0 ]; then\n" + 
-          "  echo \"Error: WebLogic NodeManager process not found.\"\n" +
-          "  exit 1\n" + 
-          "fi\n" + 
-          "\n" + 
-          "if [ ! -f ${STATEFILE} ]; then\n" + 
-          "  echo \"Error: WebLogic Server state file not found.\"\n" +
-          "  exit 2\n" + 
-          "fi\n" + 
-          "\n" + 
-          "cat ${STATEFILE} | cut -f 1 -d ':'\n" +
-          "exit 0");
-
-      cm.setData(data);
+      cm.setData(loadScripts());
 
       return cm;
+    }
+
+    private Map<String, String> loadScripts() {
+      URI uri = null;
+      try {
+        uri = getClass().getResource(SCRIPT_LOCATION).toURI();
+      } catch (URISyntaxException e) {
+        LOGGER.warning(MessageKeys.EXCEPTION, e);
+        throw new RuntimeException(e);
+      }
+
+      try {
+        FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.<String, Object>emptyMap());
+        Stream<Path> walk = Files.walk(fileSystem.getPath(SCRIPT_LOCATION), 1);
+        Map<String, String> data = new HashMap<>();
+        for (Iterator<Path> it = walk.iterator(); it.hasNext();) {
+          Path script = it.next();
+          String scriptName = script.toString();
+          if (!SCRIPT_LOCATION.equals(scriptName)) {
+            data.put(script.getFileName().toString(), readScript(getClass().getResourceAsStream(scriptName)));
+          }
+        }
+        LOGGER.info(MessageKeys.SCRIPT_LOADED, domainNamespace);
+        return data;
+      } catch (IOException e) {
+        LOGGER.warning(MessageKeys.EXCEPTION, e);
+        throw new RuntimeException(e);
+      }
+    }
+
+    private String readScript(InputStream inputStream) throws IOException {
+      ByteArrayOutputStream result = new ByteArrayOutputStream();
+      byte[] buffer = new byte[1024];
+      int length;
+      while ((length = inputStream.read(buffer)) != -1) {
+        result.write(buffer, 0, length);
+      }
+      return result.toString();
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -141,4 +141,5 @@ public class MessageKeys {
   public static final String WLS_UPDATE_CLUSTER_SIZE_INVALID_CLUSTER = "WLSKO-0131";
   public static final String WLS_CLUSTER_SIZE_UPDATED = "WLSKO-0132";
   public static final String WLS_SERVER_TEMPLATE_NOT_FOUND = "WLSKO-0133";
+  public static final String SCRIPT_LOADED = "WLSKO-0134";
 }

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -132,3 +132,4 @@ WLSKO-0130=Failed to update WebLogic dynamic cluster size for cluster {0} within
 WLSKO-0131=Failed to update WebLogic dynamic cluster size for cluster {0}. Cluster is not a dynamic cluster
 WLSKO-0132=Updated cluster size for WebLogic dynamic cluster {0} to {1}. Time taken {2} ms
 WLSKO-0133=Cannot find WebLogic server template with name {0} which is referenced by WebLogic cluster {1}
+WLSKO-0134=Loading scripts into domain control config map for namespace: {0}

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Kubernetes periodically calls this liveness probe script to determine whether
+# the pod should be restarted. The script checks a WebLogic Server state file which
+# is updated by the node manager.
+DN=${DOMAIN_NAME:-$1}
+SN=${SERVER_NAME:-$2}
+STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state
+if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
+  echo "Error: WebLogic NodeManager process not found."
+  exit 1
+fi
+if [ -f ${STATEFILE} ] && [ `grep -c "FAILED_NOT_RESTARTABLE" ${STATEFILE}` -eq 1 ]; then
+  echo "Error: WebLogic Server state is FAILED_NOT_RESTARTABLE."
+  exit 1
+fi
+exit 0

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Reads the current state of a server. The script checks a WebLogic Server state
+# file which is updated by the node manager.
+
+DN=${DOMAIN_NAME:-$1}
+SN=${SERVER_NAME:-$2}
+STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state
+
+if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
+  echo "Error: WebLogic NodeManager process not found."
+  exit 1
+fi
+
+if [ ! -f ${STATEFILE} ]; then
+  echo "Error: WebLogic Server state file not found."
+  exit 2
+fi
+
+cat ${STATEFILE} | cut -f 1 -d ':'
+exit 0

--- a/operator/src/main/resources/scripts/readinessProbe.sh
+++ b/operator/src/main/resources/scripts/readinessProbe.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Kubernetes periodically calls this readiness probe script to determine whether
+# the pod should be included in load balancing. The script checks a WebLogic Server state
+# file which is updated by the node manager.
+
+DN=${DOMAIN_NAME:-$1}
+SN=${SERVER_NAME:-$2}
+STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state
+
+if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
+  echo "Error: WebLogic NodeManager process not found."
+  exit 1
+fi
+
+if [ ! -f ${STATEFILE} ]; then
+  echo "Error: WebLogic Server state file not found."
+  exit 2
+fi
+
+state=$(cat ${STATEFILE} | cut -f 1 -d ':')
+if [ "$state" != "RUNNING" ]; then
+  echo "Not ready: WebLogic Server state: ${state}"
+  exit 3
+fi
+exit 0

--- a/operator/src/main/resources/scripts/start-server.py
+++ b/operator/src/main/resources/scripts/start-server.py
@@ -1,0 +1,68 @@
+import sys;
+#
+# +++ Start of common code for reading domain secrets
+
+# Read username secret
+file = open('/weblogic-operator/secrets/username', 'r')
+admin_username = file.read()
+file.close()
+
+# Read password secret
+file = open('/weblogic-operator/secrets/password', 'r')
+admin_password = file.read()
+file.close()
+
+# +++ End of common code for reading domain secrets
+#
+domain_uid = sys.argv[1]
+server_name = sys.argv[2]
+domain_name = sys.argv[3]
+if (len(sys.argv) == 5):
+  admin_server_url = sys.argv[4]
+else:
+  admin_server_url = None
+
+domain_path='/shared/domain/%s' % domain_name
+
+print 'admin username is %s' % admin_username
+print 'domain path is %s' % domain_path
+print 'server name is %s' % server_name
+print 'admin server url is %s' % admin_server_url
+
+# Encrypt the admin username and password
+adminUsernameEncrypted=encrypt(admin_username, domain_path)
+adminPasswordEncrypted=encrypt(admin_password, domain_path)
+
+print 'Create boot.properties files for this server'
+
+# Define the folder path
+secdir='%s/servers/%s/security' % (domain_path, server_name)
+
+# Create the security folder (if it does not already exist)
+try:
+  os.makedirs(secdir)
+except OSError:
+  if not os.path.isdir(secdir):
+    raise
+
+print 'writing boot.properties to %s/servers/%s/security/boot.properties' % (domain_path, server_name)
+
+bpFile=open('%s/servers/%s/security/boot.properties' % (domain_path, server_name), 'w+')
+bpFile.write("username=%s\n" % adminUsernameEncrypted)
+bpFile.write("password=%s\n" % adminPasswordEncrypted)
+bpFile.close()
+
+service_name = domain_uid + "-" + server_name
+
+# Connect to nodemanager and start server
+try:
+  nmConnect(admin_username, admin_password, service_name,  '5556', domain_name, domain_path, 'plain')
+  nmStart(server_name)
+  nmDisconnect()
+except WLSTException, e:
+  nmDisconnect()
+  print e
+
+# Exit WLST
+exit()
+

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+domain_uid=$1
+server_name=$2
+domain_name=$3
+as_name=$4
+as_port=$5
+as_hostname=$1-$4
+
+echo "debug arguments are $1 $2 $3 $4 $5"
+
+nmProp="/u01/nodemanager/nodemanager.properties"
+
+# TODO: parameterize shared home and domain name
+export DOMAIN_HOME=/shared/domain/$domain_name
+
+#
+# Create a folder
+# $1 - path of folder to create
+function createFolder {
+  mkdir -m 777 -p $1
+  if [ ! -d $1 ]; then
+    fail "Unable to create folder $1"
+  fi
+}
+
+# Function to create server specific scripts and properties (e.g startup.properties, etc)
+# $1 - Domain UID
+# $2 - Server Name
+# $3 - Domain Name
+# $4 - Admin Server Hostname (only passed for managed servers)
+# $5 - Admin Server port (only passed for managed servers)
+function createServerScriptsProperties() {
+
+  # Create nodemanager home for the server
+  srvr_nmdir=/u01/nodemanager
+  createFolder ${srvr_nmdir}
+  cp /shared/domain/$3/nodemanager/nodemanager.domains ${srvr_nmdir}
+  cp /shared/domain/$3/bin/startNodeManager.sh ${srvr_nmdir}
+
+  # Edit the start nodemanager script to use the home for the server
+  sed -i -e "s:/shared/domain/$3/nodemanager:/u01/nodemanager:g" ${srvr_nmdir}/startNodeManager.sh
+
+  # Create startup.properties file
+  datadir=${DOMAIN_HOME}/servers/$2/data/nodemanager
+  nmdir=${DOMAIN_HOME}/nodemgr_home
+  stateFile=${datadir}/$2.state
+  startProp=${datadir}/startup.properties
+  if [ -f "$startProp" ]; then
+    echo "startup.properties already exists"
+    return 0
+  fi
+
+  createFolder ${datadir}
+  echo "# Server startup properties" > ${startProp}
+  echo "AutoRestart=true" >> ${startProp}
+  if [ -n "$4" ]; then
+    echo "AdminURL=http\://$4\:$5" >> ${startProp}
+  fi
+  echo "RestartMax=2" >> ${startProp}
+  echo "RotateLogOnStartup=false" >> ${startProp}
+  echo "RotationType=bySize" >> ${startProp}
+  echo "RotationTimeStart=00\:00" >> ${startProp}
+  echo "RotatedFileCount=100" >> ${startProp}
+  echo "RestartDelaySeconds=0" >> ${startProp}
+  echo "FileSizeKB=5000" >> ${startProp}
+  echo "FileTimeSpanFactor=3600000" >> ${startProp}
+  echo "RestartInterval=3600" >> ${startProp}
+  echo "NumberOfFilesLimited=true" >> ${startProp}
+  echo "FileTimeSpan=24" >> ${startProp}
+  echo "NMHostName=$1-$2" >> ${startProp}
+}
+
+# Check for stale state file and remove if found"
+if [ -f "$stateFile" ]; then
+  echo "Removing stale file $stateFile"
+  rm ${stateFile}
+fi
+
+# Create nodemanager home directory that is local to the k8s node
+mkdir -p /u01/nodemanager
+cp ${DOMAIN_HOME}/nodemanager/* /u01/nodemanager/
+
+# Edit the nodemanager properties file to use the home for the server
+sed -i -e "s:DomainsFile=.*:DomainsFile=/u01/nodemanager/nodemanager.domains:g" /u01/nodemanager/nodemanager.properties
+sed -i -e "s:NodeManagerHome=.*:NodeManagerHome=/u01/nodemanager:g" /u01/nodemanager/nodemanager.properties
+sed -i -e "s:ListenAddress=.*:ListenAddress=$1-$2:g" /u01/nodemanager/nodemanager.properties
+sed -i -e "s:LogFile=.*:LogFile=/shared/logs/nodemanager-$2.log:g" /u01/nodemanager/nodemanager.properties
+
+export JAVA_PROPERTIES="-DLogFile=/shared/logs/nodemanager-$server_name.log -DNodeManagerHome=/u01/nodemanager"
+export NODEMGR_HOME="/u01/nodemanager"
+
+
+# Create startup.properties
+echo "Create startup.properties"
+if [ -n "$4" ]; then
+  echo "this is managed server"
+  createServerScriptsProperties $domain_uid $server_name $domain_name $as_hostname $as_port
+else
+  echo "this is admin server"
+  createServerScriptsProperties $domain_uid $server_name $domain_name
+fi
+
+echo "Start the nodemanager"
+. ${NODEMGR_HOME}/startNodeManager.sh &
+
+echo "Allow the nodemanager some time to start before attempting to connect"
+sleep 15
+echo "Finished waiting for the nodemanager to start"
+
+echo "Update JVM arguments"
+echo "Arguments=${USER_MEM_ARGS} -XX\:+UnlockExperimentalVMOptions -XX\:+UseCGroupMemoryLimitForHeap ${JAVA_OPTIONS}" >> ${startProp}
+
+admin_server_t3_url=
+if [ -n "$4" ]; then
+  admin_server_t3_url=t3://$domain_uid-$as_name:$as_port
+fi
+
+echo "Start the server"
+wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/start-server.py $domain_uid $server_name $domain_name $admin_server_t3_url
+
+echo "Wait indefinitely so that the Kubernetes pod does not exit and try to restart"
+while true; do sleep 60; done
+

--- a/operator/src/main/resources/scripts/stop-server.py
+++ b/operator/src/main/resources/scripts/stop-server.py
@@ -1,0 +1,40 @@
+#
+# +++ Start of common code for reading domain secrets
+
+# Read username secret
+file = open('/weblogic-operator/secrets/username', 'r')
+admin_username = file.read()
+file.close()
+
+# Read password secret
+file = open('/weblogic-operator/secrets/password', 'r')
+admin_password = file.read()
+file.close()
+
+# +++ End of common code for reading domain secrets
+#
+domain_uid = sys.argv[1]
+server_name = sys.argv[2]
+domain_name = sys.argv[3]
+
+service_name = domain_uid + "-" + server_name
+domain_path='/shared/domain/%s' % domain_name
+
+# Connect to nodemanager and stop server
+try:
+  nmConnect(admin_username, admin_password, service_name,  '5556', domain_name, domain_path, 'plain')
+except:
+  print('Failed to connect to the NodeManager')
+  exit(exitcode=2)
+
+# Kill the server
+try:
+  nmKill(server_name)
+except:
+  print('Connected to the NodeManager, but failed to stop the server')
+  exit(exitcode=2)
+
+# Exit WLST
+nmDisconnect()
+exit()
+

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Stop the server"
+
+wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/stop-server.py $1 $2 $3
+
+# Return status of 2 means failed to stop a server through the NodeManager.
+# Look to see if there is a server process that can be killed.
+if [ $? -eq 2 ]; then
+  pid=$(jps -v | grep '[D]weblogic.Name=$2' | awk '{print $1}')
+  if [ ! -z $pid ]; then
+    echo "Killing the server process $pid"
+    kill -15 $pid
+  fi
+fi
+
+


### PR DESCRIPTION
The change includes following content
1. Move the shell and python scripts out of operator java helper source code to operator/src/main/resource/scripts
2. Modify the helper to load scripts from /scripts directory that in the operator jar file
