### PR TITLE
Fix a bug where we were checking against the wrong version string whe…

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -99,7 +99,7 @@ public class ConfigMapHelper {
               }
             });
             return doNext(create, packet);
-          } else if (VersionHelper.matchesResourceVersion(result.getMetadata(), LabelConstants.RESOURCE_VERSION_LABEL) &&
+          } else if (VersionHelper.matchesResourceVersion(result.getMetadata(), VersionConstants.DOMAIN_V1) &&
                      result.getData().entrySet().containsAll(cm.getData().entrySet())) {
             // existing config map has correct data
             LOGGER.fine(MessageKeys.CM_EXISTS, domainNamespace);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -407,7 +407,7 @@ public class PodHelper {
     // returns fields, such as nodeName, even when export=true is specified.
     // Therefore, we'll just compare specific fields
     
-    if (!VersionHelper.matchesResourceVersion(current.getMetadata(), LabelConstants.RESOURCE_VERSION_LABEL)) {
+    if (!VersionHelper.matchesResourceVersion(current.getMetadata(), VersionConstants.DOMAIN_V1)) {
       return false;
     }
     

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -368,7 +368,7 @@ public class ServiceHelper {
     V1ServiceSpec buildSpec = build.getSpec();
     V1ServiceSpec currentSpec = current.getSpec();
     
-    if (!VersionHelper.matchesResourceVersion(current.getMetadata(), LabelConstants.RESOURCE_VERSION_LABEL)) {
+    if (!VersionHelper.matchesResourceVersion(current.getMetadata(), VersionConstants.DOMAIN_V1)) {
       return false;
     }
     


### PR DESCRIPTION
Three of the helpers should have been recreating resources if their version wasn't 'domain-v1'.
Instead, they were checking for the string 'weblogic.resourceVersion'.  This caused them to always
create the resources (i.e server pods, server config maps and server services).

It's important we get this fix in soon - the bug probably is causing a lot of failures.
