### PR TITLE
Voyager update

### DIFF
--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -718,7 +718,7 @@ function setupVoyagerLoadBalancer {
     local mnow=`date +%s`
     local vdep=`kubectl get ingresses.voyager.appscode.com -n ${namespace} | grep ${domainUID}-voyager | wc | awk ' { print $1; } '`
     if [ "$vdep" = "1" ]; then
-      echo 'The Voyager Ingress resource ${domainUID}-voyager is created successfully.'
+      echo "The Voyager Ingress resource ${domainUID}-voyager is created successfully."
       break
     fi
     if [ $((mnow - mstart)) -gt $((maxwaitsecs)) ]; then
@@ -734,7 +734,7 @@ function setupVoyagerLoadBalancer {
     local mnow=`date +%s`
     local st=`kubectl get pod -n ${namespace} | grep ^voyager-${domainUID}-voyager- | awk ' { print $3; } '`
     if [ "$st" = "Running" ]; then
-      echo 'The HAProxy pod for Voyaer Ingress ${domainUID}-voyager is created successfully.'
+      echo "The HAProxy pod for Voyaer Ingress ${domainUID}-voyager is created successfully."
       break
     fi
     if [ $((mnow - mstart)) -gt $((maxwaitsecs)) ]; then

--- a/kubernetes/internal/voyager-ingress-template.yaml
+++ b/kubernetes/internal/voyager-ingress-template.yaml
@@ -10,9 +10,10 @@ metadata:
   annotations:
     ingress.appscode.com/type: 'NodePort'
     ingress.appscode.com/stats: 'true'
+    ingress.appscode.com/affinity: 'cookie'
 spec:
   rules:
-  - host: %DOMAIN_UID%.%CLUSTER_NAME%
+  - host: '*' 
     http:
       nodePort: '%LOAD_BALANCER_WEB_PORT%'
       paths:

--- a/site/voyager.md
+++ b/site/voyager.md
@@ -65,9 +65,10 @@ metadata:
   annotations:
     ingress.appscode.com/type: 'NodePort'
     ingress.appscode.com/stats: 'true'
+    ingress.appscode.com/affinity: 'cookie'
 spec:
   rules:
-  - host: domain1.cluster-1
+  - host: '*'
     http:
       nodePort: '30305'
       paths:

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -1161,12 +1161,11 @@ function verify_webapp_load_balancing {
     local max_count=30
     local wait_time=6
     local count=0
-    local vheader="host: $DOMAIN_UID.$WL_CLUSTER_NAME" # this is only needed for voyager but it does no harm to traefik etc
 
     while [ "${HTTP_RESPONSE}" != "200" -a $count -lt $max_count ] ; do
       local count=`expr $count + 1`
       echo "NO_DATA" > $CURL_RESPONSE_BODY
-      local HTTP_RESPONSE=$(eval "curl --silent --show-error -H '${vheader}' --noproxy ${NODEPORT_HOST} ${TEST_APP_URL} \
+      local HTTP_RESPONSE=$(eval "curl --silent --show-error --noproxy ${NODEPORT_HOST} ${TEST_APP_URL} \
         --write-out '%{http_code}' \
         -o ${CURL_RESPONSE_BODY}" \
       )


### PR DESCRIPTION
two changes to the Voyager Ingress resources:
1. Enable session sticky.
2. Loose the hostname-based routing since there is only one cluster in created WebLogic domain via create-weblogic-domain.sh.