### PR TITLE
Let unit test run resource list steps

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -28,7 +28,7 @@
     </licenses>
 
     <build>
-        <plugins>  
+        <plugins>
 
             <plugin>
                 <groupId>pl.project13.maven</groupId>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -28,7 +28,7 @@
     </licenses>
 
     <build>
-        <plugins>
+        <plugins>  
 
             <plugin>
                 <groupId>pl.project13.maven</groupId>

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -30,7 +31,6 @@ import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
@@ -75,6 +75,7 @@ import oracle.kubernetes.operator.work.FiberGate;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.operator.work.ThreadFactorySingleton;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainList;
 import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
@@ -82,15 +83,7 @@ import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 /** A Kubernetes Operator for WebLogic. */
 public class Main {
 
-  private static final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
-  private static final ThreadFactory factory =
-      (r) -> {
-        Thread t = defaultFactory.newThread(r);
-        if (!t.isDaemon()) {
-          t.setDaemon(true);
-        }
-        return t;
-      };
+  private static final ThreadFactory factory = ThreadFactorySingleton.getInstance();
 
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final ConcurrentMap<String, DomainPresenceInfo> domains =
@@ -112,7 +105,7 @@ public class Main {
     }
   }
 
-  static final CallBuilderFactory callBuilderFactory = new CallBuilderFactory();
+  private static final CallBuilderFactory callBuilderFactory = new CallBuilderFactory();
 
   private static final Container container = new Container();
   private static final ScheduledExecutorService wrappedExecutorService =
@@ -154,6 +147,10 @@ public class Main {
   private static final String READINESS_PROBE_FAILURE_EVENT_FILTER =
       "reason=Unhealthy,type=Warning,involvedObject.fieldPath=spec.containers{weblogic-server}";
 
+  static Map<String, DomainPresenceInfo> getDomainPresenceInfos() {
+    return Collections.unmodifiableMap(domains);
+  }
+
   /**
    * Entry point
    *
@@ -189,7 +186,7 @@ public class Main {
     stopRestServer();
   }
 
-  static void begin() {
+  private static void begin() {
     // read the operator configuration
     String namespace = getOperatorNamespace();
 
@@ -238,84 +235,100 @@ public class Main {
       LOGGER.info(MessageKeys.LISTING_DOMAINS);
       for (String ns : targetNamespaces) {
         initialized.put(ns, Boolean.TRUE);
-        Step domainList =
-            callBuilderFactory.create().listDomainAsync(ns, new ExistingDomainListResponseStep(ns));
-        V1beta1IngressListResponseStep ingressListResponseStep =
-            new V1beta1IngressListResponseStep(domainList, ns);
-        V1ServiceListResponseStep serviceListResponseStep =
-            new V1ServiceListResponseStep(ns, ingressListResponseStep);
-        V1EventListResponseStep eventListResponseStep =
-            new V1EventListResponseStep(ns, serviceListResponseStep);
-        V1PodListResponseStep podListResponseStep =
-            new V1PodListResponseStep(ns, eventListResponseStep);
-
-        Step initialize =
-            ConfigMapHelper.createScriptConfigMapStep(
-                namespace,
-                ns,
-                new ConfigMapAfterStep(
-                    ns,
-                    configMapWatchers,
-                    stopping,
-                    Main::dispatchConfigMapWatch,
-                    callBuilderFactory
-                        .create()
-                        .with(
-                            $ ->
-                                $.labelSelector =
-                                    LabelConstants.DOMAINUID_LABEL
-                                        + ","
-                                        + LabelConstants.CREATEDBYOPERATOR_LABEL)
-                        .listPodAsync(ns, podListResponseStep)));
-
         engine
             .createFiber()
             .start(
-                initialize,
-                new Packet(),
-                new CompletionCallback() {
-                  @Override
-                  public void onCompletion(Packet packet) {
-                    // no-op
-                  }
-
-                  @Override
-                  public void onThrowable(Packet packet, Throwable throwable) {
-                    LOGGER.severe(MessageKeys.EXCEPTION, throwable);
-                  }
-                });
+                readExistingResources(namespace, ns), new Packet(), new NullCompletionCallback());
       }
 
       // delete stranded resources
       for (Map.Entry<String, DomainPresenceInfo> entry : domains.entrySet()) {
         String domainUID = entry.getKey();
         DomainPresenceInfo info = entry.getValue();
-        if (info != null) {
-          if (info.getDomain() == null) {
-            // no domain resource
-            deleteDomainPresence(info.getNamespace(), domainUID);
-          }
+        if (info != null && info.getDomain() == null) {
+          deleteDomainPresence(info.getNamespace(), domainUID);
         }
       }
 
       // start periodic retry and recheck
-      MainTuning main = tuningAndConfig.getMainTuning();
+      int recheckInterval = tuningAndConfig.getMainTuning().domainPresenceRecheckIntervalSeconds;
       engine
           .getExecutor()
           .scheduleWithFixedDelay(
-              () -> {
-                for (DomainPresenceInfo info : domains.values()) {
-                  checkAndCreateDomainPresence(info, false);
-                }
-              },
-              main.domainPresenceRecheckIntervalSeconds,
-              main.domainPresenceRecheckIntervalSeconds,
+              updateDomainPresenceInfos(domains.values()),
+              recheckInterval,
+              recheckInterval,
               TimeUnit.SECONDS);
     } catch (Throwable e) {
       LOGGER.warning(MessageKeys.EXCEPTION, e);
     } finally {
       LOGGER.info(MessageKeys.OPERATOR_SHUTTING_DOWN);
     }
+  }
+
+  private static Runnable updateDomainPresenceInfos(Collection<DomainPresenceInfo> infos) {
+    return () -> {
+      for (DomainPresenceInfo info : infos) {
+        checkAndCreateDomainPresence(info, false);
+      }
+    };
+  }
+
+  static Step readExistingResources(String operatorNamespace, String ns) {
+    Step domainStep = listDomains(ns, new DomainListStep(ns));
+    Step ingressStep = listIngresses(ns, new IngressListStep(ns, domainStep));
+    Step serviceStep = listServices(ns, new ServiceListStep(ns, ingressStep));
+    Step eventStep = listEvents(ns, new EventListStep(ns, serviceStep));
+    Step podStep = listPods(ns, new PodListStep(ns, eventStep));
+    Step configMapStep = createConfigMapStep(ns, podStep);
+
+    return ConfigMapHelper.createScriptConfigMapStep(operatorNamespace, ns, configMapStep);
+  }
+
+  private static Step listDomains(String ns, ResponseStep<DomainList> responseStep) {
+    return callBuilderFactory.create().listDomainAsync(ns, responseStep);
+  }
+
+  private static Step listIngresses(String ns, ResponseStep<V1beta1IngressList> responseStep) {
+    return Main.callBuilderFactory
+        .create()
+        .with(
+            $ ->
+                $.labelSelector =
+                    LabelConstants.DOMAINUID_LABEL + "," + LabelConstants.CREATEDBYOPERATOR_LABEL)
+        .listIngressAsync(ns, responseStep);
+  }
+
+  private static Step listServices(String ns, ResponseStep<V1ServiceList> responseStep) {
+    return Main.callBuilderFactory
+        .create()
+        .with(
+            $ ->
+                $.labelSelector =
+                    LabelConstants.DOMAINUID_LABEL + "," + LabelConstants.CREATEDBYOPERATOR_LABEL)
+        .listServiceAsync(ns, responseStep);
+  }
+
+  private static Step listEvents(String ns, ResponseStep<V1EventList> eventListResponseStep1) {
+    return Main.callBuilderFactory
+        .create()
+        .with($ -> $.fieldSelector = Main.READINESS_PROBE_FAILURE_EVENT_FILTER)
+        .listEventAsync(ns, eventListResponseStep1);
+  }
+
+  private static Step listPods(String ns, ResponseStep<V1PodList> podListResponseStep) {
+    return callBuilderFactory
+        .create()
+        .with(
+            $ ->
+                $.labelSelector =
+                    LabelConstants.DOMAINUID_LABEL + "," + LabelConstants.CREATEDBYOPERATOR_LABEL)
+        .listPodAsync(ns, podListResponseStep);
+  }
+
+  private static ConfigMapAfterStep createConfigMapStep(String ns, Step nextStep) {
+    return new ConfigMapAfterStep(
+        ns, configMapWatchers, stopping, Main::dispatchConfigMapWatch, nextStep);
   }
 
   // -----------------------------------------------------------------------------
@@ -485,6 +498,7 @@ public class Main {
     doCheckAndCreateDomainPresence(dom, false, false, null, null);
   }
 
+  @SuppressWarnings("SameParameterValue")
   private static void doCheckAndCreateDomainPresence(Domain dom, boolean explicitRecheck) {
     doCheckAndCreateDomainPresence(dom, explicitRecheck, false, null, null);
   }
@@ -599,9 +613,7 @@ public class Main {
               engine
                   .getExecutor()
                   .schedule(
-                      () -> {
-                        checkAndCreateDomainPresence(info, false);
-                      },
+                      () -> checkAndCreateDomainPresence(info, false),
                       tuningAndConfig.getMainTuning().domainPresenceFailureRetrySeconds,
                       TimeUnit.SECONDS);
             }
@@ -1034,11 +1046,11 @@ public class Main {
     return namespace;
   }
 
-  private static class V1beta1IngressListResponseStep extends ResponseStep<V1beta1IngressList> {
+  private static class IngressListStep extends ResponseStep<V1beta1IngressList> {
     private final String ns;
 
-    V1beta1IngressListResponseStep(Step domainList, String ns) {
-      super(domainList);
+    IngressListStep(String ns, Step nextStep) {
+      super(nextStep);
       this.ns = ns;
     }
 
@@ -1079,20 +1091,55 @@ public class Main {
     }
   }
 
-  private static class V1ServiceListResponseStep extends ResponseStep<V1ServiceList> {
+  private static class DomainListStep extends ResponseStep<DomainList> {
     private final String ns;
 
-    V1ServiceListResponseStep(String ns, V1beta1IngressListResponseStep ingressListResponseStep) {
-      super(
-          Main.callBuilderFactory
-              .create()
-              .with(
-                  $ ->
-                      $.labelSelector =
-                          LabelConstants.DOMAINUID_LABEL
-                              + ","
-                              + LabelConstants.CREATEDBYOPERATOR_LABEL)
-              .listIngressAsync(ns, ingressListResponseStep));
+    DomainListStep(String ns) {
+      super(null);
+      this.ns = ns;
+    }
+
+    @Override
+    public NextAction onFailure(
+        Packet packet, ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
+      if (statusCode == CallBuilder.NOT_FOUND) {
+        return onSuccess(packet, null, statusCode, responseHeaders);
+      }
+      return super.onFailure(packet, e, statusCode, responseHeaders);
+    }
+
+    @Override
+    public NextAction onSuccess(
+        Packet packet,
+        DomainList result,
+        int statusCode,
+        Map<String, List<String>> responseHeaders) {
+      if (result != null) {
+        for (Domain dom : result.getItems()) {
+          doCheckAndCreateDomainPresence(dom);
+        }
+      }
+
+      domainWatchers.put(ns, createDomainWatcher(ns, getResourceVersion(result)));
+      return doNext(packet);
+    }
+
+    String getResourceVersion(DomainList result) {
+      return result != null ? result.getMetadata().getResourceVersion() : "";
+    }
+
+    private static DomainWatcher createDomainWatcher(
+        String namespace, String initialResourceVersion) {
+      return DomainWatcher.create(
+          factory, namespace, initialResourceVersion, Main::dispatchDomainWatch, stopping);
+    }
+  }
+
+  private static class ServiceListStep extends ResponseStep<V1ServiceList> {
+    private final String ns;
+
+    ServiceListStep(String ns, Step nextStep) {
+      super(nextStep);
       this.ns = ns;
     }
 
@@ -1139,20 +1186,11 @@ public class Main {
     }
   }
 
-  private static class V1EventListResponseStep extends ResponseStep<V1EventList> {
+  private static class EventListStep extends ResponseStep<V1EventList> {
     private final String ns;
 
-    V1EventListResponseStep(String ns, V1ServiceListResponseStep serviceListResponseStep) {
-      super(
-          Main.callBuilderFactory
-              .create()
-              .with(
-                  $ ->
-                      $.labelSelector =
-                          LabelConstants.DOMAINUID_LABEL
-                              + ","
-                              + LabelConstants.CREATEDBYOPERATOR_LABEL)
-              .listServiceAsync(ns, serviceListResponseStep));
+    EventListStep(String ns, Step nextStep) {
+      super(nextStep);
       this.ns = ns;
     }
 
@@ -1183,15 +1221,11 @@ public class Main {
     }
   }
 
-  private static class V1PodListResponseStep extends ResponseStep<V1PodList> {
+  private static class PodListStep extends ResponseStep<V1PodList> {
     private final String ns;
 
-    V1PodListResponseStep(String ns, V1EventListResponseStep eventListResponseStep) {
-      super(
-          Main.callBuilderFactory
-              .create()
-              .with($ -> $.fieldSelector = Main.READINESS_PROBE_FAILURE_EVENT_FILTER)
-              .listEventAsync(ns, eventListResponseStep));
+    PodListStep(String ns, Step nextStep) {
+      super(nextStep);
       this.ns = ns;
     }
 
@@ -1232,47 +1266,15 @@ public class Main {
     }
   }
 
-  private static class ExistingDomainListResponseStep extends ResponseStep<DomainList> {
-    private final String ns;
-
-    ExistingDomainListResponseStep(String ns) {
-      super(null);
-      this.ns = ns;
+  private static class NullCompletionCallback implements CompletionCallback {
+    @Override
+    public void onCompletion(Packet packet) {
+      // no-op
     }
 
     @Override
-    public NextAction onFailure(
-        Packet packet, ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
-      if (statusCode == CallBuilder.NOT_FOUND) {
-        return onSuccess(packet, null, statusCode, responseHeaders);
-      }
-      return super.onFailure(packet, e, statusCode, responseHeaders);
-    }
-
-    @Override
-    public NextAction onSuccess(
-        Packet packet,
-        DomainList result,
-        int statusCode,
-        Map<String, List<String>> responseHeaders) {
-      if (result != null) {
-        for (Domain dom : result.getItems()) {
-          doCheckAndCreateDomainPresence(dom);
-        }
-      }
-
-      domainWatchers.put(ns, createDomainWatcher(ns, getResourceVersion(result)));
-      return doNext(packet);
-    }
-
-    String getResourceVersion(DomainList result) {
-      return result != null ? result.getMetadata().getResourceVersion() : "";
-    }
-
-    private static DomainWatcher createDomainWatcher(
-        String namespace, String initialResourceVersion) {
-      return DomainWatcher.create(
-          factory, namespace, initialResourceVersion, Main::dispatchDomainWatch, stopping);
+    public void onThrowable(Packet packet, Throwable throwable) {
+      LOGGER.severe(MessageKeys.EXCEPTION, throwable);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ClientPool.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ClientPool.java
@@ -20,7 +20,7 @@ public class ClientPool extends Pool<ApiClient> {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final ClientPool SINGLETON = new ClientPool();
 
-  private static final DefaultClientFactory FACTORY = new DefaultClientFactory();
+  private static final ClientFactory FACTORY = new DefaultClientFactory();
 
   public static ClientPool getInstance() {
     return SINGLETON;

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ConfigMapAfterStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ConfigMapAfterStep.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.steps;
 
 import io.kubernetes.client.models.V1ConfigMap;
 import java.util.Map;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.ConfigMapWatcher;
 import oracle.kubernetes.operator.ProcessingConstants;
@@ -45,11 +46,8 @@ public class ConfigMapAfterStep extends Step {
   }
 
   private ConfigMapWatcher createConfigMapWatcher(String namespace, String initialResourceVersion) {
-    return ConfigMapWatcher.create(
-        ThreadFactorySingleton.getInstance(),
-        namespace,
-        initialResourceVersion,
-        listener,
-        stopping);
+    ThreadFactory factory = ThreadFactorySingleton.getInstance();
+
+    return ConfigMapWatcher.create(factory, namespace, initialResourceVersion, listener, stopping);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ConfigMapAfterStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ConfigMapAfterStep.java
@@ -6,15 +6,14 @@ package oracle.kubernetes.operator.steps;
 
 import io.kubernetes.client.models.V1ConfigMap;
 import java.util.Map;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.ConfigMapWatcher;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.watcher.WatchListener;
-import oracle.kubernetes.operator.work.ContainerResolver;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.operator.work.ThreadFactorySingleton;
 
 public class ConfigMapAfterStep extends Step {
   private final String ns;
@@ -46,9 +45,11 @@ public class ConfigMapAfterStep extends Step {
   }
 
   private ConfigMapWatcher createConfigMapWatcher(String namespace, String initialResourceVersion) {
-    ThreadFactory factory =
-        ContainerResolver.getInstance().getContainer().getSPI(ThreadFactory.class);
-
-    return ConfigMapWatcher.create(factory, namespace, initialResourceVersion, listener, stopping);
+    return ConfigMapWatcher.create(
+        ThreadFactorySingleton.getInstance(),
+        namespace,
+        initialResourceVersion,
+        listener,
+        stopping);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/work/ThreadFactorySingleton.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/ThreadFactorySingleton.java
@@ -1,0 +1,25 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.work;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public class ThreadFactorySingleton {
+
+  private static final ThreadFactory DEFAULT_FACTORY = Executors.defaultThreadFactory();
+  private static final ThreadFactory INSTANCE =
+      (r) -> {
+        Thread t = DEFAULT_FACTORY.newThread(r);
+        if (!t.isDaemon()) {
+          t.setDaemon(true);
+        }
+        return t;
+      };
+
+  public static ThreadFactory getInstance() {
+    return INSTANCE;
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/TestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/TestUtils.java
@@ -88,6 +88,7 @@ public class TestUtils {
     void throwLoggedThrowable() {
       if (throwable == null) return;
 
+      throwable.printStackTrace();
       if (throwable instanceof Error) throw (Error) throwable;
       if (throwable instanceof RuntimeException) throw (RuntimeException) throwable;
       throw new RuntimeException(throwable);

--- a/operator/src/test/java/oracle/kubernetes/operator/ConfigMapWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ConfigMapWatcherTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.util.Watch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.watcher.WatchListener;
@@ -45,13 +44,7 @@ public class ConfigMapWatcherTest extends WatcherTestBase implements WatchListen
   }
 
   @Override
-  protected ConfigMapWatcher createWatcher(
-      String nameSpace, AtomicBoolean stopping, int initialResourceVersion) {
-    return ConfigMapWatcher.create(
-        Executors.defaultThreadFactory(),
-        nameSpace,
-        Integer.toString(initialResourceVersion),
-        this,
-        stopping);
+  protected ConfigMapWatcher createWatcher(String ns, AtomicBoolean stopping, int rv) {
+    return ConfigMapWatcher.create(this, ns, Integer.toString(rv), this, stopping);
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -207,16 +207,4 @@ public class DomainPresenceTest {
       return new ApiClient();
     }
   }
-
-  public static void main(String[] args) throws Exception {
-
-    for (int i = 0; i < 1000; i++) runTest();
-  }
-
-  private static void runTest() throws Exception {
-    DomainPresenceTest test = new DomainPresenceTest();
-    test.setUp();
-    test.whenNoPreexistingDomains_createEmptyDomainPresenceInfoMap();
-    test.tearDown();
-  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -94,6 +94,7 @@ public class DomainPresenceTest {
     mementos.add(testSupport.installRequestStepFactory());
     mementos.add(SynchronousCallFactoryStub.install());
     mementos.add(ClientFactoryStub.install());
+    mementos.add(StubWatchFactory.install());
   }
 
   @After

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -5,6 +5,8 @@
 package oracle.kubernetes.operator;
 
 import static com.meterware.simplestub.Stub.createStub;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -12,7 +14,10 @@ import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
+import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1EventList;
+import io.kubernetes.client.models.V1ListMeta;
+import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1PersistentVolumeList;
 import io.kubernetes.client.models.V1PodList;
 import io.kubernetes.client.models.V1SelfSubjectRulesReview;
@@ -21,21 +26,63 @@ import io.kubernetes.client.models.V1SubjectRulesReviewStatus;
 import io.kubernetes.client.models.V1beta1IngressList;
 import io.kubernetes.client.models.VersionInfo;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.helpers.CallBuilder;
+import oracle.kubernetes.operator.helpers.ClientFactory;
+import oracle.kubernetes.operator.helpers.ClientPool;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.SynchronousCallFactory;
 import oracle.kubernetes.operator.work.AsyncCallTestSupport;
 import oracle.kubernetes.weblogic.domain.v1.DomainList;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class DomainPresenceTest {
+
+  private static final String NS = "default";
+  private final DomainList expectedDomains = createEmptyDomainList();
+  private final V1beta1IngressList expectedIngresses = createEmptyIngressList();
+  private final V1ServiceList expectedServices = createEmptyServiceList();
+  private final V1EventList expectedEvents = createEmptyEventList();
+  private final V1PodList expectedPods = createEmptyPodList();
+  private final V1ConfigMap expectedDomainConfigMap = createEmptyConfigMap();
+
+  private DomainList createEmptyDomainList() {
+    return new DomainList().withMetadata(createListMetadata());
+  }
+
+  private V1ListMeta createListMetadata() {
+    return new V1ListMeta().resourceVersion("1");
+  }
+
+  private V1beta1IngressList createEmptyIngressList() {
+    return new V1beta1IngressList().metadata(createListMetadata());
+  }
+
+  private V1ServiceList createEmptyServiceList() {
+    return new V1ServiceList().metadata(createListMetadata());
+  }
+
+  private V1EventList createEmptyEventList() {
+    return new V1EventList().metadata(createListMetadata());
+  }
+
+  private V1PodList createEmptyPodList() {
+    return new V1PodList().metadata(createListMetadata());
+  }
+
+  private V1ConfigMap createEmptyConfigMap() {
+    return new V1ConfigMap().metadata(createObjectMetaData()).data(new HashMap<>());
+  }
+
+  private V1ObjectMeta createObjectMetaData() {
+    return new V1ObjectMeta().resourceVersion("1");
+  }
 
   private List<Memento> mementos = new ArrayList<>();
   private AsyncCallTestSupport testSupport = new AsyncCallTestSupport();
@@ -45,38 +92,43 @@ public class DomainPresenceTest {
     mementos.add(TestUtils.silenceOperatorLogger());
     mementos.add(StubWatchFactory.install());
     mementos.add(testSupport.installRequestStepFactory());
-    mementos.add(
-        StaticStubSupport.install(
-            CallBuilder.class, "CALL_FACTORY", createStub(SynchronousCallFactoryStub.class)));
+    mementos.add(SynchronousCallFactoryStub.install());
+    mementos.add(ClientFactoryStub.install());
   }
 
   @After
   public void tearDown() throws Exception {
     for (Memento memento : mementos) memento.revert();
+
+    testSupport.throwOnCompletionFailure();
+  }
+
+  @Test
+  public void whenNoPreexistingDomains_createEmptyDomainPresenceInfoMap() throws Exception {
+    createCannedListDomainResponses();
+
+    testSupport.runStep(Main.readExistingResources("operator", NS));
+
+    assertThat(Main.getDomainPresenceInfos(), is(anEmptyMap()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test
-  @Ignore
-  public void watchPresenceWithNoPreexistingData_doesNothing() throws Exception {
+  private void createCannedListDomainResponses() {
+    testSupport.createCannedResponse("listDomain").withNamespace(NS).returning(expectedDomains);
+    testSupport.createCannedResponse("listIngress").withNamespace(NS).returning(expectedIngresses);
+    testSupport.createCannedResponse("listService").withNamespace(NS).returning(expectedServices);
+    testSupport.createCannedResponse("listEvent").withNamespace(NS).returning(expectedEvents);
+    testSupport.createCannedResponse("listPod").withNamespace(NS).returning(expectedPods);
     testSupport
-        .createCannedResponse("listDomain")
-        .withNamespace("default")
-        .returning(new DomainList());
+        .createCannedResponse("readConfigMap")
+        .withNamespace(NS)
+        .withName(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
+        .returning(expectedDomainConfigMap);
     testSupport
-        .createCannedResponse("listIngress")
-        .withNamespace("default")
-        .returning(new V1beta1IngressList());
-    testSupport
-        .createCannedResponse("listService")
-        .withNamespace("default")
-        .returning(new V1ServiceList());
-    testSupport
-        .createCannedResponse("listEvent")
-        .withNamespace("default")
-        .returning(new V1EventList());
-    testSupport.createCannedResponse("listPod").withNamespace("default").returning(new V1PodList());
-    Main.begin();
+        .createCannedResponse("replaceConfigMap")
+        .withNamespace(NS)
+        .withName(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
+        .returning(expectedDomainConfigMap);
   }
 
   @Test
@@ -90,6 +142,15 @@ public class DomainPresenceTest {
   }
 
   abstract static class SynchronousCallFactoryStub implements SynchronousCallFactory {
+
+    static Memento install() throws NoSuchFieldException {
+      return StaticStubSupport.install(CallBuilder.class, "CALL_FACTORY", create());
+    }
+
+    private static SynchronousCallFactoryStub create() {
+      return createStub(SynchronousCallFactoryStub.class);
+    }
+
     @Override
     public VersionInfo getVersionCode(ApiClient client) throws ApiException {
       return new VersionInfo().major("1").minor("8");
@@ -133,5 +194,29 @@ public class DomainPresenceTest {
         ApiClient client, V1SelfSubjectRulesReview body, String pretty) throws ApiException {
       return new V1SelfSubjectRulesReview().status(new V1SubjectRulesReviewStatus());
     }
+  }
+
+  static class ClientFactoryStub implements ClientFactory {
+
+    static Memento install() throws NoSuchFieldException {
+      return StaticStubSupport.install(ClientPool.class, "FACTORY", new ClientFactoryStub());
+    }
+
+    @Override
+    public ApiClient get() {
+      return new ApiClient();
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    for (int i = 0; i < 1000; i++) runTest();
+  }
+
+  private static void runTest() throws Exception {
+    DomainPresenceTest test = new DomainPresenceTest();
+    test.setUp();
+    test.whenNoPreexistingDomains_createEmptyDomainPresenceInfoMap();
+    test.tearDown();
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainWatcherTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.hasEntry;
 
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.util.Watch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.watcher.WatchListener;
@@ -42,13 +41,7 @@ public class DomainWatcherTest extends WatcherTestBase implements WatchListener<
   }
 
   @Override
-  protected DomainWatcher createWatcher(
-      String nameSpace, AtomicBoolean stopping, int initialResourceVersion) {
-    return DomainWatcher.create(
-        Executors.defaultThreadFactory(),
-        nameSpace,
-        Integer.toString(initialResourceVersion),
-        this,
-        stopping);
+  protected DomainWatcher createWatcher(String ns, AtomicBoolean stopping, int rv) {
+    return DomainWatcher.create(this, ns, Integer.toString(rv), this, stopping);
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/IngressWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/IngressWatcherTest.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableMap;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1beta1Ingress;
 import io.kubernetes.client.util.Watch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.watcher.WatchListener;
@@ -89,13 +88,7 @@ public class IngressWatcherTest extends WatcherTestBase implements WatchListener
   }
 
   @Override
-  protected IngressWatcher createWatcher(
-      String nameSpace, AtomicBoolean stopping, int initialResourceVersion) {
-    return IngressWatcher.create(
-        Executors.defaultThreadFactory(),
-        nameSpace,
-        Integer.toString(initialResourceVersion),
-        this,
-        stopping);
+  protected IngressWatcher createWatcher(String ns, AtomicBoolean stopping, int rv) {
+    return IngressWatcher.create(this, ns, Integer.toString(rv), this, stopping);
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.operator;
 
+import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static org.hamcrest.Matchers.both;
@@ -55,11 +56,7 @@ public class PodWatcherTest extends WatcherTestBase implements WatchListener<V1P
     assertThat(
         StubWatchFactory.getRecordedParameters().get(0),
         both(hasEntry("resourceVersion", Integer.toString(INITIAL_RESOURCE_VERSION)))
-            .and(
-                hasEntry(
-                    "labelSelector",
-                    asList(
-                        LabelConstants.DOMAINUID_LABEL, LabelConstants.CREATEDBYOPERATOR_LABEL))));
+            .and(hasEntry("labelSelector", asList(DOMAINUID_LABEL, CREATEDBYOPERATOR_LABEL))));
   }
 
   private String asList(String... selectors) {
@@ -73,10 +70,8 @@ public class PodWatcherTest extends WatcherTestBase implements WatchListener<V1P
   }
 
   @Override
-  protected PodWatcher createWatcher(
-      String nameSpace, AtomicBoolean stopping, int initialResourceVersion) {
-    return PodWatcher.create(
-        this, nameSpace, Integer.toString(initialResourceVersion), this, stopping);
+  protected PodWatcher createWatcher(String ns, AtomicBoolean stopping, int rv) {
+    return PodWatcher.create(this, ns, Integer.toString(rv), this, stopping);
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/ServiceWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ServiceWatcherTest.java
@@ -5,6 +5,7 @@
 package oracle.kubernetes.operator;
 
 import static oracle.kubernetes.operator.LabelConstants.CHANNELNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static org.hamcrest.Matchers.both;
@@ -17,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.util.Watch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.watcher.WatchListener;
@@ -34,18 +34,13 @@ public class ServiceWatcherTest extends WatcherTestBase implements WatchListener
   }
 
   @Test
-  public void initialRequest_specifiesStartingResourceVersionAndStandardLabelSelector()
-      throws Exception {
+  public void initialRequest_specifiesStartingResourceVersionAndLabelSelector() throws Exception {
     sendInitialRequest(INITIAL_RESOURCE_VERSION);
 
     assertThat(
         StubWatchFactory.getRecordedParameters().get(0),
         both(hasEntry("resourceVersion", Integer.toString(INITIAL_RESOURCE_VERSION)))
-            .and(
-                hasEntry(
-                    "labelSelector",
-                    asList(
-                        LabelConstants.DOMAINUID_LABEL, LabelConstants.CREATEDBYOPERATOR_LABEL))));
+            .and(hasEntry("labelSelector", asList(DOMAINUID_LABEL, CREATEDBYOPERATOR_LABEL))));
   }
 
   private String asList(String... selectors) {
@@ -59,14 +54,8 @@ public class ServiceWatcherTest extends WatcherTestBase implements WatchListener
   }
 
   @Override
-  protected ServiceWatcher createWatcher(
-      String nameSpace, AtomicBoolean stopping, int initialResourceVersion) {
-    return ServiceWatcher.create(
-        Executors.defaultThreadFactory(),
-        nameSpace,
-        Integer.toString(initialResourceVersion),
-        this,
-        stopping);
+  protected ServiceWatcher createWatcher(String ns, AtomicBoolean stopping, int rv) {
+    return ServiceWatcher.create(this, ns, Integer.toString(rv), this, stopping);
   }
 
   @Test


### PR DESCRIPTION
The issue was that Main.begin was running the steps in a fiber on a separate thread, so that there was race conditions on when the async requests were made. This change isolates the step construction from running them, allowing the test to run them on a synchronous test fiber.

It also restructures setting up the steps to make it clearer what is going on.