### PR TITLE
Issue 271

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -90,7 +90,6 @@ public class DomainPresenceTest {
   @Before
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger());
-    mementos.add(StubWatchFactory.install());
     mementos.add(testSupport.installRequestStepFactory());
     mementos.add(SynchronousCallFactoryStub.install());
     mementos.add(ClientFactoryStub.install());

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.helpers.CallBuilder;
@@ -51,6 +52,8 @@ public class DomainPresenceTest {
   private final V1EventList expectedEvents = createEmptyEventList();
   private final V1PodList expectedPods = createEmptyPodList();
   private final V1ConfigMap expectedDomainConfigMap = createEmptyConfigMap();
+
+  private AtomicBoolean stopping;
 
   private DomainList createEmptyDomainList() {
     return new DomainList().withMetadata(createListMetadata());
@@ -89,6 +92,8 @@ public class DomainPresenceTest {
 
   @Before
   public void setUp() throws Exception {
+    stopping = getStoppingVariable();
+
     mementos.add(TestUtils.silenceOperatorLogger());
     mementos.add(testSupport.installRequestStepFactory());
     mementos.add(SynchronousCallFactoryStub.install());
@@ -96,8 +101,15 @@ public class DomainPresenceTest {
     mementos.add(StubWatchFactory.install());
   }
 
+  private AtomicBoolean getStoppingVariable() throws NoSuchFieldException {
+    Memento stoppingMemento = StaticStubSupport.preserve(Main.class, "stopping");
+    return stoppingMemento.getOriginalValue();
+  }
+
   @After
   public void tearDown() throws Exception {
+    stopping.set(true);
+
     for (Memento memento : mementos) memento.revert();
 
     testSupport.throwOnCompletionFailure();


### PR DESCRIPTION
The problem turns out to have been in DomainPresenceTest. When it runs the steps from Main which read in k8s artifacts, those steps start watchers. The StubWatcherFactory is installed, so they can run with canned data; however, when the test ends, it refers the WatcherFactory but fails to stop the watchers.

The new change stops the watchers by capturing the Main.stopping AtomicBoolean, and also removes a superfluous installation of the StubWatcherFactory.

The unit tests now pass in Jenkins http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator/lastBuild/

Given the additional threads running in later tests, it is very possible that this aggravated various race conditions. 