### PR TITLE
Start unit testing to prepare for domain presence refactoring

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -89,7 +89,7 @@ public class DomainStatusUpdater {
       DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
       return doNext(
           ServerStatusReader.createDomainStatusReaderStep(
-              info, timeoutSeconds, new StatusUpdateStep(next)),
+              info, timeoutSeconds, new StatusUpdateStep(getNext())),
           packet);
     }
   }
@@ -306,7 +306,7 @@ public class DomainStatusUpdater {
       LOGGER.exiting();
 
       return madeChange == true
-          ? doDomainUpdate(dom, info, packet, StatusUpdateStep.this, next)
+          ? doDomainUpdate(dom, info, packet, StatusUpdateStep.this, getNext())
           : doNext(packet);
     }
   }
@@ -446,7 +446,7 @@ public class DomainStatusUpdater {
       LOGGER.exiting();
 
       return madeChange == true
-          ? doDomainUpdate(dom, info, packet, ProgressingStep.this, next)
+          ? doDomainUpdate(dom, info, packet, ProgressingStep.this, getNext())
           : doNext(packet);
     }
   }
@@ -514,7 +514,7 @@ public class DomainStatusUpdater {
       LOGGER.exiting();
 
       return madeChange == true
-          ? doDomainUpdate(dom, info, packet, EndProgressingStep.this, next)
+          ? doDomainUpdate(dom, info, packet, EndProgressingStep.this, getNext())
           : doNext(packet);
     }
   }
@@ -630,7 +630,7 @@ public class DomainStatusUpdater {
       LOGGER.info(MessageKeys.DOMAIN_STATUS, dom.getSpec().getDomainUID(), status);
       LOGGER.exiting();
       return madeChange == true
-          ? doDomainUpdate(dom, info, packet, AvailableStep.this, next)
+          ? doDomainUpdate(dom, info, packet, AvailableStep.this, getNext())
           : doNext(packet);
     }
   }
@@ -792,7 +792,7 @@ public class DomainStatusUpdater {
       LOGGER.exiting();
 
       return madeChange == true
-          ? doDomainUpdate(dom, info, packet, FailedStep.this, next)
+          ? doDomainUpdate(dom, info, packet, FailedStep.this, getNext())
           : doNext(packet);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -151,6 +151,10 @@ public class Main {
     return Collections.unmodifiableMap(domains);
   }
 
+  static ServerKubernetesObjects getKubernetesObjects(String serverLegalName) {
+    return skoFactory.lookup(serverLegalName);
+  }
+
   /**
    * Entry point
    *
@@ -238,14 +242,7 @@ public class Main {
         runSteps(readExistingResources(namespace, ns));
       }
 
-      // delete stranded resources
-      for (Map.Entry<String, DomainPresenceInfo> entry : domains.entrySet()) {
-        String domainUID = entry.getKey();
-        DomainPresenceInfo info = entry.getValue();
-        if (info != null && info.getDomain() == null) {
-          deleteDomainPresence(info.getNamespace(), domainUID);
-        }
-      }
+      deleteStrandedResources();
 
       // start periodic retry and recheck
       int recheckInterval = tuningAndConfig.getMainTuning().domainPresenceRecheckIntervalSeconds;
@@ -260,6 +257,16 @@ public class Main {
       LOGGER.warning(MessageKeys.EXCEPTION, e);
     } finally {
       LOGGER.info(MessageKeys.OPERATOR_SHUTTING_DOWN);
+    }
+  }
+
+  private static void deleteStrandedResources() {
+    for (Map.Entry<String, DomainPresenceInfo> entry : domains.entrySet()) {
+      String domainUID = entry.getKey();
+      DomainPresenceInfo info = entry.getValue();
+      if (info != null && info.getDomain() == null) {
+        deleteDomainPresence(info.getNamespace(), domainUID);
+      }
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -79,7 +79,7 @@ public class ServerStatusReader {
       if (startDetails.isEmpty()) {
         return doNext(packet);
       }
-      return doForkJoin(next, packet, startDetails);
+      return doForkJoin(getNext(), packet, startDetails);
     }
   }
 
@@ -193,7 +193,7 @@ public class ServerStatusReader {
 
       if (WebLogicConstants.STATES_SUPPORTING_REST.contains(state)) {
         packet.put(ProcessingConstants.SERVER_NAME, serverName);
-        return doNext(WlsRetriever.readHealthStep(next), packet);
+        return doNext(WlsRetriever.readHealthStep(getNext()), packet);
       }
 
       return doNext(packet);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -90,23 +90,6 @@ public class CallBuilder {
     return this;
   }
 
-  /**
-   * Converts value to nearest DNS-1123 legal name, which can be used as a Kubernetes identifier
-   *
-   * @param value Input value
-   * @return nearest DNS-1123 legal name
-   */
-  public static String toDNS1123LegalName(String value) {
-    if (value != null) {
-      value = value.toLowerCase();
-
-      // replace '_'
-      value = value.replace('_', '-');
-    }
-
-    return value;
-  }
-
   /* Version */
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -75,7 +75,7 @@ public class ConfigMapHelper {
               .readConfigMapAsync(
                   cm.getMetadata().getName(),
                   domainNamespace,
-                  new ResponseStep<V1ConfigMap>(next) {
+                  new ResponseStep<V1ConfigMap>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -101,7 +101,7 @@ public class ConfigMapHelper {
                                 .createConfigMapAsync(
                                     domainNamespace,
                                     cm,
-                                    new ResponseStep<V1ConfigMap>(next) {
+                                    new ResponseStep<V1ConfigMap>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -148,7 +148,7 @@ public class ConfigMapHelper {
                                     cm.getMetadata().getName(),
                                     domainNamespace,
                                     cm,
-                                    new ResponseStep<V1ConfigMap>(next) {
+                                    new ResponseStep<V1ConfigMap>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -251,6 +251,21 @@ public class DomainPresenceInfo {
     this.serverStartupInfo.set(serverStartupInfo);
   }
 
+  @Override
+  public String toString() {
+    StringBuilder sb =
+        new StringBuilder(
+            String.format(
+                "DomainPresenceInfo{uid=%s, namespace=%s",
+                getDomain().getSpec().getDomainUID(), getDomain().getMetadata().getNamespace()));
+    if (!ingresses.isEmpty()) {
+      sb.append(", ingresses ").append(String.join(",", ingresses.keySet()));
+    }
+    sb.append("}");
+
+    return sb.toString();
+  }
+
   /** Details about a specific managed server that will be started up */
   public static class ServerStartupInfo {
     public final WlsServerConfig serverConfig;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/IngressHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/IngressHelper.java
@@ -62,10 +62,9 @@ public class IngressHelper {
         String weblogicDomainUID = spec.getDomainUID();
         String weblogicDomainName = spec.getDomainName();
 
-        String serviceName =
-            CallBuilder.toDNS1123LegalName(weblogicDomainUID + "-cluster-" + clusterName);
+        String serviceName = LegalNames.toClusterServiceName(weblogicDomainUID, clusterName);
 
-        String ingressName = CallBuilder.toDNS1123LegalName(weblogicDomainUID + "-" + clusterName);
+        String ingressName = LegalNames.toIngressName(weblogicDomainUID, clusterName);
 
         V1beta1Ingress v1beta1Ingress = new V1beta1Ingress();
         v1beta1Ingress.setApiVersion(KubernetesConstants.EXTENSIONS_API_VERSION);
@@ -114,7 +113,7 @@ public class IngressHelper {
                 .readIngressAsync(
                     ingressName,
                     meta.getNamespace(),
-                    new ResponseStep<V1beta1Ingress>(next) {
+                    new ResponseStep<V1beta1Ingress>(getNext()) {
                       @Override
                       public NextAction onFailure(
                           Packet packet,
@@ -141,7 +140,7 @@ public class IngressHelper {
                                   .createIngressAsync(
                                       meta.getNamespace(),
                                       v1beta1Ingress,
-                                      new ResponseStep<V1beta1Ingress>(next) {
+                                      new ResponseStep<V1beta1Ingress>(getNext()) {
                                         @Override
                                         public NextAction onFailure(
                                             Packet packet,
@@ -182,7 +181,7 @@ public class IngressHelper {
                                       ingressName,
                                       meta.getNamespace(),
                                       v1beta1Ingress,
-                                      new ResponseStep<V1beta1Ingress>(next) {
+                                      new ResponseStep<V1beta1Ingress>(getNext()) {
                                         @Override
                                         public NextAction onFailure(
                                             Packet packet,

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -1,0 +1,50 @@
+// Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
+
+/** A class to create DNS-1123 legal names for Kubernetes objects. */
+public class LegalNames {
+
+  private static final String INGRESS_PATTERN = "%s-%s";
+  private static final String SERVER_PATTERN = "%s-%s";
+  private static final String CLUSTER_SERVICE_PATTERN = "%s-cluster-%s";
+  private static final String NAP_PATTERN = "%s-%s-extchannel-%s";
+
+  static String toIngressName(String domainUID, String clusterName) {
+    return toDNS1123LegalName(String.format(INGRESS_PATTERN, domainUID, clusterName));
+  }
+
+  public static String toServerServiceName(String domainUID, String serverName) {
+    return toServerName(domainUID, serverName);
+  }
+
+  public static String toServerName(String domainUID, String serverName) {
+    return toDNS1123LegalName(String.format(SERVER_PATTERN, domainUID, serverName));
+  }
+
+  static String toPodName(String domainUID, String serverName) {
+    return toServerName(domainUID, serverName);
+  }
+
+  static String toClusterServiceName(String domainUID, String clusterName) {
+    return toDNS1123LegalName(String.format(CLUSTER_SERVICE_PATTERN, domainUID, clusterName));
+  }
+
+  static String toNAPName(String domainUID, String serverName, NetworkAccessPoint nap) {
+    return toDNS1123LegalName(String.format(NAP_PATTERN, domainUID, serverName, nap.getName()));
+  }
+
+  /**
+   * Converts value to nearest DNS-1123 legal name, which can be used as a Kubernetes identifier
+   *
+   * @param value Input value
+   * @return nearest DNS-1123 legal name
+   */
+  private static String toDNS1123LegalName(String value) {
+    return value.toLowerCase().replace('_', '-');
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -104,7 +104,7 @@ public class PodHelper {
               .readPodAsync(
                   podName,
                   namespace,
-                  new ResponseStep<V1Pod>(next) {
+                  new ResponseStep<V1Pod>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -132,7 +132,7 @@ public class PodHelper {
                                 .createPodAsync(
                                     namespace,
                                     adminPod,
-                                    new ResponseStep<V1Pod>(next) {
+                                    new ResponseStep<V1Pod>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -184,7 +184,7 @@ public class PodHelper {
                                 asName,
                                 info,
                                 sko,
-                                next);
+                                getNext());
                         return doNext(replace, packet);
                       }
                     }
@@ -206,7 +206,7 @@ public class PodHelper {
       String weblogicDomainName = spec.getDomainName();
 
       // Create local admin server Pod object
-      String podName = CallBuilder.toDNS1123LegalName(weblogicDomainUID + "-" + spec.getAsName());
+      String podName = LegalNames.toPodName(weblogicDomainUID, spec.getAsName());
 
       String imageName = spec.getImage();
       if (imageName == null || imageName.length() == 0) {
@@ -416,7 +416,7 @@ public class PodHelper {
                   podName,
                   namespace,
                   deleteOptions,
-                  new ResponseStep<V1Status>(next) {
+                  new ResponseStep<V1Status>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -445,7 +445,7 @@ public class PodHelper {
                               .createPodAsync(
                                   namespace,
                                   newPod,
-                                  new ResponseStep<V1Pod>(next) {
+                                  new ResponseStep<V1Pod>(getNext()) {
                                     @Override
                                     public NextAction onFailure(
                                         Packet packet,
@@ -469,7 +469,7 @@ public class PodHelper {
                                       }
 
                                       PodWatcher pw = packet.getSPI(PodWatcher.class);
-                                      return doNext(pw.waitForReady(result, next), packet);
+                                      return doNext(pw.waitForReady(result, getNext()), packet);
                                     }
                                   });
                       return doNext(create, packet);
@@ -600,7 +600,7 @@ public class PodHelper {
               .readPodAsync(
                   podName,
                   namespace,
-                  new ResponseStep<V1Pod>(next) {
+                  new ResponseStep<V1Pod>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -627,7 +627,7 @@ public class PodHelper {
                                 .createPodAsync(
                                     namespace,
                                     pod,
-                                    new ResponseStep<V1Pod>(next) {
+                                    new ResponseStep<V1Pod>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -685,7 +685,7 @@ public class PodHelper {
                                 weblogicServerName,
                                 info,
                                 sko,
-                                next);
+                                getNext());
                         synchronized (packet) {
                           @SuppressWarnings("unchecked")
                           Map<String, StepAndPacket> rolling =
@@ -731,7 +731,7 @@ public class PodHelper {
       String weblogicServerName = scan.getName();
 
       // Create local managed server Pod object
-      String podName = CallBuilder.toDNS1123LegalName(weblogicDomainUID + "-" + weblogicServerName);
+      String podName = LegalNames.toPodName(weblogicDomainUID, weblogicServerName);
 
       String weblogicClusterName = null;
       if (cluster != null) weblogicClusterName = cluster.getClusterName();
@@ -955,7 +955,7 @@ public class PodHelper {
                     oldPod.getMetadata().getName(),
                     namespace,
                     deleteOptions,
-                    new ResponseStep<V1Status>(next) {
+                    new ResponseStep<V1Status>(getNext()) {
                       @Override
                       public NextAction onFailure(
                           Packet packet,
@@ -974,7 +974,7 @@ public class PodHelper {
                           V1Status result,
                           int statusCode,
                           Map<String, List<String>> responseHeaders) {
-                        return doNext(next, packet);
+                        return doNext(getNext(), packet);
                       }
                     }),
             packet);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
@@ -131,7 +131,7 @@ public class RollingHelper {
       }
 
       if (!work.isEmpty()) {
-        return doForkJoin(next, packet, work);
+        return doForkJoin(getNext(), packet, work);
       }
 
       return doNext(packet);
@@ -149,7 +149,7 @@ public class RollingHelper {
 
     @Override
     public NextAction apply(Packet packet) {
-      return doForkJoin(next, packet, serversThatCanRestartNow);
+      return doForkJoin(getNext(), packet, serversThatCanRestartNow);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
@@ -124,7 +124,7 @@ public class SecretHelper {
               .readSecretAsync(
                   secretName,
                   namespace,
-                  new ResponseStep<V1Secret>(next) {
+                  new ResponseStep<V1Secret>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsFactory.java
@@ -7,13 +7,14 @@ package oracle.kubernetes.operator.helpers;
 import java.util.concurrent.ConcurrentMap;
 
 public class ServerKubernetesObjectsFactory {
+  /** A map of server names to server kubernetes objects. */
   private final ConcurrentMap<String, ServerKubernetesObjects> serverMap;
 
   public ServerKubernetesObjectsFactory(ConcurrentMap<String, ServerKubernetesObjects> serverMap) {
     this.serverMap = serverMap;
   }
 
-  public ServerKubernetesObjects getOrCreate(DomainPresenceInfo info, String serverName) {
+  ServerKubernetesObjects getOrCreate(DomainPresenceInfo info, String serverName) {
     return getOrCreate(info, info.getDomain().getSpec().getDomainUID(), serverName);
   }
 
@@ -22,14 +23,13 @@ public class ServerKubernetesObjectsFactory {
     ServerKubernetesObjects created = new ServerKubernetesObjects();
     ServerKubernetesObjects current = info.getServers().putIfAbsent(serverName, created);
     if (current == null) {
-      String podName = CallBuilder.toDNS1123LegalName(domainUID + "-" + serverName);
-      serverMap.put(podName, created);
+      serverMap.put(LegalNames.toServerName(domainUID, serverName), created);
       return created;
     }
     return current;
   }
 
-  public ServerKubernetesObjects lookup(String podName) {
-    return serverMap.get(podName);
+  public ServerKubernetesObjects lookup(String serverLegalName) {
+    return serverMap.get(serverLegalName);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -66,7 +66,7 @@ public class ServiceHelper {
       String weblogicDomainUID = spec.getDomainUID();
       String weblogicDomainName = spec.getDomainName();
 
-      String name = CallBuilder.toDNS1123LegalName(weblogicDomainUID + "-" + serverName);
+      String name = LegalNames.toServerServiceName(weblogicDomainUID, serverName);
 
       V1Service service = new V1Service();
 
@@ -119,7 +119,7 @@ public class ServiceHelper {
               .readServiceAsync(
                   name,
                   namespace,
-                  new ResponseStep<V1Service>(next) {
+                  new ResponseStep<V1Service>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -145,7 +145,7 @@ public class ServiceHelper {
                                 .createServiceAsync(
                                     namespace,
                                     service,
-                                    new ResponseStep<V1Service>(next) {
+                                    new ResponseStep<V1Service>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -204,7 +204,7 @@ public class ServiceHelper {
                                 weblogicDomainUID,
                                 serverName,
                                 sko,
-                                next);
+                                getNext());
                         return doNext(replace, packet);
                       }
                     }
@@ -252,7 +252,7 @@ public class ServiceHelper {
                 .deleteServiceAsync(
                     oldService.getMetadata().getName(),
                     namespace,
-                    new ResponseStep<V1Status>(next) {
+                    new ResponseStep<V1Status>(getNext()) {
                       @Override
                       public NextAction onFailure(
                           Packet packet,
@@ -271,7 +271,7 @@ public class ServiceHelper {
                           V1Status result,
                           int statusCode,
                           Map<String, List<String>> responseHeaders) {
-                        return doNext(next, packet);
+                        return doNext(getNext(), packet);
                       }
                     }),
             packet);
@@ -309,7 +309,7 @@ public class ServiceHelper {
       String weblogicDomainUID = spec.getDomainUID();
       String weblogicDomainName = spec.getDomainName();
 
-      String name = CallBuilder.toDNS1123LegalName(weblogicDomainUID + "-cluster-" + clusterName);
+      String name = LegalNames.toClusterServiceName(weblogicDomainUID, clusterName);
 
       V1Service service = new V1Service();
 
@@ -351,7 +351,7 @@ public class ServiceHelper {
               .readServiceAsync(
                   name,
                   namespace,
-                  new ResponseStep<V1Service>(next) {
+                  new ResponseStep<V1Service>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -377,7 +377,7 @@ public class ServiceHelper {
                                 .createServiceAsync(
                                     namespace,
                                     service,
-                                    new ResponseStep<V1Service>(next) {
+                                    new ResponseStep<V1Service>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -425,7 +425,7 @@ public class ServiceHelper {
                                 .deleteServiceAsync(
                                     name,
                                     namespace,
-                                    new ResponseStep<V1Status>(next) {
+                                    new ResponseStep<V1Status>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -456,7 +456,7 @@ public class ServiceHelper {
                                                 .createServiceAsync(
                                                     namespace,
                                                     service,
-                                                    new ResponseStep<V1Service>(next) {
+                                                    new ResponseStep<V1Service>(getNext()) {
                                                       @Override
                                                       public NextAction onFailure(
                                                           Packet packet,
@@ -615,7 +615,7 @@ public class ServiceHelper {
               .deleteServiceAsync(
                   serviceName,
                   namespace,
-                  new ResponseStep<V1Status>(next) {
+                  new ResponseStep<V1Status>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -640,7 +640,7 @@ public class ServiceHelper {
                               .createServiceAsync(
                                   namespace,
                                   newService,
-                                  new ResponseStep<V1Service>(next) {
+                                  new ResponseStep<V1Service>(getNext()) {
                                     @Override
                                     public NextAction onFailure(
                                         Packet packet,
@@ -710,9 +710,7 @@ public class ServiceHelper {
       String weblogicDomainUID = spec.getDomainUID();
       String weblogicDomainName = spec.getDomainName();
 
-      String name =
-          CallBuilder.toDNS1123LegalName(
-              weblogicDomainUID + "-" + serverName + "-extchannel-" + networkAccessPoint.getName());
+      String name = LegalNames.toNAPName(weblogicDomainUID, serverName, networkAccessPoint);
 
       V1Service service = new V1Service();
 
@@ -756,7 +754,7 @@ public class ServiceHelper {
               .readServiceAsync(
                   name,
                   namespace,
-                  new ResponseStep<V1Service>(next) {
+                  new ResponseStep<V1Service>(getNext()) {
                     @Override
                     public NextAction onFailure(
                         Packet packet,
@@ -783,7 +781,7 @@ public class ServiceHelper {
                                 .createServiceAsync(
                                     namespace,
                                     service,
-                                    new ResponseStep<V1Service>(next) {
+                                    new ResponseStep<V1Service>(getNext()) {
                                       @Override
                                       public NextAction onFailure(
                                           Packet packet,
@@ -844,7 +842,7 @@ public class ServiceHelper {
                                 serverName,
                                 sko,
                                 networkAccessPoint.getName(),
-                                next);
+                                getNext());
                         return doNext(replace, packet);
                       }
                     }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/HttpClient.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/HttpClient.java
@@ -173,7 +173,7 @@ public class HttpClient {
     public NextAction apply(Packet packet) {
       Step readSecret =
           SecretHelper.getSecretData(
-              SecretHelper.SecretType.AdminCredentials, adminSecretName, namespace, next);
+              SecretHelper.SecretType.AdminCredentials, adminSecretName, namespace, getNext());
       return doNext(readSecret, packet);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RestBackendImpl.java
@@ -27,8 +27,8 @@ import oracle.kubernetes.operator.helpers.AuthorizationProxy;
 import oracle.kubernetes.operator.helpers.AuthorizationProxy.Operation;
 import oracle.kubernetes.operator.helpers.AuthorizationProxy.Resource;
 import oracle.kubernetes.operator.helpers.AuthorizationProxy.Scope;
-import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.CallBuilderFactory;
+import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
@@ -40,6 +40,7 @@ import oracle.kubernetes.operator.work.ContainerResolver;
 import oracle.kubernetes.weblogic.domain.v1.ClusterStartup;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainList;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 
 /**
  * RestBackendImpl implements the backend of the WebLogic operator REST api by making calls to
@@ -213,7 +214,7 @@ public class RestBackendImpl implements RestBackend {
     // Domain UID
     Domain domain = findDomain(domainUID);
     String namespace = getNamespace(domainUID);
-    String adminServerServiceName = getAdminServerServiceName(domain);
+    String adminServerServiceName = getAdminServerServiceName(domain.getSpec());
     String adminSecretName = getAdminServiceSecretName(domain);
     Map<String, WlsClusterConfig> wlsClusterConfigs =
         getWLSConfiguredClusters(namespace, adminServerServiceName, adminSecretName);
@@ -222,10 +223,8 @@ public class RestBackendImpl implements RestBackend {
     return result;
   }
 
-  private static String getAdminServerServiceName(Domain domain) {
-    String adminServerServiceName =
-        domain.getSpec().getDomainUID() + "-" + domain.getSpec().getAsName();
-    return CallBuilder.toDNS1123LegalName(adminServerServiceName);
+  private static String getAdminServerServiceName(DomainSpec domainSpec) {
+    return LegalNames.toServerServiceName(domainSpec.getDomainUID(), domainSpec.getAsName());
   }
 
   /** {@inheritDoc} */
@@ -311,7 +310,7 @@ public class RestBackendImpl implements RestBackend {
       String namespace, Domain domain, String cluster, int managedServerCount) {
     // Query WebLogic Admin Server for current configured WebLogic Cluster size
     // and verify we have enough configured managed servers to auto-scale
-    String adminServerServiceName = getAdminServerServiceName(domain);
+    String adminServerServiceName = getAdminServerServiceName(domain.getSpec());
     String adminSecretName = getAdminServiceSecretName(domain);
     WlsClusterConfig wlsClusterConfig =
         getWlsClusterConfig(namespace, cluster, adminServerServiceName, adminSecretName);

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ClusterServicesStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ClusterServicesStep.java
@@ -52,6 +52,6 @@ public class ClusterServicesStep extends Step {
     if (startDetails.isEmpty()) {
       return doNext(packet);
     }
-    return doForkJoin(next, packet, startDetails);
+    return doForkJoin(getNext(), packet, startDetails);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/DeleteDomainStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/DeleteDomainStep.java
@@ -53,7 +53,7 @@ public class DeleteDomainStep extends Step {
                 })
             .deleteCollectionPodAsync(
                 namespace,
-                new ResponseStep<V1Status>(next) {
+                new ResponseStep<V1Status>(getNext()) {
                   @Override
                   public NextAction onFailure(
                       Packet packet,

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ExternalAdminChannelsStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ExternalAdminChannelsStep.java
@@ -34,7 +34,7 @@ public class ExternalAdminChannelsStep extends Step {
     Collection<NetworkAccessPoint> validChannels =
         adminChannelsToCreate(info.getScan(), info.getDomain());
     if (validChannels != null && !validChannels.isEmpty()) {
-      return doNext(new ExternalAdminChannelIteratorStep(info, validChannels, next), packet);
+      return doNext(new ExternalAdminChannelIteratorStep(info, validChannels, getNext()), packet);
     }
 
     return doNext(packet);

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ListPersistentVolumeClaimStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ListPersistentVolumeClaimStep.java
@@ -49,7 +49,7 @@ public class ListPersistentVolumeClaimStep extends Step {
                 })
             .listPersistentVolumeClaimAsync(
                 namespace,
-                new ResponseStep<V1PersistentVolumeClaimList>(next) {
+                new ResponseStep<V1PersistentVolumeClaimList>(getNext()) {
                   @Override
                   public NextAction onFailure(
                       Packet packet,

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpAfterStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpAfterStep.java
@@ -52,6 +52,6 @@ public class ManagedServerUpAfterStep extends Step {
       return doNext(packet);
     }
 
-    return doNext(RollingHelper.rollServers(rolling, next), packet);
+    return doNext(RollingHelper.rollServers(rolling, getNext()), packet);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -72,7 +72,7 @@ public class ManagedServerUpIteratorStep extends Step {
     if (startDetails.isEmpty()) {
       return doNext(packet);
     }
-    return doForkJoin(new ManagedServerUpAfterStep(next), packet, startDetails);
+    return doForkJoin(new ManagedServerUpAfterStep(getNext()), packet, startDetails);
   }
 
   // pre-conditions: DomainPresenceInfo SPI

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -210,7 +210,7 @@ public class ManagedServersUpStep extends Step {
             scaleDownIfNecessary(
                 info,
                 servers,
-                new ClusterServicesStep(info, new ManagedServerUpIteratorStep(ssic, next))),
+                new ClusterServicesStep(info, new ManagedServerUpIteratorStep(ssic, getNext()))),
             packet);
       case StartupControlConstants.ADMIN_STARTUPCONTROL:
       case StartupControlConstants.NONE_STARTUPCONTROL:
@@ -218,7 +218,7 @@ public class ManagedServersUpStep extends Step {
         info.setServerStartupInfo(null);
         LOGGER.exiting();
         return doNext(
-            scaleDownIfNecessary(info, servers, new ClusterServicesStep(info, next)), packet);
+            scaleDownIfNecessary(info, servers, new ClusterServicesStep(info, getNext())), packet);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownFinalizeStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownFinalizeStep.java
@@ -17,6 +17,6 @@ public class ServerDownFinalizeStep extends Step {
   public NextAction apply(Packet packet) {
     DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
     info.getServers().remove(serverName);
-    return doNext(next, packet);
+    return doNext(getNext(), packet);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
@@ -58,6 +58,6 @@ public class ServerDownIteratorStep extends Step {
     if (startDetails.isEmpty()) {
       return doNext(packet);
     }
-    return doForkJoin(next, packet, startDetails);
+    return doForkJoin(getNext(), packet, startDetails);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -26,7 +26,8 @@ public class ServerDownStep extends Step {
     return doNext(
         PodHelper.deletePodStep(
             sko,
-            ServiceHelper.deleteServiceStep(sko, new ServerDownFinalizeStep(serverName, next))),
+            ServiceHelper.deleteServiceStep(
+                sko, new ServerDownFinalizeStep(serverName, getNext()))),
         packet);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/WatchPodReadyAdminStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/WatchPodReadyAdminStep.java
@@ -32,6 +32,6 @@ public class WatchPodReadyAdminStep extends Step {
         .getComponents()
         .put(ProcessingConstants.PODWATCHER_COMPONENT_NAME, Component.createFor(pw));
 
-    return doNext(pw.waitForReady(adminPod, next), packet);
+    return doNext(pw.waitForReady(adminPod, getNext()), packet);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsRetriever.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsRetriever.java
@@ -160,7 +160,7 @@ public class WlsRetriever {
             HttpClient.createAuthenticatedClientForServer(
                 namespace,
                 adminSecretName,
-                new WithHttpClientStep(requestType, sko.getService().get(), next));
+                new WithHttpClientStep(requestType, sko.getService().get(), getNext()));
         packet.remove(RETRY_COUNT);
         return doNext(getClient, packet);
       } catch (Throwable t) {
@@ -290,7 +290,9 @@ public class WlsRetriever {
           if (!suggestedConfigUpdates.isEmpty()) {
             Step nextStep =
                 new WithHttpClientStep(
-                    requestType, service, next); // read WebLogic config again after config updates
+                    requestType,
+                    service,
+                    getNext()); // read WebLogic config again after config updates
             for (ConfigUpdate suggestedConfigUpdate : suggestedConfigUpdates) {
               nextStep = suggestedConfigUpdate.createStep(nextStep);
             }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceInfoMatcher.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceInfoMatcher.java
@@ -1,0 +1,85 @@
+// Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import javax.annotation.Nonnull;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+class DomainPresenceInfoMatcher extends TypeSafeDiagnosingMatcher<DomainPresenceInfo> {
+  private String expectedUID;
+  private String expectedNamespace;
+  private String ingressClusterName;
+
+  private DomainPresenceInfoMatcher(String expectedUID) {
+    this.expectedUID = expectedUID;
+  }
+
+  static DomainPresenceInfoMatcher domain(@Nonnull String expectedUID) {
+    return new DomainPresenceInfoMatcher(expectedUID);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  DomainPresenceInfoMatcher withNamespace(@Nonnull String expectedNamespace) {
+    this.expectedNamespace = expectedNamespace;
+    return this;
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  DomainPresenceInfoMatcher withIngressForCluster(@Nonnull String ingressClusterName) {
+    this.ingressClusterName = ingressClusterName;
+    return this;
+  }
+
+  @Override
+  protected boolean matchesSafely(DomainPresenceInfo item, Description mismatchDescription) {
+    if (!expectedUID.equals(getDomainUID(item))) {
+      return mismatchedUID(mismatchDescription, getDomainUID(item));
+    } else if (expectedNamespace != null && !expectedNamespace.equals(getNamespace(item))) {
+      return mismatchedNamespace(mismatchDescription, getNamespace(item));
+    } else if (ingressClusterName != null && !hasIngressForCluster(item, ingressClusterName)) {
+      return missingIngress(mismatchDescription, ingressClusterName);
+    }
+
+    return true;
+  }
+
+  private String getDomainUID(DomainPresenceInfo item) {
+    return item.getDomain().getSpec().getDomainUID();
+  }
+
+  private boolean mismatchedUID(Description description, String actualDomainUID) {
+    description.appendText("domain with UID ").appendValue(actualDomainUID);
+    return false;
+  }
+
+  private String getNamespace(DomainPresenceInfo item) {
+    return item.getDomain().getMetadata().getNamespace();
+  }
+
+  private boolean mismatchedNamespace(Description description, String actualNamespace) {
+    description.appendText("domain with namespace ").appendValue(actualNamespace);
+    return false;
+  }
+
+  private boolean hasIngressForCluster(DomainPresenceInfo item, String ingressClusterName) {
+    return item.getIngresses().containsKey(ingressClusterName);
+  }
+
+  private boolean missingIngress(Description description, String ingressClusterName) {
+    description.appendText("domain with ingress for cluster ").appendValue(ingressClusterName);
+    return false;
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description
+        .appendText("domain with UID ")
+        .appendValue(expectedUID)
+        .appendText(" and namespace ")
+        .appendValue(expectedNamespace);
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -5,53 +5,65 @@
 package oracle.kubernetes.operator;
 
 import static com.meterware.simplestub.Stub.createStub;
+import static oracle.kubernetes.operator.DomainPresenceInfoMatcher.domain;
+import static oracle.kubernetes.operator.KubernetesConstants.DOMAIN_CONFIG_MAP_NAME;
+import static oracle.kubernetes.operator.LabelConstants.CHANNELNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.ApiClient;
-import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1EventList;
 import io.kubernetes.client.models.V1ListMeta;
 import io.kubernetes.client.models.V1ObjectMeta;
-import io.kubernetes.client.models.V1PersistentVolumeList;
 import io.kubernetes.client.models.V1PodList;
-import io.kubernetes.client.models.V1SelfSubjectRulesReview;
+import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServiceList;
-import io.kubernetes.client.models.V1SubjectRulesReviewStatus;
+import io.kubernetes.client.models.V1beta1Ingress;
 import io.kubernetes.client.models.V1beta1IngressList;
-import io.kubernetes.client.models.VersionInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
-import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.ClientFactory;
 import oracle.kubernetes.operator.helpers.ClientPool;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
-import oracle.kubernetes.operator.helpers.SynchronousCallFactory;
+import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.work.AsyncCallTestSupport;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainList;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@SuppressWarnings("SameParameterValue")
 public class DomainPresenceTest {
 
   private static final String NS = "default";
-  private final DomainList expectedDomains = createEmptyDomainList();
-  private final V1beta1IngressList expectedIngresses = createEmptyIngressList();
-  private final V1ServiceList expectedServices = createEmptyServiceList();
-  private final V1EventList expectedEvents = createEmptyEventList();
-  private final V1PodList expectedPods = createEmptyPodList();
-  private final V1ConfigMap expectedDomainConfigMap = createEmptyConfigMap();
+  private final DomainList domains = createEmptyDomainList();
+  private final V1beta1IngressList ingresses = createEmptyIngressList();
+  private final V1ServiceList services = createEmptyServiceList();
+  private final V1EventList events = createEmptyEventList();
+  private final V1PodList pods = createEmptyPodList();
+  private final V1ConfigMap domainConfigMap = createEmptyConfigMap();
 
   private AtomicBoolean stopping;
 
@@ -92,13 +104,13 @@ public class DomainPresenceTest {
 
   @Before
   public void setUp() throws Exception {
-    stopping = getStoppingVariable();
-
     mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(StaticStubSupport.install(Main.class, "domains", new ConcurrentHashMap<>()));
     mementos.add(testSupport.installRequestStepFactory());
-    mementos.add(SynchronousCallFactoryStub.install());
     mementos.add(ClientFactoryStub.install());
     mementos.add(StubWatchFactory.install());
+
+    stopping = getStoppingVariable();
   }
 
   private AtomicBoolean getStoppingVariable() throws NoSuchFieldException {
@@ -117,30 +129,126 @@ public class DomainPresenceTest {
 
   @Test
   public void whenNoPreexistingDomains_createEmptyDomainPresenceInfoMap() throws Exception {
-    createCannedListDomainResponses();
-
-    testSupport.runStep(Main.readExistingResources("operator", NS));
+    readExistingResources();
 
     assertThat(Main.getDomainPresenceInfos(), is(anEmptyMap()));
   }
 
+  private void readExistingResources() {
+    createCannedListDomainResponses();
+    testSupport.runSteps(Main.readExistingResources("operator", NS));
+  }
+
+  @Test
+  public void whenK8sHasOneDomainWithAssociatedIngress_readIt() throws Exception {
+    addDomainResource("UID1", "ns1");
+    addIngressResource("UID1", "cluster1");
+
+    readExistingResources();
+
+    assertThat(
+        Main.getDomainPresenceInfos(),
+        hasValue(domain("UID1").withNamespace("ns1").withIngressForCluster("cluster1")));
+  }
+
+  private void addDomainResource(String uid, String namespace) {
+    domains.getItems().add(createDomain(uid, namespace));
+  }
+
+  private Domain createDomain(String uid, String namespace) {
+    return new Domain()
+        .withSpec(new DomainSpec().withDomainUID(uid))
+        .withMetadata(new V1ObjectMeta().namespace(namespace));
+  }
+
+  private void addIngressResource(String uid, String clusterName) {
+    ingresses.getItems().add(createIngress(uid, clusterName));
+  }
+
+  private V1beta1Ingress createIngress(String uid, String clusterName) {
+    return new V1beta1Ingress().metadata(createIngressMetaData(uid, clusterName));
+  }
+
+  private V1ObjectMeta createIngressMetaData(String uid, String clusterName) {
+    return new V1ObjectMeta()
+        .labels(createMap(DOMAINUID_LABEL, uid, CLUSTERNAME_LABEL, clusterName));
+  }
+
+  private Map<String, String> createMap(String key1, String value1, String key2, String value2) {
+    Map<String, String> map = new HashMap<>();
+    map.put(key1, value1);
+    map.put(key2, value2);
+    return map;
+  }
+
+  @Test
+  public void whenK8sHasOneDomainWithChannelService_createSkoEntry() throws Exception {
+    addDomainResource("UID1", "ns1");
+    V1Service serviceResource = addServiceResource("UID1", "admin", "channel1");
+
+    readExistingResources();
+
+    assertThat(
+        Main.getKubernetesObjects(LegalNames.toServerName("UID1", "admin")).getChannels(),
+        hasEntry(equalTo("channel1"), sameInstance(serviceResource)));
+  }
+
+  private V1Service addServiceResource(String uid, String serverName, String channelName) {
+    V1Service service = createService(uid, serverName, channelName);
+    services.getItems().add(service);
+    return service;
+  }
+
+  private V1Service createService(String uid, String serverName, String channelName) {
+    V1ObjectMeta metadata = createServiceMetadata(uid, serverName);
+    metadata.putLabelsItem(CHANNELNAME_LABEL, channelName);
+    return new V1Service().metadata(metadata);
+  }
+
+  private V1ObjectMeta createServiceMetadata(String uid, String serverName) {
+    return new V1ObjectMeta().labels(createMap(DOMAINUID_LABEL, uid, SERVERNAME_LABEL, serverName));
+  }
+
+  @Test
+  @Ignore("running into a problem with the map")
+  public void whenK8sHasOneDomainWithoutChannelService_createSkoEntry() throws Exception {
+    addDomainResource("UID1", "ns1");
+    V1Service serviceResource = addServiceResource("UID1", "admin");
+
+    readExistingResources();
+
+    assertThat(
+        Main.getKubernetesObjects(LegalNames.toServerName("UID1", "admin")).getService(),
+        equalTo(serviceResource));
+  }
+
+  private V1Service addServiceResource(String uid, String serverName) {
+    V1Service service = createService(uid, serverName);
+    services.getItems().add(service);
+    return service;
+  }
+
+  private V1Service createService(String uid, String serverName) {
+    return new V1Service().metadata(createServiceMetadata(uid, serverName));
+  }
+
   @SuppressWarnings("unchecked")
   private void createCannedListDomainResponses() {
-    testSupport.createCannedResponse("listDomain").withNamespace(NS).returning(expectedDomains);
-    testSupport.createCannedResponse("listIngress").withNamespace(NS).returning(expectedIngresses);
-    testSupport.createCannedResponse("listService").withNamespace(NS).returning(expectedServices);
-    testSupport.createCannedResponse("listEvent").withNamespace(NS).returning(expectedEvents);
-    testSupport.createCannedResponse("listPod").withNamespace(NS).returning(expectedPods);
+    testSupport.createCannedResponse("listDomain").withNamespace(NS).returning(domains);
+    testSupport.createCannedResponse("listIngress").withNamespace(NS).returning(ingresses);
+    testSupport.createCannedResponse("listService").withNamespace(NS).returning(services);
+    testSupport.createCannedResponse("listEvent").withNamespace(NS).returning(events);
+    testSupport.createCannedResponse("listPod").withNamespace(NS).returning(pods);
     testSupport
         .createCannedResponse("readConfigMap")
         .withNamespace(NS)
-        .withName(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
-        .returning(expectedDomainConfigMap);
+        .withName(DOMAIN_CONFIG_MAP_NAME)
+        .returning(domainConfigMap);
     testSupport
         .createCannedResponse("replaceConfigMap")
         .withNamespace(NS)
-        .withName(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
-        .returning(expectedDomainConfigMap);
+        .withName(DOMAIN_CONFIG_MAP_NAME)
+        .returning(domainConfigMap);
   }
 
   @Test
@@ -151,61 +259,6 @@ public class DomainPresenceTest {
     DomainPresenceControl.cancelDomainStatusUpdating(info);
 
     assertThat(info.getStatusUpdater().get(), nullValue());
-  }
-
-  abstract static class SynchronousCallFactoryStub implements SynchronousCallFactory {
-
-    static Memento install() throws NoSuchFieldException {
-      return StaticStubSupport.install(CallBuilder.class, "CALL_FACTORY", create());
-    }
-
-    private static SynchronousCallFactoryStub create() {
-      return createStub(SynchronousCallFactoryStub.class);
-    }
-
-    @Override
-    public VersionInfo getVersionCode(ApiClient client) throws ApiException {
-      return new VersionInfo().major("1").minor("8");
-    }
-
-    @Override
-    public DomainList getDomainList(
-        ApiClient client,
-        String namespace,
-        String pretty,
-        String _continue,
-        String fieldSelector,
-        Boolean includeUninitialized,
-        String labelSelector,
-        Integer limit,
-        String resourceVersion,
-        Integer timeoutSeconds,
-        Boolean watch)
-        throws ApiException {
-      return new DomainList();
-    }
-
-    @Override
-    public V1PersistentVolumeList listPersistentVolumes(
-        ApiClient client,
-        String pretty,
-        String _continue,
-        String fieldSelector,
-        Boolean includeUninitialized,
-        String labelSelector,
-        Integer limit,
-        String resourceVersion,
-        Integer timeoutSeconds,
-        Boolean watch)
-        throws ApiException {
-      return new V1PersistentVolumeList();
-    }
-
-    @Override
-    public V1SelfSubjectRulesReview createSelfSubjectRulesReview(
-        ApiClient client, V1SelfSubjectRulesReview body, String pretty) throws ApiException {
-      return new V1SelfSubjectRulesReview().status(new V1SubjectRulesReviewStatus());
-    }
   }
 
   static class ClientFactoryStub implements ClientFactory {

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
@@ -59,7 +59,7 @@ public class AsyncRequestStepTest {
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger());
 
-    testSupport.runStep(asyncRequestStep);
+    testSupport.runSteps(asyncRequestStep);
   }
 
   @After

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
@@ -47,11 +47,10 @@ public class IngressHelperTest {
   private final Integer server1Port = 8001;
   private final String server2Name = "server2";
   private final Integer server2Port = 8002;
-  private final String service1Name = CallBuilder.toDNS1123LegalName(domainUID + "-" + server1Name);
-  private final String service2Name = CallBuilder.toDNS1123LegalName(domainUID + "-" + server2Name);
-  private final String ingressName = CallBuilder.toDNS1123LegalName(domainUID + "-" + clusterName);
-  private final String clusterServiceName =
-      CallBuilder.toDNS1123LegalName(domainUID + "-cluster-" + clusterName);
+  private final String service1Name = LegalNames.toServerServiceName(domainUID, server1Name);
+  private final String service2Name = LegalNames.toServerServiceName(domainUID, server2Name);
+  private final String ingressName = LegalNames.toIngressName(domainUID, clusterName);
+  private final String clusterServiceName = LegalNames.toClusterServiceName(domainUID, clusterName);
 
   private DomainPresenceInfo info;
   private Engine engine;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/LegalNamesTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/LegalNamesTest.java
@@ -1,0 +1,48 @@
+// Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import static oracle.kubernetes.operator.helpers.LegalNames.toClusterServiceName;
+import static oracle.kubernetes.operator.helpers.LegalNames.toIngressName;
+import static oracle.kubernetes.operator.helpers.LegalNames.toNAPName;
+import static oracle.kubernetes.operator.helpers.LegalNames.toServerServiceName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
+import org.junit.Test;
+
+public class LegalNamesTest {
+  @Test
+  public void namecreateValidIngressNames() throws Exception {
+    assertThat(toIngressName("abc", "cls1"), equalTo("abc-cls1"));
+    assertThat(toIngressName("Abc", "cLs1"), equalTo("abc-cls1"));
+    assertThat(toIngressName("Abc", "cls_1"), equalTo("abc-cls-1"));
+  }
+
+  @Test
+  public void createValidServerServiceNames() throws Exception {
+    assertThat(toServerServiceName("abc", "cls1"), equalTo("abc-cls1"));
+    assertThat(toServerServiceName("Abc", "cLs1"), equalTo("abc-cls1"));
+    assertThat(toServerServiceName("Abc", "cls_1"), equalTo("abc-cls-1"));
+  }
+
+  @Test
+  public void createValidClusterServiceNames() throws Exception {
+    assertThat(toClusterServiceName("abc", "cls1"), equalTo("abc-cluster-cls1"));
+    assertThat(toClusterServiceName("Abc", "cLs1"), equalTo("abc-cluster-cls1"));
+    assertThat(toClusterServiceName("Abc", "cls_1"), equalTo("abc-cluster-cls-1"));
+  }
+
+  @Test
+  public void createValidNAPNames() throws Exception {
+    NetworkAccessPoint nap1 = new NetworkAccessPoint("nap1", "http", 17000, 7001);
+    assertThat(toNAPName("abc", "cls1", nap1), equalTo("abc-cls1-extchannel-nap1"));
+    assertThat(toNAPName("Abc", "cLs1", nap1), equalTo("abc-cls1-extchannel-nap1"));
+
+    NetworkAccessPoint nap2 = new NetworkAccessPoint("nap-2", "http", 17000, 7001);
+    assertThat(toNAPName("Abc", "cls_1", nap2), equalTo("abc-cls-1-extchannel-nap-2"));
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/DeleteIngressListStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/DeleteIngressListStepTest.java
@@ -44,7 +44,7 @@ public class DeleteIngressListStepTest {
 
   private void runDeleteStep(V1beta1Ingress... ingresses) {
     this.ingresses.addAll(Arrays.asList(ingresses));
-    testSupport.runStep(new DeleteIngressListStep(this.ingresses, terminalStep));
+    testSupport.runSteps(new DeleteIngressListStep(this.ingresses, terminalStep));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
@@ -3,7 +3,6 @@ package oracle.kubernetes.operator.work;
 import static com.meterware.simplestub.Stub.createStrictStub;
 import static com.meterware.simplestub.Stub.createStub;
 
-import io.kubernetes.client.ApiException;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Iterator;
@@ -76,8 +75,9 @@ public class FiberTestSupport {
    *
    * @param step the first step to run
    */
-  public void runStep(Step step) {
+  public Packet runSteps(Step step) {
     fiber.start(step, packet, completionCallback);
+    return packet;
   }
 
   /**
@@ -87,7 +87,7 @@ public class FiberTestSupport {
    *
    * @param throwableClass the class of the excepted throwable
    */
-  public void verifyCompletionThrowable(Class<ApiException> throwableClass) {
+  public void verifyCompletionThrowable(Class<? extends Throwable> throwableClass) {
     completionCallback.verifyThrowable(throwableClass);
   }
 
@@ -189,17 +189,13 @@ public class FiberTestSupport {
   }
 
   static class CompletionCallbackStub implements Fiber.CompletionCallback {
-    private Packet packet;
     private Throwable throwable;
 
     @Override
-    public void onCompletion(Packet packet) {
-      this.packet = packet;
-    }
+    public void onCompletion(Packet packet) {}
 
     @Override
     public void onThrowable(Packet packet, Throwable throwable) {
-      this.packet = packet;
       this.throwable = throwable;
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/work/StepChainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/StepChainTest.java
@@ -1,0 +1,81 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.work;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.meterware.simplestub.Memento;
+import java.util.ArrayList;
+import java.util.List;
+import oracle.kubernetes.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StepChainTest {
+  private FiberTestSupport testSupport = new FiberTestSupport();
+
+  private List<Memento> mementos = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+    mementos.add(TestUtils.silenceOperatorLogger());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    for (Memento memento : mementos) {
+      memento.revert();
+    }
+    testSupport.throwOnCompletionFailure();
+  }
+
+  @Test
+  public void afterChainingGroupsOfSteps_fiberRunsThemInOrder() throws Exception {
+    Step group1 = new NamedStep("one", new NamedStep("two"));
+    Step group2 = new NamedStep("three", new NamedStep("four", new NamedStep("five")));
+    Step group3 = new NamedStep("six");
+
+    Step chain = Step.chain(group1, group2, group3);
+
+    Packet packet = testSupport.runSteps(chain);
+
+    assertThat(NamedStep.getNames(packet), contains("one", "two", "three", "four", "five", "six"));
+  }
+
+  private static class NamedStep extends Step {
+    private static final String NAMES = "names";
+    private String name;
+
+    NamedStep(String name) {
+      this(name, null);
+    }
+
+    NamedStep(String name, Step next) {
+      super(next);
+      this.name = name;
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      getStepNames(packet).add(name);
+      return doNext(packet);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getStepNames(Packet packet) {
+      if (!packet.containsKey(NAMES)) {
+        packet.put(NAMES, new ArrayList<String>());
+      }
+      return (List<String>) packet.get(NAMES);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> getNames(Packet p) {
+      return (List<String>) p.get(NAMES);
+    }
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/work/StepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/StepTest.java
@@ -8,10 +8,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
@@ -65,7 +67,7 @@ public class StepTest {
 
   @Test
   public void test() throws InterruptedException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
     Packet p = new Packet();
 
     Semaphore signal = new Semaphore(0);
@@ -109,9 +111,31 @@ public class StepTest {
     assertTrue(throwables.isEmpty());
   }
 
+  /**
+   * Simplifies creation of stepline. Steps will be connected following the list ordering of their
+   * classes
+   *
+   * @param steps List of step classes
+   * @return Head step
+   */
+  private static Step createStepline(List<Class<? extends Step>> steps) {
+    try {
+      Step s = null;
+      ListIterator<Class<? extends Step>> it = steps.listIterator(steps.size());
+      while (it.hasPrevious()) {
+        Class<? extends Step> c = it.previous();
+        Constructor<? extends Step> construct = c.getConstructor(Step.class);
+        s = construct.newInstance(s);
+      }
+      return s;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Test
   public void testRetry() throws InterruptedException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
     Packet p = new Packet();
 
     Map<Class<? extends BaseStep>, Command> commandMap = new HashMap<>();
@@ -165,7 +189,7 @@ public class StepTest {
 
   @Test
   public void testThrow() throws InterruptedException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
     Packet p = new Packet();
 
     Map<Class<? extends BaseStep>, Command> commandMap = new HashMap<>();
@@ -215,7 +239,7 @@ public class StepTest {
 
   @Test
   public void testSuspendAndThrow() throws InterruptedException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
     Packet p = new Packet();
 
     Map<Class<? extends BaseStep>, Command> commandMap = new HashMap<>();
@@ -267,7 +291,7 @@ public class StepTest {
 
   @Test
   public void testMany() throws InterruptedException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
 
     List<Semaphore> sems = new ArrayList<>();
     List<List<Step>> calls = new ArrayList<>();
@@ -330,7 +354,7 @@ public class StepTest {
 
   @Test
   public void testFuture() throws InterruptedException, ExecutionException, TimeoutException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
     Packet p = new Packet();
 
     List<Step> called = new ArrayList<>();
@@ -372,7 +396,7 @@ public class StepTest {
 
   @Test
   public void testCancel() throws InterruptedException {
-    Step stepline = Step.createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
+    Step stepline = createStepline(Arrays.asList(Step1.class, Step2.class, Step3.class));
     Packet p = new Packet();
 
     Map<Class<? extends BaseStep>, Command> commandMap = new HashMap<>();


### PR DESCRIPTION
Added unit tests for DomainPresence
Refactored legal name code to single class to indicate purpose
Added Step.chain to merge multiple step lists
 - note: making the next field non-final necessitated using a get accessor to limit updates
 - note: created a separate unit test for Step.chain in order to avoid thread usage. It may be possible to simplify some of the other unit Step unit tests to work the same way, but it wasn't immediately clear how. 