### PR TITLE
Keep server map in sync with domain presence info server maps

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -22,7 +22,7 @@ import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.CallBuilderFactory;
 import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.helpers.ServerKubernetesObjects;
-import oracle.kubernetes.operator.helpers.ServerKubernetesObjectsFactory;
+import oracle.kubernetes.operator.helpers.ServerKubernetesObjectsManager;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
@@ -93,8 +93,8 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod> {
         Boolean isReady = isReady(pod);
         String podName = pod.getMetadata().getName();
         Container c = ContainerResolver.getInstance().getContainer();
-        ServerKubernetesObjectsFactory skoFactory =
-            c != null ? c.getSPI(ServerKubernetesObjectsFactory.class) : null;
+        ServerKubernetesObjectsManager skoFactory =
+            c != null ? c.getSPI(ServerKubernetesObjectsManager.class) : null;
         ServerKubernetesObjects sko = skoFactory != null ? skoFactory.lookup(podName) : null;
         if (sko != null) {
           sko.getLastKnownStatus().set(isReady ? WebLogicConstants.RUNNING_STATE : null);

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -93,9 +93,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod> {
         Boolean isReady = isReady(pod);
         String podName = pod.getMetadata().getName();
         Container c = ContainerResolver.getInstance().getContainer();
-        ServerKubernetesObjectsManager skoFactory =
-            c != null ? c.getSPI(ServerKubernetesObjectsManager.class) : null;
-        ServerKubernetesObjects sko = skoFactory != null ? skoFactory.lookup(podName) : null;
+        ServerKubernetesObjects sko = ServerKubernetesObjectsManager.lookup(podName);
         if (sko != null) {
           sko.getLastKnownStatus().set(isReady ? WebLogicConstants.RUNNING_STATE : null);
         }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -9,7 +9,9 @@ import io.kubernetes.client.models.V1PersistentVolumeClaimList;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1beta1Ingress;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -35,7 +37,8 @@ public class DomainPresenceInfo {
   private final AtomicReference<ScheduledFuture<?>> statusUpdater;
   private final AtomicReference<Collection<ServerStartupInfo>> serverStartupInfo;
 
-  private final ConcurrentMap<String, ServerKubernetesObjects> servers = new ConcurrentHashMap<>();
+  private final ServerKubernetesObjectsFactory skoFactory;
+  private final ConcurrentMap<String, ServerKubernetesObjects> servers = new ServerMap();
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, V1beta1Ingress> ingresses = new ConcurrentHashMap<>();
 
@@ -54,7 +57,8 @@ public class DomainPresenceInfo {
    *
    * @param domain Domain
    */
-  public DomainPresenceInfo(Domain domain) {
+  DomainPresenceInfo(ServerKubernetesObjectsFactory skoFactory, Domain domain) {
+    this.skoFactory = skoFactory;
     this.domain = new AtomicReference<>(domain);
     this.namespace = domain.getMetadata().getNamespace();
     this.serverStartupInfo = new AtomicReference<>(null);
@@ -66,7 +70,8 @@ public class DomainPresenceInfo {
    *
    * @param namespace Namespace
    */
-  public DomainPresenceInfo(String namespace) {
+  DomainPresenceInfo(ServerKubernetesObjectsFactory skoFactory, String namespace) {
+    this.skoFactory = skoFactory;
     this.domain = new AtomicReference<>(null);
     this.namespace = namespace;
     this.serverStartupInfo = new AtomicReference<>(null);
@@ -156,7 +161,12 @@ public class DomainPresenceInfo {
    * @param domain Domain
    */
   public void setDomain(Domain domain) {
-    this.domain.set(domain);
+    Domain old = this.domain.getAndSet(domain);
+    if (old == null) {
+      for (Map.Entry<String, ServerKubernetesObjects> entry : servers.entrySet()) {
+        skoFactory.register(domain.getSpec().getDomainUID(), entry.getKey(), entry.getValue());
+      }
+    }
   }
 
   /**
@@ -300,5 +310,139 @@ public class DomainPresenceInfo {
    */
   public AtomicReference<ScheduledFuture<?>> getStatusUpdater() {
     return statusUpdater;
+  }
+
+  private class ServerMap implements ConcurrentMap<String, ServerKubernetesObjects> {
+    private final ConcurrentMap<String, ServerKubernetesObjects> delegate =
+        new ConcurrentHashMap<>();
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+      return delegate.containsValue(value);
+    }
+
+    @Override
+    public ServerKubernetesObjects get(Object key) {
+      return delegate.get(key);
+    }
+
+    @Override
+    public ServerKubernetesObjects put(String key, ServerKubernetesObjects value) {
+      Domain d = domain.get();
+      if (d != null) {
+        skoFactory.register(d.getSpec().getDomainUID(), key, value);
+      }
+      return delegate.put(key, value);
+    }
+
+    @Override
+    public ServerKubernetesObjects remove(Object key) {
+      Domain d = domain.get();
+      if (d != null) {
+        skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+      }
+      return delegate.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends ServerKubernetesObjects> m) {
+      Domain d = domain.get();
+      if (d != null) {
+        for (Map.Entry<? extends String, ? extends ServerKubernetesObjects> entry : m.entrySet()) {
+          skoFactory.register(d.getSpec().getDomainUID(), entry.getKey(), entry.getValue());
+        }
+      }
+      delegate.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+      Domain d = domain.get();
+      if (d != null) {
+        for (Map.Entry<? extends String, ? extends ServerKubernetesObjects> entry : entrySet()) {
+          skoFactory.unregister(d.getSpec().getDomainUID(), entry.getKey());
+        }
+      }
+      delegate.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+      return Collections.unmodifiableSet(delegate.keySet());
+    }
+
+    @Override
+    public Collection<ServerKubernetesObjects> values() {
+      return Collections.unmodifiableCollection(delegate.values());
+    }
+
+    @Override
+    public Set<Entry<String, ServerKubernetesObjects>> entrySet() {
+      return Collections.unmodifiableSet(delegate.entrySet());
+    }
+
+    @Override
+    public ServerKubernetesObjects putIfAbsent(String key, ServerKubernetesObjects value) {
+      ServerKubernetesObjects result = delegate.putIfAbsent(key, value);
+      if (result == null) {
+        Domain d = domain.get();
+        if (d != null) {
+          skoFactory.register(d.getSpec().getDomainUID(), key, value);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+      boolean result = delegate.remove(key, value);
+      if (result) {
+        Domain d = domain.get();
+        if (d != null) {
+          skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public boolean replace(
+        String key, ServerKubernetesObjects oldValue, ServerKubernetesObjects newValue) {
+      boolean result = delegate.replace(key, oldValue, newValue);
+      if (result) {
+        Domain d = domain.get();
+        if (d != null) {
+          skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public ServerKubernetesObjects replace(String key, ServerKubernetesObjects value) {
+      ServerKubernetesObjects result = delegate.replace(key, value);
+      if (result == null) {
+        Domain d = domain.get();
+        if (d != null) {
+          skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+        }
+      }
+      return result;
+    }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -37,7 +37,6 @@ public class DomainPresenceInfo {
   private final AtomicReference<ScheduledFuture<?>> statusUpdater;
   private final AtomicReference<Collection<ServerStartupInfo>> serverStartupInfo;
 
-  private final ServerKubernetesObjectsFactory skoFactory;
   private final ConcurrentMap<String, ServerKubernetesObjects> servers = new ServerMap();
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, V1beta1Ingress> ingresses = new ConcurrentHashMap<>();
@@ -57,8 +56,7 @@ public class DomainPresenceInfo {
    *
    * @param domain Domain
    */
-  DomainPresenceInfo(ServerKubernetesObjectsFactory skoFactory, Domain domain) {
-    this.skoFactory = skoFactory;
+  DomainPresenceInfo(Domain domain) {
     this.domain = new AtomicReference<>(domain);
     this.namespace = domain.getMetadata().getNamespace();
     this.serverStartupInfo = new AtomicReference<>(null);
@@ -70,8 +68,7 @@ public class DomainPresenceInfo {
    *
    * @param namespace Namespace
    */
-  DomainPresenceInfo(ServerKubernetesObjectsFactory skoFactory, String namespace) {
-    this.skoFactory = skoFactory;
+  DomainPresenceInfo(String namespace) {
     this.domain = new AtomicReference<>(null);
     this.namespace = namespace;
     this.serverStartupInfo = new AtomicReference<>(null);
@@ -164,7 +161,8 @@ public class DomainPresenceInfo {
     Domain old = this.domain.getAndSet(domain);
     if (old == null) {
       for (Map.Entry<String, ServerKubernetesObjects> entry : servers.entrySet()) {
-        skoFactory.register(domain.getSpec().getDomainUID(), entry.getKey(), entry.getValue());
+        ServerKubernetesObjectsManager.register(
+            domain.getSpec().getDomainUID(), entry.getKey(), entry.getValue());
       }
     }
   }
@@ -345,7 +343,7 @@ public class DomainPresenceInfo {
     public ServerKubernetesObjects put(String key, ServerKubernetesObjects value) {
       Domain d = domain.get();
       if (d != null) {
-        skoFactory.register(d.getSpec().getDomainUID(), key, value);
+        ServerKubernetesObjectsManager.register(d.getSpec().getDomainUID(), key, value);
       }
       return delegate.put(key, value);
     }
@@ -354,7 +352,7 @@ public class DomainPresenceInfo {
     public ServerKubernetesObjects remove(Object key) {
       Domain d = domain.get();
       if (d != null) {
-        skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+        ServerKubernetesObjectsManager.unregister(d.getSpec().getDomainUID(), (String) key);
       }
       return delegate.remove(key);
     }
@@ -364,7 +362,8 @@ public class DomainPresenceInfo {
       Domain d = domain.get();
       if (d != null) {
         for (Map.Entry<? extends String, ? extends ServerKubernetesObjects> entry : m.entrySet()) {
-          skoFactory.register(d.getSpec().getDomainUID(), entry.getKey(), entry.getValue());
+          ServerKubernetesObjectsManager.register(
+              d.getSpec().getDomainUID(), entry.getKey(), entry.getValue());
         }
       }
       delegate.putAll(m);
@@ -375,7 +374,7 @@ public class DomainPresenceInfo {
       Domain d = domain.get();
       if (d != null) {
         for (Map.Entry<? extends String, ? extends ServerKubernetesObjects> entry : entrySet()) {
-          skoFactory.unregister(d.getSpec().getDomainUID(), entry.getKey());
+          ServerKubernetesObjectsManager.unregister(d.getSpec().getDomainUID(), entry.getKey());
         }
       }
       delegate.clear();
@@ -402,7 +401,7 @@ public class DomainPresenceInfo {
       if (result == null) {
         Domain d = domain.get();
         if (d != null) {
-          skoFactory.register(d.getSpec().getDomainUID(), key, value);
+          ServerKubernetesObjectsManager.register(d.getSpec().getDomainUID(), key, value);
         }
       }
       return result;
@@ -414,7 +413,7 @@ public class DomainPresenceInfo {
       if (result) {
         Domain d = domain.get();
         if (d != null) {
-          skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+          ServerKubernetesObjectsManager.unregister(d.getSpec().getDomainUID(), (String) key);
         }
       }
       return result;
@@ -427,7 +426,7 @@ public class DomainPresenceInfo {
       if (result) {
         Domain d = domain.get();
         if (d != null) {
-          skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+          ServerKubernetesObjectsManager.unregister(d.getSpec().getDomainUID(), (String) key);
         }
       }
       return result;
@@ -439,7 +438,7 @@ public class DomainPresenceInfo {
       if (result == null) {
         Domain d = domain.get();
         if (d != null) {
-          skoFactory.unregister(d.getSpec().getDomainUID(), (String) key);
+          ServerKubernetesObjectsManager.unregister(d.getSpec().getDomainUID(), (String) key);
         }
       }
       return result;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoFactory.java
@@ -1,0 +1,52 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+
+public class DomainPresenceInfoFactory {
+  private static final DomainPresenceInfoFactory SINGELTON = new DomainPresenceInfoFactory();
+
+  public static DomainPresenceInfoFactory getInstance() {
+    return SINGELTON;
+  }
+
+  /** A map of domainUID to DomainPresenceInfo */
+  private static final ConcurrentMap<String, DomainPresenceInfo> domains =
+      new ConcurrentHashMap<>();
+
+  public DomainPresenceInfoFactory() {}
+
+  public DomainPresenceInfo getOrCreate(String ns, String domainUID) {
+    DomainPresenceInfo createdInfo =
+        new DomainPresenceInfo(ServerKubernetesObjectsFactory.getInstance(), ns);
+    DomainPresenceInfo existingInfo = domains.putIfAbsent(domainUID, createdInfo);
+    return existingInfo != null ? existingInfo : createdInfo;
+  }
+
+  public DomainPresenceInfo getOrCreate(Domain domain) {
+    DomainPresenceInfo createdInfo =
+        new DomainPresenceInfo(ServerKubernetesObjectsFactory.getInstance(), domain);
+    DomainPresenceInfo existingInfo =
+        domains.putIfAbsent(domain.getSpec().getDomainUID(), createdInfo);
+    return existingInfo != null ? existingInfo : createdInfo;
+  }
+
+  public DomainPresenceInfo lookup(String domainUID) {
+    return domains.get(domainUID);
+  }
+
+  public DomainPresenceInfo remove(String domainUID) {
+    return domains.remove(domainUID);
+  }
+
+  public Map<String, DomainPresenceInfo> getDomainPresenceInfos() {
+    return Collections.unmodifiableMap(domains);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoManager.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoManager.java
@@ -10,43 +10,35 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 
-public class DomainPresenceInfoFactory {
-  private static final DomainPresenceInfoFactory SINGELTON = new DomainPresenceInfoFactory();
-
-  public static DomainPresenceInfoFactory getInstance() {
-    return SINGELTON;
-  }
-
+public class DomainPresenceInfoManager {
   /** A map of domainUID to DomainPresenceInfo */
   private static final ConcurrentMap<String, DomainPresenceInfo> domains =
       new ConcurrentHashMap<>();
 
-  public DomainPresenceInfoFactory() {}
+  private DomainPresenceInfoManager() {}
 
-  public DomainPresenceInfo getOrCreate(String ns, String domainUID) {
-    DomainPresenceInfo createdInfo =
-        new DomainPresenceInfo(ServerKubernetesObjectsFactory.getInstance(), ns);
+  public static DomainPresenceInfo getOrCreate(String ns, String domainUID) {
+    DomainPresenceInfo createdInfo = new DomainPresenceInfo(ns);
     DomainPresenceInfo existingInfo = domains.putIfAbsent(domainUID, createdInfo);
     return existingInfo != null ? existingInfo : createdInfo;
   }
 
-  public DomainPresenceInfo getOrCreate(Domain domain) {
-    DomainPresenceInfo createdInfo =
-        new DomainPresenceInfo(ServerKubernetesObjectsFactory.getInstance(), domain);
+  public static DomainPresenceInfo getOrCreate(Domain domain) {
+    DomainPresenceInfo createdInfo = new DomainPresenceInfo(domain);
     DomainPresenceInfo existingInfo =
         domains.putIfAbsent(domain.getSpec().getDomainUID(), createdInfo);
     return existingInfo != null ? existingInfo : createdInfo;
   }
 
-  public DomainPresenceInfo lookup(String domainUID) {
+  public static DomainPresenceInfo lookup(String domainUID) {
     return domains.get(domainUID);
   }
 
-  public DomainPresenceInfo remove(String domainUID) {
+  public static DomainPresenceInfo remove(String domainUID) {
     return domains.remove(domainUID);
   }
 
-  public Map<String, DomainPresenceInfo> getDomainPresenceInfos() {
+  public static Map<String, DomainPresenceInfo> getDomainPresenceInfos() {
     return Collections.unmodifiableMap(domains);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -76,7 +76,6 @@ public class PodHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
       TuningParameters configMapHelper = c.getSPI(TuningParameters.class);
 
       // Compute the desired pod configuration for the admin server
@@ -95,7 +94,7 @@ public class PodHelper {
       boolean isExplicitRestartThisServer =
           info.getExplicitRestartAdmin().get() || info.getExplicitRestartServers().contains(asName);
 
-      ServerKubernetesObjects sko = skoFactory.getOrCreate(info, asName);
+      ServerKubernetesObjects sko = ServerKubernetesObjectsManager.getOrCreate(info, asName);
 
       // First, verify existing Pod
       Step read =
@@ -569,7 +568,6 @@ public class PodHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
       TuningParameters configMapHelper = c.getSPI(TuningParameters.class);
 
       // Compute the desired pod configuration for the managed server
@@ -591,7 +589,8 @@ public class PodHelper {
               || (weblogicClusterName != null
                   && info.getExplicitRestartClusters().contains(weblogicClusterName));
 
-      ServerKubernetesObjects sko = skoFactory.getOrCreate(info, weblogicServerName);
+      ServerKubernetesObjects sko =
+          ServerKubernetesObjectsManager.getOrCreate(info, weblogicServerName);
 
       // First, verify there existing Pod
       Step read =

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -76,7 +76,7 @@ public class PodHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsFactory skoFactory = c.getSPI(ServerKubernetesObjectsFactory.class);
+      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
       TuningParameters configMapHelper = c.getSPI(TuningParameters.class);
 
       // Compute the desired pod configuration for the admin server
@@ -569,7 +569,7 @@ public class PodHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsFactory skoFactory = c.getSPI(ServerKubernetesObjectsFactory.class);
+      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
       TuningParameters configMapHelper = c.getSPI(TuningParameters.class);
 
       // Compute the desired pod configuration for the managed server

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsFactory.java
@@ -4,15 +4,22 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import java.util.concurrent.ConcurrentMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ServerKubernetesObjectsFactory {
-  /** A map of server names to server kubernetes objects. */
-  private final ConcurrentMap<String, ServerKubernetesObjects> serverMap;
+  private static final ServerKubernetesObjectsFactory SINGLETON =
+      new ServerKubernetesObjectsFactory();
 
-  public ServerKubernetesObjectsFactory(ConcurrentMap<String, ServerKubernetesObjects> serverMap) {
-    this.serverMap = serverMap;
+  public static ServerKubernetesObjectsFactory getInstance() {
+    return SINGLETON;
   }
+
+  /** A map of pod names to ServerKubernetesObjects */
+  private static final Map<String, ServerKubernetesObjects> serverMap = new ConcurrentHashMap<>();
+
+  ServerKubernetesObjectsFactory() {}
 
   ServerKubernetesObjects getOrCreate(DomainPresenceInfo info, String serverName) {
     return getOrCreate(info, info.getDomain().getSpec().getDomainUID(), serverName);
@@ -22,14 +29,22 @@ public class ServerKubernetesObjectsFactory {
       DomainPresenceInfo info, String domainUID, String serverName) {
     ServerKubernetesObjects created = new ServerKubernetesObjects();
     ServerKubernetesObjects current = info.getServers().putIfAbsent(serverName, created);
-    if (current == null) {
-      serverMap.put(LegalNames.toServerName(domainUID, serverName), created);
-      return created;
-    }
-    return current;
+    return (current == null) ? created : current;
   }
 
   public ServerKubernetesObjects lookup(String serverLegalName) {
     return serverMap.get(serverLegalName);
+  }
+
+  void register(String domainUID, String serverName, ServerKubernetesObjects sko) {
+    serverMap.put(LegalNames.toServerName(domainUID, serverName), sko);
+  }
+
+  void unregister(String domainUID, String serverName) {
+    serverMap.remove(LegalNames.toServerName(domainUID, serverName));
+  }
+
+  Map<String, ServerKubernetesObjects> getServerKubernetesObjects() {
+    return Collections.unmodifiableMap(serverMap);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsManager.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsManager.java
@@ -8,43 +8,36 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class ServerKubernetesObjectsFactory {
-  private static final ServerKubernetesObjectsFactory SINGLETON =
-      new ServerKubernetesObjectsFactory();
-
-  public static ServerKubernetesObjectsFactory getInstance() {
-    return SINGLETON;
-  }
-
+public class ServerKubernetesObjectsManager {
   /** A map of pod names to ServerKubernetesObjects */
   private static final Map<String, ServerKubernetesObjects> serverMap = new ConcurrentHashMap<>();
 
-  ServerKubernetesObjectsFactory() {}
+  private ServerKubernetesObjectsManager() {}
 
-  ServerKubernetesObjects getOrCreate(DomainPresenceInfo info, String serverName) {
+  static ServerKubernetesObjects getOrCreate(DomainPresenceInfo info, String serverName) {
     return getOrCreate(info, info.getDomain().getSpec().getDomainUID(), serverName);
   }
 
-  public ServerKubernetesObjects getOrCreate(
+  public static ServerKubernetesObjects getOrCreate(
       DomainPresenceInfo info, String domainUID, String serverName) {
     ServerKubernetesObjects created = new ServerKubernetesObjects();
     ServerKubernetesObjects current = info.getServers().putIfAbsent(serverName, created);
     return (current == null) ? created : current;
   }
 
-  public ServerKubernetesObjects lookup(String serverLegalName) {
+  public static ServerKubernetesObjects lookup(String serverLegalName) {
     return serverMap.get(serverLegalName);
   }
 
-  void register(String domainUID, String serverName, ServerKubernetesObjects sko) {
+  static void register(String domainUID, String serverName, ServerKubernetesObjects sko) {
     serverMap.put(LegalNames.toServerName(domainUID, serverName), sko);
   }
 
-  void unregister(String domainUID, String serverName) {
+  static void unregister(String domainUID, String serverName) {
     serverMap.remove(LegalNames.toServerName(domainUID, serverName));
   }
 
-  Map<String, ServerKubernetesObjects> getServerKubernetesObjects() {
+  static Map<String, ServerKubernetesObjects> getServerKubernetesObjects() {
     return Collections.unmodifiableMap(serverMap);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -50,7 +50,7 @@ public class ServiceHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsFactory skoFactory = c.getSPI(ServerKubernetesObjectsFactory.class);
+      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
 
       DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
       KubernetesVersion version = packet.getSPI(KubernetesVersion.class);
@@ -695,7 +695,7 @@ public class ServiceHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsFactory skoFactory = c.getSPI(ServerKubernetesObjectsFactory.class);
+      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
 
       DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
       String serverName = (String) packet.get(ProcessingConstants.SERVER_NAME);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -50,7 +50,6 @@ public class ServiceHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
 
       DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
       KubernetesVersion version = packet.getSPI(KubernetesVersion.class);
@@ -110,7 +109,7 @@ public class ServiceHelper {
 
       // Verify if Kubernetes api server has a matching Service
       // Create or replace, if necessary
-      ServerKubernetesObjects sko = skoFactory.getOrCreate(info, serverName);
+      ServerKubernetesObjects sko = ServerKubernetesObjectsManager.getOrCreate(info, serverName);
 
       // First, verify existing Service
       Step read =
@@ -695,7 +694,6 @@ public class ServiceHelper {
     public NextAction apply(Packet packet) {
       Container c = ContainerResolver.getInstance().getContainer();
       CallBuilderFactory factory = c.getSPI(CallBuilderFactory.class);
-      ServerKubernetesObjectsManager skoFactory = c.getSPI(ServerKubernetesObjectsManager.class);
 
       DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
       String serverName = (String) packet.get(ProcessingConstants.SERVER_NAME);
@@ -745,7 +743,7 @@ public class ServiceHelper {
 
       // Verify if Kubernetes api server has a matching Service
       // Create or replace, if necessary
-      ServerKubernetesObjects sko = skoFactory.getOrCreate(info, serverName);
+      ServerKubernetesObjects sko = ServerKubernetesObjectsManager.getOrCreate(info, serverName);
 
       // First, verify existing Service
       Step read =

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -44,7 +44,9 @@ import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.helpers.ClientFactory;
 import oracle.kubernetes.operator.helpers.ClientPool;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfoFactory;
 import oracle.kubernetes.operator.helpers.LegalNames;
+import oracle.kubernetes.operator.helpers.ServerKubernetesObjectsFactory;
 import oracle.kubernetes.operator.work.AsyncCallTestSupport;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainList;
@@ -105,7 +107,12 @@ public class DomainPresenceTest {
   @Before
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger());
-    mementos.add(StaticStubSupport.install(Main.class, "domains", new ConcurrentHashMap<>()));
+    mementos.add(
+        StaticStubSupport.install(
+            DomainPresenceInfoFactory.class, "domains", new ConcurrentHashMap<>()));
+    mementos.add(
+        StaticStubSupport.install(
+            ServerKubernetesObjectsFactory.class, "serverMap", new ConcurrentHashMap<>()));
     mementos.add(testSupport.installRequestStepFactory());
     mementos.add(ClientFactoryStub.install());
     mementos.add(StubWatchFactory.install());
@@ -253,7 +260,8 @@ public class DomainPresenceTest {
 
   @Test
   public void afterCancelDomainStatusUpdating_statusUpdaterIsNull() throws Exception {
-    DomainPresenceInfo info = new DomainPresenceInfo("namespace");
+    DomainPresenceInfo info =
+        DomainPresenceInfoFactory.getInstance().getOrCreate("namespace", "domainUID");
     info.getStatusUpdater().getAndSet(createStub(ScheduledFuture.class));
 
     DomainPresenceControl.cancelDomainStatusUpdating(info);

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -44,9 +44,9 @@ import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.helpers.ClientFactory;
 import oracle.kubernetes.operator.helpers.ClientPool;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
-import oracle.kubernetes.operator.helpers.DomainPresenceInfoFactory;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfoManager;
 import oracle.kubernetes.operator.helpers.LegalNames;
-import oracle.kubernetes.operator.helpers.ServerKubernetesObjectsFactory;
+import oracle.kubernetes.operator.helpers.ServerKubernetesObjectsManager;
 import oracle.kubernetes.operator.work.AsyncCallTestSupport;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainList;
@@ -109,10 +109,10 @@ public class DomainPresenceTest {
     mementos.add(TestUtils.silenceOperatorLogger());
     mementos.add(
         StaticStubSupport.install(
-            DomainPresenceInfoFactory.class, "domains", new ConcurrentHashMap<>()));
+            DomainPresenceInfoManager.class, "domains", new ConcurrentHashMap<>()));
     mementos.add(
         StaticStubSupport.install(
-            ServerKubernetesObjectsFactory.class, "serverMap", new ConcurrentHashMap<>()));
+            ServerKubernetesObjectsManager.class, "serverMap", new ConcurrentHashMap<>()));
     mementos.add(testSupport.installRequestStepFactory());
     mementos.add(ClientFactoryStub.install());
     mementos.add(StubWatchFactory.install());
@@ -260,8 +260,7 @@ public class DomainPresenceTest {
 
   @Test
   public void afterCancelDomainStatusUpdating_statusUpdaterIsNull() throws Exception {
-    DomainPresenceInfo info =
-        DomainPresenceInfoFactory.getInstance().getOrCreate("namespace", "domainUID");
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate("namespace", "domainUID");
     info.getStatusUpdater().getAndSet(createStub(ScheduledFuture.class));
 
     DomainPresenceControl.cancelDomainStatusUpdating(info);

--- a/operator/src/test/java/oracle/kubernetes/operator/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ServiceHelperTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.CallBuilderFactory;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfoFactory;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Engine;
@@ -84,7 +85,7 @@ public class ServiceHelperTest {
     Step s = ServiceHelper.createForServerStep(null);
     Engine e = new Engine("ServiceHelperTest");
     Packet p = new Packet();
-    DomainPresenceInfo info = new DomainPresenceInfo(dom);
+    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(dom);
     p.getComponents().put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(info));
     p.put(ProcessingConstants.SERVER_NAME, "admin");
     p.put(ProcessingConstants.PORT, Integer.valueOf(7001));

--- a/operator/src/test/java/oracle/kubernetes/operator/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ServiceHelperTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.CallBuilderFactory;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
-import oracle.kubernetes.operator.helpers.DomainPresenceInfoFactory;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfoManager;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Engine;
@@ -85,7 +85,7 @@ public class ServiceHelperTest {
     Step s = ServiceHelper.createForServerStep(null);
     Engine e = new Engine("ServiceHelperTest");
     Packet p = new Packet();
-    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(dom);
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(dom);
     p.getComponents().put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(info));
     p.put(ProcessingConstants.SERVER_NAME, "admin");
     p.put(ProcessingConstants.PORT, Integer.valueOf(7001));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
@@ -72,7 +72,7 @@ public class IngressHelperTest {
     spec.setDomainUID(domainUID);
     domain.setSpec(spec);
 
-    info = new DomainPresenceInfo(domain);
+    info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
 
     // Create scan
     WlsDomainConfig scan = new WlsDomainConfig(null);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
@@ -72,7 +72,7 @@ public class IngressHelperTest {
     spec.setDomainUID(domainUID);
     domain.setSpec(spec);
 
-    info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
+    info = DomainPresenceInfoManager.getOrCreate(domain);
 
     // Create scan
     WlsDomainConfig scan = new WlsDomainConfig(null);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperConfigTest.java
@@ -11,13 +11,17 @@ import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.*;
 import static oracle.kubernetes.operator.utils.YamlUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.models.V1PersistentVolumeClaimList;
 import io.kubernetes.client.models.V1Pod;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
-import oracle.kubernetes.operator.TuningParameters.PodTuning;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.Component;
@@ -25,6 +29,8 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 import oracle.kubernetes.weblogic.domain.v1.ServerStartup;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Test that PodHelper computes the correct admin and managed server pod configurations */
@@ -56,6 +62,24 @@ public class PodHelperConfigTest {
   private static final String MANAGED_OPTION3_VALUE = "ManagedOption3Value";
   private static final String MANAGED_OPTION4_NAME = "ManagedOption4Name";
   private static final String MANAGED_OPTION4_VALUE = "ManagedOption4Value";
+
+  private List<Memento> mementos = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(
+        StaticStubSupport.install(
+            DomainPresenceInfoFactory.class, "domains", new ConcurrentHashMap<>()));
+    mementos.add(
+        StaticStubSupport.install(
+            ServerKubernetesObjectsFactory.class, "serverMap", new ConcurrentHashMap<>()));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    for (Memento memento : mementos) memento.revert();
+  }
 
   @Test
   public void computedAdminServerPodConfigForDefaults_isCorrect() throws Exception {
@@ -351,7 +375,7 @@ public class PodHelperConfigTest {
   }
 
   private static Packet newPacket(Domain domain, V1PersistentVolumeClaimList claims) {
-    DomainPresenceInfo info = new DomainPresenceInfo(domain);
+    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
     info.setClaims(claims);
     Packet packet = new Packet();
     packet

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperConfigTest.java
@@ -70,10 +70,10 @@ public class PodHelperConfigTest {
     mementos.add(TestUtils.silenceOperatorLogger());
     mementos.add(
         StaticStubSupport.install(
-            DomainPresenceInfoFactory.class, "domains", new ConcurrentHashMap<>()));
+            DomainPresenceInfoManager.class, "domains", new ConcurrentHashMap<>()));
     mementos.add(
         StaticStubSupport.install(
-            ServerKubernetesObjectsFactory.class, "serverMap", new ConcurrentHashMap<>()));
+            ServerKubernetesObjectsManager.class, "serverMap", new ConcurrentHashMap<>()));
   }
 
   @After
@@ -375,7 +375,7 @@ public class PodHelperConfigTest {
   }
 
   private static Packet newPacket(Domain domain, V1PersistentVolumeClaimList claims) {
-    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
     info.setClaims(claims);
     Packet packet = new Packet();
     packet

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
@@ -1,0 +1,92 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import io.kubernetes.client.models.V1ObjectMeta;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import oracle.kubernetes.TestUtils;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServerKubernetesObjectsLookupTest {
+
+  private List<Memento> mementos = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(
+        StaticStubSupport.install(
+            DomainPresenceInfoFactory.class, "domains", new ConcurrentHashMap<>()));
+    mementos.add(
+        StaticStubSupport.install(
+            ServerKubernetesObjectsFactory.class, "serverMap", new ConcurrentHashMap<>()));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    for (Memento memento : mementos) memento.revert();
+  }
+
+  private Domain createDomain(String uid, String namespace) {
+    return new Domain()
+        .withSpec(new DomainSpec().withDomainUID(uid))
+        .withMetadata(new V1ObjectMeta().namespace(namespace));
+  }
+
+  @Test
+  public void whenNoPreexistingDomains_createEmptyServerKubernetesObjectsMap() {
+    assertThat(
+        ServerKubernetesObjectsFactory.getInstance().getServerKubernetesObjects(),
+        is(anEmptyMap()));
+  }
+
+  @Test
+  public void whenK8sHasDomainWithOneServer_canLookupFromServerKubernetesObjectsFactory() {
+    Domain domain = createDomain("UID1", "ns1");
+    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
+
+    ServerKubernetesObjects sko =
+        ServerKubernetesObjectsFactory.getInstance().getOrCreate(info, "admin");
+
+    assertThat(info.getServers(), hasEntry(equalTo("admin"), sameInstance(sko)));
+
+    assertThat(
+        ServerKubernetesObjectsFactory.getInstance().getServerKubernetesObjects(),
+        hasEntry(equalTo(LegalNames.toServerName("UID1", "admin")), sameInstance(sko)));
+  }
+
+  @Test
+  public void
+      whenK8sHasDomainAndServerIsRemoved_canNoLongerLookupFromServerKubernetesObjectsFactory() {
+    Domain domain = createDomain("UID1", "ns1");
+    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
+
+    ServerKubernetesObjects sko =
+        ServerKubernetesObjectsFactory.getInstance().getOrCreate(info, "admin");
+
+    info.getServers().remove("admin", sko);
+
+    assertThat(info.getServers(), is(anEmptyMap()));
+
+    assertThat(
+        ServerKubernetesObjectsFactory.getInstance().getServerKubernetesObjects(),
+        is(anEmptyMap()));
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
@@ -33,10 +33,10 @@ public class ServerKubernetesObjectsLookupTest {
     mementos.add(TestUtils.silenceOperatorLogger());
     mementos.add(
         StaticStubSupport.install(
-            DomainPresenceInfoFactory.class, "domains", new ConcurrentHashMap<>()));
+            DomainPresenceInfoManager.class, "domains", new ConcurrentHashMap<>()));
     mementos.add(
         StaticStubSupport.install(
-            ServerKubernetesObjectsFactory.class, "serverMap", new ConcurrentHashMap<>()));
+            ServerKubernetesObjectsManager.class, "serverMap", new ConcurrentHashMap<>()));
   }
 
   @After
@@ -52,23 +52,20 @@ public class ServerKubernetesObjectsLookupTest {
 
   @Test
   public void whenNoPreexistingDomains_createEmptyServerKubernetesObjectsMap() {
-    assertThat(
-        ServerKubernetesObjectsFactory.getInstance().getServerKubernetesObjects(),
-        is(anEmptyMap()));
+    assertThat(ServerKubernetesObjectsManager.getServerKubernetesObjects(), is(anEmptyMap()));
   }
 
   @Test
   public void whenK8sHasDomainWithOneServer_canLookupFromServerKubernetesObjectsFactory() {
     Domain domain = createDomain("UID1", "ns1");
-    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
 
-    ServerKubernetesObjects sko =
-        ServerKubernetesObjectsFactory.getInstance().getOrCreate(info, "admin");
+    ServerKubernetesObjects sko = ServerKubernetesObjectsManager.getOrCreate(info, "admin");
 
     assertThat(info.getServers(), hasEntry(equalTo("admin"), sameInstance(sko)));
 
     assertThat(
-        ServerKubernetesObjectsFactory.getInstance().getServerKubernetesObjects(),
+        ServerKubernetesObjectsManager.getServerKubernetesObjects(),
         hasEntry(equalTo(LegalNames.toServerName("UID1", "admin")), sameInstance(sko)));
   }
 
@@ -76,17 +73,14 @@ public class ServerKubernetesObjectsLookupTest {
   public void
       whenK8sHasDomainAndServerIsRemoved_canNoLongerLookupFromServerKubernetesObjectsFactory() {
     Domain domain = createDomain("UID1", "ns1");
-    DomainPresenceInfo info = DomainPresenceInfoFactory.getInstance().getOrCreate(domain);
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
 
-    ServerKubernetesObjects sko =
-        ServerKubernetesObjectsFactory.getInstance().getOrCreate(info, "admin");
+    ServerKubernetesObjects sko = ServerKubernetesObjectsManager.getOrCreate(info, "admin");
 
     info.getServers().remove("admin", sko);
 
     assertThat(info.getServers(), is(anEmptyMap()));
 
-    assertThat(
-        ServerKubernetesObjectsFactory.getInstance().getServerKubernetesObjects(),
-        is(anEmptyMap()));
+    assertThat(ServerKubernetesObjectsManager.getServerKubernetesObjects(), is(anEmptyMap()));
   }
 }


### PR DESCRIPTION
The intention is that you can lookup servers (across domains) using the server legal name (i.e. the Pod name).

This map must stay in-sync with the per-domain server maps held by the DomainPresenceInfo instances.