### PR TITLE
specify bash in generate-security-policy.sh

### DIFF
--- a/kubernetes/internal/generate-security-policy.sh
+++ b/kubernetes/internal/generate-security-policy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 


### PR DESCRIPTION
bash string substitution such as: for i in ${TARGET_NAMESPACES//,/ } may result in "Bad substitution error" in some environments such as under dash shell in ubuntu. Proposed fix is to ensure generate-security-policy.sh is run with bash.