### PR TITLE
fix issue where operator mistaken a new domain as existing one

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -520,10 +520,11 @@ public class Main {
     DomainPresenceControl.normalizeDomainSpec(spec);
     String domainUID = spec.getDomainUID();
 
+    boolean existingDomain = DomainPresenceInfoManager.lookup(domainUID) != null;
     DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(dom);
     // Has the spec actually changed? We will get watch events for status updates
     Domain current = info.getDomain();
-    if (current != null) {
+    if (existingDomain && current != null) {
       if (!explicitRecheck && !hasExplicitRestarts && spec.equals(current.getSpec())) {
         // nothing in the spec has changed
         LOGGER.fine(MessageKeys.NOT_STARTING_DOMAINUID_THREAD, domainUID);


### PR DESCRIPTION
Proposed change to address the issue where domain is not started due to "Watch event ignored for domain with domain UID domain1 because no change to domain specification” in operator log when a new domain is added.