### PR TITLE
Mark build timeout

### DIFF
--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -1609,7 +1609,7 @@ function test_mvn_integration_wercker {
     trace "Running mvn -P integration-tests install.  Output in $RESULT_DIR/mvn.out"
 
     local mstart=`date +%s`
-    mvn -P integration-tests install > $RESULT_DIR/mvn.out 2>&1
+    mvn -P integration-tests install 2>&1 | tee $RESULT_DIR/mvn.out
     local mend=`date +%s`
     local msecs=$((mend-mstart))
     trace "mvn complete, runtime $msecs seconds"

--- a/wercker.yml
+++ b/wercker.yml
@@ -184,6 +184,14 @@ integration-test:
 
       # integration tests
       $WERCKER_SOURCE_DIR/src/integration-tests/bash/run.sh
+      RUN_SH_RC=$?
+
+      if [ "$RUN_SH_RC" = "0" ]; then 
+        echo "run.sh finished successfully"
+      else
+        echo "run.sh failed with return code ${RUN_SH_RC}"
+        exit $RUN_SH_RC
+      fi
     
       cleanup_and_store
 


### PR DESCRIPTION
These changes will fix the hanging of the `mvn -P integration-tests install` in `run.sh` and will also fail the pipeline if `run.sh` fails