### PR TITLE
Ingress helper test

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Workarounds.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Workarounds.java
@@ -1,0 +1,19 @@
+// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+/**
+ * This class lists bugs in libraries that require workarounds. Code using those workarounds should
+ * use the appropriate constants to enable them. That will allow tracking.
+ */
+public class Workarounds {
+
+  // io.kubernetes.client.custom.IntOrString does not define equals() so it
+  // fails when comparing objects that are equal but not the same instance.
+  // This breaks some K8s model comparisons.
+
+  // Reported to https://github.com/kubernetes-client/java as issue #282
+  public static final boolean INTORSTRING_BAD_EQUALS = true;
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/IngressHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/IngressHelper.java
@@ -11,6 +11,7 @@ import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
+import static oracle.kubernetes.operator.VersionConstants.DOMAIN_V1;
 import static oracle.kubernetes.operator.Workarounds.INTORSTRING_BAD_EQUALS;
 
 import io.kubernetes.client.custom.IntOrString;
@@ -22,9 +23,9 @@ import io.kubernetes.client.models.V1beta1IngressBackend;
 import io.kubernetes.client.models.V1beta1IngressRule;
 import io.kubernetes.client.models.V1beta1IngressSpec;
 import java.util.Objects;
+import java.util.Optional;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
@@ -66,10 +67,10 @@ public class IngressHelper {
       clusterName = (String) packet.get(ProcessingConstants.CLUSTER_NAME);
       port = (Integer) packet.get(ProcessingConstants.PORT);
 
-      if (!hasClusterData()) {
-        return doNext(packet);
-      } else {
+      if (hasClusterData()) {
         return doNext(verifyIngressStep(getNext()), packet);
+      } else {
+        return doNext(packet);
       }
     }
 
@@ -79,65 +80,15 @@ public class IngressHelper {
 
     private Step verifyIngressStep(Step next) {
       return new CallBuilder()
-          .readIngressAsync(getIngressName(), getNamespace(), new ReadIngressResponseStep(next));
+          .readIngressAsync(getName(), getNamespace(), new ReadIngressResponseStep(next));
     }
 
-    V1beta1Ingress createDesiredResource() {
-      return new V1beta1Ingress()
-          .apiVersion(KubernetesConstants.EXTENSIONS_API_VERSION)
-          .kind(KubernetesConstants.KIND_INGRESS)
-          .metadata(
-              new V1ObjectMeta()
-                  .name(getIngressName())
-                  .namespace(getNamespace())
-                  .putAnnotationsItem(CLASS_INGRESS, CLASS_INGRESS_VALUE)
-                  .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1)
-                  .putLabelsItem(DOMAINUID_LABEL, getUid())
-                  .putLabelsItem(DOMAINNAME_LABEL, getDomainName())
-                  .putLabelsItem(CLUSTERNAME_LABEL, clusterName)
-                  .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"))
-          .spec(createIngressSpec());
+    private String getName() {
+      return LegalNames.toIngressName(getUid(), clusterName);
     }
 
     private String getNamespace() {
       return info.getDomain().getMetadata().getNamespace();
-    }
-
-    private String getClusterServiceName() {
-      return LegalNames.toClusterServiceName(getUid(), clusterName);
-    }
-
-    private String getDomainName() {
-      return info.getDomain().getSpec().getDomainName();
-    }
-
-    private String getUid() {
-      return info.getDomain().getSpec().getDomainUID();
-    }
-
-    String getIngressName() {
-      return LegalNames.toIngressName(getUid(), clusterName);
-    }
-
-    V1beta1IngressSpec createIngressSpec() {
-      String serviceName = getClusterServiceName();
-      return new V1beta1IngressSpec()
-          .addRulesItem(
-              new V1beta1IngressRule()
-                  .http(
-                      new V1beta1HTTPIngressRuleValue()
-                          .addPathsItem(
-                              new V1beta1HTTPIngressPath()
-                                  .path("/")
-                                  .backend(
-                                      new V1beta1IngressBackend()
-                                          .serviceName(serviceName)
-                                          .servicePort(new IntOrString(port))))));
-    }
-
-    private boolean isCompatible(V1beta1Ingress result) {
-      return VersionHelper.matchesResourceVersion(result.getMetadata(), VersionConstants.DOMAIN_V1)
-          && equalObjects(result.getSpec(), createIngressSpec());
     }
 
     private class ReadIngressResponseStep extends DefaultResponseStep<V1beta1Ingress> {
@@ -162,71 +113,96 @@ public class IngressHelper {
 
       private Step createIngressStep(Step next) {
         return new CallBuilder()
-            .createIngressAsync(
-                getNamespace(), createDesiredResource(), new CreateIngressResponseStep(next));
+            .createIngressAsync(getNamespace(), defineIngress(), new UpdateStep(next));
       }
 
       Step replaceIngressStep(Step next) {
         return new CallBuilder()
-            .replaceIngressAsync(
-                getIngressName(),
-                getNamespace(),
-                createDesiredResource(),
-                new ReplaceIngressResponseStep(next));
+            .replaceIngressAsync(getName(), getNamespace(), defineIngress(), new UpdateStep(next));
+      }
+
+      private boolean isCompatible(V1beta1Ingress result) {
+        return VersionHelper.matchesResourceVersion(result.getMetadata(), DOMAIN_V1)
+            && equalObjects(result.getSpec(), createIngressSpec());
+      }
+
+      private boolean equalObjects(V1beta1IngressSpec object1, V1beta1IngressSpec object2) {
+        return INTORSTRING_BAD_EQUALS
+            ? yamlEquals(object1, object2)
+            : Objects.equals(object1, object2);
+      }
+
+      private boolean yamlEquals(Object actual, Object expected) {
+        return Objects.equals(objectToYaml(actual), objectToYaml(expected));
+      }
+
+      private String objectToYaml(Object object) {
+        return new Yaml().dump(object);
       }
     }
 
-    private class CreateIngressResponseStep extends ResponseStep<V1beta1Ingress> {
-      CreateIngressResponseStep(Step next) {
+    V1beta1Ingress defineIngress() {
+      return new V1beta1Ingress()
+          .apiVersion(KubernetesConstants.EXTENSIONS_API_VERSION)
+          .kind(KubernetesConstants.KIND_INGRESS)
+          .metadata(
+              new V1ObjectMeta()
+                  .name(getName())
+                  .namespace(getNamespace())
+                  .putAnnotationsItem(CLASS_INGRESS, CLASS_INGRESS_VALUE)
+                  .putLabelsItem(RESOURCE_VERSION_LABEL, DOMAIN_V1)
+                  .putLabelsItem(DOMAINUID_LABEL, getUid())
+                  .putLabelsItem(DOMAINNAME_LABEL, getDomainName())
+                  .putLabelsItem(CLUSTERNAME_LABEL, clusterName)
+                  .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"))
+          .spec(createIngressSpec());
+    }
+
+    private String getUid() {
+      return info.getDomain().getSpec().getDomainUID();
+    }
+
+    private String getDomainName() {
+      return info.getDomain().getSpec().getDomainName();
+    }
+
+    V1beta1IngressSpec createIngressSpec() {
+      String serviceName = getClusterServiceName();
+      return new V1beta1IngressSpec()
+          .addRulesItem(
+              new V1beta1IngressRule()
+                  .http(
+                      new V1beta1HTTPIngressRuleValue()
+                          .addPathsItem(
+                              new V1beta1HTTPIngressPath()
+                                  .path("/")
+                                  .backend(
+                                      new V1beta1IngressBackend()
+                                          .serviceName(serviceName)
+                                          .servicePort(new IntOrString(port))))));
+    }
+
+    private String getClusterServiceName() {
+      return LegalNames.toClusterServiceName(getUid(), clusterName);
+    }
+
+    private class UpdateStep extends ResponseStep<V1beta1Ingress> {
+      UpdateStep(Step next) {
         super(next);
       }
 
       @Override
       public NextAction onFailure(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
-        return super.onFailure(CreateClusterStep.this, packet, callResponse);
+        return onFailure(CreateClusterStep.this, packet, callResponse);
       }
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
-        V1beta1Ingress result = callResponse.getResult();
-        if (result != null) {
-          addToDomainInfo(result);
-        }
+        Optional.ofNullable(callResponse.getResult())
+            .ifPresent(CreateClusterStep.this::addToDomainInfo);
+
         return doNext(packet);
       }
     }
-
-    private class ReplaceIngressResponseStep extends ResponseStep<V1beta1Ingress> {
-
-      ReplaceIngressResponseStep(Step next) {
-        super(next);
-      }
-
-      @Override
-      public NextAction onFailure(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
-        return super.onFailure(CreateClusterStep.this, packet, callResponse);
-      }
-
-      @Override
-      public NextAction onSuccess(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
-        V1beta1Ingress result = callResponse.getResult();
-        if (result != null) {
-          addToDomainInfo(result);
-        }
-        return doNext(packet);
-      }
-    }
-  }
-
-  private static boolean equalObjects(V1beta1IngressSpec object1, V1beta1IngressSpec object2) {
-    return INTORSTRING_BAD_EQUALS ? yamlEquals(object1, object2) : Objects.equals(object1, object2);
-  }
-
-  private static boolean yamlEquals(Object actual, Object expected) {
-    return Objects.equals(objectToYaml(actual), objectToYaml(expected));
-  }
-
-  private static String objectToYaml(Object object) {
-    return new Yaml().dump(object);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/IngressHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/IngressHelper.java
@@ -4,7 +4,15 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import io.kubernetes.client.ApiException;
+import static oracle.kubernetes.operator.KubernetesConstants.CLASS_INGRESS;
+import static oracle.kubernetes.operator.KubernetesConstants.CLASS_INGRESS_VALUE;
+import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
+import static oracle.kubernetes.operator.Workarounds.INTORSTRING_BAD_EQUALS;
+
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1beta1HTTPIngressPath;
@@ -13,21 +21,16 @@ import io.kubernetes.client.models.V1beta1Ingress;
 import io.kubernetes.client.models.V1beta1IngressBackend;
 import io.kubernetes.client.models.V1beta1IngressRule;
 import io.kubernetes.client.models.V1beta1IngressSpec;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import oracle.kubernetes.operator.KubernetesConstants;
-import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.work.ContainerResolver;
+import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
-import oracle.kubernetes.weblogic.domain.v1.Domain;
-import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
+import org.yaml.snakeyaml.Yaml;
 
 /** Helper class to add/remove server from Ingress. */
 public class IngressHelper {
@@ -44,173 +47,186 @@ public class IngressHelper {
   }
 
   private static class CreateClusterStep extends Step {
-    public CreateClusterStep(Step next) {
+
+    private DomainPresenceInfo info;
+    private String clusterName;
+    private Integer port;
+
+    CreateClusterStep(Step next) {
       super(next);
+    }
+
+    private void addToDomainInfo(V1beta1Ingress ingress) {
+      info.getIngresses().put(clusterName, ingress);
     }
 
     @Override
     public NextAction apply(Packet packet) {
-      DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
-      String clusterName = (String) packet.get(ProcessingConstants.CLUSTER_NAME);
-      Integer port = (Integer) packet.get(ProcessingConstants.PORT);
+      info = packet.getSPI(DomainPresenceInfo.class);
+      clusterName = (String) packet.get(ProcessingConstants.CLUSTER_NAME);
+      port = (Integer) packet.get(ProcessingConstants.PORT);
 
-      if (clusterName != null && port != null) {
-        Domain dom = info.getDomain();
-        V1ObjectMeta meta = dom.getMetadata();
-        DomainSpec spec = dom.getSpec();
-        String namespace = meta.getNamespace();
+      if (!hasClusterData()) {
+        return doNext(packet);
+      } else {
+        return doNext(verifyIngressStep(getNext()), packet);
+      }
+    }
 
-        String weblogicDomainUID = spec.getDomainUID();
-        String weblogicDomainName = spec.getDomainName();
+    private boolean hasClusterData() {
+      return clusterName != null && port != null;
+    }
 
-        String serviceName = LegalNames.toClusterServiceName(weblogicDomainUID, clusterName);
+    private Step verifyIngressStep(Step next) {
+      return new CallBuilder()
+          .readIngressAsync(getIngressName(), getNamespace(), new ReadIngressResponseStep(next));
+    }
 
-        String ingressName = LegalNames.toIngressName(weblogicDomainUID, clusterName);
+    V1beta1Ingress createDesiredResource() {
+      return new V1beta1Ingress()
+          .apiVersion(KubernetesConstants.EXTENSIONS_API_VERSION)
+          .kind(KubernetesConstants.KIND_INGRESS)
+          .metadata(
+              new V1ObjectMeta()
+                  .name(getIngressName())
+                  .namespace(getNamespace())
+                  .putAnnotationsItem(CLASS_INGRESS, CLASS_INGRESS_VALUE)
+                  .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1)
+                  .putLabelsItem(DOMAINUID_LABEL, getUid())
+                  .putLabelsItem(DOMAINNAME_LABEL, getDomainName())
+                  .putLabelsItem(CLUSTERNAME_LABEL, clusterName)
+                  .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"))
+          .spec(createIngressSpec());
+    }
 
-        V1beta1Ingress v1beta1Ingress = new V1beta1Ingress();
-        v1beta1Ingress.setApiVersion(KubernetesConstants.EXTENSIONS_API_VERSION);
-        v1beta1Ingress.setKind(KubernetesConstants.KIND_INGRESS);
+    private String getNamespace() {
+      return info.getDomain().getMetadata().getNamespace();
+    }
 
-        V1ObjectMeta v1ObjectMeta = new V1ObjectMeta();
-        v1ObjectMeta.setName(ingressName);
-        v1ObjectMeta.setNamespace(namespace);
+    private String getClusterServiceName() {
+      return LegalNames.toClusterServiceName(getUid(), clusterName);
+    }
 
-        v1ObjectMeta.putAnnotationsItem(
-            KubernetesConstants.CLASS_INGRESS, KubernetesConstants.CLASS_INGRESS_VALUE);
+    private String getDomainName() {
+      return info.getDomain().getSpec().getDomainName();
+    }
 
-        Map<String, String> labels = new HashMap<>();
-        labels.put(LabelConstants.RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1);
-        labels.put(LabelConstants.DOMAINUID_LABEL, weblogicDomainUID);
-        labels.put(LabelConstants.DOMAINNAME_LABEL, weblogicDomainName);
-        labels.put(LabelConstants.CLUSTERNAME_LABEL, clusterName);
-        labels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
-        v1ObjectMeta.setLabels(labels);
-        v1beta1Ingress.setMetadata(v1ObjectMeta);
+    private String getUid() {
+      return info.getDomain().getSpec().getDomainUID();
+    }
 
-        V1beta1IngressSpec v1beta1IngressSpec = new V1beta1IngressSpec();
-        List<V1beta1IngressRule> rules = new ArrayList<>();
-        V1beta1IngressRule v1beta1IngressRule = new V1beta1IngressRule();
+    String getIngressName() {
+      return LegalNames.toIngressName(getUid(), clusterName);
+    }
 
-        V1beta1HTTPIngressRuleValue v1beta1HTTPIngressRuleValue = new V1beta1HTTPIngressRuleValue();
-        List<V1beta1HTTPIngressPath> paths = new ArrayList<>();
-        V1beta1HTTPIngressPath v1beta1HTTPIngressPath = new V1beta1HTTPIngressPath();
-        v1beta1HTTPIngressPath.setPath("/");
-        V1beta1IngressBackend v1beta1IngressBackend = new V1beta1IngressBackend();
-        v1beta1IngressBackend.setServiceName(serviceName);
-        v1beta1IngressBackend.setServicePort(new IntOrString(port));
-        v1beta1HTTPIngressPath.setBackend(v1beta1IngressBackend);
-        paths.add(v1beta1HTTPIngressPath);
-        v1beta1HTTPIngressRuleValue.setPaths(paths);
-        v1beta1IngressRule.setHttp(v1beta1HTTPIngressRuleValue);
-        rules.add(v1beta1IngressRule);
-        v1beta1IngressSpec.setRules(rules);
-        v1beta1Ingress.setSpec(v1beta1IngressSpec);
+    V1beta1IngressSpec createIngressSpec() {
+      String serviceName = getClusterServiceName();
+      return new V1beta1IngressSpec()
+          .addRulesItem(
+              new V1beta1IngressRule()
+                  .http(
+                      new V1beta1HTTPIngressRuleValue()
+                          .addPathsItem(
+                              new V1beta1HTTPIngressPath()
+                                  .path("/")
+                                  .backend(
+                                      new V1beta1IngressBackend()
+                                          .serviceName(serviceName)
+                                          .servicePort(new IntOrString(port))))));
+    }
 
-        CallBuilderFactory factory =
-            ContainerResolver.getInstance().getContainer().getSPI(CallBuilderFactory.class);
-        return doNext(
-            factory
-                .create()
-                .readIngressAsync(
-                    ingressName,
-                    meta.getNamespace(),
-                    new ResponseStep<V1beta1Ingress>(getNext()) {
-                      @Override
-                      public NextAction onFailure(
-                          Packet packet, CallResponse<V1beta1Ingress> callResponse) {
-                        if (callResponse.getStatusCode() == CallBuilder.NOT_FOUND) {
-                          return onSuccess(packet, callResponse);
-                        }
-                        return super.onFailure(CreateClusterStep.this, packet, callResponse);
-                      }
+    private boolean isCompatible(V1beta1Ingress result) {
+      return VersionHelper.matchesResourceVersion(result.getMetadata(), VersionConstants.DOMAIN_V1)
+          && equalObjects(result.getSpec(), createIngressSpec());
+    }
 
-                      @Override
-                      public NextAction onSuccess(
-                          Packet packet, CallResponse<V1beta1Ingress> callResponse) {
-                        V1beta1Ingress result = callResponse.getResult();
-                        if (result == null) {
-                          return doNext(
-                              factory
-                                  .create()
-                                  .createIngressAsync(
-                                      meta.getNamespace(),
-                                      v1beta1Ingress,
-                                      new ResponseStep<V1beta1Ingress>(getNext()) {
-                                        @Override
-                                        public NextAction onFailure(
-                                            Packet packet,
-                                            ApiException e,
-                                            int statusCode,
-                                            Map<String, List<String>> responseHeaders) {
-                                          return super.onFailure(
-                                              CreateClusterStep.this,
-                                              packet,
-                                              e,
-                                              statusCode,
-                                              responseHeaders);
-                                        }
+    private class ReadIngressResponseStep extends DefaultResponseStep<V1beta1Ingress> {
+      private final Step next;
 
-                                        @Override
-                                        public NextAction onSuccess(
-                                            Packet packet,
-                                            V1beta1Ingress result,
-                                            int statusCode,
-                                            Map<String, List<String>> responseHeaders) {
-                                          if (result != null) {
-                                            info.getIngresses().put(clusterName, result);
-                                          }
-                                          return doNext(packet);
-                                        }
-                                      }),
-                              packet);
-                        } else {
-                          if (VersionHelper.matchesResourceVersion(
-                                  result.getMetadata(), VersionConstants.DOMAIN_V1)
-                              && v1beta1Ingress.getSpec().equals(result.getSpec())) {
-                            return doNext(packet);
-                          }
-                          return doNext(
-                              factory
-                                  .create()
-                                  .replaceIngressAsync(
-                                      ingressName,
-                                      meta.getNamespace(),
-                                      v1beta1Ingress,
-                                      new ResponseStep<V1beta1Ingress>(getNext()) {
-                                        @Override
-                                        public NextAction onFailure(
-                                            Packet packet,
-                                            ApiException e,
-                                            int statusCode,
-                                            Map<String, List<String>> responseHeaders) {
-                                          return super.onFailure(
-                                              CreateClusterStep.this,
-                                              packet,
-                                              e,
-                                              statusCode,
-                                              responseHeaders);
-                                        }
-
-                                        @Override
-                                        public NextAction onSuccess(
-                                            Packet packet,
-                                            V1beta1Ingress result,
-                                            int statusCode,
-                                            Map<String, List<String>> responseHeaders) {
-                                          if (result != null) {
-                                            info.getIngresses().put(clusterName, result);
-                                          }
-                                          return doNext(packet);
-                                        }
-                                      }),
-                              packet);
-                        }
-                      }
-                    }),
-            packet);
+      ReadIngressResponseStep(Step next) {
+        super(next);
+        this.next = next;
       }
 
-      return doNext(packet);
+      @Override
+      public NextAction onSuccess(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
+        V1beta1Ingress result = callResponse.getResult();
+        if (result == null) {
+          return doNext(createIngressStep(next), packet);
+        } else if (!isCompatible(result)) {
+          return doNext(replaceIngressStep(next), packet);
+        } else {
+          return doNext(packet);
+        }
+      }
+
+      private Step createIngressStep(Step next) {
+        return new CallBuilder()
+            .createIngressAsync(
+                getNamespace(), createDesiredResource(), new CreateIngressResponseStep(next));
+      }
+
+      Step replaceIngressStep(Step next) {
+        return new CallBuilder()
+            .replaceIngressAsync(
+                getIngressName(),
+                getNamespace(),
+                createDesiredResource(),
+                new ReplaceIngressResponseStep(next));
+      }
     }
+
+    private class CreateIngressResponseStep extends ResponseStep<V1beta1Ingress> {
+      CreateIngressResponseStep(Step next) {
+        super(next);
+      }
+
+      @Override
+      public NextAction onFailure(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
+        return super.onFailure(CreateClusterStep.this, packet, callResponse);
+      }
+
+      @Override
+      public NextAction onSuccess(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
+        V1beta1Ingress result = callResponse.getResult();
+        if (result != null) {
+          addToDomainInfo(result);
+        }
+        return doNext(packet);
+      }
+    }
+
+    private class ReplaceIngressResponseStep extends ResponseStep<V1beta1Ingress> {
+
+      ReplaceIngressResponseStep(Step next) {
+        super(next);
+      }
+
+      @Override
+      public NextAction onFailure(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
+        return super.onFailure(CreateClusterStep.this, packet, callResponse);
+      }
+
+      @Override
+      public NextAction onSuccess(Packet packet, CallResponse<V1beta1Ingress> callResponse) {
+        V1beta1Ingress result = callResponse.getResult();
+        if (result != null) {
+          addToDomainInfo(result);
+        }
+        return doNext(packet);
+      }
+    }
+  }
+
+  private static boolean equalObjects(V1beta1IngressSpec object1, V1beta1IngressSpec object2) {
+    return INTORSTRING_BAD_EQUALS ? yamlEquals(object1, object2) : Objects.equals(object1, object2);
+  }
+
+  private static boolean yamlEquals(Object actual, Object expected) {
+    return Objects.equals(objectToYaml(actual), objectToYaml(expected));
+  }
+
+  private static String objectToYaml(Object object) {
+    return new Yaml().dump(object);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/DefaultResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/DefaultResponseStep.java
@@ -15,10 +15,10 @@ import oracle.kubernetes.operator.work.Step;
  * A response step which treats a NOT_FOUND status as success with a null result. By default, does
  * nothing on success. Subclasses must override #doSuccess to take action.
  */
-class DefaultResponseStep<T> extends ResponseStep<T> {
-  DefaultResponseStep() {}
+public class DefaultResponseStep<T> extends ResponseStep<T> {
+  protected DefaultResponseStep() {}
 
-  DefaultResponseStep(Step nextStep) {
+  protected DefaultResponseStep(Step nextStep) {
     super(nextStep);
   }
 

--- a/operator/src/test/java/oracle/kubernetes/LogMatcher.java
+++ b/operator/src/test/java/oracle/kubernetes/LogMatcher.java
@@ -58,8 +58,7 @@ public class LogMatcher
     return item.getLevel() == expectedLevel
         && item.getMessage().equals(expectedMessage)
         && (expectedParameter == null
-            ? true
-            : Arrays.stream(item.getParameters()).anyMatch(expectedParameter::equals));
+            || Arrays.stream(item.getParameters()).anyMatch(expectedParameter::equals));
   }
 
   private boolean noLogMessageFound(Description mismatchDescription) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -318,6 +318,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
         .createCannedResponse("replaceConfigMap")
         .withNamespace(NS)
         .withName(DOMAIN_CONFIG_MAP_NAME)
+        .ignoringBody()
         .returning(domainConfigMap);
   }
 
@@ -388,11 +389,13 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
         .createCannedResponse("deleteService")
         .withNamespace(NS)
         .withName("admin")
+        .ignoringBody()
         .returning(new V1Status());
     testSupport
         .createCannedResponse("deleteService")
         .withNamespace(NS)
         .withName("ms1")
+        .ignoringBody()
         .returning(new V1Status());
 
     testSupport
@@ -404,11 +407,13 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
         .createCannedResponse("deleteIngress")
         .withNamespace(NS)
         .withName("TEST-cluster1")
+        .ignoringBody()
         .returning(new V1Status());
     testSupport
         .createCannedResponse("deleteIngress")
         .withNamespace(NS)
         .withName("TEST-cluster2")
+        .ignoringBody()
         .returning(new V1Status());
 
     Main.deleteStrandedResources();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IngressHelperTest.java
@@ -4,202 +4,224 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import io.kubernetes.client.ApiException;
-import io.kubernetes.client.models.V1DeleteOptions;
+import static oracle.kubernetes.operator.KubernetesConstants.CLASS_INGRESS;
+import static oracle.kubernetes.operator.KubernetesConstants.CLASS_INGRESS_VALUE;
+import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
+import static oracle.kubernetes.operator.ProcessingConstants.CLUSTER_NAME;
+import static oracle.kubernetes.operator.ProcessingConstants.PORT;
+import static oracle.kubernetes.operator.helpers.CallBuilder.NOT_FOUND;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.meterware.simplestub.Memento;
+import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.models.V1ObjectMeta;
-import io.kubernetes.client.models.V1Service;
-import io.kubernetes.client.models.V1ServicePort;
-import io.kubernetes.client.models.V1ServiceSpec;
 import io.kubernetes.client.models.V1beta1HTTPIngressPath;
 import io.kubernetes.client.models.V1beta1HTTPIngressRuleValue;
 import io.kubernetes.client.models.V1beta1Ingress;
 import io.kubernetes.client.models.V1beta1IngressBackend;
 import io.kubernetes.client.models.V1beta1IngressRule;
 import io.kubernetes.client.models.V1beta1IngressSpec;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
-import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
-import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
-import oracle.kubernetes.operator.work.Component;
-import oracle.kubernetes.operator.work.Engine;
-import oracle.kubernetes.operator.work.Fiber;
-import oracle.kubernetes.operator.work.Fiber.CompletionCallback;
-import oracle.kubernetes.operator.work.Packet;
-import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.TestUtils;
+import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.operator.VersionConstants;
+import oracle.kubernetes.operator.work.AsyncCallTestSupport;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
-/** To test Ingress Helper */
-@Ignore
+@SuppressWarnings("unchecked")
 public class IngressHelperTest {
-  private final String namespace = "weblogic-operator";
-  private final String domainUID = "domianIngressHelperTest";
-  private final String clusterName = "cluster1";
-  private final String server1Name = "server1";
-  private final Integer server1Port = 8001;
-  private final String server2Name = "server2";
-  private final Integer server2Port = 8002;
-  private final String service1Name = LegalNames.toServerServiceName(domainUID, server1Name);
-  private final String service2Name = LegalNames.toServerServiceName(domainUID, server2Name);
-  private final String ingressName = LegalNames.toIngressName(domainUID, clusterName);
-  private final String clusterServiceName = LegalNames.toClusterServiceName(domainUID, clusterName);
 
-  private DomainPresenceInfo info;
-  private Engine engine;
+  private static final String NS = "namespace";
+  private static final int TEST_PORT = 7000;
+  private static final String TEST_CLUSTER = "cluster-1";
+  private static final String DOMAIN_NAME = "domain1";
+  private static final String UID = "uid1";
+  private static final String BAD_VERSION = "bad-version";
+  private static final int BAD_PORT = 9999;
+  private static final V1beta1Ingress INGRESS_RESOURCE = createIngressResource();
+
+  private DomainPresenceInfo domainPresenceInfo = createPresenceInfo();
+  private AsyncCallTestSupport testSupport = new AsyncCallTestSupport();
+  private List<Memento> mementos = new ArrayList<>();
+
+  private static V1beta1Ingress createIngressResource() {
+    return new V1beta1Ingress()
+        .apiVersion(KubernetesConstants.EXTENSIONS_API_VERSION)
+        .kind(KubernetesConstants.KIND_INGRESS)
+        .metadata(
+            new V1ObjectMeta()
+                .name(LegalNames.toIngressName(UID, TEST_CLUSTER))
+                .namespace(NS)
+                .putAnnotationsItem(CLASS_INGRESS, CLASS_INGRESS_VALUE)
+                .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1)
+                .putLabelsItem(DOMAINUID_LABEL, UID)
+                .putLabelsItem(DOMAINNAME_LABEL, DOMAIN_NAME)
+                .putLabelsItem(CLUSTERNAME_LABEL, TEST_CLUSTER)
+                .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"))
+        .spec(createIngressSpec());
+  }
+
+  private static V1beta1IngressSpec createIngressSpec() {
+    String serviceName = LegalNames.toClusterServiceName(UID, TEST_CLUSTER);
+    return new V1beta1IngressSpec()
+        .addRulesItem(
+            new V1beta1IngressRule()
+                .http(
+                    new V1beta1HTTPIngressRuleValue()
+                        .addPathsItem(
+                            new V1beta1HTTPIngressPath()
+                                .path("/")
+                                .backend(
+                                    new V1beta1IngressBackend()
+                                        .serviceName(serviceName)
+                                        .servicePort(new IntOrString(TEST_PORT))))));
+  }
+
+  private DomainPresenceInfo createPresenceInfo() {
+    Domain domain =
+        new Domain()
+            .withMetadata(new V1ObjectMeta().namespace(NS))
+            .withSpec(new DomainSpec().withDomainName(DOMAIN_NAME).withDomainUID(UID));
+    return new DomainPresenceInfo(domain);
+  }
 
   @Before
-  public void setUp() throws ApiException {
-    // make sure test bed is clean
-    tearDown();
+  public void setUp() throws Exception {
+    mementos.add(testSupport.installRequestStepFactory());
+    mementos.add(TestUtils.silenceOperatorLogger());
 
-    // Create domain
-    Domain domain = new Domain();
-    V1ObjectMeta metadata = new V1ObjectMeta();
-    metadata.setName("domianIngressHelperTest");
-    metadata.setNamespace(namespace);
-    domain.setMetadata(metadata);
-
-    DomainSpec spec = new DomainSpec();
-    spec.setDomainName("base_domain");
-    spec.setDomainUID(domainUID);
-    domain.setSpec(spec);
-
-    info = DomainPresenceInfoManager.getOrCreate(domain);
-
-    // Create scan
-    WlsDomainConfig scan = new WlsDomainConfig(null);
-    WlsServerConfig server1Scan =
-        new WlsServerConfig(server1Name, server1Port, server1Name, null, false, null, null);
-    WlsServerConfig server2Scan =
-        new WlsServerConfig(server2Name, server2Port, server2Name, null, false, null, null);
-
-    scan.getServerConfigs().put(server1Name, server1Scan);
-    scan.getServerConfigs().put(server2Name, server2Scan);
-
-    WlsClusterConfig cluster1Scan = new WlsClusterConfig(clusterName);
-    cluster1Scan.getServerConfigs().add(server1Scan);
-    cluster1Scan.getServerConfigs().add(server2Scan);
-
-    scan.getClusterConfigs().put(clusterName, cluster1Scan);
-
-    info.setScan(scan);
-
-    ServerKubernetesObjects sko = new ServerKubernetesObjects();
-    V1Service service = new V1Service();
-    V1ObjectMeta sm = new V1ObjectMeta();
-    sm.setName(service1Name);
-    sm.setNamespace(namespace);
-    service.setMetadata(sm);
-    V1ServiceSpec ss = new V1ServiceSpec();
-    V1ServicePort port = new V1ServicePort();
-    port.setPort(server1Port);
-    ss.addPortsItem(port);
-    service.setSpec(ss);
-    sko.getService().set(service);
-    info.getServers().put(server1Name, sko);
-
-    sko = new ServerKubernetesObjects();
-    service = new V1Service();
-    sm = new V1ObjectMeta();
-    sm.setName(service2Name);
-    sm.setNamespace(namespace);
-    service.setMetadata(sm);
-    ss = new V1ServiceSpec();
-    port = new V1ServicePort();
-    port.setPort(server2Port);
-    ss.addPortsItem(port);
-    service.setSpec(ss);
-    sko.getService().set(service);
-    info.getServers().put(server2Name, sko);
-
-    engine = new Engine("IngressHelperTest");
+    testSupport
+        .addToPacket(CLUSTER_NAME, TEST_CLUSTER)
+        .addToPacket(PORT, TEST_PORT)
+        .addDomainPresenceInfo(domainPresenceInfo);
   }
 
   @After
-  public void tearDown() throws ApiException {
-    CallBuilderFactory factory = new CallBuilderFactory();
-    try {
-      factory.create().deleteIngress(ingressName, namespace, new V1DeleteOptions());
-    } catch (ApiException api) {
-      if (api.getCode() != CallBuilder.NOT_FOUND) {
-        throw api;
-      }
-    }
+  public void tearDown() throws Exception {
+    for (Memento memento : mementos) memento.revert();
+    testSupport.throwOnCompletionFailure();
+    testSupport.verifyAllDefinedResponsesInvoked();
   }
 
   @Test
-  public void testAddThenRemoveServer() throws Throwable {
-    Packet p = new Packet();
-    p.getComponents().put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(info));
-    p.put(ProcessingConstants.SERVER_SCAN, info.getScan().getServerConfig(server1Name));
-    p.put(ProcessingConstants.CLUSTER_SCAN, info.getScan().getClusterConfig(clusterName));
-    p.put(ProcessingConstants.SERVER_NAME, server1Name);
+  public void whenPortNotInPacket_stepDoesNothing() {
+    testSupport.removeFromPacket(PORT);
 
-    Fiber f = engine.createFiber();
-    Step s = IngressHelper.createClusterStep(null);
-    AtomicReference<Throwable> t = new AtomicReference<>();
-    f.start(
-        s,
-        p,
-        new CompletionCallback() {
-          @Override
-          public void onCompletion(Packet packet) {
-            // no-op
-          }
-
-          @Override
-          public void onThrowable(Packet packet, Throwable throwable) {
-            t.set(throwable);
-          }
-        });
-    f.get(30, TimeUnit.SECONDS);
-    if (t.get() != null) {
-      throw t.get();
-    }
-
-    // Now check
-    CallBuilderFactory factory = new CallBuilderFactory();
-    V1beta1Ingress v1beta1Ingress = factory.create().readIngress(ingressName, namespace);
-
-    List<V1beta1HTTPIngressPath> v1beta1HTTPIngressPaths = getPathArray(v1beta1Ingress);
-    Assert.assertEquals(
-        "IngressPaths should have one instance of IngressPath", 1, v1beta1HTTPIngressPaths.size());
-    V1beta1HTTPIngressPath v1beta1HTTPIngressPath = v1beta1HTTPIngressPaths.get(0);
-    Assert.assertEquals("/", v1beta1HTTPIngressPath.getPath());
-    V1beta1IngressBackend v1beta1IngressBackend = v1beta1HTTPIngressPath.getBackend();
-    Assert.assertNotNull("IngressBackend Object should not be null", v1beta1IngressBackend);
-    Assert.assertEquals(
-        "Service name should be " + clusterServiceName,
-        clusterServiceName,
-        v1beta1IngressBackend.getServiceName());
-    Assert.assertEquals(
-        "Service port should be " + server1Port,
-        server1Port,
-        v1beta1IngressBackend.getServicePort().getIntValue());
+    runCreateClusterStep();
   }
 
-  private List<V1beta1HTTPIngressPath> getPathArray(V1beta1Ingress v1beta1Ingress) {
-    Assert.assertNotNull("Ingress Object should not be null", v1beta1Ingress);
-    V1beta1IngressSpec v1beta1IngressSpec = v1beta1Ingress.getSpec();
-    Assert.assertNotNull("Spec Object should not be null", v1beta1IngressSpec);
-    List<V1beta1IngressRule> v1beta1IngressRules = v1beta1IngressSpec.getRules();
-    Assert.assertNotNull("Rules List should not be null", v1beta1IngressRules);
-    Assert.assertTrue(
-        "Rules List  should have one instance of IngressRule", v1beta1IngressRules.size() == 1);
-    V1beta1IngressRule v1beta1IngressRule = v1beta1IngressRules.get(0);
-    Assert.assertNotNull("IngressRule Object should not be null", v1beta1IngressRule);
-    V1beta1HTTPIngressRuleValue v1beta1HTTPIngressRuleValue = v1beta1IngressRule.getHttp();
-    Assert.assertNotNull("IngressRuleValue Object should not be null", v1beta1HTTPIngressRuleValue);
-    List<V1beta1HTTPIngressPath> v1beta1HTTPIngressPaths = v1beta1HTTPIngressRuleValue.getPaths();
-    Assert.assertNotNull("IngressPath list should not be null", v1beta1HTTPIngressPaths);
-    return v1beta1HTTPIngressPaths;
+  private void runCreateClusterStep() {
+    testSupport.runSteps(IngressHelper.createClusterStep(null));
+  }
+
+  @Test
+  public void whenClusterNameNotInPacket_stepDoesNothing() {
+    testSupport.removeFromPacket(CLUSTER_NAME);
+
+    runCreateClusterStep();
+  }
+
+  @Test
+  public void whenNoMatchingIngressExists_createOne() {
+    createCannedReadResponse();
+    testSupport
+        .createCannedResponse("createIngress")
+        .withNamespace(NS)
+        .withBody(INGRESS_RESOURCE)
+        .returning(INGRESS_RESOURCE);
+
+    runCreateClusterStep();
+
+    assertThat(getExistingIngress(), sameInstance(INGRESS_RESOURCE));
+  }
+
+  private void createCannedReadResponse() {
+    AsyncCallTestSupport.CannedResponse cannedResponse =
+        testSupport
+            .createCannedResponse("readIngress")
+            .withNamespace(NS)
+            .withName(LegalNames.toIngressName(UID, TEST_CLUSTER));
+
+    V1beta1Ingress ingress = getExistingIngress();
+    if (ingress == null) {
+      cannedResponse.failingWithStatus(NOT_FOUND);
+    } else {
+      cannedResponse.returning(ingress);
+    }
+  }
+
+  private V1beta1Ingress getExistingIngress() {
+    return domainPresenceInfo.getIngresses().get(TEST_CLUSTER);
+  }
+
+  @Test
+  public void whenMatchingIngressExists_leaveItAlone() {
+    setExistingIngress(INGRESS_RESOURCE);
+    createCannedReadResponse();
+
+    runCreateClusterStep();
+
+    assertThat(getExistingIngress(), sameInstance(INGRESS_RESOURCE));
+  }
+
+  private void setExistingIngress(V1beta1Ingress ingressResource) {
+    domainPresenceInfo.getIngresses().put(TEST_CLUSTER, ingressResource);
+  }
+
+  @Test
+  public void whenMatchingIngressExistsButHasDifferentVersion_replaceIt() {
+    setExistingIngress(ingressWithDifferentResourceVersion());
+    createCannedReadResponse();
+    testSupport
+        .createCannedResponse("replaceIngress")
+        .withName(LegalNames.toIngressName(UID, TEST_CLUSTER))
+        .withNamespace(NS)
+        .withBody(INGRESS_RESOURCE)
+        .returning(INGRESS_RESOURCE);
+
+    runCreateClusterStep();
+
+    assertThat(getExistingIngress(), sameInstance(INGRESS_RESOURCE));
+  }
+
+  private V1beta1Ingress ingressWithDifferentResourceVersion() {
+    V1beta1Ingress ingress = createIngressResource();
+    ingress.getMetadata().putLabelsItem(RESOURCE_VERSION_LABEL, BAD_VERSION);
+    return ingress;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void whenMatchingIngressExistsButHasDifferentSpec_replaceIt() {
+    setExistingIngress(ingressWithDifferentSpec());
+    createCannedReadResponse();
+    testSupport
+        .createCannedResponse("replaceIngress")
+        .withName(LegalNames.toIngressName(UID, TEST_CLUSTER))
+        .withNamespace(NS)
+        .withBody(INGRESS_RESOURCE)
+        .returning(INGRESS_RESOURCE);
+
+    runCreateClusterStep();
+
+    assertThat(getExistingIngress(), sameInstance(INGRESS_RESOURCE));
+  }
+
+  private V1beta1Ingress ingressWithDifferentSpec() {
+    V1beta1Ingress ingress = createIngressResource();
+    ingress
+        .getSpec()
+        .setBackend(new V1beta1IngressBackend().servicePort(new IntOrString(BAD_PORT)));
+    return ingress;
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/DeleteIngressListStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/DeleteIngressListStepTest.java
@@ -64,7 +64,8 @@ public class DeleteIngressListStepTest {
     return testSupport
         .createCannedResponse("deleteIngress")
         .withNamespace(namespace)
-        .withName(name);
+        .withName(name)
+        .ignoringBody();
   }
 
   @Test


### PR DESCRIPTION
Rewrote disabled IngressHelperTest as a pure unit test
Refactored IngressHelper
Implemented workaround for bug in k8s Java client

Note: IngressHelper has only one method, which creates a CreateClusterStep, and is called once (outside of the tests) from the steps package. Maybe that step should be extracted and moved to the steps package and IngressHelper should be removed entirely?