### PR TITLE
Allow WebLogic Docker image to be specified in inputs file for genera…

### DIFF
--- a/kubernetes/create-weblogic-domain-inputs.yaml
+++ b/kubernetes/create-weblogic-domain-inputs.yaml
@@ -40,6 +40,9 @@ managedServerNameBase: managed-server
 # Port number for each managed server
 managedServerPort: 8001
 
+# WebLogic Docker image
+weblogicImage: store/oracle/weblogic:12.2.1.3
+
 # Persistent volume type for the domain's storage.
 # The value must be 'HOST_PATH' or 'NFS'. 
 # If using 'NFS', weblogicDomainStorageNFSServer must be specified.

--- a/kubernetes/internal/create-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/create-weblogic-domain-job-template.yaml
@@ -275,7 +275,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: create-weblogic-domain-job
-          image: store/oracle/weblogic:12.2.1.3
+          image: %WEBLOGIC_IMAGE%
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7001

--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -454,6 +454,14 @@ function createYamlFiles {
   enabledPrefix=""     # uncomment the feature
   disabledPrefix="# "  # comment out the feature
 
+  # For backward compatability, default to "store/oracle/weblogic:12.2.1.3" if not defined in
+  # create-weblogic-domain-inputs.yaml
+  if [ -z "${weblogicImage}" ]; then
+    weblogicImage="store/oracle/weblogic:12.2.1.3"
+  fi
+  # Must escape the ':' value in weblogicImage for sed to properly parse and replace
+  weblogicImage=$(echo ${weblogicImage} | sed -e "s/\:/\\\:/g")
+
   # Generate the yaml to create the persistent volume
   echo Generating ${domainPVOutput}
 
@@ -491,6 +499,7 @@ function createYamlFiles {
   cp ${createJobInput} ${createJobOutput}
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${createJobOutput}
   sed -i -e "s:%WEBLOGIC_CREDENTIALS_SECRET_NAME%:${weblogicCredentialsSecretName}:g" ${createJobOutput}
+  sed -i -e "s:%WEBLOGIC_IMAGE%:${weblogicImage}:g" ${createJobOutput}
   sed -i -e "s:%WEBLOGIC_IMAGE_PULL_SECRET_NAME%:${weblogicImagePullSecretName}:g" ${createJobOutput}
   sed -i -e "s:%WEBLOGIC_IMAGE_PULL_SECRET_PREFIX%:${weblogicImagePullSecretPrefix}:g" ${createJobOutput}
   sed -i -e "s:%DOMAIN_UID%:${domainUID}:g" ${createJobOutput}
@@ -511,6 +520,7 @@ function createYamlFiles {
 
   cp ${deleteJobInput} ${deleteJobOutput}
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${deleteJobOutput}
+  sed -i -e "s:%WEBLOGIC_IMAGE%:${weblogicImage}:g" ${deleteJobOutput}
   sed -i -e "s:%WEBLOGIC_CREDENTIALS_SECRET_NAME%:${weblogicCredentialsSecretName}:g" ${deleteJobOutput}
   sed -i -e "s:%WEBLOGIC_IMAGE_PULL_SECRET_NAME%:${weblogicImagePullSecretName}:g" ${deleteJobOutput}
   sed -i -e "s:%WEBLOGIC_IMAGE_PULL_SECRET_PREFIX%:${weblogicImagePullSecretPrefix}:g" ${deleteJobOutput}
@@ -538,7 +548,6 @@ function createYamlFiles {
   sed -i -e "s:%DOMAIN_UID%:${domainUID}:g" ${dcrOutput}
   sed -i -e "s:%DOMAIN_NAME%:${domainName}:g" ${dcrOutput}
   sed -i -e "s:%ADMIN_SERVER_NAME%:${adminServerName}:g" ${dcrOutput}
-  weblogicImage=$(echo ${weblogicImage} | sed -e "s/\:/\\\:/g")
   sed -i -e "s:%WEBLOGIC_IMAGE%:${weblogicImage}:g" ${dcrOutput}
   sed -i -e "s:%ADMIN_PORT%:${adminPort}:g" ${dcrOutput}
   sed -i -e "s:%INITIAL_MANAGED_SERVER_REPLICAS%:${initialManagedServerReplicas}:g" ${dcrOutput}

--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -538,6 +538,8 @@ function createYamlFiles {
   sed -i -e "s:%DOMAIN_UID%:${domainUID}:g" ${dcrOutput}
   sed -i -e "s:%DOMAIN_NAME%:${domainName}:g" ${dcrOutput}
   sed -i -e "s:%ADMIN_SERVER_NAME%:${adminServerName}:g" ${dcrOutput}
+  weblogicImage=$(echo ${weblogicImage} | sed -e "s/\:/\\\:/g")
+  sed -i -e "s:%WEBLOGIC_IMAGE%:${weblogicImage}:g" ${dcrOutput}
   sed -i -e "s:%ADMIN_PORT%:${adminPort}:g" ${dcrOutput}
   sed -i -e "s:%INITIAL_MANAGED_SERVER_REPLICAS%:${initialManagedServerReplicas}:g" ${dcrOutput}
   sed -i -e "s:%EXPOSE_T3_CHANNEL_PREFIX%:${exposeAdminT3ChannelPrefix}:g" ${dcrOutput}

--- a/kubernetes/internal/delete-weblogic-domain-job-template.yaml
+++ b/kubernetes/internal/delete-weblogic-domain-job-template.yaml
@@ -35,7 +35,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: delete-weblogic-domain-job
-          image: store/oracle/weblogic:12.2.1.3
+          image: %WEBLOGIC_IMAGE%
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 7001

--- a/kubernetes/internal/domain-custom-resource-template.yaml
+++ b/kubernetes/internal/domain-custom-resource-template.yaml
@@ -21,7 +21,7 @@ spec:
   # The WebLogic Domain Name
   domainName: %DOMAIN_NAME%
   # The Operator currently does not support other images
-  image: "store/oracle/weblogic:12.2.1.3"
+  image: "%WEBLOGIC_IMAGE%"
   # imagePullPolicy defaults to "Always" if image version is :latest
   imagePullPolicy: "IfNotPresent"
   # Identify which Secret contains the WebLogic Admin credentials (note that there is an example of

--- a/operator/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsFileTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsFileTest.java
@@ -55,6 +55,7 @@ public class CreateDomainInputsFileTest {
                 .clusterName("cluster-1")
                 .clusterType("DYNAMIC")
                 .domainName("base_domain")
+                .weblogicImage("store/oracle/weblogic:12.2.1.3")
                 .domainUID("")
                 .exposeAdminNodePort("false")
                 .exposeAdminT3Channel("false")

--- a/operator/src/test/java/oracle/kubernetes/operator/utils/CreateDomainInputs.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/utils/CreateDomainInputs.java
@@ -78,6 +78,7 @@ public class CreateDomainInputs {
   private String loadBalancerExposeAdminPort = "";
   private String javaOptions = "";
   private String version = "";
+  private String weblogicImage = "";
 
   public static CreateDomainInputs newInputs() throws Exception {
     return readDefaultInputsFile()
@@ -87,6 +88,7 @@ public class CreateDomainInputs {
         .clusterName("TestCluster")
         .clusterType(CLUSTER_TYPE_DYNAMIC)
         .domainName("TestDomain")
+        .weblogicImage("store/oracle/weblogic:12.2.1.3")
         .domainUID("test-domain-uid")
         .javaOptions("TestJavaOptions")
         .loadBalancerDashboardPort("31315")
@@ -154,6 +156,19 @@ public class CreateDomainInputs {
 
   public CreateDomainInputs adminServerName(String adminServerName) {
     setAdminServerName(adminServerName);
+    return this;
+  }
+
+  public String getWeblogicImage() {
+    return weblogicImage;
+  }
+
+  public void setWeblogicImage(String weblogicImage) {
+    this.weblogicImage = convertNullToEmptyString(weblogicImage);
+  }
+
+  public CreateDomainInputs weblogicImage(String weblogicImage) {
+    setWeblogicImage(weblogicImage);
     return this;
   }
 


### PR DESCRIPTION
…ting CRD

Added a new 'weblogicImage' value to the  create-weblogic-domain-inputs.yaml  file to allow the ability to explicitly specify different version of a WebLogic Docker image to be used.  This is a usability enhancement as requested in JIRA WLS-66115.