### PR TITLE
Support headless service in HttpClient.getServiceURL()

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/http/HttpClient.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/HttpClient.java
@@ -279,7 +279,13 @@ public class HttpClient {
     if (service != null) {
       V1ServiceSpec spec = service.getSpec();
       if (spec != null) {
-        String portalIP = spec.getClusterIP();
+        String portalIP =
+            "None".equalsIgnoreCase(spec.getClusterIP())
+                ? service.getMetadata().getName()
+                    + "."
+                    + service.getMetadata().getNamespace()
+                    + ".svc.cluster.local"
+                : spec.getClusterIP();
         int port = spec.getPorts().iterator().next().getPort();
         portalIP += ":" + port;
         String serviceURL = HTTP_PROTOCOL + portalIP;


### PR DESCRIPTION
Add support for headless service in HttpClienet.getServiceURL(). Before this fix, the method always build URL from service clusterIP, which results in invalid URL for headless service.