### PR TITLE
Issue#330: Add validation for Apache loadBalancerVolumePath

### DIFF
--- a/kubernetes/create-weblogic-domain-inputs.yaml
+++ b/kubernetes/create-weblogic-domain-inputs.yaml
@@ -102,10 +102,13 @@ loadBalancer: TRAEFIK
 # This defines the /location in the built-in Apache plugin configuration module for WebLogic
 loadBalancerAppPrepath: /
 
-# Docker volume path for APACHE. By default, it is empty, which causes the volume mount be 
-# disabled and, thereforem the built-in Apache plugin config be used.
-# Use this to provide your own Apache plugin configuration as needed; simply define this 
-# path and put your own custom_mod_wl_apache.conf file under this path.
+# Docker volume path for APACHE.
+# By default, the path is empty, and therefore, the built-in default Apache plugin
+# configuration is used.
+# Use this to provide your own Apache plugin configuration as needed; simply define
+# this path and put your own custom_mod_wl_apache.conf file under this path.
+# If specified path does not exist, or customer_mod_wl_apache.conf file is missing 
+# under the specified path, the create domain script will fail with a validation error.
 loadBalancerVolumePath:
 
 # Boolean to indicate if the admin port is going to be exposed for APACHE. By default, it is false.

--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -604,11 +604,20 @@ function createYamlFiles {
       enableLoadBalancerExposeAdminPortPrefix="${disabledPrefix}"
     fi
 
+    enableLoadBalancerVolumePathPrefix="${disabledPrefix}"
+    apacheConfigFileName="custom_mod_wl_apache.conf"
     if [ ! -z "${loadBalancerVolumePath}" ]; then
-      enableLoadBalancerVolumePathPrefix="${enabledPrefix}"
-      sed -i -e "s:%LOAD_BALANCER_VOLUME_PATH%:${loadBalancerVolumePath}:g" ${apacheOutput}
-    else
-      enableLoadBalancerVolumePathPrefix="${disabledPrefix}"
+      if [ ! -d ${loadBalancerVolumePath} ]; then
+        echo -e "\nERROR: \nThe specified loadBalancerVolumePath $loadBalancerVolumePath does not exist! \n"
+        fail "Exiting due to a validation error"
+      elif [ ! -f ${loadBalancerVolumePath}/${apacheConfigFileName} ]; then
+        echo -e "\nERROR: \nThe required file ${apacheConfigFileName} does not exist under the specified loadBalancerVolumePath $loadBalancerVolumePath! \n"
+        fail "Exiting due to a validation error"
+      else
+        enableLoadBalancerVolumePathPrefix="${enabledPrefix}"
+        sed -i -e "s:%LOAD_BALANCER_VOLUME_PATH%:${loadBalancerVolumePath}:g" ${apacheOutput}
+
+      fi
     fi
 
     sed -i -e "s:%ENABLE_LOAD_BALANCER_EXPOSE_ADMIN_PORT%:${enableLoadBalancerExposeAdminPortPrefix}:g" ${apacheOutput}

--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -608,10 +608,10 @@ function createYamlFiles {
     apacheConfigFileName="custom_mod_wl_apache.conf"
     if [ ! -z "${loadBalancerVolumePath}" ]; then
       if [ ! -d ${loadBalancerVolumePath} ]; then
-        echo -e "\nERROR: \nThe specified loadBalancerVolumePath $loadBalancerVolumePath does not exist! \n"
+        echo -e "\nERROR - The specified loadBalancerVolumePath $loadBalancerVolumePath does not exist! \n"
         fail "Exiting due to a validation error"
       elif [ ! -f ${loadBalancerVolumePath}/${apacheConfigFileName} ]; then
-        echo -e "\nERROR: \nThe required file ${apacheConfigFileName} does not exist under the specified loadBalancerVolumePath $loadBalancerVolumePath! \n"
+        echo -e "\nERROR - The required file ${apacheConfigFileName} does not exist under the specified loadBalancerVolumePath $loadBalancerVolumePath! \n"
         fail "Exiting due to a validation error"
       else
         enableLoadBalancerVolumePathPrefix="${enabledPrefix}"

--- a/operator/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsValidationTest.java
@@ -58,6 +58,7 @@ public class CreateDomainInputsValidationTest {
   private static final String PARAM_LOAD_BALANCER = "loadBalancer";
   private static final String PARAM_LOAD_BALANCER_WEB_PORT = "loadBalancerWebPort";
   private static final String PARAM_LOAD_BALANCER_DASHBOARD_PORT = "loadBalancerDashboardPort";
+  private static final String PARAM_LOAD_BALANCER_VOLUME_PATH = "loadBalancerVolumePath";
   private static final String PARAM_JAVA_OPTIONS = "javaOptions";
   private static final String PARAM_VERSION = "version";
 
@@ -554,6 +555,26 @@ public class CreateDomainInputsValidationTest {
         failsAndPrints(invalidIntegerParamValueError(PARAM_LOAD_BALANCER_DASHBOARD_PORT, val)));
   }
 
+  @Test
+  public void createDomain_with_invalidLoadBalancerVolumePath_failsAndReturnsError()
+      throws Exception {
+    String val = "invalid-load-balancer-volume-path";
+    assertThat(
+        execCreateDomain(
+            newInputs().loadBalancer(LOAD_BALANCER_APACHE).loadBalancerVolumePath(val)),
+        failsAndPrints(missingDirectoryError(PARAM_LOAD_BALANCER_VOLUME_PATH, val)));
+  }
+
+  public void createDomain_with_invalidLoadBalancerVolumePath_missingFile_failsAndReturnsError()
+      throws Exception {
+    String val = "/";
+    assertThat(
+        execCreateDomain(
+            newInputs().loadBalancer(LOAD_BALANCER_APACHE).loadBalancerVolumePath(val)),
+        failsAndPrints(
+            missingFileError(PARAM_LOAD_BALANCER_VOLUME_PATH, val, "custom-mod-wl-apache.conf")));
+  }
+
   // TBD - shouldn't we allow empty java options?
   @Test
   public void createDomain_with_missingJavaOptions_failsAndReturnsError() throws Exception {
@@ -611,6 +632,14 @@ public class CreateDomainInputsValidationTest {
   private String invalidRelatedParamValueError(
       String param, String val, String param2, String val2) {
     return errorRegexp("Invalid.*" + param + ".*" + val + " with " + param2 + ".*" + val2);
+  }
+
+  private String missingDirectoryError(String param, String val) {
+    return errorRegexp(param + ".*" + val + ".*" + "does not exist!");
+  }
+
+  private String missingFileError(String param, String val, String dir) {
+    return errorRegexp(param + ".*" + val + ".*" + "does not exist under" + ".*" + dir + ".*");
   }
 
   private String paramMissingError(String param) {


### PR DESCRIPTION
Add code to the create domain script to check whether the specified loadBalancerVolumePath and the required file under the directory exist. If either one does not exist, the script fails with a validation error.

Signed-off-by: doxiao <dongbo.xiao@oracle.com>

@rjeberhard @rosemarymarano 