### PR TITLE
Issue #330: Add validation for loadBalancerVolumePath

### DIFF
--- a/kubernetes/create-weblogic-domain-inputs.yaml
+++ b/kubernetes/create-weblogic-domain-inputs.yaml
@@ -99,10 +99,14 @@ loadBalancer: TRAEFIK
 # This defines the /location in the built-in Apache plugin configuration module for WebLogic
 loadBalancerAppPrepath: /
 
-# Docker volume path for APACHE. By default, it is empty, which causes the volume mount be 
-# disabled and, thereforem the built-in Apache plugin config be used.
-# Use this to provide your own Apache plugin configuration as needed; simply define this 
-# path and put your own custom_mod_wl_apache.conf file under this path.
+# Docker volume path for APACHE.
+# By default, the path is empty, and therefore, the built-in default Apache plugin
+# configuration is used.
+# Use this to provide your own Apache plugin configuration as needed; simply define
+# this path and put your own custom_mod_wl_apache.conf file under this path.
+# If the specified path does not exist, or the customer_mod_wl_apache.conf file 
+# is missing under the specified path, the create domain script will fail with 
+# a validation error.
 loadBalancerVolumePath:
 
 # Load balancer web port

--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -567,14 +567,24 @@ function createYamlFiles {
     sed -i -e "s:%WEB_APP_PREPATH%:$loadBalancerAppPrepath:g" ${apacheOutput}
 
     if [ ! -z "${loadBalancerVolumePath}" ]; then
-      sed -i -e "s:%LOAD_BALANCER_VOLUME_PATH%:${loadBalancerVolumePath}:g" ${apacheOutput}
-      sed -i -e "s:# volumes:volumes:g" ${apacheOutput}
-      sed -i -e "s:# - name:- name:g" ${apacheOutput}
-      sed -i -e "s:#   hostPath:  hostPath:g" ${apacheOutput}
-      sed -i -e "s:#     path:    path:g" ${apacheOutput}
-      sed -i -e "s:# volumeMounts:volumeMounts:g" ${apacheOutput}
-      sed -i -e "s:# - name:- name:g" ${apacheOutput}
-      sed -i -e "s:#   mountPath:  mountPath:g" ${apacheOutput}
+      apacheConfigFileName="custom_mod_wl_apache.conf"
+      if [ ! -d ${loadBalancerVolumePath} ]; then
+        echo -e "\nERROR - The specified loadBalancerVolumePath $loadBalancerVolumePath does not exist! \n"
+        fail "Exiting due to a validation error"
+      elif [ ! -f ${loadBalancerVolumePath}/${apacheConfigFileName} ]; then
+        echo -e "\nERROR - The required file ${apacheConfigFileName} does not exist under the specified loadBalancerVolumePath $loadBalancerVolumePath! \n"
+        fail "Exiting due to a validation error"
+      else
+        sed -i -e "s:%LOAD_BALANCER_VOLUME_PATH%:${loadBalancerVolumePath}:g" ${apacheOutput}
+        sed -i -e "s:# volumes:volumes:g" ${apacheOutput}
+        sed -i -e "s:# - name:- name:g" ${apacheOutput}
+        sed -i -e "s:#   hostPath:  hostPath:g" ${apacheOutput}
+        sed -i -e "s:#     path:    path:g" ${apacheOutput}
+        sed -i -e "s:# volumeMounts:volumeMounts:g" ${apacheOutput}
+        sed -i -e "s:# - name:- name:g" ${apacheOutput}
+        sed -i -e "s:#   mountPath:  mountPath:g" ${apacheOutput}
+
+      fi
     fi
  
     # Apache security file

--- a/operator/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsValidationTest.java
@@ -47,6 +47,7 @@ public class CreateDomainInputsValidationTest {
   private static final String PARAM_LOAD_BALANCER = "loadBalancer";
   private static final String PARAM_LOAD_BALANCER_WEB_PORT = "loadBalancerWebPort";
   private static final String PARAM_LOAD_BALANCER_DASHBOARD_PORT = "loadBalancerDashboardPort";
+  private static final String PARAM_LOAD_BALANCER_VOLUME_PATH = "loadBalancerVolumePath";
   private static final String PARAM_JAVA_OPTIONS = "javaOptions";
   private static final String PARAM_VERSION = "version";
 
@@ -516,6 +517,25 @@ public class CreateDomainInputsValidationTest {
       failsAndPrints(invalidIntegerParamValueError(PARAM_LOAD_BALANCER_DASHBOARD_PORT, val)));
   }
 
+  @Test
+  public void createDomain_with_invalidLoadBalancerVolumePath_failsAndReturnsError()
+      throws Exception {
+    String val = "invalid-load-balancer-volume-path";
+    assertThat(
+        execCreateDomain(
+            newInputs().loadBalancer(LOAD_BALANCER_APACHE).loadBalancerVolumePath(val)),
+        failsAndPrints(missingDirectoryError(PARAM_LOAD_BALANCER_VOLUME_PATH, val)));
+  }
+
+  public void createDomain_with_invalidLoadBalancerVolumePath_missingFile_failsAndReturnsError()
+      throws Exception {
+    String val = "/";
+    assertThat(
+        execCreateDomain(
+            newInputs().loadBalancer(LOAD_BALANCER_APACHE).loadBalancerVolumePath(val)),
+        failsAndPrints(
+            missingFileError(PARAM_LOAD_BALANCER_VOLUME_PATH, val, "custom-mod-wl-apache.conf")));
+  }
   // TBD - shouldn't we allow empty java options?
   @Test
   public void createDomain_with_missingJavaOptions_failsAndReturnsError() throws Exception {
@@ -571,6 +591,15 @@ public class CreateDomainInputsValidationTest {
   private String invalidRelatedParamValueError(String param, String val, String param2, String val2) {
     return errorRegexp("Invalid.*" + param + ".*" + val + " with " + param2 + ".*" + val2);
   }
+
+  private String missingDirectoryError(String param, String val) {
+    return errorRegexp(param + ".*" + val + ".*" + "does not exist!");
+  }
+
+  private String missingFileError(String param, String val, String dir) {
+    return errorRegexp(param + ".*" + val + ".*" + "does not exist under" + ".*" + dir + ".*");
+  }
+
 
   private String paramMissingError(String param) {
     return errorRegexp(param + ".*missing");


### PR DESCRIPTION
Add validation in create-weblogic-domain.sh to check if the specified directory and the required Apache config file exist or not. The script fails if either is missing.

Signed-off-by: doxiao <dongbo.xiao@oracle.com>
@rjeberhard 