### PR TITLE
replace put with remove in Main.dispatchServiceWatch method

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -891,7 +891,7 @@ public class Main {
             case "DELETED":
               if (sko != null) {
                 if (channelName != null) {
-                  V1Service oldService = sko.getChannels().put(channelName, null);
+                  V1Service oldService = sko.getChannels().remove(channelName);
                   if (oldService != null) {
                     // Service was deleted, but sko still contained a non-null entry
                     LOGGER.info(


### PR DESCRIPTION
Saw the following NPE in operator log file from a failed jenkins integration test run:

{"timestamp":"07-24-2018T21:28:48.035+0000","thread":43,"level":"WARNING","class":"oracle.kubernetes.operator.Watcher","method":"watchForEvents","timeInMillis":1532467728035,"message":"Exception thrown: {0}","exception":"\njava.lang.NullPointerException\n\tat java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)\n\tat java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)\n\tat oracle.kubernetes.operator.Main.dispatchServiceWatch(Main.java:894)\n\tat oracle.kubernetes.operator.Watcher.handleRegularUpdate(Watcher.java:144)\n\tat oracle.kubernetes.operator.Watcher.watchForEvents(Watcher.java:121)\n\tat oracle.kubernetes.operator.Watcher.doWatch(Watcher.java:94)\n\tat java.lang.Thread.run(Thread.java:748)\n","code":"","headers":{},"body":""}

According to javadoc, ConcurrentHashMap does not support null key or values, but the code at Main.java:894 is putting a null value to the map. Proposed fix is to replace the put(channelName, null) with remove(channelName).
