### PR TITLE
integration tests with helm charts

### DIFF
--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -437,6 +437,12 @@ echo "@@ RESULT_ROOT=$RESULT_ROOT TMP_DIR=$TMP_DIR RESULT_DIR=$RESULT_DIR PROJEC
 
 mkdir -p $TMP_DIR || fail No permision to create directory $TMP_DIR
 
+# if helm is installed, delete all installed helm charts
+if [ -x "$(command -v helm)" ]; then
+  echo @@ Deleting installed helm charts
+  helm list --short | xargs -L1 helm delete --purge
+fi
+
 # first, try to delete with labels since the conversion is that all created resources need to
 # have the proper label(s)
 echo @@ Starting deleteWithLabels

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -671,7 +671,7 @@ function create_image_pull_secret_wercker {
 
 function op_define {
     if [ "$#" != 5 ] ; then
-      fail "requires 4 parameters: OP_KEY NAMESPACE TARGET_NAMESPACES EXTERNAL_REST_HTTPSPORT SETUP_KUBERNETES_CLUSTER"
+      fail "requires 5 parameters: OP_KEY NAMESPACE TARGET_NAMESPACES EXTERNAL_REST_HTTPSPORT SETUP_KUBERNETES_CLUSTER"
     fi
     local opkey="`echo \"${1?}\" | sed 's/-/_/g'`"
     eval export OP_${opkey}_NAMESPACE="$2"

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -557,6 +557,16 @@ function setup_jenkins {
     docker build -t "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" --no-cache=true .
 
     docker images
+
+    trace "Helm installation starts" 
+    wget -q -O  /tmp/helm-v2.7.2-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.7.2-linux-amd64.tar.gz
+    mkdir /tmp/helm
+    tar xzf /tmp/helm-v2.7.2-linux-amd64.tar.gz -C /tmp/helm
+    chmod +x /tmp/helm/linux-amd64/helm
+    /usr/local/packages/aime/ias/run_as_root "cp /tmp/helm/linux-amd64/helm /usr/bin/"
+    rm -rf /tmp/helm
+    helm init
+    trace "Helm is configured."
 }
 
 # setup_local is for arbitrary dev hosted linux - it assumes docker & k8s are already installed
@@ -572,6 +582,24 @@ function setup_local {
   docker pull wlsldi-v2.docker.oraclecorp.com/weblogic-webtier-apache-12.2.1.3.0:latest
   docker tag wlsldi-v2.docker.oraclecorp.com/weblogic-webtier-apache-12.2.1.3.0:latest store/oracle/apache:12.2.1.3
 
+}
+
+function setup_wercker {
+  trace "Perform setup for running in wercker"
+
+  if [ "$USE_HELM" = "true" ]; then
+
+    trace "Install tiller"
+    helm init
+
+    helm version
+
+    kubectl get po -n kube-system
+
+    setup_tiller_rbac
+  fi
+
+  trace "Completed setup_wercker"
 }
 
 function create_image_pull_secret_jenkins {
@@ -625,7 +653,7 @@ function create_image_pull_secret_wercker {
 
 }
 
-# op_define OP_KEY NAMESPACE TARGET_NAMESPACES EXTERNAL_REST_HTTPSPORT
+# op_define OP_KEY NAMESPACE TARGET_NAMESPACES EXTERNAL_REST_HTTPSPORT SETUP_KUBERNETES_CLUSTER
 #   sets up table of operator values.
 #
 # op_get    OP_KEY
@@ -642,13 +670,14 @@ function create_image_pull_secret_wercker {
 #
 
 function op_define {
-    if [ "$#" != 4 ] ; then
-      fail "requires 4 parameters: OP_KEY NAMESPACE TARGET_NAMESPACES EXTERNAL_REST_HTTPSPORT"
+    if [ "$#" != 5 ] ; then
+      fail "requires 4 parameters: OP_KEY NAMESPACE TARGET_NAMESPACES EXTERNAL_REST_HTTPSPORT SETUP_KUBERNETES_CLUSTER"
     fi
     local opkey="`echo \"${1?}\" | sed 's/-/_/g'`"
     eval export OP_${opkey}_NAMESPACE="$2"
     eval export OP_${opkey}_TARGET_NAMESPACES="$3"
     eval export OP_${opkey}_EXTERNAL_REST_HTTPSPORT="$4"
+    eval export OP_${opkey}_SETUP_KUBERNETES_CLUSTER="$5"
 
     # generated TMP_DIR for operator = $USER_PROJECTS_DIR/weblogic-operators/$NAMESPACE :
     eval export OP_${opkey}_TMP_DIR="$USER_PROJECTS_DIR/weblogic-operators/$2"
@@ -669,6 +698,34 @@ function op_echo_all {
     env | grep "^OP_${opkey}_"
 }
 
+function operator_ready_wait {
+    if [ "$#" != 1 ] ; then
+      fail "requires 1 parameter: operatorKey"
+    fi
+    local OP_KEY=${1}
+    local OPERATOR_NS="`op_get $OP_KEY NAMESPACE`"
+    local TMP_DIR="`op_get $OP_KEY TMP_DIR`"
+
+    local namespace=$OPERATOR_NS
+    trace Waiting for operator deployment to be ready...
+    local AVAILABLE="0"
+    local max=30
+    local count=0
+    while [ "$AVAILABLE" != "1" -a $count -lt $max ] ; do
+        sleep 10
+        local AVAILABLE=`kubectl get deploy weblogic-operator -n $namespace -o jsonpath='{.status.availableReplicas}'`
+        trace "status is $AVAILABLE, iteration $count of $max"
+        local count=`expr $count + 1`
+    done
+
+    if [ "$AVAILABLE" != "1" ]; then
+        kubectl get deploy weblogic-operator -n ${namespace}
+        kubectl describe deploy weblogic-operator -n ${namespace}
+        kubectl describe pods -n ${namespace}
+        fail "The WebLogic operator deployment is not available, after waiting 300 seconds"
+    fi
+}
+
 function deploy_operator {
     if [ "$#" != 1 ] ; then
       fail "requires 1 parameter: opkey"
@@ -685,30 +742,68 @@ function deploy_operator {
     fi
 
     trace 'customize the yaml'
-    local inputs="$TMP_DIR/create-weblogic-operator-inputs.yaml"
     mkdir -p $TMP_DIR
-    cp $PROJECT_ROOT/kubernetes/create-weblogic-operator-inputs.yaml $inputs
+    if [ "$USE_HELM" = "true" ]; then
+      local inputs="$TMP_DIR/weblogic-operator-values.yaml"
+      local SETUP_KUBERNETES_CLUSTER="`op_get $opkey SETUP_KUBERNETES_CLUSTER`"
 
-    trace 'customize the inputs yaml file to use our pre-built docker image'
-    sed -i -e "s|\(weblogicOperatorImagePullPolicy:\).*|\1${IMAGE_PULL_POLICY_OPERATOR}|g" $inputs
-    sed -i -e "s|\(weblogicOperatorImage:\).*|\1${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}|g" $inputs
-    if [ -n "${IMAGE_PULL_SECRET_OPERATOR}" ]; then
-      sed -i -e "s|#weblogicOperatorImagePullSecretName:.*|weblogicOperatorImagePullSecretName: ${IMAGE_PULL_SECRET_OPERATOR}|g" $inputs
+      # generate certificates
+      $PROJECT_ROOT/kubernetes/generate-internal-weblogic-operator-certificate.sh > $inputs
+      $PROJECT_ROOT/kubernetes/generate-external-weblogic-operator-certificate.sh DNS:${NODEPORT_HOST} >> $inputs
+
+      echo "setupKubernetesCluster: $SETUP_KUBERNETES_CLUSTER" >> $inputs
+
+      trace 'customize the inputs yaml file to add test namespace'
+      echo "createDomainsNamespace: false" >> $inputs
+      echo "domainsNamespaces:" >> $inputs
+      for i in $(echo $TARGET_NAMESPACES | sed "s/,/ /g")
+      do
+        echo "  $i: {}" >> $inputs
+      done
+      echo "operatorImagPullPolicy: ${IMAGE_PULL_POLICY_OPERATOR}" >> $inputs
+      echo "operatorImage: ${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" >> $inputs
+      echo "externalRestEnabled: true" >> $inputs
+      trace 'customize the inputs yaml file to set the java logging level to $LOGLEVEL_OPERATOR'
+      echo "javaLoggingLevel: \"$LOGLEVEL_OPERATOR\"" >> $inputs
+      echo "externalRestHttpsPort: ${EXTERNAL_REST_HTTPSPORT}" >>  $inputs
+      echo "createOperatorNamespace: false" >> $inputs
+      echo "operatorNamespace: \"${NAMESPACE}\"" >> $inputs
+      echo "operatorServiceAccount: weblogic-operator" >> $inputs
+      trace "Contents after customization in file $inputs"
+      cat $inputs
+
+      local outfile="${TMP_DIR}/create-weblogic-operator-helm.out"
+      trace "Run helm install to deploy the weblogic operator, see \"$outfile\" for tracking."
+      cd $PROJECT_ROOT/kubernetes/charts
+      helm install weblogic-operator --name ${NAMESPACE} -f $inputs 2>&1 | opt_tee ${outfile}
+      trace "helm install output:"
+      cat $outfile
+      operator_ready_wait $opkey
+    else
+      local inputs="$TMP_DIR/create-weblogic-operator-inputs.yaml"
+      cp $PROJECT_ROOT/kubernetes/create-weblogic-operator-inputs.yaml $inputs
+
+      trace 'customize the inputs yaml file to use our pre-built docker image'
+      sed -i -e "s|\(weblogicOperatorImagePullPolicy:\).*|\1 ${IMAGE_PULL_POLICY_OPERATOR}|g" $inputs
+      sed -i -e "s|\(weblogicOperatorImage:\).*|\1 ${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}|g" $inputs
+      if [ -n "${IMAGE_PULL_SECRET_OPERATOR}" ]; then
+        sed -i -e "s|#weblogicOperatorImagePullSecretName:.*|weblogicOperatorImagePullSecretName: ${IMAGE_PULL_SECRET_OPERATOR}|g" $inputs
+      fi
+      trace 'customize the inputs yaml file to generate a self-signed cert for the external Operator REST https port'
+      sed -i -e "s|\(externalRestOption:\).*|\1 SELF_SIGNED_CERT|g" $inputs
+      sed -i -e "s|\(externalSans:\).*|\1 DNS:${NODEPORT_HOST}|g" $inputs
+      trace 'customize the inputs yaml file to set the java logging level to $LOGLEVEL_OPERATOR'
+      sed -i -e "s|\(javaLoggingLevel:\).*|\1 $LOGLEVEL_OPERATOR|g" $inputs
+      sed -i -e "s|\(externalRestHttpsPort:\).*|\1 ${EXTERNAL_REST_HTTPSPORT}|g" $inputs
+      trace 'customize the inputs yaml file to add test namespace' 
+      sed -i -e "s/^namespace:.*/namespace: ${NAMESPACE}/" $inputs
+      sed -i -e "s/^targetNamespaces:.*/targetNamespaces: ${TARGET_NAMESPACES}/" $inputs
+      sed -i -e "s/^serviceAccount:.*/serviceAccount: weblogic-operator/" $inputs
+      local outfile="${TMP_DIR}/create-weblogic-operator.sh.out"
+      trace "Run the script to deploy the weblogic operator, see \"$outfile\" for tracking."
+      sh $PROJECT_ROOT/kubernetes/create-weblogic-operator.sh -i $inputs -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfile}
     fi
-    trace 'customize the inputs yaml file to generate a self-signed cert for the external Operator REST https port'
-    sed -i -e "s|\(externalRestOption:\).*|\1SELF_SIGNED_CERT|g" $inputs
-    sed -i -e "s|\(externalSans:\).*|\1DNS:${NODEPORT_HOST}|g" $inputs
-    trace 'customize the inputs yaml file to set the java logging level to $LOGLEVEL_OPERATOR'
-    sed -i -e "s|\(javaLoggingLevel:\).*|\1$LOGLEVEL_OPERATOR|g" $inputs
-    sed -i -e "s|\(externalRestHttpsPort:\).*|\1${EXTERNAL_REST_HTTPSPORT}|g" $inputs
-    trace 'customize the inputs yaml file to add test namespace' 
-    sed -i -e "s/^namespace:.*/namespace: ${NAMESPACE}/" $inputs
-    sed -i -e "s/^targetNamespaces:.*/targetNamespaces: ${TARGET_NAMESPACES}/" $inputs
-    sed -i -e "s/^serviceAccount:.*/serviceAccount: weblogic-operator/" $inputs
 
-    local outfile="${TMP_DIR}/create-weblogic-operator.sh.out"
-    trace "Run the script to deploy the weblogic operator, see \"$outfile\" for tracking."
-    sh $PROJECT_ROOT/kubernetes/create-weblogic-operator.sh -i $inputs -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfile}
     if [ "$?" = "0" ]; then
        # Prepend "+" to detailed debugging to make it easy to filter out
        cat ${outfile} | sed 's/^/+/g'
@@ -865,7 +960,11 @@ function run_create_domain_job {
 
     # Common inputs file for creating a domain
     local inputs="$tmp_dir/create-weblogic-domain-inputs.yaml"
-    cp $PROJECT_ROOT/kubernetes/create-weblogic-domain-inputs.yaml $inputs
+    if [ "$USE_HELM" = "true" ]; then
+      cp $PROJECT_ROOT/kubernetes/charts/weblogic-domain/values.yaml $inputs
+    else
+      cp $PROJECT_ROOT/kubernetes/create-weblogic-domain-inputs.yaml $inputs
+    fi
 
     # accept the default domain name (i.e. don't customize it)
     local domain_name=`egrep 'domainName' $inputs | awk '{print $2}'`
@@ -952,9 +1051,18 @@ function run_create_domain_job {
     fi
 
     local outfile="${tmp_dir}/create-weblogic-domain.sh.out"
-    trace "Run the script to create the domain, see \"$outfile\" for tracing."
 
-    sh $PROJECT_ROOT/kubernetes/create-weblogic-domain.sh -i $inputs -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfile}
+    if [ "$USE_HELM" = "true" ]; then
+      trace "Run helm install to create the domain, see \"$outfile\" for tracing."
+      cd $PROJECT_ROOT/kubernetes/charts
+      helm install weblogic-domain --name $1 -f $inputs --namespace ${NAMESPACE} 2>&1 | opt_tee ${outfile}
+      trace "helm install output:"
+      cat $outfile
+    else
+      trace "Run the script to create the domain, see \"$outfile\" for tracing."
+
+      sh $PROJECT_ROOT/kubernetes/create-weblogic-domain.sh -i $inputs -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfile}
+    fi
 
     if [ "$?" = "0" ]; then
        cat ${outfile} | sed 's/^/+/g'
@@ -1504,7 +1612,11 @@ function call_operator_rest {
     local SECRET="`kubectl get serviceaccount weblogic-operator -n $OPERATOR_NS -o jsonpath='{.secrets[0].name}'`"
     local ENCODED_TOKEN="`kubectl get secret ${SECRET} -n $OPERATOR_NS -o jsonpath='{.data.token}'`"
     local TOKEN="`echo ${ENCODED_TOKEN} | base64 --decode`"
-    local OPERATOR_CERT_DATA="`grep externalOperatorCert ${OPERATOR_TMP_DIR}/weblogic-operator.yaml | awk '{ print $2 }'`"
+    if [ "$USE_HELM" = "true" ]; then
+      local OPERATOR_CERT_DATA="`grep externalOperatorCert: ${OPERATOR_TMP_DIR}/weblogic-operator-values.yaml | awk '{ print $2 }'`"
+    else
+      local OPERATOR_CERT_DATA="`grep externalOperatorCert ${OPERATOR_TMP_DIR}/weblogic-operator.yaml | awk '{ print $2 }'`"
+    fi
     local OPERATOR_CERT_FILE="${OPERATOR_TMP_DIR}/operator.cert.pem"
     echo ${OPERATOR_CERT_DATA} | base64 --decode > ${OPERATOR_CERT_FILE}
 
@@ -1696,6 +1808,7 @@ function test_mvn_integration_local {
 
     local mstart=`date +%s`
     mvn -P integration-tests clean install 2>&1 | opt_tee $RESULT_DIR/mvn.out
+
     local mend=`date +%s`
     local msecs=$((mend-mstart))
     trace "mvn complete, runtime $msecs seconds"
@@ -1721,6 +1834,16 @@ function test_mvn_integration_wercker {
 
     confirm_mvn_build $RESULT_DIR/mvn.out
     declare_test_pass
+}
+
+function setup_tiller_rbac {
+    trace "Running setup_tiller_rbac"
+
+    kubectl create serviceaccount --namespace kube-system tiller
+    kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+    kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
+
+    trace "setup_tiller_rbac completed"
 }
 
 function check_pv {
@@ -2291,7 +2414,13 @@ function shutdown_domain {
 
     local replicas=`get_cluster_replicas $DOM_KEY`
 
-    kubectl delete -f ${TMP_DIR}/domain-custom-resource.yaml
+    if [ "$USE_HELM" = "true" ]; then
+      trace "calling helm delete ${DOM_KEY} --purge"
+      helm delete ${DOM_KEY} --purge
+    else
+      kubectl delete -f ${TMP_DIR}/domain-custom-resource.yaml
+    fi
+
     verify_domain_deleted $DOM_KEY $replicas
     trace Done. 
 }
@@ -2304,8 +2433,19 @@ function startup_domain {
     local DOM_KEY="$1"
 
     local TMP_DIR="`dom_get $1 TMP_DIR`"
+    local NAMESPACE="`dom_get $1 NAMESPACE`"
 
-    kubectl create -f ${TMP_DIR}/domain-custom-resource.yaml
+    if [ "$USE_HELM" = "true" ]; then
+      local inputs=$TMP_DIR/create-weblogic-domain-inputs.yaml
+      local outfile="$TMP_DIR/startup-weblogic-domain.out"
+      cd $PROJECT_ROOT/kubernetes/charts
+      trace "calling helm install weblogic-domain --name ${DOM_KEY} -f $inputs --namespace ${NAMESPACE} --set createWeblogicDomain=false"
+      helm install weblogic-domain --name ${DOM_KEY} -f $inputs --namespace ${NAMESPACE} --set createWeblogicDomain=false 2>&1 | opt_tee ${outfile}
+      trace "helm install output:"
+      cat $outfile
+    else   
+      kubectl create -f ${TMP_DIR}/domain-custom-resource.yaml
+    fi
 
     verify_domain_created $DOM_KEY 
 }
@@ -2355,7 +2495,12 @@ function shutdown_operator {
     local OPERATOR_NS="`op_get $OP_KEY NAMESPACE`"
     local TMP_DIR="`op_get $OP_KEY TMP_DIR`"
 
-    kubectl delete -f $TMP_DIR/weblogic-operator.yaml
+    if [ "$USE_HELM" = "true" ]; then
+      helm delete $OPERATOR_NS --purge
+    else
+      kubectl delete -f $TMP_DIR/weblogic-operator.yaml
+    fi
+
     trace "Checking REST service is deleted"
     set +x
     local servicenum=`kubectl get services -n $OPERATOR_NS | egrep weblogic-operator-svc | wc -l`
@@ -2374,26 +2519,19 @@ function startup_operator {
     local OPERATOR_NS="`op_get $OP_KEY NAMESPACE`"
     local TMP_DIR="`op_get $OP_KEY TMP_DIR`"
 
-    kubectl create -f $TMP_DIR/weblogic-operator.yaml
+    if [ "$USE_HELM" = "true" ]; then
+      local inputs="$TMP_DIR/weblogic-operator-values.yaml"
+      local outfile="$TMP_DIR/startup-weblogic-operator.out"
+      helm install weblogic-operator --name ${OPERATOR_NS} -f $inputs 2>&1 | opt_tee ${outfile}
+      trace "helm install output:"
+      cat $outfile
+    else
+      kubectl create -f $TMP_DIR/weblogic-operator.yaml
+    fi
+
+    operator_ready_wait $OP_KEY
 
     local namespace=$OPERATOR_NS
-    trace Waiting for operator deployment to be ready...
-    local AVAILABLE="0"
-    local max=30
-    local count=0
-    while [ "$AVAILABLE" != "1" -a $count -lt $max ] ; do
-        sleep 10
-        local AVAILABLE=`kubectl get deploy weblogic-operator -n $namespace -o jsonpath='{.status.availableReplicas}'`
-        trace "status is $AVAILABLE, iteration $count of $max"
-        local count=`expr $count + 1`
-    done
-
-    if [ "$AVAILABLE" != "1" ]; then
-        kubectl get deploy weblogic-operator -n ${namespace}
-        kubectl describe deploy weblogic-operator -n ${namespace}
-        kubectl describe pods -n ${namespace}
-        fail "The WebLogic operator deployment is not available, after waiting 300 seconds"
-    fi
 
     trace "Checking the operator pods"
     local REPLICA_SET=`kubectl describe deploy weblogic-operator -n ${namespace} | grep NewReplicaSet: | awk ' { print $2; }'`
@@ -2532,6 +2670,7 @@ function test_cluster_scale {
 
     local DOM_KEY="$1"
     local VERIFY_DOM_KEY="$2"
+    local NAMESPACE="`dom_get $1 NAMESPACE`"
 
     local TMP_DIR="`dom_get $1 TMP_DIR`"
 
@@ -2540,6 +2679,9 @@ function test_cluster_scale {
 
     trace "test cluster scale-up from 2 to 3"
     local domainCR="$TMP_DIR/domain-custom-resource.yaml"
+    if [ "$USE_HELM" = "true" ]; then
+      kubectl get domain $DOM_KEY -n $NAMESPACE -o yaml > $domainCR
+    fi
     sed -i -e "0,/replicas:/s/replicas:.*/replicas: 3/"  $domainCR
     kubectl apply -f $domainCR
 
@@ -2547,6 +2689,9 @@ function test_cluster_scale {
     verify_webapp_load_balancing $DOM_KEY 3
 
     trace "test cluster scale-down from 3 to 2"
+    if [ "$USE_HELM" = "true" ]; then
+      kubectl get domain $DOM_KEY -n $NAMESPACE -o yaml > $domainCR
+    fi
     sed -i -e "0,/replicas:/s/replicas:.*/replicas: 2/"  $domainCR
     kubectl apply -f $domainCR
 
@@ -2657,7 +2802,7 @@ function test_suite_init {
       export LB_TYPE=TRAEFIK
     fi
 
-    if [ -z "$DEBUG_OUT"; then
+    if [ -z "$DEBUG_OUT" ]; then
       export DEBUG_OUT="false"
     fi
 
@@ -2722,8 +2867,20 @@ function test_suite_init {
     cd $PROJECT_ROOT || fail "Could not cd to $PROJECT_ROOT"
    
 
+    # Test installation using helm charts if helm is available
+    #
+    if ! [ -x "$(command -v helm)" ]; then
+      trace 'helm is not installed. Skipping helm charts tests'
+    else
+      USE_HELM="true"
+      trace 'helm is installed. Using helm for the tests'
+    fi
+
     if [ "$WERCKER" = "true" ]; then 
       trace "Test Suite is running locally on Wercker and k8s is running on remote nodes."
+
+      # do not use helm when running on wercker, for now
+      USE_HELM="false"
 
       # No need to check M2_HOME or docker_pass -- not used by local runs
 
@@ -2733,6 +2890,8 @@ function test_suite_init {
       mkdir -p $RESULT_ROOT/acceptance_test_tmp || fail "Could not mkdir -p RESULT_ROOT/acceptance_test_tmp (RESULT_ROOT=$RESULT_ROOT)"
 
       create_image_pull_secret_wercker
+
+      setup_wercker
       
     elif [ "$JENKINS" = "true" ]; then
     
@@ -2817,9 +2976,9 @@ function test_suite {
     
     declare_new_test 1 define_operators_and_domains
 
-    #          OP_KEY  NAMESPACE            TARGET_NAMESPACES  EXTERNAL_REST_HTTPSPORT
-    op_define  oper1   weblogic-operator-1  "default,test1"    31001
-    op_define  oper2   weblogic-operator-2  test2              32001
+    #          OP_KEY  NAMESPACE            TARGET_NAMESPACES  EXTERNAL_REST_HTTPSPORT  SETUP_KUBERNETES_CLUSTER
+    op_define  oper1   weblogic-operator-1  "default,test1"    31001                    true
+    op_define  oper2   weblogic-operator-2  test2              32001                    false
 
     #          DOM_KEY  OP_KEY  NAMESPACE DOMAIN_UID STARTUP_CONTROL WL_CLUSTER_NAME WL_CLUSTER_TYPE  MS_BASE_NAME   ADMIN_PORT ADMIN_WLST_PORT ADMIN_NODE_PORT MS_PORT LOAD_BALANCER_WEB_PORT LOAD_BALANCER_DASHBOARD_PORT
     dom_define domain1  oper1   default   domain1    AUTO            cluster-1       DYNAMIC          managed-server 7001       30012           30701           8001    30305                  30315
@@ -2833,12 +2992,13 @@ function test_suite {
     # TODO have the op_define commands themselves create target namespace if it doesn't already exist, or test if the namespace creation is needed in the first place, and if so, ask MikeG to create them as part of domain create job
     kubectl create namespace test1 2>&1 | sed 's/^/+/g' 
     kubectl create namespace test2 2>&1 | sed 's/^/+/g' 
+
     kubectl create namespace weblogic-operator-1 2>&1 | sed 's/^/+/g' 
     kubectl create namespace weblogic-operator-2 2>&1 | sed 's/^/+/g' 
 
     # This test pass pairs with 'declare_new_test 1 define_operators_and_domains' above
     declare_test_pass
-    
+   
     trace 'Running mvn integration tests...'
     if [ "$WERCKER" = "true" ]; then
       test_mvn_integration_wercker
@@ -2847,6 +3007,7 @@ function test_suite {
     else
       test_mvn_integration_local
     fi
+
 
     # create and start first operator, manages namespaces default & test1
     test_first_operator oper1
@@ -2890,7 +3051,7 @@ function test_suite {
 
       # test scaling domain4 cluster from 2 to 3 servers and back to 2, plus verify no impact on domain1
       test_cluster_scale domain4 domain1 
-  
+ 
       # cycle domain1 down and back up, plus verify no impact on domain4
       test_domain_lifecycle domain1 domain4 
 


### PR DESCRIPTION
updated integration test src/integration-tests/bash/run.sh and cleanup.sh to use helm charts - 1.0 style domain charts and 2.0 style operator helm charts, instead of scripts.

wercker test would still be using install scripts with this change. Will continue to get wercker to work with helm charts in OWLS-67340