### PR TITLE
use helm in wercker integration test

### DIFF
--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -423,6 +423,12 @@ function orderlyDelete {
   kubectl delete job $JOB_NAME --ignore-not-found=true
 }
 
+function cleanup_tiller {
+  kubectl -n kube-system delete deployment tiller-deploy
+  kubectl delete clusterrolebinding tiller-cluster-rule
+  kubectl -n kube-system delete serviceaccount tiller
+}
+
 function fail {
   echo @@ cleanup.sh: Error "$@"
   exit 1
@@ -441,6 +447,11 @@ mkdir -p $TMP_DIR || fail No permision to create directory $TMP_DIR
 if [ -x "$(command -v helm)" ]; then
   echo @@ Deleting installed helm charts
   helm list --short | xargs -L1 helm delete --purge
+
+  # cleanup tiller artifacts that are created in run.sh
+  if [ "$WERCKER" = "true" ]; then
+    cleanup_tiller
+  fi
 fi
 
 # first, try to delete with labels since the conversion is that all created resources need to

--- a/wercker.yml
+++ b/wercker.yml
@@ -64,6 +64,7 @@ build:
 
 # This pipeline runs the integration tests against a k8s cluster on OCI.
 command-timeout: 60
+no-response-timeout: 10
 integration-test:
   steps:
   - script:
@@ -79,7 +80,17 @@ integration-test:
         # clean up
         yum clean all
 
-        # store the artifacts so we can download them easily
+        if [ -x "$(command -v helm)" ]; then
+          echo @@ "Deleting installed helm charts"
+          helm list --short | xargs -L1 helm delete --purge
+
+          echo @@ "Calling helm reset -f"
+          helm reset -f
+        else
+          echo @@ "helm not installed, skipping helm reset"
+        fi
+
+        echo @@ "store the artifacts so we can download them easily"
         tar czvf ${WERCKER_REPORT_ARTIFACTS_DIR}/integration-test-data.tar.gz /pipeline/output/*
       }
 
@@ -136,6 +147,16 @@ integration-test:
 
       echo @@ "Calling 'kubectl version'"
       kubectl version
+
+      echo @@ "Helm installation starts"
+      curl -LO http://kubernetes-helm.storage.googleapis.com/helm-v2.8.2-linux-amd64.tar.gz
+      mkdir /tmp/helm
+      tar xzf helm-v2.8.2-linux-amd64.tar.gz -C /tmp/helm
+      chmod +x /tmp/helm/linux-amd64/helm
+      mv /tmp/helm/linux-amd64/helm /usr/local/bin/
+      rm -rf /tmp/helm
+      helm version
+      echo @@ "Helm is installed."
 
       # obtain an exclusive k8s cluster lease using the 'lease.sh' helper script
       #   - first set LEASE_ID to a unique value


### PR DESCRIPTION
Using helm charts in integration test running in wercker.

This involves 
- installing helm
- set up the tiller rbac artifacts that seems to be required when running in our wercker environment (https://docs.helm.sh/using_helm/#role-based-access-control)
- calling helm init to set up tiller
- using helm charts in the integration tests instead of scripts for both operator and WebLogic domains
- clean up after the run
- this change also include running the -Phelm-integration-tests unit tests in wercker

Notes
- I have temporarily disabled t3 channel verification test using WLST, as it has been failing intermittently regardless of whether scripts or helm charts were used. I will file a separate jira task to continue the investigation.  
- the proposed change uses helm init with --wait option, which requires helm 2.8.2 version
- Passed wercker integration test (https://app.wercker.com/Oracle/weblogic-kubernetes-operator/runs/integration-test185/5b61fedf6d65010007863d98) and jenkins (http://wls-jenkins/job/weblogic-kubernetes-operator/479/)