### PR TITLE
OWLS-67651: WLS cluster is unstable when startupControl …

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -123,7 +123,7 @@ public class MessageKeys {
   public static final String RESTART_SERVERS_STARTING = "WLSKO-0116";
   public static final String ROLLING_CLUSTERS_STARTING = "WLSKO-0117";
   public static final String CYCLING_SERVERS = "WLSKO-0118";
-  public static final String ROLLING_SERVERS = "WLSKO-0118";
+  public static final String ROLLING_SERVERS = "WLSKO-0119";
   public static final String REMOVING_INGRESS = "WLSKO-0120";
   public static final String LIST_INGRESS_FOR_DOMAIN = "WLSKO-0121";
   public static final String POD_DELETED = "WLSKO-0122";

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -168,6 +168,13 @@ public class ManagedServersUpStep extends Step {
               String serverName = wlsServerConfig.getListenAddress();
               // do not start admin server
               if (!serverName.equals(asName) && !servers.contains(serverName)) {
+                List<V1EnvVar> env = null;
+                // find ClusterStartup for WlsClusterConfig
+                ClusterStartup cs = findClusterStartup(wlsClusterConfig.getClusterName(), lcs);
+                if (cs != null) {
+                  env = cs.getEnv();
+                }
+
                 // start server
                 servers.add(serverName);
                 ssic.add(new ServerStartupInfo(wlsServerConfig, wlsClusterConfig, null, null));
@@ -220,6 +227,26 @@ public class ManagedServersUpStep extends Step {
         return doNext(
             scaleDownIfNecessary(info, servers, new ClusterServicesStep(info, getNext())), packet);
     }
+  }
+
+  /**
+   * Find corresponding ClusterStartup for WLS cluster, if defined.
+   *
+   * @param wlsClusterName - name of WLS cluster
+   * @param lcs - List of defined ClusterStartup's
+   * @return - ClusterStartup, if exists, or Null
+   */
+  private static ClusterStartup findClusterStartup(
+      String wlsClusterName, List<ClusterStartup> lcs) {
+    if (lcs != null) {
+      for (ClusterStartup cs : lcs) {
+        String clusterName = cs.getClusterName();
+        if (clusterName.equals(wlsClusterName)) {
+          return cs;
+        }
+      }
+    }
+    return null;
   }
 
   private static List<V1EnvVar> startInAdminMode(List<V1EnvVar> env) {


### PR DESCRIPTION
When startupControl is set to ALL, we must use the defined Env variables provided in ClusterStartup when extra servers are being started for the associated WLS cluster.  The prevents managed server pods from being stopped and restarted due to changed environment variables.