### PR TITLE
Fix wercker t3channel test

### DIFF
--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -1921,6 +1921,7 @@ EOF
 #   -   local  --> run locally - requires java & weblogic to be installed
 #   -   remote --> run remotely on admin server, construct URL using admin pod name
 #   -   hybrid --> run remotely on admin server, construct URL using 'NODEPORT_HOST'
+#                  (using K8S_NODEPORT_IP instead since NODEPORT_HOST sometimes does not work in OCI)
 #
 function run_wlst_script {
   if [ "$#" -lt 3 ] ; then
@@ -1943,7 +1944,7 @@ function run_wlst_script {
   local password=`get_wladmin_pass $1`
   local pyfile_lcl="$3"
   local pyfile_pod="/shared/`basename $pyfile_lcl`"
-  local t3url_lcl="t3://$NODEPORT_HOST:$ADMIN_WLST_PORT"
+  local t3url_lcl="t3://$K8S_NODEPORT_IP:$ADMIN_WLST_PORT"
   local t3url_pod="t3://$AS_NAME:$ADMIN_WLST_PORT"
   local wlcmdscript_lcl="$TMP_DIR/wlcmd.sh"
   local wlcmdscript_pod="/shared/wlcmd.sh"
@@ -2032,6 +2033,7 @@ EOF
 
     if [ "$result" = "0" ];
     then 
+      cat ${pyfile_lcl}.out
       break
     fi
 
@@ -2205,9 +2207,10 @@ function verify_service_and_pod_created {
       local EXTCHANNEL_T3CHANNEL_SERVICE_NAME=${SERVICE_NAME}-extchannel-t3channel
       trace "checking if service ${EXTCHANNEL_T3CHANNEL_SERVICE_NAME} is created"
       count=0
+      srv_count=0
       while [ "${srv_count:=Error}" != "1" -a $count -lt $max_count_srv ] ; do
         local count=`expr $count + 1`
-        local srv_count=`kubectl -n $NAMESPACE get services | grep "^$SERVICE_NAME " | wc -l`
+        local srv_count=`kubectl -n $NAMESPACE get services | grep "^$EXTCHANNEL_T3CHANNEL_SERVICE_NAME " | wc -l`
         if [ "${srv_count:=Error}" != "1" ]; then
           trace "Did not find service $EXTCHANNEL_T3CHANNEL_SERVICE_NAME, iteration $count of $max_count_srv"
           sleep $wait_time
@@ -2258,6 +2261,9 @@ function verify_service_and_pod_created {
     fi
 
     if [ "${IS_ADMIN_SERVER}" = "true" ]; then
+      trace "listing pods"
+      kubectl -n $NAMESPACE get pods -o wide
+
       verify_wlst_access $DOM_KEY
     fi
 }

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -1921,7 +1921,7 @@ EOF
 #   -   local  --> run locally - requires java & weblogic to be installed
 #   -   remote --> run remotely on admin server, construct URL using admin pod name
 #   -   hybrid --> run remotely on admin server, construct URL using 'NODEPORT_HOST'
-#                  (using K8S_NODEPORT_IP instead since NODEPORT_HOST sometimes does not work in OCI)
+#                  or 'K8S_NODEPORT_IP' in wercker since NODEPORT_HOST sometimes does not work in OCI
 #
 function run_wlst_script {
   if [ "$#" -lt 3 ] ; then
@@ -1944,7 +1944,12 @@ function run_wlst_script {
   local password=`get_wladmin_pass $1`
   local pyfile_lcl="$3"
   local pyfile_pod="/shared/`basename $pyfile_lcl`"
-  local t3url_lcl="t3://$K8S_NODEPORT_IP:$ADMIN_WLST_PORT"
+  if [ "$WERCKER" = "true" ]; then 
+    # use OCI public IP in wercker
+    local t3url_lcl="t3://$K8S_NODEPORT_IP:$ADMIN_WLST_PORT"
+  else
+    local t3url_lcl="t3://$NODEPORT_HOST:$ADMIN_WLST_PORT"
+  fi
   local t3url_pod="t3://$AS_NAME:$ADMIN_WLST_PORT"
   local wlcmdscript_lcl="$TMP_DIR/wlcmd.sh"
   local wlcmdscript_pod="/shared/wlcmd.sh"

--- a/wercker.yml
+++ b/wercker.yml
@@ -108,6 +108,7 @@ integration-test:
 
       # Update KUBECONFIG for K8S cluster
       export K8S_NODEPORT_HOST="${OCI_K8S_WORKER0_HOSTNAME}"
+      export K8S_NODEPORT_IP="${OCI_K8S_WORKER0_IP}"
       sed -i -e "s,%ADDRESS%,https://$OCI_K8S_MASTER_IP:443,g" $WERCKER_SOURCE_DIR/build/kube.config
       sed -i -e "s,%CLIENT_CERT_DATA%,$OCI_K8S_CLIENT_CERT_DATA,g" $WERCKER_SOURCE_DIR/build/kube.config
       sed -i -e "s,%CLIENT_KEY_DATA%,$OCI_K8S_CLIENT_KEY_DATA,g" $WERCKER_SOURCE_DIR/build/kube.config


### PR DESCRIPTION
This proposed change should address the intermittent wrecker test failure due to T3channel test. 
- The FQDN of the OCI instance used in the URL for connecting to the T3 channel service does not work if the admin server pod happens to be running on a k8s node on the same OCI instance as specified in the OCI_K8S_WORKER0_HOSTNAME env var in wercker. It does however work if the admin server pod is running on a k8s node that resides on a different OCI instance. The test is modified to use the public IP address of the OCI instance, OCI_K8S_WORKER0_IP in the URL for connecting to the T3 channel service.
- Fixed test code that wait for the T3Channel service to be available.

passed jenkins http://wls-jenkins/job/weblogic-kubernetes-operator/486/ and wrecker
passed wercker integration-test-185 https://app.wercker.com/Oracle/weblogic-kubernetes-operator/runs/integration-test185/5b6b5c8889afc10008092c22?step=5b6b5c9ec23cb50007b7cf93