### PR TITLE
Remove jenkins helm install runsh

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -960,7 +960,7 @@ public class Main {
                   }
                 }
               } else if (clusterName != null) {
-                V1Service oldService = info.getClusters().put(clusterName, null);
+                V1Service oldService = info.getClusters().remove(clusterName);
                 if (oldService != null) {
                   // Service was deleted, but clusters still contained a non-null entry
                   LOGGER.info(

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -557,16 +557,6 @@ function setup_jenkins {
     docker build -t "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" --no-cache=true .
 
     docker images
-
-    trace "Helm installation starts" 
-    wget -q -O  /tmp/helm-v2.7.2-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.7.2-linux-amd64.tar.gz
-    mkdir /tmp/helm
-    tar xzf /tmp/helm-v2.7.2-linux-amd64.tar.gz -C /tmp/helm
-    chmod +x /tmp/helm/linux-amd64/helm
-    /usr/local/packages/aime/ias/run_as_root "cp /tmp/helm/linux-amd64/helm /usr/bin/"
-    rm -rf /tmp/helm
-    helm init
-    trace "Helm is configured."
 }
 
 # setup_local is for arbitrary dev hosted linux - it assumes docker & k8s are already installed


### PR DESCRIPTION
1. Remove code that install helm from setup_jenkins in src/integration-tests/bash/run.sh. helm installation is already done by devops-k8s-install.sh.

2. Address NPE seen in recent jenkin failures such as http://wls-jenkins/job/weblogic-kubernetes-operator/511/consoleText 

{"timestamp":"08-15-2018T16:29:57.346+0000","thread":36,"level":"WARNING","class":"oracle.kubernetes.operator.Watcher","method":"watchForEvents","timeInMillis":1534350597346,"message":"Exception thrown: {0}","exception":"\njava.lang.NullPointerException\n\tat java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)\n\tat java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)\n\tat oracle.kubernetes.operator.Main.dispatchServiceWatch(Main.java:963)\n\tat oracle.kubernetes.operator.Watcher.handleRegularUpdate(Watcher.java:144)\n\tat oracle.kubernetes.operator.Watcher.watchForEvents(Watcher.java:121)\n\tat oracle.kubernetes.operator.Watcher.doWatch(Watcher.java:94)\n\tat java.lang.Thread.run(Thread.java:748)\n","code":"","headers":{},"body":""}

by changing call to ConcurrentHashMap.put(clusterName, null) with remove(clusterName) in Main.java
Passed jenkins (http://wls-jenkins/job/weblogic-kubernetes-operator/514/consoleText)

