### PR TITLE
Java int test fix

### DIFF
--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorInputsFileTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorInputsFileTest.java
@@ -60,7 +60,7 @@ public class CreateOperatorInputsFileTest {
                 .externalRestHttpsPort("31001")
                 .externalSans("")
                 .remoteDebugNodePortEnabled("false")
-                .weblogicOperatorImage("weblogic-kubernetes-operator:1.0")
+                .weblogicOperatorImage("weblogic-kubernetes-operator:1.1")
                 .weblogicOperatorImagePullPolicy("IfNotPresent")
                 .weblogicOperatorImagePullSecretName("")
                 .internalDebugHttpPort("30999")

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsRetriever.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsRetriever.java
@@ -244,6 +244,9 @@ public class WlsRetriever {
     public WithHttpClientStep(RequestType requestType, V1Service service, Step next) {
       super(next);
       this.requestType = requestType;
+      if (service == null) {
+        throw new IllegalArgumentException("service cannot be null");
+      }
       this.service = service;
     }
 
@@ -359,18 +362,19 @@ public class WlsRetriever {
 
         return doNext(packet);
       } catch (Throwable t) {
+        // do not retry for health check
+        if (RequestType.HEALTH.equals(requestType)) {
+          LOGGER.fine(
+              MessageKeys.WLS_HEALTH_READ_FAILED, packet.get(ProcessingConstants.SERVER_NAME), t);
+          return doNext(packet);
+        }
         // exponential back-off
         Integer retryCount = (Integer) packet.get(RETRY_COUNT);
         if (retryCount == null) {
           retryCount = 0;
           // Log warning if this is the first try. Do not log for retries to prevent
           // filling up the log repeatedly  with same log message
-          if (RequestType.CONFIG.equals(requestType)) {
-            LOGGER.warning(MessageKeys.WLS_CONFIGURATION_READ_FAILED, t);
-          } else {
-            LOGGER.fine(
-                MessageKeys.WLS_HEALTH_READ_FAILED, packet.get(ProcessingConstants.SERVER_NAME), t);
-          }
+          LOGGER.warning(MessageKeys.WLS_CONFIGURATION_READ_FAILED, t);
         }
         long waitTime = Math.min((2 << ++retryCount) * SCALE, MAX) + (R.nextInt(HIGH - LOW) + LOW);
         packet.put(RETRY_COUNT, retryCount);

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -4,15 +4,32 @@
 
 package oracle.kubernetes.operator;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import io.kubernetes.client.models.V1ObjectMeta;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfoManager;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
+import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Test;
 
 public class MainTest {
+
+  final String DOMAIN_UID = "domain-uid-for-testing";
+
+  @After
+  public void tearDown() {
+    DomainPresenceInfoManager.remove(DOMAIN_UID);
+  }
 
   @Test
   public void getTargetNamespaces_withEmptyValue_should_return_default()
@@ -61,6 +78,134 @@ public class MainTest {
         invoke_getTargetNamespaces("dev-domain ,test-domain ", "default");
     assertTrue(namespaces.contains("dev-domain"));
     assertTrue(namespaces.contains("test-domain"));
+  }
+
+  @Test
+  public void deleteDomainPresenceWithTimeCheck_delete_with_same_DateTime() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    DateTime CREATION_DATETIME = DateTime.now();
+    V1ObjectMeta domainMeta = new V1ObjectMeta().creationTimestamp(CREATION_DATETIME);
+    domain.setMetadata(domainMeta);
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result =
+        Main.deleteDomainPresenceWithTimeCheck(DOMAIN_UID, CREATION_DATETIME);
+
+    assertEquals(info, result);
+    assertNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
+  }
+
+  @Test
+  public void deleteDomainPresenceWithTimeCheck_delete_with_newer_DateTime() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    DateTime CREATION_DATETIME = DateTime.now();
+    DateTime DELETE_DATETIME = CREATION_DATETIME.plusMinutes(1);
+    V1ObjectMeta domainMeta = new V1ObjectMeta().creationTimestamp(CREATION_DATETIME);
+    domain.setMetadata(domainMeta);
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result = Main.deleteDomainPresenceWithTimeCheck(DOMAIN_UID, DELETE_DATETIME);
+
+    assertEquals(info, result);
+    assertNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
+  }
+
+  @Test
+  public void deleteDomainPresenceWithTimeCheck_delete_with_null_DateTime() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    DateTime CREATION_DATETIME = DateTime.now();
+    V1ObjectMeta domainMeta = new V1ObjectMeta().creationTimestamp(CREATION_DATETIME);
+    domain.setMetadata(domainMeta);
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result = Main.deleteDomainPresenceWithTimeCheck(DOMAIN_UID, null);
+
+    assertEquals(info, result);
+    assertNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
+  }
+
+  @Test
+  public void deleteDomainPresenceWithTimeCheck_delete_without_domain_creationDateTime() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    DateTime DELETE_DATETIME = DateTime.now();
+    domain.setMetadata(new V1ObjectMeta());
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result = Main.deleteDomainPresenceWithTimeCheck(DOMAIN_UID, DELETE_DATETIME);
+
+    assertEquals(info, result);
+    assertNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
+  }
+
+  @Test
+  public void
+      deleteDomainPresenceWithTimeCheck_delete_without_domain_creationDateTime_null_dateTime() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    domain.setMetadata(new V1ObjectMeta());
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result = Main.deleteDomainPresenceWithTimeCheck(DOMAIN_UID, null);
+
+    assertEquals(info, result);
+    assertNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
+  }
+
+  @Test
+  public void deleteDomainPresenceWithTimeCheck_doNotDelete_with_older_DateTime() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    DateTime CREATION_DATETIME = DateTime.now();
+    DateTime DELETE_DATETIME = CREATION_DATETIME.minusMinutes(1);
+    V1ObjectMeta domainMeta = new V1ObjectMeta().creationTimestamp(CREATION_DATETIME);
+    domain.setMetadata(domainMeta);
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result = Main.deleteDomainPresenceWithTimeCheck(DOMAIN_UID, DELETE_DATETIME);
+
+    assertNull(result);
+    assertNotNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
+  }
+
+  @Test
+  public void deleteDomainPresenceWithTimeCheck_doNotDelete_with_different_domainUID() {
+    Domain domain = new Domain();
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    DateTime CREATION_DATETIME = DateTime.now();
+    V1ObjectMeta domainMeta = new V1ObjectMeta().creationTimestamp(CREATION_DATETIME);
+    domain.setMetadata(domainMeta);
+    domain.setSpec(domainSpec);
+
+    DomainPresenceInfo info = DomainPresenceInfoManager.getOrCreate(domain);
+
+    DomainPresenceInfo result =
+        Main.deleteDomainPresenceWithTimeCheck("DifferentDomainUID", CREATION_DATETIME);
+
+    assertNull(result);
+    assertNotNull(DomainPresenceInfoManager.lookup(DOMAIN_UID));
   }
 
   Method getTargetNamespaces;

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsRetrieverTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsRetrieverTest.java
@@ -92,7 +92,7 @@ public class WlsRetrieverTest {
     assertThat(logRecords, containsFine(WLS_HEALTH_READ_FAILED, SERVER_NAME));
   }
 
-  @Test
+  // @Test - no longer retry for Health check
   public void withHttpClientStep_Health_nologIfFailedOnRetry() {
     V1Service service = Stub.createStub(V1ServiceStub.class);
     Step next = new MockStep(null);

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsRetrieverTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsRetrieverTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.Stub;
+import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Service;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,12 +20,18 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.ProcessingConstants;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfoManager;
+import oracle.kubernetes.operator.helpers.ServerKubernetesObjectsManager;
 import oracle.kubernetes.operator.http.HttpClient;
 import oracle.kubernetes.operator.wlsconfig.WlsRetriever.RequestType;
 import oracle.kubernetes.operator.wlsconfig.WlsRetriever.WithHttpClientStep;
+import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -105,6 +112,34 @@ public class WlsRetrieverTest {
     assert (logRecords.isEmpty());
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void WithHttpClientStep_const_throws_with_null_service() {
+    Step next = new MockStep(null);
+    new WithHttpClientStep(RequestType.HEALTH, null, next);
+  }
+
+  // @Test (expected =IllegalArgumentException.class)
+  public void ReadStep_apply_throws_with_null_service() {
+    final String SERVER_NAME = "managed-server1";
+    final String DOMAIN_UID = "testDomain";
+    Step next = new MockStep(null);
+    DomainSpec domainSpec = new DomainSpec();
+    domainSpec.setDomainUID(DOMAIN_UID);
+    Domain domain =
+        new Domain()
+            .withSpec(domainSpec)
+            .withMetadata(new V1ObjectMeta().namespace("testnamespace"));
+    DomainPresenceInfo domainPresenceInfo = DomainPresenceInfoManager.getOrCreate(domain);
+    ServerKubernetesObjectsManager.getOrCreate(domainPresenceInfo, DOMAIN_UID, SERVER_NAME);
+    Packet packet =
+        Stub.createStub(PacketStub.class)
+            .addSpi(DomainPresenceInfo.class, domainPresenceInfo)
+            .withServerName(SERVER_NAME);
+
+    Step readStep = WlsRetriever.readHealthStep(next);
+    readStep.apply(packet);
+  }
+
   abstract static class PacketStub extends Packet {
 
     Integer retryCount;
@@ -117,6 +152,12 @@ public class WlsRetrieverTest {
 
     PacketStub withServerName(String serverName) {
       this.serverName = serverName;
+      return this;
+    }
+
+    PacketStub addSpi(Class clazz, Object spiObject) {
+      Component component = Component.createFor(spiObject);
+      this.getComponents().put(clazz.getName(), component);
       return this;
     }
 


### PR DESCRIPTION
Proposed changes to fix java integration tests failures on jenkins

1) Noticed that DELETE domain watch events were sent even after the domain was re-created in the domain lifecycle test. Adding check for domain metadata creationTimeStamp so delete domain event for old domain creation won’t be processed.

2) WlsRetriever$WithHttpClientStep sometimes called with a null service. This results in invalid URL for getting the configuration from WLS admin server, and WlsRetriever would retry using the same invalid URL. WithHttpClientStep constructor would now reject null service parameter and throw IllegalArgumentException. WlsRetriever will eventually get called with a valid admin server service object.

3) Unrelated to java integration test - Update operator version number in CreateOperatorInputsFileTest so test would pass with operator version 1.1 

Passed jenkins java integration test: http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/69/

Passed jenkins integration test: http://wls-jenkins/job/weblogic-kubernetes-operator/520/

Passed wrecker tests: 
https://app.wercker.com/Oracle/weblogic-kubernetes-operator/runs/integration-test185/5b7dd7d217316c0007b4a3af
https://app.wercker.com/Oracle/weblogic-kubernetes-operator/runs/integration-test-java/5b7dd7d217316c0007b4a3b3