### PR TITLE
OWLS-67486: Expose server name via javaOptions

### DIFF
--- a/kubernetes/internal/create-weblogic-domain.sh
+++ b/kubernetes/internal/create-weblogic-domain.sh
@@ -400,7 +400,6 @@ function initialize {
     weblogicDomainStorageSize \
     weblogicCredentialsSecretName \
     namespace \
-    javaOptions \
     t3PublicAddress \
     version
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsValidationTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainInputsValidationTest.java
@@ -592,14 +592,6 @@ public class CreateDomainInputsValidationTest {
             missingFileError(PARAM_LOAD_BALANCER_VOLUME_PATH, val, "custom-mod-wl-apache.conf")));
   }
 
-  // TBD - shouldn't we allow empty java options?
-  @Test
-  public void createDomain_with_missingJavaOptions_failsAndReturnsError() throws Exception {
-    assertThat(
-        execCreateDomain(newInputs().javaOptions("")),
-        failsAndPrints(paramMissingError(PARAM_JAVA_OPTIONS)));
-  }
-
   @Test
   public void createDomain_with_missingVersion_failsAndReturnsError() throws Exception {
     assertThat(

--- a/site/creating-domain.md
+++ b/site/creating-domain.md
@@ -107,7 +107,7 @@ The following parameters must be provided in the input file.
 | `exposeAdminNodePort` | Boolean indicating if the Administration Server is exposed outside of the Kubernetes cluster. | `false` |
 | `exposeAdminT3Channel` | Boolean indicating if the T3 administrative channel is exposed outside the Kubernetes cluster. | `false` |
 | `initialManagedServerReplicas` | Number of Managed Servers to initially start for the domain. | `2` |
-| `javaOptions` | Java options for starting the Administration and Managed Servers. | `-Dweblogic.StdoutDebugEnabled=false` |
+| `javaOptions` | Java options for starting the Administration and Managed Servers. A Java option can have references to one or more of the following pre-defined variables to obtain WebLogic domain information: $(DOMAIN_NAME), $(DOMAIN_HOME), $(ADMIN_NAME), $(ADMIN_PORT), and $(SERVER_NAME). | `-Dweblogic.StdoutDebugEnabled=false` |
 | `loadBalancer` | Type of load balancer to create.  Legal values are `NONE` and `TRAEFIK`. | `TRAEFIK` |
 | `loadBalancerDashboardPort` | Node port for the load balancer to accept dashboard traffic. | `30315` |
 | `loadBalancerWebPort` | Node port for the load balancer to accept user traffic. | `30305` |


### PR DESCRIPTION
Make sure the tokens in the javaOptions property is honored.
Add doc for exposing the internal pod envs in javaOptions.