### PR TITLE
Op20scriptenhdev

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -10,7 +10,7 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodSpec;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import oracle.kubernetes.operator.DomainStatusUpdater;
@@ -266,7 +266,6 @@ public class PodHelper {
     @Override
     protected List<String> getContainerCommand() {
       List<String> command = new ArrayList<>(super.getContainerCommand());
-      command.addAll(Arrays.asList(getAsName(), String.valueOf(getAsPort())));
       return command;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -10,7 +10,6 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodSpec;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import oracle.kubernetes.operator.DomainStatusUpdater;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -60,6 +60,8 @@ public abstract class PodStepContext {
   private static final String SECRETS_MOUNT_PATH = "/weblogic-operator/secrets";
   private static final String SCRIPTS_MOUNTS_PATH = "/weblogic-operator/scripts";
   private static final String STORAGE_MOUNT_PATH = "/shared";
+  private static final String NODEMGR_HOME = "/u01/nodemanager";
+  private static final String LOG_HOME = "/shared/logs";
   private static final int FAILURE_THRESHOLD = 1;
 
   @SuppressWarnings("OctalInteger")
@@ -644,7 +646,7 @@ public abstract class PodStepContext {
   }
 
   protected List<String> getContainerCommand() {
-    return Arrays.asList(START_SERVER, getDomainUID(), getServerName(), getDomainName());
+    return Arrays.asList(START_SERVER);
   }
 
   abstract List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters);
@@ -656,6 +658,9 @@ public abstract class PodStepContext {
     addEnvVar(vars, "ADMIN_NAME", getAsName());
     addEnvVar(vars, "ADMIN_PORT", getAsPort().toString());
     addEnvVar(vars, "SERVER_NAME", getServerName());
+    addEnvVar(vars, "DOMAIN_UID", getDomainUID());
+    addEnvVar(vars, "NODEMGR_HOME", NODEMGR_HOME);
+    addEnvVar(vars, "LOG_HOME", LOG_HOME);
     hideAdminUserCredentials(vars);
   }
 
@@ -696,8 +701,7 @@ public abstract class PodStepContext {
   }
 
   private V1Lifecycle createLifecycle() {
-    return new V1Lifecycle()
-        .preStop(handler(STOP_SERVER, getDomainUID(), getServerName(), getDomainName()));
+    return new V1Lifecycle().preStop(handler(STOP_SERVER));
   }
 
   private V1Handler handler(String... commandItems) {
@@ -723,7 +727,7 @@ public abstract class PodStepContext {
         .timeoutSeconds(tuning.readinessProbeTimeoutSeconds)
         .periodSeconds(tuning.readinessProbePeriodSeconds)
         .failureThreshold(FAILURE_THRESHOLD)
-        .exec(execAction(READINESS_PROBE, getDomainName(), getServerName()));
+        .exec(execAction(READINESS_PROBE));
     return readinessProbe;
   }
 
@@ -733,6 +737,6 @@ public abstract class PodStepContext {
         .timeoutSeconds(tuning.livenessProbeTimeoutSeconds)
         .periodSeconds(tuning.livenessProbePeriodSeconds)
         .failureThreshold(FAILURE_THRESHOLD)
-        .exec(execAction(LIVENESS_PROBE, getDomainName(), getServerName()));
+        .exec(execAction(LIVENESS_PROBE));
   }
 }

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
+
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
 # Kubernetes periodically calls this liveness probe script to determine whether
 # the pod should be restarted. The script checks a WebLogic Server state file which
 # is updated by the node manager.
-DN=${DOMAIN_NAME:-$1}
-SN=${SERVER_NAME:-$2}
-STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state
+
+DN=${DOMAIN_NAME?}
+SN=${SERVER_NAME?}
+DH=${DOMAIN_HOME?}
+
+STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
+
 if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
   echo "Error: WebLogic NodeManager process not found."
   exit 1

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
 # Reads the current state of a server. The script checks a WebLogic Server state
 # file which is updated by the node manager.
 
-DN=${DOMAIN_NAME:-$1}
-SN=${SERVER_NAME:-$2}
-STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state
+DN=${DOMAIN_NAME?}
+SN=${SERVER_NAME?}
+DH=${DOMAIN_HOME?}
+
+STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
 if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
   echo "Error: WebLogic NodeManager process not found."

--- a/operator/src/main/resources/scripts/readinessProbe.sh
+++ b/operator/src/main/resources/scripts/readinessProbe.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
 # Kubernetes periodically calls this readiness probe script to determine whether
 # the pod should be included in load balancing. The script checks a WebLogic Server state
 # file which is updated by the node manager.
 
-DN=${DOMAIN_NAME:-$1}
-SN=${SERVER_NAME:-$2}
-STATEFILE=/shared/domain/${DN}/servers/${SN}/data/nodemanager/${SN}.state
+DN=${DOMAIN_NAME?}
+SN=${SERVER_NAME?}
+DH=${DOMAIN_HOME?}
+
+STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
 if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
   echo "Error: WebLogic NodeManager process not found."

--- a/operator/src/main/resources/scripts/start-server.py
+++ b/operator/src/main/resources/scripts/start-server.py
@@ -1,3 +1,7 @@
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
 import sys;
 #
 # +++ Start of common code for reading domain secrets
@@ -14,20 +18,22 @@ file.close()
 
 # +++ End of common code for reading domain secrets
 #
-domain_uid = sys.argv[1]
-server_name = sys.argv[2]
-domain_name = sys.argv[3]
-if (len(sys.argv) == 5):
-  admin_server_url = sys.argv[4]
-else:
-  admin_server_url = None
 
-domain_path='/shared/domain/%s' % domain_name
+def getEnvVar(var):
+  val=os.environ.get(var)
+  if val==None:
+    print "ERROR: Env var ",var, " not set."
+    sys.exit(1)
+  return val
+
+domain_uid = getEnvVar('DOMAIN_UID')
+server_name = getEnvVar('SERVER_NAME')
+domain_name = getEnvVar('DOMAIN_NAME')
+domain_path = getEnvVar('DOMAIN_HOME')
 
 print 'admin username is %s' % admin_username
 print 'domain path is %s' % domain_path
 print 'server name is %s' % server_name
-print 'admin server url is %s' % admin_server_url
 
 # Encrypt the admin username and password
 adminUsernameEncrypted=encrypt(admin_username, domain_path)

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -1,18 +1,36 @@
 #!/bin/bash
 
-domain_uid=$1
-server_name=$2
-domain_name=$3
-as_name=$4
-as_port=$5
-as_hostname=$1-$4
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
 
-echo "debug arguments are $1 $2 $3 $4 $5"
+domain_uid=${DOMAIN_UID?}
+server_name=${SERVER_NAME?}
+domain_name=${DOMAIN_NAME?}
+admin_name=${ADMIN_NAME?}
+admin_port=${ADMIN_PORT?}
+domain_home=${DOMAIN_HOME?}
+log_home=${LOG_HOME?}
+nodemgr_home=${NODEMGR_HOME?}
 
-nmProp="/u01/nodemanager/nodemanager.properties"
+admin_hostname=${domain_uid}-${admin_name}
 
-# TODO: parameterize shared home and domain name
-export DOMAIN_HOME=/shared/domain/$domain_name
+echo "Starting WebLogic Server '${server_name}'."
+
+echo "Inputs: "
+for varname in domain_uid \
+               server_name \
+               admin_name \
+               admin_port \
+               domain_name \
+               domain_home \
+               log_home \
+               nodemgr_home \
+               ;
+do
+  echo -n " $varname=${!varname}"
+done
+echo ""
 
 #
 # Create a folder
@@ -20,30 +38,29 @@ export DOMAIN_HOME=/shared/domain/$domain_name
 function createFolder {
   mkdir -m 777 -p $1
   if [ ! -d $1 ]; then
-    fail "Unable to create folder $1"
+    echo "Unable to create folder $1"
+    exit 1
   fi
 }
 
 # Function to create server specific scripts and properties (e.g startup.properties, etc)
 # $1 - Domain UID
 # $2 - Server Name
-# $3 - Domain Name
+# $3 - Domain Home
 # $4 - Admin Server Hostname (only passed for managed servers)
 # $5 - Admin Server port (only passed for managed servers)
 function createServerScriptsProperties() {
 
   # Create nodemanager home for the server
-  srvr_nmdir=/u01/nodemanager
-  createFolder ${srvr_nmdir}
-  cp /shared/domain/$3/nodemanager/nodemanager.domains ${srvr_nmdir}
-  cp /shared/domain/$3/bin/startNodeManager.sh ${srvr_nmdir}
+  createFolder ${nodemgr_home}
+  cp $3/nodemanager/nodemanager.domains ${nodemgr_home}
+  cp $3/bin/startNodeManager.sh ${nodemgr_home}
 
   # Edit the start nodemanager script to use the home for the server
-  sed -i -e "s:/shared/domain/$3/nodemanager:/u01/nodemanager:g" ${srvr_nmdir}/startNodeManager.sh
+  sed -i -e "s:$3/nodemanager:${nodemgr_home}:g" ${nodemgr_home}/startNodeManager.sh
 
   # Create startup.properties file
-  datadir=${DOMAIN_HOME}/servers/$2/data/nodemanager
-  nmdir=${DOMAIN_HOME}/nodemgr_home
+  datadir=$3/servers/$2/data/nodemanager
   stateFile=${datadir}/$2.state
   startProp=${datadir}/startup.properties
   if [ -f "$startProp" ]; then
@@ -78,46 +95,49 @@ if [ -f "$stateFile" ]; then
 fi
 
 # Create nodemanager home directory that is local to the k8s node
-mkdir -p /u01/nodemanager
-cp ${DOMAIN_HOME}/nodemanager/* /u01/nodemanager/
+mkdir -p ${nodemgr_home}
+cp ${domain_home}/nodemanager/* ${nodemgr_home}
+
+nm_log="${log_home}/nodemanager-${server_name}.log"
 
 # Edit the nodemanager properties file to use the home for the server
-sed -i -e "s:DomainsFile=.*:DomainsFile=/u01/nodemanager/nodemanager.domains:g" /u01/nodemanager/nodemanager.properties
-sed -i -e "s:NodeManagerHome=.*:NodeManagerHome=/u01/nodemanager:g" /u01/nodemanager/nodemanager.properties
-sed -i -e "s:ListenAddress=.*:ListenAddress=$1-$2:g" /u01/nodemanager/nodemanager.properties
-sed -i -e "s:LogFile=.*:LogFile=/shared/logs/nodemanager-$2.log:g" /u01/nodemanager/nodemanager.properties
+sed -i -e "s:DomainsFile=.*:DomainsFile=${nodemgr_home}/nodemanager.domains:g" ${nodemgr_home}/nodemanager.properties
+sed -i -e "s:NodeManagerHome=.*:NodeManagerHome=${nodemgr_home}:g" ${nodemgr_home}/nodemanager.properties
+sed -i -e "s:ListenAddress=.*:ListenAddress=${domain_uid}-${server_name}:g" ${nodemgr_home}/nodemanager.properties
+sed -i -e "s:LogFile=.*:LogFile=${nm_log}:g" ${nodemgr_home}/nodemanager.properties
 
-export JAVA_PROPERTIES="-DLogFile=/shared/logs/nodemanager-$server_name.log -DNodeManagerHome=/u01/nodemanager"
-export NODEMGR_HOME="/u01/nodemanager"
-
+export JAVA_PROPERTIES="-DLogFile=${nm_log} -DNodeManagerHome=${nodemgr_home}"
 
 # Create startup.properties
 echo "Create startup.properties"
-if [ -n "$4" ]; then
+if [ ! "$admin_name" = "$server_name" ]; then
   echo "this is managed server"
-  createServerScriptsProperties $domain_uid $server_name $domain_name $as_hostname $as_port
+  createServerScriptsProperties $domain_uid $server_name $domain_home $admin_hostname $admin_port
 else
   echo "this is admin server"
-  createServerScriptsProperties $domain_uid $server_name $domain_name
+  createServerScriptsProperties $domain_uid $server_name $domain_home
 fi
 
 echo "Start the nodemanager"
-. ${NODEMGR_HOME}/startNodeManager.sh &
+rm -f ${nm_log}
+. ${nodemgr_home}/startNodeManager.sh &
 
 echo "Allow the nodemanager some time to start before attempting to connect"
-sleep 15
+wait_count=0
+while [ $wait_count -lt 15 ]; do
+  sleep 1
+  if [ -e ${nm_log} ] && [ `grep -c "Plain socket listener started" ${nm_log}` -gt 0 ]; then
+    break
+  fi
+  wait_count=$((wait_count + 1))
+done
 echo "Finished waiting for the nodemanager to start"
 
 echo "Update JVM arguments"
 echo "Arguments=${USER_MEM_ARGS} -XX\:+UnlockExperimentalVMOptions -XX\:+UseCGroupMemoryLimitForHeap ${JAVA_OPTIONS}" >> ${startProp}
 
-admin_server_t3_url=
-if [ -n "$4" ]; then
-  admin_server_t3_url=t3://$domain_uid-$as_name:$as_port
-fi
-
 echo "Start the server"
-wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/start-server.py $domain_uid $server_name $domain_name $admin_server_t3_url
+wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/start-server.py
 
 echo "Wait indefinitely so that the Kubernetes pod does not exit and try to restart"
 while true; do sleep 60; done

--- a/operator/src/main/resources/scripts/stop-server.py
+++ b/operator/src/main/resources/scripts/stop-server.py
@@ -1,3 +1,8 @@
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+import sys;
 #
 # +++ Start of common code for reading domain secrets
 
@@ -13,12 +18,20 @@ file.close()
 
 # +++ End of common code for reading domain secrets
 #
-domain_uid = sys.argv[1]
-server_name = sys.argv[2]
-domain_name = sys.argv[3]
+
+def getEnvVar(var):
+  val=os.environ.get(var)
+  if val==None:
+    print "ERROR: Env var ",var, " not set."
+    sys.exit(1)
+  return val
+
+domain_uid = getEnvVar('DOMAIN_UID')
+server_name = getEnvVar('SERVER_NAME')
+domain_name = getEnvVar('DOMAIN_NAME')
+domain_path = getEnvVar('DOMAIN_HOME')
 
 service_name = domain_uid + "-" + server_name
-domain_path='/shared/domain/%s' % domain_name
 
 # Connect to nodemanager and stop server
 try:

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-echo "Stop the server"
+# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
 
-wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/stop-server.py $1 $2 $3
+SN="${SERVER_NAME?}"
+
+echo "Stop server ${SN}"
+
+wlst.sh -skipWLSModuleScanning /weblogic-operator/scripts/stop-server.py 
 
 # Return status of 2 means failed to stop a server through the NodeManager.
 # Look to see if there is a server process that can be killed.
 if [ $? -eq 2 ]; then
-  pid=$(jps -v | grep '[D]weblogic.Name=$2' | awk '{print $1}')
+  pid=$(jps -v | grep '[D]weblogic.Name=${SN}' | awk '{print $1}')
   if [ ! -z $pid ]; then
     echo "Killing the server process $pid"
     kill -15 $pid

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -213,7 +213,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   public void whenAdminPodCreated_containerHasStartServerCommand() {
     assertThat(
         getCreatedPodSpecContainer().getCommand(),
-        contains("/weblogic-operator/scripts/startServer.sh", UID, getServerName(), DOMAIN_NAME));
+        contains("/weblogic-operator/scripts/startServer.sh"));
   }
 
   @Test
@@ -307,7 +307,6 @@ public class AdminPodHelperTest extends PodHelperTestBase {
 
   @Override
   List<String> createStartCommand() {
-    return Arrays.asList(
-        "/weblogic-operator/scripts/startServer.sh", UID, getServerName(), DOMAIN_NAME);
+    return Arrays.asList("/weblogic-operator/scripts/startServer.sh");
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -102,26 +102,14 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
 
   @Override
   List<String> createStartCommand() {
-    return Arrays.asList(
-        "/weblogic-operator/scripts/startServer.sh",
-        UID,
-        getServerName(),
-        DOMAIN_NAME,
-        ADMIN_SERVER,
-        ADMIN_PORT.toString());
+    return Arrays.asList("/weblogic-operator/scripts/startServer.sh");
   }
 
   @Test
   public void whenManagedPodCreated_containerHasStartServerCommand() {
     assertThat(
         getCreatedPodSpecContainer().getCommand(),
-        contains(
-            "/weblogic-operator/scripts/startServer.sh",
-            UID,
-            getServerName(),
-            DOMAIN_NAME,
-            ADMIN_SERVER,
-            Integer.toString(ADMIN_PORT)));
+        contains("/weblogic-operator/scripts/startServer.sh"));
   }
 
   @Test


### PR DESCRIPTION
WL Pod liveness, readiness, start, stop script update: 

* use env vars instead of command line args
* parameterize domain-home + domain-uid + nodemgr-home
* reduce boot time by about 15 seconds (replace hard coded sleep and instead monitor node mgr output to find when it's ready)
* modify run.sh to provide finer-grained control over when to enable helm

https://jira.oraclecorp.com/jira/browse/OWLS-67684
