### PR TITLE
latest changes from develop and fixed test8CreateDomainPVReclaimPolic…

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -196,7 +196,7 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain domain6 & verifing the domain creation");
     // create domain6
     Domain domain6 = TestUtils.createDomain(domain6PropsFile);
-    domain6.destroy();
+    domain6.shutdown();
     domain6.deletePVCAndCheckPVReleased();
     logger.info("SUCCESS");
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -369,6 +369,16 @@ public class Domain {
     verifyDomainDeleted(replicas);
   }
 
+  public void shutdown() throws Exception {
+    String cmd = "kubectl delete domain " + domainUid + " -n " + domainNS;
+    ExecResult result = ExecCommand.exec(cmd);
+    if (result.exitValue() != 0) {
+      throw new RuntimeException(
+          "FAILURE: command " + cmd + " failed, returned " + result.stderr());
+    }
+    String output = result.stdout().trim();
+    logger.info("command to delete domain " + cmd + " \n returned " + output);
+  }
   /**
    * verify domain is deleted
    *

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -253,7 +253,7 @@ public class TestUtils {
         if (i == (BaseTest.getMaxIterationsPod() - 1)) {
           throw new RuntimeException("FAILURE: PV is not in Released status, exiting!");
         }
-        logger.info("PV is not in Released status," + result.stdout());
+        logger.info("PV is not in Released status," + result.stdout() + "\n " + result.stderr());
         Thread.sleep(BaseTest.getWaitTimePod() * 1000);
         i++;
 


### PR DESCRIPTION
Fixing test failure in test8CreateDomainPVReclaimPolicyRecycle by calling kubectl delete domain instead of helm del --purge as helm del deletes the PV as well, but the test checks the status of PV after the domain is shutdown.