### PR TITLE
implement initial domain 2 model

### DIFF
--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesBaseTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesBaseTest.java
@@ -442,7 +442,7 @@ public abstract class CreateDomainGeneratedFilesBaseTest {
 
     DomainConfigurator configurator = DomainConfigurator.forDomain(domain);
     configurator
-        .configureServer(getInputs().getAdminServerName())
+        .configureAdminServer()
         .withDesiredState("RUNNING")
         .withEnvironmentVariable("JAVA_OPTIONS", getInputs().getJavaOptions())
         .withEnvironmentVariable("USER_MEM_ARGS", "-Xms64m -Xmx256m ");

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -68,7 +68,7 @@ public class CreateDomainGeneratedFilesOptionalFeaturesEnabledTestBase
     expected.getSpec().withExportT3Channels(newStringList().addElement("T3Channel"));
     // set the node port for the admin server:
     forDomain(expected)
-        .configureServer(getInputs().getAdminServerName())
+        .configureAdminServer()
         .withNodePort(Integer.parseInt(getInputs().getAdminNodePort()));
 
     return expected;

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -101,6 +101,31 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.9.6</version>
+            <scope>test</scope>
+        </dependency>                                       
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>3.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -132,6 +157,8 @@
                             </execution>
                         </executions>
                     </plugin>
+                    
+
                 </plugins>
             </build>
         </profile>

--- a/model/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
+++ b/model/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
@@ -6,24 +6,25 @@ package oracle.kubernetes.operator;
 
 /** Kubernetes constants. */
 public interface KubernetesConstants {
-  public static final String DEFAULT_IMAGE = "store/oracle/weblogic:12.2.1.3";
-  public static final String ALWAYS_IMAGEPULLPOLICY = "Always";
-  public static final String IFNOTPRESENT_IMAGEPULLPOLICY = "IfNotPresent";
-  public static final String NEVER_IMAGEPULLPOLICY = "Never";
-  public static final String LATEST_IMAGE_SUFFIX = ":latest";
+  String DEFAULT_IMAGE = "store/oracle/weblogic:12.2.1.3";
+  String ALWAYS_IMAGEPULLPOLICY = "Always";
+  String IFNOTPRESENT_IMAGEPULLPOLICY = "IfNotPresent";
+  String NEVER_IMAGEPULLPOLICY = "Never";
+  String LATEST_IMAGE_SUFFIX = ":latest";
 
-  public static final String EXTENSIONS_API_VERSION = "extensions/v1beta1";
-  public static final String KIND_INGRESS = "Ingress";
-  public static final String CLASS_INGRESS = "kubernetes.io/ingress.class";
-  public static final String CLASS_INGRESS_VALUE = "traefik";
+  String EXTENSIONS_API_VERSION = "extensions/v1beta1";
+  String KIND_INGRESS = "Ingress";
+  String CLASS_INGRESS = "kubernetes.io/ingress.class";
+  String CLASS_INGRESS_VALUE = "traefik";
 
-  public static final String DOMAIN_GROUP = "weblogic.oracle";
-  public static final String DOMAIN_VERSION = "v1";
-  public static final String DOMAIN_PLURAL = "domains";
-  public static final String DOMAIN_SINGULAR = "domain";
-  public static final String DOMAIN_SHORT = "dom";
+  String DOMAIN_GROUP = "weblogic.oracle";
+  String DOMAIN_VERSION = "v1";
+  String DOMAIN_PLURAL = "domains";
+  String DOMAIN_SINGULAR = "domain";
+  String DOMAIN_SHORT = "dom";
 
-  public static final String CONTAINER_NAME = "weblogic-server";
+  String CONTAINER_NAME = "weblogic-server";
 
-  public static final String DOMAIN_CONFIG_MAP_NAME = "weblogic-domain-cm";
+  String DOMAIN_CONFIG_MAP_NAME = "weblogic-domain-cm";
+  String API_VERSION_ORACLE_V2 = "weblogic.oracle/v2";
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.weblogic.domain;
 
+/** An interface for an object to configure a cluster in a test. */
 @SuppressWarnings("UnusedReturnValue")
 public interface ClusterConfigurator {
   ClusterConfigurator withReplicas(int replicas);
@@ -11,4 +12,12 @@ public interface ClusterConfigurator {
   ClusterConfigurator withDesiredState(String state);
 
   ClusterConfigurator withEnvironmentVariable(String name, String value);
+
+  ClusterConfigurator withImage(String imageName);
+
+  ClusterConfigurator withImagePullPolicy(String policy);
+
+  ClusterConfigurator withImagePullSecret(String cluster);
+
+  ClusterConfigurator withServerStartState(String cluster);
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ConfigurationNotSupportedException.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ConfigurationNotSupportedException.java
@@ -1,0 +1,24 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain;
+
+/**
+ * An exception to be thrown on an attempt to configure a field not supported by the domain model.
+ * Only used in unit testing.
+ */
+public class ConfigurationNotSupportedException extends RuntimeException {
+  private final String context;
+  private final String field;
+
+  public ConfigurationNotSupportedException(String context, String field) {
+    this.context = context;
+    this.field = field;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format("Configuring field %s is not supported for a %s", field, context);
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -4,12 +4,15 @@
 
 package oracle.kubernetes.weblogic.domain;
 
+import io.kubernetes.client.models.V1LocalObjectReference;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainV1Configurator;
 
 /**
  * Configures a domain, adding settings independently of the version of the domain representation.
+ * Note that the configurator uses a predefined domain schema, and should only be used for testing.
+ * Using it in the runtime runs the risk of corrupting the domain.
  */
 public interface DomainConfigurator {
 
@@ -39,7 +42,44 @@ public interface DomainConfigurator {
    */
   void setDefaultReplicas(int replicas);
 
+  /**
+   * Sets the default image for the domain.
+   *
+   * @param image the name of the image
+   */
+  void setDefaultImage(String image);
+
+  /**
+   * Sets the default image pull policy for the domain.
+   *
+   * @param imagepullpolicy the new policy
+   */
+  void setDefaultImagePullPolicy(String imagepullpolicy);
+
+  /**
+   * Sets the default image pull secret for the domain
+   *
+   * @param secretReference the object referring to the secret
+   */
+  void setDefaultImagePullSecret(V1LocalObjectReference secretReference);
+
   DomainConfigurator setStartupControl(String startupControl);
+
+  /**
+   * Add an environment variable to the domain
+   *
+   * @param name variable name
+   * @param value value
+   * @return this object
+   */
+  DomainConfigurator withEnvironmentVariable(String name, String value);
+
+  /**
+   * Adds an admin server configuration to the domain, if not already present.
+   *
+   * @return an object to add additional configurations
+   */
+  ServerConfigurator configureAdminServer();
 
   /**
    * Adds a default server configuration to the domain, if not already present.

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
@@ -1,0 +1,21 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain;
+
+import oracle.kubernetes.weblogic.domain.v1.ServerSpec;
+
+/**
+ * The interface for the class used by the domain model to return effective configurations to the
+ * operator runtime.
+ */
+public interface EffectiveConfigurationFactory {
+  ServerSpec getAdminServerSpec();
+
+  ServerSpec getServerSpec(String serverName, String clusterName);
+
+  int getReplicaCount(String clusterName);
+
+  void setReplicaCount(String clusterName, int replicaCount);
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
@@ -4,10 +4,20 @@
 
 package oracle.kubernetes.weblogic.domain;
 
+/** An interface for an object to configure a server in a test. */
+@SuppressWarnings("UnusedReturnValue")
 public interface ServerConfigurator {
   ServerConfigurator withNodePort(int nodePort);
 
   ServerConfigurator withDesiredState(String desiredState);
 
   ServerConfigurator withEnvironmentVariable(String name, String value);
+
+  ServerConfigurator withImage(String imageName);
+
+  ServerConfigurator withImagePullPolicy(String policy);
+
+  ServerConfigurator withImagePullSecret(String secretName);
+
+  ServerConfigurator withServerStartState(String state);
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/Domain.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/Domain.java
@@ -17,7 +17,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @SuppressWarnings("deprecation")
 public class Domain {
 
-  public static final int DEFAULT_REPLICA_LIMIT = 1;
+  /** The default number of replicas for a cluster. */
+  public static final int DEFAULT_REPLICA_LIMIT = 2;
+
   /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should
    * convert recognized schemas to the latest internal value, and may reject unrecognized values.
@@ -159,11 +161,11 @@ public class Domain {
   }
 
   public ServerSpec getAdminServerSpec() {
-    return spec.getAdminServerSpec();
+    return spec.getEffectiveConfigurationFactory(apiVersion).getAdminServerSpec();
   }
 
   public ServerSpec getServer(String serverName, String clusterName) {
-    return new ServerSpecV1Impl(spec, serverName, clusterName);
+    return spec.getEffectiveConfigurationFactory(apiVersion).getServerSpec(serverName, clusterName);
   }
 
   /**
@@ -173,11 +175,11 @@ public class Domain {
    * @return the result of applying any configurations for this value
    */
   public int getReplicaCount(String clusterName) {
-    return spec.getReplicaCount(clusterName);
+    return spec.getEffectiveConfigurationFactory(apiVersion).getReplicaCount(clusterName);
   }
 
-  void setReplicaCount(String clusterName, int replicaLimit) {
-    spec.setReplicaCount(clusterName, replicaLimit);
+  public void setReplicaCount(String clusterName, int replicaLimit) {
+    spec.getEffectiveConfigurationFactory(apiVersion).setReplicaCount(clusterName, replicaLimit);
   }
 
   String getEffectiveStartupControl() {
@@ -231,18 +233,6 @@ public class Domain {
    */
   public void setStatus(DomainStatus status) {
     this.status = status;
-  }
-
-  /**
-   * DomainStatus represents information about the status of a domain. Status may trail the actual
-   * state of a system.
-   *
-   * @param status Status
-   * @return this
-   */
-  public Domain withStatus(DomainStatus status) {
-    this.status = status;
-    return this;
   }
 
   /**

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainSpec.java
@@ -6,23 +6,31 @@ package oracle.kubernetes.weblogic.domain.v1;
 
 import static oracle.kubernetes.operator.StartupControlConstants.AUTO_STARTUPCONTROL;
 
-import com.google.common.base.Strings;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.models.V1LocalObjectReference;
 import io.kubernetes.client.models.V1SecretReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.weblogic.domain.EffectiveConfigurationFactory;
+import oracle.kubernetes.weblogic.domain.v2.AdminServer;
+import oracle.kubernetes.weblogic.domain.v2.BaseConfiguration;
+import oracle.kubernetes.weblogic.domain.v2.Cluster;
+import oracle.kubernetes.weblogic.domain.v2.ManagedServer;
+import oracle.kubernetes.weblogic.domain.v2.Server;
+import oracle.kubernetes.weblogic.domain.v2.ServerSpecV2Impl;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /** DomainSpec is a description of a domain. */
 @SuppressWarnings("NullableProblems")
-public class DomainSpec {
+public class DomainSpec extends BaseConfiguration {
 
   /** Domain unique identifier. Must be unique across the Kubernetes cluster. (Required) */
   @SerializedName("domainUID")
@@ -35,37 +43,6 @@ public class DomainSpec {
   @Expose
   @NotNull
   private String domainName;
-
-  /**
-   * The WebLogic Docker image.
-   *
-   * <p>Defaults to store/oracle/weblogic:12.2.1.3.
-   */
-  @SerializedName("image")
-  @Expose
-  private String image;
-
-  /**
-   * The image pull policy for the WebLogic Docker image. Legal values are Always, Never and
-   * IfNotPresent.
-   *
-   * <p>Defaults to Always if image ends in :latest, IfNotPresent otherwise.
-   *
-   * <p>More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   */
-  @SerializedName("imagePullPolicy")
-  @Expose
-  private String imagePullPolicy;
-
-  /**
-   * Reference to the secret used to authenticate a request for an image pull.
-   *
-   * <p>More info:
-   * https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
-   */
-  @SerializedName("imagePullSecret")
-  @Expose
-  private V1LocalObjectReference imagePullSecret;
 
   /**
    * Reference to secret containing domain administrator username and password. Secret must contain
@@ -150,29 +127,53 @@ public class DomainSpec {
   @Expose
   private Integer replicas;
 
+  /**
+   * The configuration for the admin server.
+   *
+   * @since 2.0
+   */
+  @SerializedName("adminServer")
+  @Expose
+  private AdminServer adminServer;
+
+  /**
+   * The configured managed servers.
+   *
+   * @since 2.0
+   */
+  @SerializedName("managedServers")
+  @Expose
+  private List<ManagedServer> managedServers = new ArrayList<>();
+
+  /**
+   * The configured clusters.
+   *
+   * @since 2.0
+   */
+  @SerializedName("clusters")
+  @Expose
+  protected List<Cluster> clusters = new ArrayList<>();
+
   String getEffectiveStartupControl() {
     return Optional.ofNullable(getStartupControl()).orElse(AUTO_STARTUPCONTROL).toUpperCase();
   }
 
-  ServerSpec getAdminServerSpec() {
-    return new ServerSpecV1Impl(this, getAsName(), null);
+  EffectiveConfigurationFactory getEffectiveConfigurationFactory(String apiVersion) {
+    return useVersion2(apiVersion)
+        ? new V2EffectiveConfigurationFactory()
+        : new V1EffectiveConfigurationFactory();
   }
 
-  @SuppressWarnings("deprecation")
-  ServerStartup getServerStartup(String name) {
-    if (getServerStartup() == null) return null;
-
-    for (ServerStartup ss : getServerStartup()) {
-      if (ss.getServerName().equals(name)) {
-        return ss;
-      }
-    }
-
-    return null;
+  private boolean useVersion2(String apiVersion) {
+    return isVersion2Specified(apiVersion) || hasV2Configuration() || hasV2Fields();
   }
 
-  public int getReplicaCount(String clusterName) {
-    return getReplicaCount(getClusterStartup(clusterName));
+  private boolean isVersion2Specified(String apiVersion) {
+    return KubernetesConstants.API_VERSION_ORACLE_V2.equals(apiVersion);
+  }
+
+  private boolean hasV2Configuration() {
+    return adminServer != null || !managedServers.isEmpty() || !clusters.isEmpty();
   }
 
   @SuppressWarnings("deprecation")
@@ -186,7 +187,7 @@ public class DomainSpec {
   }
 
   @SuppressWarnings("deprecation")
-  ClusterStartup getClusterStartup(String clusterName) {
+  private ClusterStartup getClusterStartup(String clusterName) {
     if (getClusterStartup() == null || clusterName == null) return null;
 
     for (ClusterStartup cs : getClusterStartup()) {
@@ -196,10 +197,6 @@ public class DomainSpec {
     }
 
     return null;
-  }
-
-  void setReplicaCount(String clusterName, int replicaLimit) {
-    getOrCreateClusterStartup(clusterName).setReplicas(replicaLimit);
   }
 
   @SuppressWarnings("deprecation")
@@ -273,66 +270,14 @@ public class DomainSpec {
   }
 
   /*
-   * The WebLogic Docker image.
-   *
-   * <p> Defaults to store/oracle/weblogic:12.2.1.3.
-   *
-   * @return image
-   */
-  public String getImage() {
-    return image;
-  }
-
-  /*
-   * The WebLogic Docker image.
-   *
-   * <p> Defaults to store/oracle/weblogic:12.2.1.3.
-   *
-   * @param image image
-   */
-  public void setImage(String image) {
-    this.image = image;
-  }
-
-  /*
-   * The WebLogic Docker image.
-   *
-   * <p> Defaults to store/oracle/weblogic:12.2.1.3.
+   * Fluent api for setting the image.
    *
    * @param image image
    * @return this
    */
   public DomainSpec withImage(String image) {
-    this.image = image;
+    setImage(image);
     return this;
-  }
-
-  /**
-   * The image pull policy for the WebLogic Docker image. Legal values are Always, Never and
-   * IfNotPresent.
-   *
-   * <p>Defaults to Always if image ends in :latest, IfNotPresent otherwise.
-   *
-   * <p>More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   *
-   * @return image pull policy
-   */
-  public String getImagePullPolicy() {
-    return imagePullPolicy;
-  }
-
-  /**
-   * The image pull policy for the WebLogic Docker image. Legal values are Always, Never and
-   * IfNotPresent.
-   *
-   * <p>Defaults to Always if image ends in :latest, IfNotPresent otherwise.
-   *
-   * <p>More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   *
-   * @param imagePullPolicy image pull policy
-   */
-  public void setImagePullPolicy(String imagePullPolicy) {
-    this.imagePullPolicy = imagePullPolicy;
   }
 
   /**
@@ -347,32 +292,8 @@ public class DomainSpec {
    * @return this
    */
   public DomainSpec withImagePullPolicy(String imagePullPolicy) {
-    this.imagePullPolicy = imagePullPolicy;
+    setImagePullPolicy(imagePullPolicy);
     return this;
-  }
-
-  /**
-   * Returns the reference to the secret used to authenticate a request for an image pull.
-   *
-   * <p>More info:
-   * https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
-   */
-  public V1LocalObjectReference getImagePullSecret() {
-    return hasImagePullSecret() ? imagePullSecret : null;
-  }
-
-  private boolean hasImagePullSecret() {
-    return imagePullSecret != null && !Strings.isNullOrEmpty(imagePullSecret.getName());
-  }
-
-  /**
-   * Reference to the secret used to authenticate a request for an image pull.
-   *
-   * <p>More info:
-   * https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
-   */
-  public void setImagePullSecret(V1LocalObjectReference imagePullSecret) {
-    this.imagePullSecret = imagePullSecret;
   }
 
   /**
@@ -382,26 +303,14 @@ public class DomainSpec {
    * https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
    */
   public DomainSpec withImagePullSecretName(String imagePullSecretName) {
-    this.imagePullSecret = new V1LocalObjectReference().name(imagePullSecretName);
+    setImagePullSecret(new V1LocalObjectReference().name(imagePullSecretName));
     return this;
   }
 
-  /**
-   * Reference to secret containing domain administrator username and password. Secret must contain
-   * keys names 'username' and 'password' (Required)
-   *
-   * @return admin secret
-   */
   public V1SecretReference getAdminSecret() {
     return adminSecret;
   }
 
-  /**
-   * Reference to secret containing domain administrator username and password. Secret must contain
-   * keys names 'username' and 'password' (Required)
-   *
-   * @param adminSecret admin secret
-   */
   @SuppressWarnings("unused")
   public void setAdminSecret(V1SecretReference adminSecret) {
     this.adminSecret = adminSecret;
@@ -419,22 +328,10 @@ public class DomainSpec {
     return this;
   }
 
-  /**
-   * Admin server name. Note: Possibly temporary as we could find this value through domain home
-   * inspection. (Required)
-   *
-   * @return admin server name
-   */
   public String getAsName() {
     return asName;
   }
 
-  /**
-   * Admin server name. Note: Possibly temporary as we could find this value through domain home
-   * inspection. (Required)
-   *
-   * @param asName admin server name
-   */
   public void setAsName(String asName) {
     this.asName = asName;
   }
@@ -451,22 +348,10 @@ public class DomainSpec {
     return this;
   }
 
-  /**
-   * Administration server port. Note: Possibly temporary as we could find this value through domain
-   * home inspection. (Required)
-   *
-   * @return admin server port
-   */
   public Integer getAsPort() {
     return asPort;
   }
 
-  /**
-   * Administration server port. Note: Possibly temporary as we could find this value through domain
-   * home inspection. (Required)
-   *
-   * @param asPort admin server port
-   */
   @SuppressWarnings("WeakerAccess")
   // public access is needed for yaml processing
   public void setAsPort(Integer asPort) {
@@ -716,10 +601,9 @@ public class DomainSpec {
   @Override
   public String toString() {
     return new ToStringBuilder(this)
+        .appendSuper(super.toString())
         .append("domainUID", domainUID)
         .append("domainName", domainName)
-        .append("image", image)
-        .append("imagePullPolicy", imagePullPolicy)
         .append("adminSecret", adminSecret)
         .append("asName", asName)
         .append("asPort", asPort)
@@ -734,8 +618,7 @@ public class DomainSpec {
   @Override
   public int hashCode() {
     return new HashCodeBuilder()
-        .append(image)
-        .append(imagePullPolicy)
+        .appendSuper(super.hashCode())
         .append(asName)
         .append(replicas)
         .append(startupControl)
@@ -751,16 +634,12 @@ public class DomainSpec {
 
   @Override
   public boolean equals(Object other) {
-    if (other == this) {
-      return true;
-    }
-    if (!(other instanceof DomainSpec)) {
-      return false;
-    }
+    if (other == this) return true;
+    if (!(other instanceof DomainSpec)) return false;
+
     DomainSpec rhs = ((DomainSpec) other);
     return new EqualsBuilder()
-        .append(image, rhs.image)
-        .append(imagePullPolicy, rhs.imagePullPolicy)
+        .appendSuper(super.equals(other))
         .append(asName, rhs.asName)
         .append(replicas, rhs.replicas)
         .append(startupControl, rhs.startupControl)
@@ -772,5 +651,119 @@ public class DomainSpec {
         .append(serverStartup, rhs.serverStartup)
         .append(adminSecret, rhs.adminSecret)
         .isEquals();
+  }
+
+  private Server getServer(String serverName) {
+    for (ManagedServer managedServer : managedServers) {
+      if (Objects.equals(serverName, managedServer.getServerName())) return managedServer;
+    }
+
+    return null;
+  }
+
+  private Cluster getCluster(String clusterName) {
+    for (Cluster cluster : clusters) {
+      if (Objects.equals(clusterName, cluster.getClusterName())) return cluster;
+    }
+
+    return null;
+  }
+
+  private int getReplicaCountFor(Cluster cluster) {
+    return hasReplicaCount(cluster) ? cluster.getReplicas() : Domain.DEFAULT_REPLICA_LIMIT;
+  }
+
+  private boolean hasReplicaCount(Cluster cluster) {
+    return cluster != null && cluster.getReplicas() != null;
+  }
+
+  public AdminServer getAdminServer() {
+    return adminServer;
+  }
+
+  public void setAdminServer(AdminServer adminServer) {
+    this.adminServer = adminServer;
+  }
+
+  public List<ManagedServer> getManagedServers() {
+    return managedServers;
+  }
+
+  public List<Cluster> getClusters() {
+    return clusters;
+  }
+
+  private class V1EffectiveConfigurationFactory implements EffectiveConfigurationFactory {
+    @Override
+    public ServerSpec getAdminServerSpec() {
+      return new ServerSpecV1Impl(DomainSpec.this, null, getServerStartup(getAsName()), null);
+    }
+
+    @Override
+    public ServerSpec getServerSpec(String serverName, String clusterName) {
+      return new ServerSpecV1Impl(
+          DomainSpec.this,
+          clusterName,
+          getServerStartup(serverName),
+          getClusterStartup(clusterName));
+    }
+
+    @Override
+    public int getReplicaCount(String clusterName) {
+      return DomainSpec.this.getReplicaCount(getClusterStartup(clusterName));
+    }
+
+    @Override
+    public void setReplicaCount(String clusterName, int replicaCount) {
+      getOrCreateClusterStartup(clusterName).setReplicas(replicaCount);
+    }
+
+    @SuppressWarnings("deprecation")
+    private ServerStartup getServerStartup(String name) {
+      if (DomainSpec.this.getServerStartup() == null) return null;
+
+      for (ServerStartup ss : DomainSpec.this.getServerStartup()) {
+        if (ss.getServerName().equals(name)) {
+          return ss;
+        }
+      }
+
+      return null;
+    }
+  }
+
+  class V2EffectiveConfigurationFactory implements EffectiveConfigurationFactory {
+    @Override
+    public ServerSpec getAdminServerSpec() {
+      return new ServerSpecV2Impl(adminServer, DomainSpec.this);
+    }
+
+    @Override
+    public ServerSpec getServerSpec(String serverName, String clusterName) {
+      return new ServerSpecV2Impl(getServer(serverName), getCluster(clusterName), DomainSpec.this);
+    }
+
+    @Override
+    public int getReplicaCount(String clusterName) {
+      return getReplicaCountFor(getCluster(clusterName));
+    }
+
+    @Override
+    public void setReplicaCount(String clusterName, int replicaCount) {
+      getOrCreateCluster(clusterName).setReplicas(replicaCount);
+    }
+
+    private Cluster getOrCreateCluster(String clusterName) {
+      Cluster cluster = getCluster(clusterName);
+      if (cluster != null) return cluster;
+
+      return createClusterWithName(clusterName);
+    }
+
+    private Cluster createClusterWithName(String clusterName) {
+      Cluster cluster = new Cluster().withClusterName(clusterName);
+      clusters.add(cluster);
+      return cluster;
+    }
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
@@ -4,10 +4,12 @@
 
 package oracle.kubernetes.weblogic.domain.v1;
 
+import io.kubernetes.client.models.V1LocalObjectReference;
 import java.util.Collections;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.weblogic.domain.ClusterConfigurator;
+import oracle.kubernetes.weblogic.domain.ConfigurationNotSupportedException;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.ServerConfigurator;
 
@@ -40,9 +42,34 @@ public class DomainV1Configurator implements DomainConfigurator {
   }
 
   @Override
+  public void setDefaultImage(String image) {
+    domain.getSpec().setImage(image);
+  }
+
+  @Override
+  public void setDefaultImagePullPolicy(String imagepullpolicy) {
+    domain.getSpec().setImagePullPolicy(imagepullpolicy);
+  }
+
+  @Override
+  public void setDefaultImagePullSecret(V1LocalObjectReference secretReference) {
+    domain.getSpec().setImagePullSecret(secretReference);
+  }
+
+  @Override
   public DomainConfigurator setStartupControl(String startupControl) {
     domain.getSpec().setStartupControl(startupControl);
     return this;
+  }
+
+  @Override
+  public DomainConfigurator withEnvironmentVariable(String name, String value) {
+    throw new ConfigurationNotSupportedException("domain", "env");
+  }
+
+  @Override
+  public ServerConfigurator configureAdminServer() {
+    return configureServer(domain.getAsName());
   }
 
   @Override
@@ -79,6 +106,7 @@ public class DomainV1Configurator implements DomainConfigurator {
     return startup;
   }
 
+  @SuppressWarnings("deprecation")
   class ServerStartupConfigurator implements ServerConfigurator {
     private ServerStartup serverStartup;
 
@@ -103,8 +131,29 @@ public class DomainV1Configurator implements DomainConfigurator {
       serverStartup.withEnvironmentVariable(name, value);
       return this;
     }
+
+    @Override
+    public ServerConfigurator withImage(String imageName) {
+      throw new ConfigurationNotSupportedException("server", "image");
+    }
+
+    @Override
+    public ServerConfigurator withImagePullPolicy(String policy) {
+      throw new ConfigurationNotSupportedException("server", "imagePullPolicy");
+    }
+
+    @Override
+    public ServerConfigurator withImagePullSecret(String secretName) {
+      throw new ConfigurationNotSupportedException("server", "imagePullSecret");
+    }
+
+    @Override
+    public ServerConfigurator withServerStartState(String state) {
+      return withDesiredState(state);
+    }
   }
 
+  @SuppressWarnings("deprecation")
   class ClusterStartupConfigurator implements ClusterConfigurator {
     private ClusterStartup clusterStartup;
 
@@ -122,6 +171,26 @@ public class DomainV1Configurator implements DomainConfigurator {
     public ClusterConfigurator withEnvironmentVariable(String name, String value) {
       clusterStartup.withEnvironmentVariable(name, value);
       return this;
+    }
+
+    @Override
+    public ClusterConfigurator withImage(String imageName) {
+      throw new ConfigurationNotSupportedException("cluster", "image");
+    }
+
+    @Override
+    public ClusterConfigurator withImagePullPolicy(String policy) {
+      throw new ConfigurationNotSupportedException("cluster", "imagePullPolicy");
+    }
+
+    @Override
+    public ClusterConfigurator withImagePullSecret(String secretName) {
+      throw new ConfigurationNotSupportedException("cluster", "imagePullSecret");
+    }
+
+    @Override
+    public ClusterConfigurator withServerStartState(String state) {
+      return withDesiredState(state);
     }
 
     @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpec.java
@@ -1,58 +1,108 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
 package oracle.kubernetes.weblogic.domain.v1;
 
+import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
+import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
+
 import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1LocalObjectReference;
+import io.kubernetes.client.models.V1PodSecurityContext;
+import io.kubernetes.client.models.V1Probe;
+import io.kubernetes.client.models.V1ResourceRequirements;
+import io.kubernetes.client.models.V1SecurityContext;
+import io.kubernetes.client.models.V1Volume;
+import io.kubernetes.client.models.V1VolumeMount;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import oracle.kubernetes.operator.KubernetesConstants;
 
-public interface ServerSpec {
+/** Represents the effective configuration for a server, as seen by the operator runtime. */
+@SuppressWarnings("WeakerAccess")
+public abstract class ServerSpec {
+
+  private static final String ADMIN_MODE_FLAG = "-Dweblogic.management.startupMode=ADMIN";
+
+  public String getImage() {
+    return Optional.ofNullable(getConfiguredImage()).orElse(DEFAULT_IMAGE);
+  }
+
+  protected abstract String getConfiguredImage();
+
+  public String getImagePullPolicy() {
+    return Optional.ofNullable(getConfiguredImagePullPolicy()).orElse(getInferredPullPolicy());
+  }
+
+  protected abstract String getConfiguredImagePullPolicy();
+
+  private String getInferredPullPolicy() {
+    return useLatestImage() ? ALWAYS_IMAGEPULLPOLICY : IFNOTPRESENT_IMAGEPULLPOLICY;
+  }
+
+  private boolean useLatestImage() {
+    return getImage().endsWith(KubernetesConstants.LATEST_IMAGE_SUFFIX);
+  }
 
   /**
-   * Temporary: to enable refactoring only. Provides a means to obtain the old implementation object
-   * from the new one.
+   * The secret used to authenticate to a docker repository when pulling an image.
    *
-   * @deprecated should be removed once the refactoring is done.
+   * @return an object containing the name of a secret. May be null.
    */
-  @Deprecated
-  ServerStartup getServerStartup();
-
-  /**
-   * The WebLogic Docker image.
-   *
-   * @return image
-   */
-  String getImage();
-
-  /**
-   * The image pull policy for the WebLogic Docker image. Legal values are Always, Never and
-   * IfNotPresent.
-   *
-   * <p>Defaults to Always if image ends in :latest, IfNotPresent otherwise.
-   *
-   * <p>More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   *
-   * @return image pull policy
-   */
-  String getImagePullPolicy();
+  public abstract V1LocalObjectReference getImagePullSecret();
 
   /**
    * Returns the environment variables to be defined for this server.
    *
    * @return a list of environment variables
    */
-  List<V1EnvVar> getEnvironmentVariables();
+  public abstract List<V1EnvVar> getEnvironmentVariables();
+
+  protected List<V1EnvVar> withStateAdjustments(List<V1EnvVar> env) {
+    if (!getDesiredState().equals("ADMIN")) {
+      return env;
+    } else {
+      List<V1EnvVar> adjustedEnv = new ArrayList<>(env);
+      V1EnvVar var = getOrCreateVar(adjustedEnv, "JAVA_OPTIONS");
+      var.setValue(prepend(var.getValue(), ADMIN_MODE_FLAG));
+      return adjustedEnv;
+    }
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1EnvVar getOrCreateVar(List<V1EnvVar> env, String name) {
+    for (V1EnvVar var : env) {
+      if (var.getName().equals(name)) return var;
+    }
+    V1EnvVar var = new V1EnvVar().name(name);
+    env.add(var);
+    return var;
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private String prepend(String value, String prefix) {
+    return value == null ? prefix : value.contains(prefix) ? value : prefix + ' ' + value;
+  }
 
   /**
    * Desired startup state. Legal values are RUNNING or ADMIN.
    *
    * @return desired state
    */
-  String getDesiredState();
+  public abstract String getDesiredState();
 
   /**
    * Returns the port on which this server will be exposed.
    *
    * @return the port number. May be null.
    */
-  Integer getNodePort();
+  public abstract Integer getNodePort();
 
   /**
    * Returns true if the specified server should be started, based on the current domain spec.
@@ -60,5 +110,62 @@ public interface ServerSpec {
    * @param currentReplicas the number of replicas already selected for the cluster.
    * @return whether to start the server
    */
-  boolean shouldStart(int currentReplicas);
+  public abstract boolean shouldStart(int currentReplicas);
+
+  @Nonnull
+  public List<V1VolumeMount> getAdditionalVolumeMounts() {
+    return Collections.emptyList();
+  }
+
+  @Nonnull
+  public List<V1Volume> getAdditionalVolumes() {
+    return Collections.emptyList();
+  }
+
+  @Nonnull
+  public V1Probe getLivenessProbe() {
+    return new V1Probe();
+  }
+
+  @Nonnull
+  public V1Probe getReadinessProbe() {
+    return new V1Probe();
+  }
+
+  @Nonnull
+  public Map<String, String> getPodLabels() {
+    return Collections.emptyMap();
+  }
+
+  @Nonnull
+  public Map<String, String> getPodAnnotations() {
+    return Collections.emptyMap();
+  }
+
+  @Nonnull
+  public Map<String, String> getListenAddressServiceLabels() {
+    return Collections.emptyMap();
+  }
+
+  @Nonnull
+  public Map<String, String> getListenAddressServiceAnnotations() {
+    return Collections.emptyMap();
+  }
+
+  @Nonnull
+  public Map<String, String> getNodeSelectors() {
+    return Collections.emptyMap();
+  }
+
+  public V1ResourceRequirements getResources() {
+    return null;
+  }
+
+  public V1PodSecurityContext getPodSecurityContext() {
+    return null;
+  }
+
+  public V1SecurityContext getContainerSecurityContext() {
+    return null;
+  }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
@@ -1,0 +1,7 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+public class AdminServer extends Server {}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
@@ -1,0 +1,217 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static java.util.Collections.emptyList;
+
+import com.google.common.base.Strings;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1LocalObjectReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Configuration values shared by multiple levels: domain, admin server, managed server, and
+ * cluster.
+ *
+ * @since 2.0
+ */
+public abstract class BaseConfiguration {
+  /**
+   * The WebLogic Docker image.
+   *
+   * <p>Defaults to store/oracle/weblogic:12.2.1.3.
+   */
+  @SerializedName("image")
+  @Expose
+  private String image;
+
+  /**
+   * The image pull policy for the WebLogic Docker image. Legal values are Always, Never and
+   * IfNotPresent.
+   *
+   * <p>Defaults to Always if image ends in :latest, IfNotPresent otherwise.
+   *
+   * <p>More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+   */
+  @SerializedName("imagePullPolicy")
+  @Expose
+  private String imagePullPolicy;
+
+  /**
+   * Reference to the secret used to authenticate a request for an image pull.
+   *
+   * <p>More info:
+   * https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
+   */
+  @SerializedName("imagePullSecret")
+  @Expose
+  private V1LocalObjectReference imagePullSecret;
+
+  /**
+   * Environment variables to pass while starting a server.
+   *
+   * @since 2.0
+   */
+  @SerializedName("env")
+  @Expose
+  @Valid
+  private List<V1EnvVar> env = new ArrayList<>();
+
+  /**
+   * Desired startup state. Legal values are RUNNING or ADMIN.
+   *
+   * @since 2.0
+   */
+  @SerializedName("serverStartState")
+  @Expose
+  private String serverStartState;
+
+  /**
+   * Fills in any undefined settings in this configuration from another configuration.
+   *
+   * @param other the other configuration which can override this one
+   */
+  void fillInFrom(BaseConfiguration other) {
+    if (other == null) return;
+
+    if (image == null) image = other.getImage();
+    if (imagePullPolicy == null) imagePullPolicy = other.getImagePullPolicy();
+    if (imagePullSecret == null) imagePullSecret = other.getImagePullSecret();
+    if (serverStartState == null) serverStartState = other.getServerStartState();
+
+    for (V1EnvVar var : getV1EnvVars(other)) addIfMissing(var);
+  }
+
+  private List<V1EnvVar> getV1EnvVars(BaseConfiguration configuration) {
+    return Optional.ofNullable(configuration.getEnv()).orElse(emptyList());
+  }
+
+  private void addIfMissing(V1EnvVar var) {
+    if (!hasEnvVar(var.getName())) addEnvVar(var);
+  }
+
+  private boolean hasEnvVar(String name) {
+    if (env == null) return false;
+    for (V1EnvVar var : env) {
+      if (var.getName().equals(name)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns true if any version 2 configuration fields are specified.
+   *
+   * @return whether there is version 2 configuration in this instance
+   */
+  protected boolean hasV2Fields() {
+    return serverStartState != null || !env.isEmpty();
+  }
+
+  @Nullable
+  public String getImage() {
+    return image;
+  }
+
+  public void setImage(@Nullable String image) {
+    this.image = image;
+  }
+
+  @Nullable
+  public String getImagePullPolicy() {
+    return imagePullPolicy;
+  }
+
+  public void setImagePullPolicy(@Nullable String imagePullPolicy) {
+    this.imagePullPolicy = imagePullPolicy;
+  }
+
+  @Nullable
+  public V1LocalObjectReference getImagePullSecret() {
+    return hasImagePullSecret() ? imagePullSecret : null;
+  }
+
+  private boolean hasImagePullSecret() {
+    return imagePullSecret != null && !Strings.isNullOrEmpty(imagePullSecret.getName());
+  }
+
+  public void setImagePullSecret(@Nullable V1LocalObjectReference imagePullSecret) {
+    this.imagePullSecret = imagePullSecret;
+  }
+
+  @Nullable
+  String getServerStartState() {
+    return serverStartState;
+  }
+
+  void setServerStartState(@Nullable String serverStartState) {
+    this.serverStartState = serverStartState;
+  }
+
+  @Nullable
+  public List<V1EnvVar> getEnv() {
+    return env;
+  }
+
+  public void setEnv(@Nullable List<V1EnvVar> env) {
+    this.env = env;
+  }
+
+  void addEnvironmentVariable(String name, String value) {
+    addEnvVar(new V1EnvVar().name(name).value(value));
+  }
+
+  private void addEnvVar(V1EnvVar var) {
+    if (env == null) env = new ArrayList<>();
+    env.add(var);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("image", image)
+        .append("imagePullPolicy", imagePullPolicy)
+        .append("imagePullSecret", imagePullSecret)
+        .append("serverStartState", serverStartState)
+        .append("env", env)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    BaseConfiguration that = (BaseConfiguration) o;
+
+    return new EqualsBuilder()
+        .append(image, that.image)
+        .append(imagePullPolicy, that.imagePullPolicy)
+        .append(imagePullSecret, that.imagePullSecret)
+        .append(env, that.env)
+        .append(serverStartState, that.serverStartState)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(image)
+        .append(imagePullPolicy)
+        .append(imagePullSecret)
+        .append(env)
+        .append(serverStartState)
+        .toHashCode();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
@@ -1,0 +1,47 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import javax.annotation.Nonnull;
+
+/**
+ * An element representing a cluster in the domain configuration.
+ *
+ * @since 2.0
+ */
+public class Cluster extends BaseConfiguration {
+  /** The name of the cluster. Required. */
+  @SerializedName("clusterName")
+  @Expose
+  private String clusterName;
+
+  /** The number of replicas to run in the cluster, if specified. */
+  @SerializedName("replicas")
+  @Expose
+  private Integer replicas;
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public void setClusterName(@Nonnull String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public Cluster withClusterName(@Nonnull String clusterName) {
+    setClusterName(clusterName);
+    return this;
+  }
+
+  public Integer getReplicas() {
+    return replicas;
+  }
+
+  public void setReplicas(Integer replicas) {
+    this.replicas = replicas;
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -1,0 +1,220 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import io.kubernetes.client.models.V1LocalObjectReference;
+import javax.annotation.Nonnull;
+import oracle.kubernetes.weblogic.domain.ClusterConfigurator;
+import oracle.kubernetes.weblogic.domain.DomainConfigurator;
+import oracle.kubernetes.weblogic.domain.ServerConfigurator;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
+
+public class DomainV2Configurator implements DomainConfigurator {
+  private Domain domain;
+
+  DomainV2Configurator(Domain domain) {
+    this.domain = domain;
+  }
+
+  @Override
+  public void defineAdminServer(String adminServerName) {}
+
+  @Override
+  public void defineAdminServer(String adminServerName, int port) {}
+
+  @Override
+  public void setDefaultReplicas(int replicas) {}
+
+  @Override
+  public void setDefaultImage(String image) {
+    getDomainSpec().setImage(image);
+  }
+
+  @Override
+  public void setDefaultImagePullPolicy(String imagepullpolicy) {
+    getDomainSpec().setImagePullPolicy(imagepullpolicy);
+  }
+
+  @Override
+  public void setDefaultImagePullSecret(V1LocalObjectReference secretReference) {
+    getDomainSpec().setImagePullSecret(secretReference);
+  }
+
+  @Override
+  public DomainConfigurator setStartupControl(String startupControl) {
+    return null;
+  }
+
+  @Override
+  public DomainConfigurator withEnvironmentVariable(String name, String value) {
+    ((BaseConfiguration) getDomainSpec()).addEnvironmentVariable(name, value);
+    return this;
+  }
+
+  @Override
+  public ServerConfigurator configureAdminServer() {
+    return new AdminServerConfiguratorImpl(getOrCreateAdminServer());
+  }
+
+  class AdminServerConfiguratorImpl extends ServerConfiguratorImpl {
+    AdminServerConfiguratorImpl(AdminServer adminServer) {
+      super(adminServer);
+    }
+  }
+
+  private AdminServer getOrCreateAdminServer() {
+    AdminServer adminServer = getDomainSpec().getAdminServer();
+    if (adminServer != null) return adminServer;
+
+    return createAdminServer();
+  }
+
+  private DomainSpec getDomainSpec() {
+    return domain.getSpec();
+  }
+
+  private AdminServer createAdminServer() {
+    AdminServer adminServer = new AdminServer();
+    getDomainSpec().setAdminServer(adminServer);
+    return adminServer;
+  }
+
+  @Override
+  public ServerConfigurator configureServer(@Nonnull String serverName) {
+    return new ServerConfiguratorImpl(getOrCreateManagedServer(serverName));
+  }
+
+  private Server getOrCreateManagedServer(@Nonnull String serverName) {
+    for (ManagedServer server : getDomainSpec().getManagedServers()) {
+      if (serverName.equals(server.getServerName())) return server;
+    }
+
+    return createManagedServer(serverName);
+  }
+
+  private Server createManagedServer(String serverName) {
+    ManagedServer server = new ManagedServer().withServerName(serverName);
+    getDomainSpec().getManagedServers().add(server);
+    return server;
+  }
+
+  class ServerConfiguratorImpl implements ServerConfigurator {
+    private Server server;
+
+    ServerConfiguratorImpl(Server server) {
+      this.server = server;
+    }
+
+    @Override
+    public ServerConfigurator withNodePort(int nodePort) {
+      server.setNodePort(nodePort);
+      return this;
+    }
+
+    @Override
+    public ServerConfigurator withDesiredState(String desiredState) {
+      server.setServerStartState(desiredState);
+      return this;
+    }
+
+    @Override
+    public ServerConfigurator withEnvironmentVariable(String name, String value) {
+      server.addEnvironmentVariable(name, value);
+      return this;
+    }
+
+    @Override
+    public ServerConfigurator withImage(String imageName) {
+      server.setImage(imageName);
+      return this;
+    }
+
+    @Override
+    public ServerConfigurator withImagePullPolicy(String policy) {
+      server.setImagePullPolicy(policy);
+      return this;
+    }
+
+    @Override
+    public ServerConfigurator withImagePullSecret(String secretName) {
+      server.setImagePullSecret(new V1LocalObjectReference().name(secretName));
+      return this;
+    }
+
+    @Override
+    public ServerConfigurator withServerStartState(String state) {
+      return withDesiredState(state);
+    }
+  }
+
+  @Override
+  public ClusterConfigurator configureCluster(@Nonnull String clusterName) {
+    return new ClusterConfiguratorImpl(getOrCreateCluster(clusterName));
+  }
+
+  private Cluster getOrCreateCluster(@Nonnull String clusterName) {
+    for (Cluster cluster : getDomainSpec().getClusters()) {
+      if (clusterName.equals(cluster.getClusterName())) return cluster;
+    }
+
+    return createCluster(clusterName);
+  }
+
+  private Cluster createCluster(@Nonnull String clusterName) {
+    Cluster cluster = new Cluster().withClusterName(clusterName);
+    getDomainSpec().getClusters().add(cluster);
+    return cluster;
+  }
+
+  class ClusterConfiguratorImpl implements ClusterConfigurator {
+    private Cluster cluster;
+
+    ClusterConfiguratorImpl(Cluster cluster) {
+      this.cluster = cluster;
+    }
+
+    @Override
+    public ClusterConfigurator withReplicas(int replicas) {
+      cluster.setReplicas(replicas);
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withDesiredState(String state) {
+      cluster.setServerStartState(state);
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withEnvironmentVariable(String name, String value) {
+      cluster.addEnvironmentVariable(name, value);
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withImage(String imageName) {
+      cluster.setImage(imageName);
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withImagePullPolicy(String policy) {
+      cluster.setImagePullPolicy(policy);
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withImagePullSecret(String secretName) {
+      cluster.setImagePullSecret(new V1LocalObjectReference().name(secretName));
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withServerStartState(String state) {
+      return withDesiredState(state);
+    }
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ManagedServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ManagedServer.java
@@ -1,0 +1,29 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import javax.annotation.Nonnull;
+
+public class ManagedServer extends Server {
+  /** The name of the managed server. Required. */
+  @SerializedName("serverName")
+  @Expose
+  private String serverName;
+
+  public String getServerName() {
+    return serverName;
+  }
+
+  public void setServerName(@Nonnull String serverName) {
+    this.serverName = serverName;
+  }
+
+  ManagedServer withServerName(@Nonnull String serverName) {
+    setServerName(serverName);
+    return this;
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Server.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Server.java
@@ -1,0 +1,30 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Server extends BaseConfiguration {
+  /** The node port associated with this server. The introspector will override this value. */
+  @SerializedName("nodePort")
+  @Expose
+  private Integer nodePort;
+
+  protected Server getConfiguration() {
+    Server configuration = new Server();
+    configuration.fillInFrom(this);
+    configuration.setNodePort(nodePort);
+    return configuration;
+  }
+
+  public void setNodePort(Integer nodePort) {
+    this.nodePort = nodePort;
+  }
+
+  public Integer getNodePort() {
+    return nodePort;
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
@@ -1,0 +1,71 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
+
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1LocalObjectReference;
+import java.util.List;
+import java.util.Optional;
+import oracle.kubernetes.weblogic.domain.v1.ServerSpec;
+
+/** The effective configuration for a server configured by the version 2 domain model. */
+public class ServerSpecV2Impl extends ServerSpec {
+  private final Server server;
+
+  public ServerSpecV2Impl(Server server, BaseConfiguration... configurations) {
+    this.server = getBaseConfiguration(server);
+    for (BaseConfiguration configuration : configurations) this.server.fillInFrom(configuration);
+  }
+
+  private Server getBaseConfiguration(Server server) {
+    return server != null ? server.getConfiguration() : new Server();
+  }
+
+  @Override
+  public String getImage() {
+    return Optional.ofNullable(getConfiguredImage()).orElse(DEFAULT_IMAGE);
+  }
+
+  @Override
+  protected String getConfiguredImage() {
+    return server.getImage();
+  }
+
+  @Override
+  protected String getConfiguredImagePullPolicy() {
+    return server.getImagePullPolicy();
+  }
+
+  @Override
+  public V1LocalObjectReference getImagePullSecret() {
+    return server.getImagePullSecret();
+  }
+
+  @Override
+  public List<V1EnvVar> getEnvironmentVariables() {
+    return withStateAdjustments(server.getEnv());
+  }
+
+  @Override
+  public String getDesiredState() {
+    return Optional.ofNullable(getConfiguredDesiredState()).orElse("RUNNING");
+  }
+
+  private String getConfiguredDesiredState() {
+    return server.getServerStartState();
+  }
+
+  @Override
+  public Integer getNodePort() {
+    return server.getNodePort();
+  }
+
+  @Override
+  public boolean shouldStart(int currentReplicas) {
+    return false;
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -1,0 +1,448 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain;
+
+import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
+import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
+import static oracle.kubernetes.operator.KubernetesConstants.LATEST_IMAGE_SUFFIX;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1LocalObjectReference;
+import io.kubernetes.client.models.V1SecretReference;
+import java.io.IOException;
+import java.net.URL;
+import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
+import oracle.kubernetes.weblogic.domain.v1.ServerSpec;
+import org.junit.Test;
+
+public abstract class DomainTestBase {
+  private static final String NAME1 = "name1";
+  private static final String NAME2 = "name2";
+  private static final String VALUE1 = "value1";
+  private static final String VALUE2 = "value2";
+  private static final V1SecretReference SECRET = new V1SecretReference().name("secret");
+  private static final int AS_PORT = 8000;
+  private static final String DOMAIN_NAME = "test";
+  private static final String DOMAIN_UID = "uid1";
+  private static final String DOMAIN_V1_SAMPLE_YAML = "v1/domain-sample.yaml";
+  private static final String IMAGE = "myimage";
+  private static final String PULL_SECRET_NAME = "pull-secret";
+  private static final String AS_NAME = "admin";
+  protected static final String CLUSTER_NAME = "cluster1";
+  protected static final String SERVER1 = "ms1";
+  protected final Domain domain =
+      new Domain()
+          .withSpec(
+              new DomainSpec()
+                  .withAdminSecret(SECRET)
+                  .withAsName(AS_NAME)
+                  .withAsPort(AS_PORT)
+                  .withDomainName(DOMAIN_NAME)
+                  .withDomainUID(DOMAIN_UID));
+
+  protected abstract DomainConfigurator configureDomain(Domain domain);
+
+  @Test
+  public void canGetAdminServerInfoFromDomain() {
+    assertThat(domain.getAsName(), equalTo(AS_NAME));
+    assertThat(domain.getAsPort(), equalTo(AS_PORT));
+    assertThat(domain.getAdminSecret(), equalTo(SECRET));
+  }
+
+  @Test
+  public void canGetDomainInfoFromDomain() {
+    assertThat(domain.getDomainName(), equalTo(DOMAIN_NAME));
+    assertThat(domain.getDomainUID(), equalTo(DOMAIN_UID));
+  }
+
+  @Test
+  public void adminServerSpecHasStandardValues() {
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    verifyStandardFields(spec);
+  }
+
+  // Confirms the value of fields that are constant across the domain
+  private void verifyStandardFields(ServerSpec spec) {
+    assertThat(spec.getImage(), equalTo(DEFAULT_IMAGE));
+    assertThat(spec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
+    assertThat(spec.getImagePullSecret(), nullValue());
+  }
+
+  @Test
+  public void unconfiguredManagedServerSpecHasStandardValues() {
+    ServerSpec spec = domain.getServer("aServer", CLUSTER_NAME);
+
+    verifyStandardFields(spec);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1EnvVar envVar(String name, String value) {
+    return new V1EnvVar().name(name).value(value);
+  }
+
+  @Test
+  public void unconfiguredAdminServer_hasNoEnvironmentVariables() {
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getEnvironmentVariables(), empty());
+  }
+
+  @Test
+  public void whenDefaultImageSpecified_serversHaveSpecifiedImage() {
+    configureDomain(domain).setDefaultImage(IMAGE);
+
+    assertThat(domain.getAdminServerSpec().getImage(), equalTo(IMAGE));
+    assertThat(domain.getServer("aServer", "aCluster").getImage(), equalTo(IMAGE));
+  }
+
+  @Test
+  public void whenLatestImageSpecifiedAsDefault_serversHaveAlwaysPullPolicy() {
+    configureDomain(domain).setDefaultImage(IMAGE + LATEST_IMAGE_SUFFIX);
+
+    assertThat(domain.getAdminServerSpec().getImagePullPolicy(), equalTo(ALWAYS_IMAGEPULLPOLICY));
+    assertThat(
+        domain.getServer("aServer", "aCluster").getImagePullPolicy(),
+        equalTo(ALWAYS_IMAGEPULLPOLICY));
+  }
+
+  @Test
+  public void whenNotSpecified_imageHasDefault() {
+    domain.getSpec().setImage(null);
+
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getImage(), equalTo(KubernetesConstants.DEFAULT_IMAGE));
+  }
+
+  @Test
+  public void whenImageTagIsLatestAndPullPolicyNotSpecified_pullPolicyIsAlways() {
+    domain.getSpec().setImage("test:latest");
+    domain.getSpec().setImagePullPolicy(null);
+
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getImagePullPolicy(), equalTo(ALWAYS_IMAGEPULLPOLICY));
+  }
+
+  @Test
+  public void whenImageTagIsNotLatestAndPullPolicyNotSpecified_pullPolicyIsIfAbsent() {
+    domain.getSpec().setImage("test:1.0");
+    domain.getSpec().setImagePullPolicy(null);
+
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
+  }
+
+  @Test
+  public void whenImagePullPolicySpecifiedAsDefault_allServersHaveIt() {
+    configureDomain(domain).setDefaultImagePullPolicy(ALWAYS_IMAGEPULLPOLICY);
+
+    assertThat(domain.getAdminServerSpec().getImagePullPolicy(), equalTo(ALWAYS_IMAGEPULLPOLICY));
+    assertThat(
+        domain.getServer("aServer", "aCluster").getImagePullPolicy(),
+        equalTo(ALWAYS_IMAGEPULLPOLICY));
+  }
+
+  @Test
+  public void whenDefaultImagePullSecretSpecified_allServersHaveIt() {
+    V1LocalObjectReference secretReference = createSecretReference(PULL_SECRET_NAME);
+    configureDomain(domain).setDefaultImagePullSecret(secretReference);
+
+    assertThat(domain.getAdminServerSpec().getImagePullSecret(), equalTo(secretReference));
+    assertThat(
+        domain.getServer("aServer", "aCluster").getImagePullSecret(), equalTo(secretReference));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1LocalObjectReference createSecretReference(String pullSecretName) {
+    return new V1LocalObjectReference().name(pullSecretName);
+  }
+
+  @Test
+  public void whenSpecified_adminServerHasEnvironmentVariables() {
+    configureAdminServer()
+        .withEnvironmentVariable(NAME1, VALUE1)
+        .withEnvironmentVariable(NAME2, VALUE2);
+
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getEnvironmentVariables(), containsInAnyOrder(createEnvironment()));
+  }
+
+  protected ServerConfigurator configureAdminServer() {
+    return configureDomain(domain).configureAdminServer();
+  }
+
+  private V1EnvVar[] createEnvironment() {
+    return new V1EnvVar[] {envVar(NAME1, VALUE1), envVar(NAME2, VALUE2)};
+  }
+
+  @Test
+  public void whenOtherServersDefined_adminServerHasNoEnvironmentVariables() {
+    configureServer(SERVER1)
+        .withEnvironmentVariable(NAME1, VALUE1)
+        .withEnvironmentVariable(NAME2, VALUE2);
+
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getEnvironmentVariables(), empty());
+  }
+
+  @Test
+  public void whenSpecified_adminServerDesiredStateIsAsSpecified() {
+    configureAdminServer().withDesiredState("ADMIN");
+
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getDesiredState(), equalTo("ADMIN"));
+  }
+
+  protected ServerConfigurator configureServer(String serverName) {
+    return configureDomain(domain).configureServer(serverName);
+  }
+
+  @Test
+  public void whenNotSpecified_adminServerDesiredStateIsRunning() {
+    ServerSpec spec = domain.getAdminServerSpec();
+
+    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
+  }
+
+  @Test
+  public void whenNotSpecified_managedServerDesiredStateIsRunning() {
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
+  }
+
+  @Test
+  public void whenSpecified_managedServerDesiredStateIsAsSpecified() {
+    configureServer(SERVER1).withDesiredState("STAND-BY");
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getDesiredState(), equalTo("STAND-BY"));
+  }
+
+  @Test
+  public void whenOnlyAsStateSpecified_managedServerDesiredStateIsRunning() {
+    configureAdminServer().withDesiredState("ADMIN");
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
+  }
+
+  @Test
+  public void whenClusterStateSpecified_managedServerDesiredStateIsAsSpecified() {
+    configureCluster(CLUSTER_NAME).withDesiredState("NEVER");
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getDesiredState(), equalTo("NEVER"));
+  }
+
+  protected ClusterConfigurator configureCluster(String clusterName) {
+    return configureDomain(domain).configureCluster(clusterName);
+  }
+
+  @Test
+  public void whenNoReplicaCountSpecified_useDefaultValue() {
+    assertThat(domain.getReplicaCount("cluster1"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
+  }
+
+  @Test
+  public void whenNoReplicaCountSpecified_canChangeIt() {
+    domain.setReplicaCount("cluster1", 7);
+
+    assertThat(domain.getReplicaCount("cluster1"), equalTo(7));
+  }
+
+  @Test
+  public void afterReplicaCountSetForCluster_canReadIt() {
+    configureCluster("cluster1").withReplicas(5);
+
+    assertThat(domain.getReplicaCount("cluster1"), equalTo(5));
+  }
+
+  @Test
+  public void afterReplicaCountSetForCluster_canChangeIt() {
+    configureCluster("cluster1").withReplicas(5);
+
+    domain.setReplicaCount("cluster1", 4);
+    assertThat(domain.getReplicaCount("cluster1"), equalTo(4));
+  }
+
+  @Test
+  public void whenServerNotConfigured_nodePortIsNull() {
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getNodePort(), nullValue());
+  }
+
+  @Test
+  public void whenServerConfiguredWithoutNodePort_nodePortIsNull() {
+    configureServer(SERVER1);
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getNodePort(), nullValue());
+  }
+
+  @Test // reverse order of overrides, capture server, need tests for cascading settings
+  public void whenServerConfiguredWithNodePort_returnNodePort() {
+    configureServer(SERVER1).withNodePort(31);
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getNodePort(), equalTo(31));
+  }
+
+  @Test
+  public void whenBothClusterAndServerStateSpecified_managedServerUsesServerState() {
+    configureServer(SERVER1).withDesiredState("STAND-BY");
+    configureCluster(CLUSTER_NAME).withDesiredState("NEVER");
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getDesiredState(), equalTo("STAND-BY"));
+  }
+
+  @Test
+  public void whenSpecifiedOnServer_managedServerHasEnvironmentVariables() {
+    configureServer(SERVER1)
+        .withEnvironmentVariable(NAME1, VALUE1)
+        .withEnvironmentVariable(NAME2, VALUE2);
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getEnvironmentVariables(), containsInAnyOrder(createEnvironment()));
+  }
+
+  @Test
+  public void whenDesiredStateAdminAndSpecifiedOnServer_managedServerHasJavaOption() {
+    configureServer(SERVER1)
+        .withDesiredState("ADMIN")
+        .withEnvironmentVariable(NAME1, VALUE1)
+        .withEnvironmentVariable(NAME2, VALUE2);
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(
+        spec.getEnvironmentVariables(),
+        hasItem(envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN")));
+  }
+
+  @Test
+  public void whenSpecifiedOnCluster_managedServerHasEnvironmentVariables() {
+    configureCluster(CLUSTER_NAME)
+        .withEnvironmentVariable(NAME1, VALUE1)
+        .withEnvironmentVariable(NAME2, VALUE2);
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getEnvironmentVariables(), containsInAnyOrder(createEnvironment()));
+  }
+
+  @Test
+  public void whenDesiredStateAdminAndSpecifiedOnCluster_managedServerHasEnvironmentVariables() {
+    configureCluster(CLUSTER_NAME)
+        .withDesiredState("ADMIN")
+        .withEnvironmentVariable("JAVA_OPTIONS", "value");
+
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(
+        spec.getEnvironmentVariables(),
+        hasItem(envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN value")));
+  }
+
+  @Test
+  public void whenDomainReadFromYaml_unconfiguredServerHasDomainDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V1_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getServer("server0", null);
+
+    assertThat(serverSpec.getImage(), equalTo(DEFAULT_IMAGE));
+    assertThat(serverSpec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
+    assertThat(serverSpec.getImagePullSecret().getName(), equalTo("pull-secret"));
+    assertThat(serverSpec.getEnvironmentVariables(), empty());
+    assertThat(serverSpec.getNodePort(), nullValue());
+    assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
+  }
+
+  @Test
+  public void whenDomainReadFromYaml_Server1OverridesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V1_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getServer("server1", null);
+
+    assertThat(
+        serverSpec.getEnvironmentVariables(),
+        both(hasItem(envVar("JAVA_OPTIONS", "-server")))
+            .and(hasItem(envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "))));
+    assertThat(serverSpec.getNodePort(), equalTo(7001));
+    assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
+  }
+
+  @Test
+  public void whenDomainReadFromYaml_Server2OverridesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V1_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getServer("server2", null);
+
+    assertThat(
+        serverSpec.getEnvironmentVariables(),
+        hasItem(envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN")));
+    assertThat(serverSpec.getNodePort(), nullValue());
+    assertThat(serverSpec.getDesiredState(), equalTo("ADMIN"));
+  }
+
+  @Test
+  public void whenDomainReadFromYaml_Cluster1UsesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V1_SAMPLE_YAML);
+
+    assertThat(domain.getReplicaCount("cluster1"), equalTo(1));
+    assertThat(domain.getServer("server3", "cluster1").getEnvironmentVariables(), empty());
+  }
+
+  @Test
+  public void whenDomainReadFromYaml_Cluster2OverridesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V1_SAMPLE_YAML);
+
+    assertThat(domain.getReplicaCount("cluster2"), equalTo(5));
+    assertThat(
+        domain.getServer("server3", "cluster2").getEnvironmentVariables(),
+        both(hasItem(envVar("JAVA_OPTIONS", "-verbose")))
+            .and(hasItem(envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "))));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  protected Domain readDomain(String resourceName) throws IOException {
+    String json = jsonFromYaml(resourceName);
+    Gson gson = new GsonBuilder().create();
+    return gson.fromJson(json, Domain.class);
+  }
+
+  private String jsonFromYaml(String resourceName) throws IOException {
+    URL resource = DomainTestBase.class.getResource(resourceName);
+    ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+    Object obj = yamlReader.readValue(resource, Object.class);
+
+    ObjectMapper jsonWriter = new ObjectMapper();
+    return jsonWriter.writeValueAsString(obj);
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
@@ -1,67 +1,36 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
 package oracle.kubernetes.weblogic.domain.v1;
 
-import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
-import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
 import static oracle.kubernetes.operator.StartupControlConstants.ALL_STARTUPCONTROL;
 import static oracle.kubernetes.operator.StartupControlConstants.AUTO_STARTUPCONTROL;
 import static oracle.kubernetes.operator.StartupControlConstants.NONE_STARTUPCONTROL;
 import static oracle.kubernetes.operator.StartupControlConstants.SPECIFIED_STARTUPCONTROL;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1SecretReference;
-import java.util.Arrays;
-import java.util.Collections;
-import oracle.kubernetes.operator.KubernetesConstants;
+import io.kubernetes.client.models.V1Probe;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
+import oracle.kubernetes.weblogic.domain.DomainTestBase;
+import org.junit.Before;
 import org.junit.Test;
 
-public class DomainV1Test {
+public class DomainV1Test extends DomainTestBase {
 
-  private static final V1SecretReference SECRET = new V1SecretReference().name("secret");
-  private static final String AS_NAME = "admin";
-  private static final int AS_PORT = 8000;
-  private static final String DOMAIN_NAME = "test";
-  private static final String DOMAIN_UID = "uid1";
-  private static final String IMAGE_NAME = "myimage";
-  private static final String IMAGE_PULL_POLICY = "pull";
-  private static final String NAME1 = "name1";
-  private static final String NAME2 = "name2";
-  private static final String VALUE1 = "value1";
-  private static final String VALUE2 = "value2";
-  private static final String CLUSTER_NAME = "cluster1";
-  private static final String SERVER1 = "ms1";
-
-  private final Domain domain =
-      new Domain()
-          .withSpec(
-              new DomainSpec()
-                  .withAdminSecret(SECRET)
-                  .withAsName(AS_NAME)
-                  .withAsPort(AS_PORT)
-                  .withDomainName(DOMAIN_NAME)
-                  .withDomainUID(DOMAIN_UID)
-                  .withImage(IMAGE_NAME)
-                  .withImagePullPolicy(IMAGE_PULL_POLICY)
-                  .withStartupControl(NONE_STARTUPCONTROL));
-
-  @Test
-  public void canGetAdminServerInfoFromDomain() {
-    assertThat(domain.getAsName(), equalTo(AS_NAME));
-    assertThat(domain.getAsPort(), equalTo(AS_PORT));
-    assertThat(domain.getAdminSecret(), equalTo(SECRET));
+  @Before
+  public void setUp() {
+    domain.getSpec().setStartupControl(NONE_STARTUPCONTROL);
   }
 
-  @Test
-  public void canGetDomainInfoFromDomain() {
-    assertThat(domain.getDomainName(), equalTo(DOMAIN_NAME));
-    assertThat(domain.getDomainUID(), equalTo(DOMAIN_UID));
+  @Override
+  protected DomainConfigurator configureDomain(Domain domain) {
+    return new DomainV1Configurator(domain);
   }
 
   @Test
@@ -84,88 +53,6 @@ public class DomainV1Test {
   }
 
   @Test
-  public void adminServerSpecHasStandardValues() {
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    verifyStandardFields(spec);
-  }
-
-  // Confirms the value of fields that are constant across the domain
-  private void verifyStandardFields(ServerSpec spec) {
-    assertThat(spec.getImage(), equalTo(IMAGE_NAME));
-    assertThat(spec.getImagePullPolicy(), equalTo(IMAGE_PULL_POLICY));
-  }
-
-  @Test
-  public void whenServerStartupIsNull_adminServerHasNoEnvironmentVariables() {
-    domain.getSpec().setServerStartup(null);
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getEnvironmentVariables(), empty());
-  }
-
-  @Test
-  public void whenNotSpecified_adminServerHasNoEnvironmentVariables() {
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getEnvironmentVariables(), empty());
-  }
-
-  @Test
-  public void whenSpecified_adminServerHasEnvironmentVariables() {
-    addServerStartup(
-        new ServerStartup().withServerName(AS_NAME).withEnv(Arrays.asList(createEnvironment())));
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getEnvironmentVariables(), containsInAnyOrder(createEnvironment()));
-  }
-
-  private void addServerStartup(ServerStartup serverStartup) {
-    domain.getSpec().setServerStartup(Collections.singletonList(serverStartup));
-  }
-
-  private V1EnvVar[] createEnvironment() {
-    return new V1EnvVar[] {
-      new V1EnvVar().name(NAME1).value(VALUE1), new V1EnvVar().name(NAME2).value(VALUE2)
-    };
-  }
-
-  @Test
-  public void whenOtherServersDefined_adminServerHasNoEnvironmentVariables() {
-    addServerStartup(
-        new ServerStartup().withServerName(SERVER1).withEnv(Arrays.asList(createEnvironment())));
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getEnvironmentVariables(), empty());
-  }
-
-  @Test
-  public void whenNotSpecified_adminServerDesiredStateIsRunning() {
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
-  }
-
-  @Test
-  public void whenSpecified_adminServerDesiredStateIsAsSpecified() {
-    addServerStartup(new ServerStartup().withServerName(AS_NAME).withDesiredState("ADMIN"));
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getDesiredState(), equalTo("ADMIN"));
-  }
-
-  @Test
-  public void managedServerSpecHasStandardValues() {
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    verifyStandardFields(spec);
-  }
-
-  @Test
   public void whenStartAll_shouldStartReturnsTrue() {
     domain.getSpec().setStartupControl(ALL_STARTUPCONTROL);
 
@@ -184,7 +71,7 @@ public class DomainV1Test {
   public void whenStartAutoAndNamedClusterHasRoomExplicitly_shouldStartReturnsTrue() {
     domain.getSpec().setStartupControl(AUTO_STARTUPCONTROL);
     domain.getSpec().setReplicas(1);
-    addClusterStartup(new ClusterStartup().withClusterName(CLUSTER_NAME).withReplicas(3));
+    configureCluster(CLUSTER_NAME).withReplicas(3);
 
     assertThat(domain.getServer(SERVER1, CLUSTER_NAME).shouldStart(2), is(true));
   }
@@ -201,7 +88,7 @@ public class DomainV1Test {
   public void whenStartAutoAndNamedClusterHasNoRoomExplicitly_shouldStartReturnsFalse() {
     domain.getSpec().setStartupControl(AUTO_STARTUPCONTROL);
     domain.getSpec().setReplicas(5);
-    addClusterStartup(new ClusterStartup().withClusterName(CLUSTER_NAME).withReplicas(1));
+    configureCluster(CLUSTER_NAME).withReplicas(1);
 
     assertThat(domain.getServer(SERVER1, CLUSTER_NAME).shouldStart(2), is(false));
   }
@@ -210,7 +97,7 @@ public class DomainV1Test {
   public void whenStartAutoAndServerSpecifiedWithoutCluster_shouldStartReturnsTrue() {
     domain.getSpec().setStartupControl(AUTO_STARTUPCONTROL);
     domain.getSpec().setReplicas(5);
-    addServerStartup(new ServerStartup().withServerName(SERVER1));
+    configureServer(SERVER1);
 
     assertThat(domain.getServer(SERVER1, null).shouldStart(0), is(true));
   }
@@ -218,7 +105,7 @@ public class DomainV1Test {
   @Test
   public void whenStartSpecifiedAndSpecifiedClusterHasRoom_shouldStartReturnsTrue() {
     domain.getSpec().setStartupControl(SPECIFIED_STARTUPCONTROL);
-    addClusterStartup(new ClusterStartup().withClusterName(CLUSTER_NAME).withReplicas(3));
+    configureCluster(CLUSTER_NAME).withReplicas(3);
 
     assertThat(domain.getServer(SERVER1, CLUSTER_NAME).shouldStart(2), is(true));
   }
@@ -227,7 +114,7 @@ public class DomainV1Test {
   public void whenStartSpecifiedAndServerSpecifiedWithoutCluster_shouldStartReturnsTrue() {
     domain.getSpec().setStartupControl(SPECIFIED_STARTUPCONTROL);
     domain.getSpec().setReplicas(5);
-    addServerStartup(new ServerStartup().withServerName(SERVER1));
+    configureServer(SERVER1);
 
     assertThat(domain.getServer(SERVER1, null).shouldStart(0), is(true));
   }
@@ -236,7 +123,7 @@ public class DomainV1Test {
   public void whenStartSpecifiedAndNamedClusterHasRoom_shouldStartReturnsTrue() {
     domain.getSpec().setStartupControl(SPECIFIED_STARTUPCONTROL);
     domain.getSpec().setReplicas(3);
-    addClusterStartup(new ClusterStartup().withClusterName(CLUSTER_NAME).withReplicas(3));
+    configureCluster(CLUSTER_NAME).withReplicas(3);
 
     assertThat(domain.getServer(SERVER1, CLUSTER_NAME).shouldStart(2), is(true));
   }
@@ -250,204 +137,80 @@ public class DomainV1Test {
   }
 
   @Test
-  public void whenClusterStartupIsNull_managedServerDesiredStateIsRunning() {
-    domain.getSpec().setClusterStartup(null);
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
-  }
-
-  @Test
-  public void whenNotSpecified_managedServerDesiredStateIsRunning() {
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
-  }
-
-  @Test
-  public void whenSpecified_managedServerDesiredStateIsAsSpecified() {
-    addServerStartup(new ServerStartup().withServerName(SERVER1).withDesiredState("STAND-BY"));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getDesiredState(), equalTo("STAND-BY"));
-  }
-
-  @Test
-  public void whenOnlyAsStateSpecified_managedServerDesiredStateIsRunning() {
-    addServerStartup(new ServerStartup().withServerName(AS_NAME).withDesiredState("ADMIN"));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getDesiredState(), equalTo("RUNNING"));
-  }
-
-  @Test
-  public void whenClusterStateSpecified_managedServerDesiredStateIsAsSpecified() {
-    addClusterStartup(new ClusterStartup().withClusterName(CLUSTER_NAME).withDesiredState("NEVER"));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getDesiredState(), equalTo("NEVER"));
-  }
-
-  private void addClusterStartup(ClusterStartup clusterStartup) {
-    domain.getSpec().setClusterStartup(Collections.singletonList(clusterStartup));
-  }
-
-  @Test
-  public void whenBothClusterAndServerStateSpecified_managedServerUsesServerState() {
-    addServerStartup(new ServerStartup().withServerName(SERVER1).withDesiredState("STAND-BY"));
-    addClusterStartup(new ClusterStartup().withClusterName(CLUSTER_NAME).withDesiredState("NEVER"));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getDesiredState(), equalTo("STAND-BY"));
-  }
-
-  @Test
-  public void whenSpecifiedOnServer_managedServerHasEnvironmentVariables() {
-    addServerStartup(
-        new ServerStartup().withServerName(SERVER1).withEnv(Arrays.asList(createEnvironment())));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getEnvironmentVariables(), containsInAnyOrder(createEnvironment()));
-  }
-
-  @Test
-  public void whenDesiredStateAdminAndSpecifiedOnServer_managedServerHasJavaOption() {
-    addServerStartup(
-        new ServerStartup()
-            .withServerName(SERVER1)
-            .withDesiredState("ADMIN")
-            .withEnv(Arrays.asList(createEnvironment())));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(
-        spec.getEnvironmentVariables(),
-        hasItem(envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN")));
-  }
-
-  @SuppressWarnings("SameParameterValue")
-  private V1EnvVar envVar(String name, String value) {
-    return new V1EnvVar().name(name).value(value);
-  }
-
-  @Test
-  public void whenSpecifiedOnCluster_managedServerHasEnvironmentVariables() {
-    addClusterStartup(
-        new ClusterStartup()
-            .withClusterName(CLUSTER_NAME)
-            .withEnv(Arrays.asList(createEnvironment())));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getEnvironmentVariables(), containsInAnyOrder(createEnvironment()));
-  }
-
-  @Test
-  public void whenDesiredStateAdminAndSpecifiedOnCluster_managedServerHasEnvironmentVariables() {
-    addClusterStartup(
-        new ClusterStartup()
-            .withDesiredState("ADMIN")
-            .withClusterName(CLUSTER_NAME)
-            .withEnv(Collections.singletonList(envVar("JAVA_OPTIONS", "value"))));
-
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(
-        spec.getEnvironmentVariables(),
-        hasItem(envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN value")));
-  }
-
-  @Test
-  public void whenNotSpecified_imageHasDefault() {
-    domain.getSpec().setImage(null);
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getImage(), equalTo(KubernetesConstants.DEFAULT_IMAGE));
-  }
-
-  @Test
-  public void whenImageTagIsLatestAndPullPolicyNotSpecified_pullPolicyIsAlways() {
-    domain.getSpec().setImage("test:latest");
-    domain.getSpec().setImagePullPolicy(null);
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getImagePullPolicy(), equalTo(ALWAYS_IMAGEPULLPOLICY));
-  }
-
-  @Test
-  public void whenImageTagIsNotLatestAndPullPolicyNotSpecified_pullPolicyIsIfAbsent() {
-    domain.getSpec().setImage("test:1.0");
-    domain.getSpec().setImagePullPolicy(null);
-
-    ServerSpec spec = domain.getAdminServerSpec();
-
-    assertThat(spec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
-  }
-
-  @Test
-  public void whenNoReplicaCountSpecified_useDefaultValue() {
-    assertThat(domain.getReplicaCount("nosuchcluster"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
-  }
-
-  @Test
-  public void whenNoStartupForCluster_useDefaultReplicaCount() {
-    DomainConfigurator.forDomain(domain).setDefaultReplicas(5);
+  public void whenClusterNotConfigured_useDefaultReplicaCount() {
+    configureDomain(domain).setDefaultReplicas(5);
 
     assertThat(domain.getReplicaCount("nosuchcluster"), equalTo(5));
   }
 
   @Test
-  public void afterReplicaCountSetForCluster_canReadIt() {
-    DomainConfigurator.forDomain(domain).configureCluster("cluster1").withReplicas(5);
-
-    assertThat(domain.getReplicaCount("cluster1"), equalTo(5));
-  }
-
-  @Test
   public void afterReplicaCountSetForCluster_defaultIsUnchanged() {
-    DomainConfigurator.forDomain(domain).configureCluster("cluster1").withReplicas(5);
+    configureCluster("cluster1").withReplicas(5);
 
-    assertThat(domain.getReplicaCount("cluster2"), equalTo(1));
+    assertThat(domain.getReplicaCount("cluster2"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
   }
 
   @Test
-  public void whenStartupDefinedForClusterWithReplicas_useClusterReplicaCount() {
-    domain.getSpec().setReplicas(5);
-    domain
-        .getSpec()
-        .addClusterStartupItem(new ClusterStartup().withClusterName("cluster1").withReplicas(3));
+  public void whenClusterDefinedWithReplicas_useClusterReplicaCount() {
+    configureDomain(domain).setDefaultReplicas(5);
+    configureCluster("cluster1").withReplicas(3);
 
     assertThat(domain.getReplicaCount("cluster1"), equalTo(3));
   }
 
   @Test
-  public void whenStartupDefinedForClusterWithoutReplicas_useDomainReplicaCount() {
-    domain.getSpec().setReplicas(5);
-    domain.getSpec().addClusterStartupItem(new ClusterStartup().withClusterName("cluster1"));
+  public void whenClusterDefinedWithoutReplicas_useDomainReplicaCount() {
+    configureDomain(domain).setDefaultReplicas(5);
+    configureCluster("cluster1");
 
     assertThat(domain.getReplicaCount("cluster1"), equalTo(5));
   }
 
   @Test
-  public void whenNoServerStartupDefined_nodePortIsNull() {
+  public void domainV2Lists_areEmpty() {
     ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
 
-    assertThat(spec.getNodePort(), nullValue());
+    assertThat(spec.getAdditionalVolumeMounts(), empty());
+    assertThat(spec.getAdditionalVolumes(), empty());
   }
 
   @Test
-  public void whenServerStartupDefined_returnNodePort() {
-    addServerStartup(new ServerStartup().withServerName(SERVER1).withNodePort(31));
+  public void domainV2Maps_areEmpty() {
     ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
 
-    assertThat(spec.getNodePort(), equalTo(31));
+    assertThat(spec.getPodLabels(), anEmptyMap());
+    assertThat(spec.getPodAnnotations(), anEmptyMap());
+    assertThat(spec.getListenAddressServiceLabels(), anEmptyMap());
+    assertThat(spec.getListenAddressServiceAnnotations(), anEmptyMap());
+    assertThat(spec.getNodeSelectors(), anEmptyMap());
+  }
+
+  @Test
+  public void domainV2Objects_areNull() {
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getResources(), nullValue());
+    assertThat(spec.getPodSecurityContext(), nullValue());
+    assertThat(spec.getContainerSecurityContext(), nullValue());
+  }
+
+  @Test
+  public void livenessProbeSettings_returnsNullValues() {
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+    V1Probe probe = spec.getLivenessProbe();
+
+    assertThat(probe.getInitialDelaySeconds(), nullValue());
+    assertThat(probe.getFailureThreshold(), nullValue());
+    assertThat(probe.getPeriodSeconds(), nullValue());
+  }
+
+  @Test
+  public void readinessProbeSettings_returnsNullValues() {
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+    V1Probe probe = spec.getReadinessProbe();
+
+    assertThat(probe.getInitialDelaySeconds(), nullValue());
+    assertThat(probe.getFailureThreshold(), nullValue());
+    assertThat(probe.getPeriodSeconds(), nullValue());
   }
 }

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -1,0 +1,159 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
+import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import io.kubernetes.client.models.V1EnvVar;
+import java.io.IOException;
+import oracle.kubernetes.weblogic.domain.DomainConfigurator;
+import oracle.kubernetes.weblogic.domain.DomainTestBase;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+import oracle.kubernetes.weblogic.domain.v1.ServerSpec;
+import org.junit.Test;
+
+public class DomainV2Test extends DomainTestBase {
+
+  private static final String DOMAIN_V2_SAMPLE_YAML = "v2/domain-sample.yaml";
+
+  @Override
+  protected DomainConfigurator configureDomain(Domain domain) {
+    return new DomainV2Configurator(domain);
+  }
+
+  @Test
+  public void whenImageConfiguredOnDomainAndAdminServer_userServerSetting() {
+    configureDomain(domain).setDefaultImage("domain-image");
+    configureAdminServer().withImage("server-image");
+
+    assertThat(domain.getAdminServerSpec().getImage(), equalTo("server-image"));
+  }
+
+  @Test
+  public void whenImageConfiguredOnDomainAndServer_userServerSetting() {
+    configureDomain(domain).setDefaultImage("domain-image");
+    configureServer("server1").withImage("server-image");
+
+    assertThat(domain.getServer("server1", "cluster1").getImage(), equalTo("server-image"));
+  }
+
+  @Test
+  public void whenImageConfiguredOnDomainAndCluster_useClusterSetting() {
+    configureDomain(domain).setDefaultImage("domain-image");
+    configureCluster("cluster1").withImage("cluster-image");
+
+    assertThat(domain.getServer("ms1", "cluster1").getImage(), equalTo("cluster-image"));
+  }
+
+  @Test
+  public void whenClusterNotConfigured_useDefaultReplicaCount() {
+    assertThat(domain.getReplicaCount("nosuchcluster"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
+  }
+
+  @Test
+  public void whenImagePullPolicyConfiguredOnClusterAndServer_useServerSetting() {
+    configureCluster("cluster1").withImagePullPolicy("always");
+    configureServer("server1").withImagePullPolicy("never");
+
+    assertThat(domain.getServer("server1", "cluster1").getImagePullPolicy(), equalTo("never"));
+  }
+
+  @Test
+  public void whenImagePullSecretConfiguredOnClusterAndServer_useServerSetting() {
+    configureCluster("cluster1").withImagePullSecret("cluster");
+    configureServer("server1").withImagePullSecret("server");
+
+    assertThat(
+        domain.getServer("server1", "cluster1").getImagePullSecret().getName(), equalTo("server"));
+  }
+
+  @Test
+  public void whenServerStartStateConfiguredOnClusterAndServer_useServerSetting() {
+    configureCluster("cluster1").withServerStartState("cluster");
+    configureServer("server1").withServerStartState("server");
+
+    assertThat(domain.getServer("server1", "cluster1").getDesiredState(), equalTo("server"));
+  }
+
+  @Test
+  public void whenEnvironmentConfiguredOnMultipleLevels_useCombination() {
+    configureDomain(domain)
+        .withEnvironmentVariable("name1", "domain")
+        .withEnvironmentVariable("name2", "domain");
+    configureCluster("cluster1")
+        .withEnvironmentVariable("name2", "cluster")
+        .withEnvironmentVariable("name3", "cluster")
+        .withEnvironmentVariable("name4", "cluster");
+    configureServer("server1").withEnvironmentVariable("name4", "server");
+
+    assertThat(
+        domain.getServer("server1", "cluster1").getEnvironmentVariables(),
+        containsInAnyOrder(
+            envVar("name1", "domain"),
+            envVar("name2", "cluster"),
+            envVar("name3", "cluster"),
+            envVar("name4", "server")));
+  }
+
+  private V1EnvVar envVar(String name, String value) {
+    return new V1EnvVar().name(name).value(value);
+  }
+
+  @Test
+  public void whenDomain2ReadFromYaml_unconfiguredServerHasDomainDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getServer("server0", null);
+
+    assertThat(serverSpec.getImage(), equalTo(DEFAULT_IMAGE));
+    assertThat(serverSpec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
+    assertThat(serverSpec.getImagePullSecret().getName(), equalTo("pull-secret"));
+    assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
+    assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
+  }
+
+  @Test
+  public void whenDomain2ReadFromYaml_adminServerOverridesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getAdminServerSpec();
+
+    assertThat(serverSpec.getImage(), equalTo("store/oracle/weblogic:latest"));
+    assertThat(serverSpec.getImagePullSecret().getName(), equalTo("pull-secret"));
+    assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value1")));
+  }
+
+  @Test
+  public void whenDomain2ReadFromYaml_server1OverridesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getServer("server1", "cluster1");
+
+    assertThat(serverSpec.getImage(), equalTo(DEFAULT_IMAGE));
+    assertThat(serverSpec.getNodePort(), equalTo(7001));
+    assertThat(
+        serverSpec.getEnvironmentVariables(),
+        containsInAnyOrder(
+            envVar("JAVA_OPTIONS", "-server"),
+            envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
+            envVar("var1", "value0")));
+  }
+
+  @Test
+  public void whenDomain2ReadFromYaml_cluster2OverridesDefaults() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
+    ServerSpec serverSpec = domain.getServer("server2", "cluster2");
+
+    assertThat(serverSpec.getDesiredState(), equalTo("ADMIN"));
+    assertThat(
+        serverSpec.getEnvironmentVariables(),
+        containsInAnyOrder(
+            envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN -verbose"),
+            envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
+            envVar("var1", "value0")));
+  }
+}

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v1/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v1/domain-sample.yaml
@@ -1,0 +1,83 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+apiVersion: "weblogic.oracle/v1"
+kind: Domain
+metadata:
+  name: domain1
+  namespace: domain_ns
+spec:
+  # Identify which Secret contains the WebLogic Admin credentials
+  adminSecret:
+    name: admin-secret
+  # The name of the Admin Server
+  asName: admin
+  # The Admin Server's ListenPort
+  asPort: 8001
+  # The WebLogic Domain Name
+
+  domainName: base_domain
+  # The domainUID must be unique across the entire Kubernetes Cluster.   Each WebLogic Domain must
+  # have its own unique domainUID.  This does not have to be the same as the Domain Name.  It is allowed
+  # to have multiple Domains with the same Domain Name, but they MUST have different domainUID's.
+  # The domainUID is also used to identify the Persistent Volume that belongs to/with this Domain.
+  domainUID: test-domain
+
+  # The Operator currently does not support other images
+  image: "store/oracle/weblogic:12.2.1.3"
+  # imagePullPolicy defaults to "Always" if image version is :latest
+  imagePullPolicy: IfNotPresent
+  # Identify which Secret contains the credentials for pulling the image
+  imagePullSecret:
+    name: pull-secret
+
+  # startupControl legal values are "NONE", "ALL", "ADMIN", "SPECIFIED", or "AUTO"
+  # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
+  # - "ALL" will start up all defined servers
+  # - "ADMIN" will start up only the AdminServer (no managed servers will be started)
+  # - "SPECIFIED" will start the AdminServer and then will look at the "serverStartup" and
+  #   "clusterStartup" entries below to work out which servers to start
+  # - "AUTO" will start the servers as with "SPECIFIED", but then also start servers from
+  #   other clusters up to the replicas count
+  startupControl: AUTO
+  # serverStartup is used to list the desired behavior for starting servers.  The Operator will
+  # use this field only if startupControl is set to "SPECIFIED" or "AUTO".  You may provide a list of
+  # entries, each entry should contain the keys should below:
+  # The number of managed servers to start from clusters not listed by clusterStartup
+  replicas: 1
+  # a list of T3 channel names
+  exportT3Channels:
+  - T3Channel
+
+  # list of configurations per named server. 
+  serverStartup:
+    # the name of the server to apply these rules to
+  - serverName: server1
+    # desiredState legal values are "RUNNING" or "ADMIN"
+    # "RUNNING" means the listed server will be started up to "RUNNING" mode
+    # "ADMIN" means the listed server will be start up to "ADMIN" mode
+    desiredState: "RUNNING"
+    # The Admin Server's NodePort
+    nodePort: 7001
+    # an (optional) list of environment variable to be set on the server
+    env:
+    - name: JAVA_OPTIONS
+      value: "-server"
+    - name: USER_MEM_ARGS
+      value: "-Xms64m -Xmx256m "
+  - serverName: server2
+    desiredState: ADMIN
+
+  # clusterStartup has the same structure as serverStartup, but it allows you to specify the name
+  # of a cluster instead of an individual server.  If you use this entry, then the rules will be
+  # applied to ALL servers that are members of the named clusters.
+  clusterStartup:
+  - clusterName: cluster2
+    desiredState: "RUNNING"
+    replicas: 5
+    env:
+    - name: JAVA_OPTIONS
+      value: "-verbose"
+    - name: USER_MEM_ARGS
+      value: "-Xms64m -Xmx256m "

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v1/invalid-domain.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v1/invalid-domain.yaml
@@ -1,0 +1,12 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+apiVersion: "weblogic.oracle/v1"
+kind: Domain
+metadata:
+  name: domain1
+  namespace: domain_ns
+spec:
+  adminServer:
+    name: asname

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -1,0 +1,70 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+apiVersion: "weblogic.oracle/v2"
+kind: Domain
+metadata:
+  name: domain1
+  namespace: domain_ns
+spec:
+  # Identify which Secret contains the WebLogic Admin credentials
+  adminSecret:
+    name: admin-secret
+  # The name of the Admin Server
+  asName: admin
+  # The Admin Server's ListenPort
+  asPort: 8001
+  # The WebLogic Domain Name
+
+  domainName: base_domain
+  # The domainUID must be unique across the entire Kubernetes Cluster.   Each WebLogic Domain must
+  # have its own unique domainUID.  This does not have to be the same as the Domain Name.  It is allowed
+  # to have multiple Domains with the same Domain Name, but they MUST have different domainUID's.
+  # The domainUID is also used to identify the Persistent Volume that belongs to/with this Domain.
+  domainUID: test-domain
+
+  # The Operator currently does not support other images
+  image: "store/oracle/weblogic:12.2.1.3"
+  # imagePullPolicy defaults to "Always" if image version is :latest
+  imagePullPolicy: IfNotPresent
+  # Identify which Secret contains the credentials for pulling the image
+  imagePullSecret:
+    name: pull-secret
+  env:
+  - name: var1
+    value: value0
+
+  adminServer:
+    image: "store/oracle/weblogic:latest"
+    env:
+    - name: var1
+      value: value1
+
+  # list of configurations per named server.
+  managedServers:
+    # the name of the server to apply these rules to
+  - serverName: server1
+    # The Admin Server's NodePort
+    nodePort: 7001
+    # an (optional) list of environment variable to be set on the server
+    env:
+    - name: JAVA_OPTIONS
+      value: "-server"
+    - name: USER_MEM_ARGS
+      value: "-Xms64m -Xmx256m "
+  - serverName: server2
+    serverStartState: ADMIN
+
+  # clusterStartup has the same structure as serverStartup, but it allows you to specify the name
+  # of a cluster instead of an individual server.  If you use this entry, then the rules will be
+  # applied to ALL servers that are members of the named clusters.
+  clusters:
+  - clusterName: cluster2
+    desiredState: "RUNNING"
+    replicas: 5
+    env:
+    - name: JAVA_OPTIONS
+      value: "-verbose"
+    - name: USER_MEM_ARGS
+      value: "-Xms64m -Xmx256m "

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -29,6 +29,7 @@ import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -254,16 +255,6 @@ public abstract class PodStepContext {
     return new CallBuilder().createPodAsync(getNamespace(), getPodModel(), replaceResponse(next));
   }
 
-  /**
-   * Reads the specified pod and records it.
-   *
-   * @param next the next step to perform after the pod creation is complete.
-   * @return a step to be scheduled.
-   */
-  private Step readPod(Step next) {
-    return new CallBuilder().readPodAsync(getPodName(), getNamespace(), readResponse(next));
-  }
-
   private void logPodCreated() {
     LOGGER.info(getPodCreatedMessageKey(), getDomainUID(), getServerName());
   }
@@ -389,32 +380,6 @@ public abstract class PodStepContext {
 
   Set<String> getExplicitRestartServers() {
     return info.getExplicitRestartServers();
-  }
-
-  private ResponseStep<V1Pod> readResponse(Step next) {
-    return new ReadResponseStep(next);
-  }
-
-  private class ReadResponseStep extends DefaultResponseStep<V1Pod> {
-
-    ReadResponseStep(Step next) {
-      super(next);
-    }
-
-    @Override
-    public NextAction onFailure(Packet packet, CallResponse<V1Pod> callResponse) {
-      if (callResponse.getStatusCode() == CallBuilder.NOT_FOUND) {
-        return onSuccess(packet, callResponse);
-      }
-      return super.onFailure(packet, callResponse);
-    }
-
-    @Override
-    public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
-      V1Pod currentPod = callResponse.getResult();
-      setRecordedPod(currentPod);
-      return doNext(packet);
-    }
   }
 
   private class VerifyPodStep extends Step {
@@ -612,7 +577,7 @@ public abstract class PodStepContext {
                             .name(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
                             .defaultMode(ALL_READ_AND_EXECUTE)));
 
-    V1LocalObjectReference imagePullSecret = info.getDomain().getSpec().getImagePullSecret();
+    V1LocalObjectReference imagePullSecret = getServerSpec().getImagePullSecret();
     if (imagePullSecret != null) {
       podSpec.addImagePullSecretsItem(imagePullSecret);
     }
@@ -651,7 +616,7 @@ public abstract class PodStepContext {
   }
 
   protected List<String> getContainerCommand() {
-    return Arrays.asList(START_SERVER);
+    return Collections.singletonList(START_SERVER);
   }
 
   abstract List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters);

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RestBackendImpl.java
@@ -4,8 +4,6 @@
 
 package oracle.kubernetes.operator.rest;
 
-import static oracle.kubernetes.weblogic.domain.DomainConfigurator.forDomain;
-
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1TokenReviewStatus;
 import io.kubernetes.client.models.V1UserInfo;
@@ -67,8 +65,7 @@ public class RestBackendImpl implements RestBackend {
    * @param targetNamespaces a list of Kubernetes namepaces that contain domains that the WebLogic
    *     operator manages.
    */
-  public RestBackendImpl(
-      String principal, String accessToken, Collection<String> targetNamespaces) {
+  RestBackendImpl(String principal, String accessToken, Collection<String> targetNamespaces) {
     LOGGER.entering(principal, targetNamespaces);
     this.principal = principal;
     userInfo = authenticate(accessToken);
@@ -83,7 +80,7 @@ public class RestBackendImpl implements RestBackend {
 
   private void authorize(String domainUID, Operation operation) {
     LOGGER.entering(domainUID, operation);
-    boolean authorized = false;
+    boolean authorized;
     if (domainUID == null) {
       authorized =
           atz.check(
@@ -172,7 +169,7 @@ public class RestBackendImpl implements RestBackend {
   }
 
   private List<Domain> getDomainsList() {
-    Collection<List<Domain>> c = new ArrayList<List<Domain>>();
+    Collection<List<Domain>> c = new ArrayList<>();
     try {
       for (String ns : targetNamespaces) {
         DomainList dl = new CallBuilder().listDomain(ns);
@@ -191,9 +188,8 @@ public class RestBackendImpl implements RestBackend {
   @Override
   public boolean isDomainUID(String domainUID) {
     LOGGER.entering(domainUID);
-    boolean result = false;
     authorize(null, Operation.list);
-    result = getDomainUIDs().contains(domainUID);
+    boolean result = getDomainUIDs().contains(domainUID);
     LOGGER.exiting(result);
     return result;
   }
@@ -260,7 +256,7 @@ public class RestBackendImpl implements RestBackend {
   private void updateReplicasForDomain(
       String namespace, Domain domain, String cluster, int newReplicaCount) {
     if (newReplicaCount != domain.getReplicaCount(cluster)) {
-      forDomain(domain).configureCluster(cluster).withReplicas(newReplicaCount);
+      domain.setReplicaCount(cluster, newReplicaCount);
       overwriteDomain(namespace, domain);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
-import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.WlsDomain;
 
 /** Contains a snapshot of configuration for a WebLogic Domain */
@@ -294,29 +294,28 @@ public class WlsDomainConfig implements WlsDomain {
     return null;
   }
 
-  public boolean validate(DomainSpec domainSpec) {
-    return validate(domainSpec, null);
+  public boolean validate(Domain domain) {
+    return validate(domain, null);
   }
 
   /**
    * Checks the provided k8s domain spec to see if it is consistent with the configuration of the
    * WLS domain. The method also logs warning if inconsistent WLS configurations are found.
    *
-   * @param domainSpec The DomainSpec to be validated against the WLS configuration
+   * @param domain The Domain to be validated against the WLS configuration
    * @param suggestedConfigUpdates a List of ConfigUpdate objects containing suggested WebLogic
    *     config updates that are necessary to make the WebLogic domain consistent with the
    *     DomainSpec. Optional.
    * @return true if the DomainSpec has been updated, false otherwise
    */
-  public boolean validate(DomainSpec domainSpec, List<ConfigUpdate> suggestedConfigUpdates) {
-
+  public boolean validate(Domain domain, List<ConfigUpdate> suggestedConfigUpdates) {
     LOGGER.entering();
 
     boolean updated = false;
     for (String clusterName : getClusterNames()) {
       WlsClusterConfig wlsClusterConfig = getClusterConfig(clusterName);
       if (wlsClusterConfig.getMaxClusterSize() > 0) {
-        int proposedReplicas = domainSpec.getReplicaCount(clusterName);
+        int proposedReplicas = domain.getReplicaCount(clusterName);
         int replicaLimit = getReplicaLimit(clusterName);
         if (proposedReplicas > replicaLimit) {
           LOGGER.warning(
@@ -334,8 +333,7 @@ public class WlsDomainConfig implements WlsDomain {
       if (clusterConfig.getMaxClusterSize() == 0) {
         LOGGER.warning(MessageKeys.NO_WLS_SERVER_IN_CLUSTER, clusterName);
       } else {
-        clusterConfig.validateCluster(
-            domainSpec.getReplicaCount(clusterName), suggestedConfigUpdates);
+        clusterConfig.validateCluster(domain.getReplicaCount(clusterName), suggestedConfigUpdates);
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsRetriever.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsRetriever.java
@@ -277,7 +277,7 @@ public class WlsRetriever {
 
           // This logs warning messages as well as returning a list of suggested
           // WebLogic configuration updates, but it does not update the DomainSpec.
-          wlsDomainConfig.validate(dom.getSpec(), suggestedConfigUpdates);
+          wlsDomainConfig.validate(dom, suggestedConfigUpdates);
 
           info.setScan(wlsDomainConfig);
           info.setLastScanTime(new DateTime());

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainNormalizationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainNormalizationTest.java
@@ -63,7 +63,7 @@ public class DomainNormalizationTest {
     assertThat(domainSpec.getExportT3Channels(), empty());
     assertThat(
         domainSpec.getStartupControl(), equalTo(StartupControlConstants.AUTO_STARTUPCONTROL));
-    assertThat(domainSpec.getReplicaCount("nocluster"), equalTo(1));
+    assertThat(domain.getReplicaCount("nocluster"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -22,7 +22,6 @@ import io.kubernetes.client.models.V1ContainerPort;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodSpec;
 import io.kubernetes.client.models.V1Status;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import oracle.kubernetes.operator.PodAwaiterStepFactory;
@@ -229,7 +228,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
 
   @Test
   public void whenDomainHasEnvironmentItems_createAdminPodStartupWithThem() {
-    configureServer(ADMIN_SERVER)
+    configureAdminServer()
         .withEnvironmentVariable("item1", "value1")
         .withEnvironmentVariable("item2", "value2");
 
@@ -238,13 +237,13 @@ public class AdminPodHelperTest extends PodHelperTestBase {
         allOf(hasEnvVar("item1", "value1"), hasEnvVar("item2", "value2")));
   }
 
-  private ServerConfigurator configureServer(String serverName) {
-    return getConfigurator().configureServer(serverName);
+  private ServerConfigurator configureAdminServer() {
+    return getConfigurator().configureAdminServer();
   }
 
   @Test
   public void whenDomainHasEnvironmentItemsWithVariables_createAdminPodStartupWithThem() {
-    configureServer(ADMIN_SERVER)
+    configureAdminServer()
         .withEnvironmentVariable("item1", "find $(DOMAIN_NAME) at $(DOMAIN_HOME)")
         .withEnvironmentVariable("item2", "$(SERVER_NAME) is $(ADMIN_NAME):$(ADMIN_PORT)");
 
@@ -278,6 +277,6 @@ public class AdminPodHelperTest extends PodHelperTestBase {
 
   @Override
   List<String> createStartCommand() {
-    return Arrays.asList("/weblogic-operator/scripts/startServer.sh");
+    return Collections.singletonList("/weblogic-operator/scripts/startServer.sh");
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/BeforeAdminServiceStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/BeforeAdminServiceStepTest.java
@@ -1,3 +1,7 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
 package oracle.kubernetes.operator.steps;
 
 import static oracle.kubernetes.operator.ProcessingConstants.NODE_PORT;
@@ -81,7 +85,7 @@ public class BeforeAdminServiceStepTest {
 
   @Test
   public void whenAdminServerNodePortDefined_packetContainsItAfterProcessing() {
-    configurator.configureServer(ADMIN_NAME).withNodePort(NODE_PORT_NUM);
+    configurator.configureAdminServer().withNodePort(NODE_PORT_NUM);
     Packet packet = invokeStep();
 
     assertThat(packet, hasEntry(NODE_PORT, NODE_PORT_NUM));

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfigTest.java
@@ -162,7 +162,7 @@ public class WlsDomainConfigTest {
     configureCluster("DockerCluster").withReplicas(3);
 
     ArrayList<ConfigUpdate> suggestedConfigUpdates = new ArrayList<>();
-    wlsDomainConfig.validate(domainSpec, suggestedConfigUpdates);
+    wlsDomainConfig.validate(domain, suggestedConfigUpdates);
 
     assertEquals(1, suggestedConfigUpdates.size());
     WlsClusterConfig.DynamicClusterSizeConfigUpdate configUpdate =
@@ -309,7 +309,7 @@ public class WlsDomainConfigTest {
     createDomainConfig(JSON_STRING_1_CLUSTER);
     configureCluster("DockerCluster").withReplicas(10);
 
-    wlsDomainConfig.validate(domainSpec);
+    wlsDomainConfig.validate(domain);
     assertThat(logRecords, containsWarning(REPLICA_MORE_THAN_WLS_SERVERS, "DockerCluster"));
   }
 
@@ -318,7 +318,7 @@ public class WlsDomainConfigTest {
     createDomainConfig(JSON_STRING_1_CLUSTER);
     configureCluster("DockerCluster").withReplicas(5);
 
-    wlsDomainConfig.validate(domainSpec);
+    wlsDomainConfig.validate(domain);
     assertTrue(logRecords.isEmpty());
   }
 
@@ -327,7 +327,7 @@ public class WlsDomainConfigTest {
     createDomainConfig(JSON_STRING_2_CLUSTERS);
     configureCluster("DockerCluster2").withReplicas(3);
 
-    wlsDomainConfig.validate(domainSpec);
+    wlsDomainConfig.validate(domain);
     assertThat(logRecords, containsWarning(REPLICA_MORE_THAN_WLS_SERVERS, "DockerCluster2"));
   }
 
@@ -337,7 +337,7 @@ public class WlsDomainConfigTest {
     configureCluster("DockerCluster").withReplicas(10);
     configureCluster("DockerCluster2").withReplicas(10);
 
-    wlsDomainConfig.validate(domainSpec);
+    wlsDomainConfig.validate(domain);
     assertThat(logRecords, containsWarning(REPLICA_MORE_THAN_WLS_SERVERS, "DockerCluster"));
     assertThat(logRecords, containsWarning(REPLICA_MORE_THAN_WLS_SERVERS, "DockerCluster2"));
   }
@@ -348,7 +348,7 @@ public class WlsDomainConfigTest {
     configureDefaultReplicas(1);
     configureCluster("DockerCluster2").withReplicas(2);
 
-    wlsDomainConfig.validate(domainSpec);
+    wlsDomainConfig.validate(domain);
     assertTrue(logRecords.isEmpty());
   }
 
@@ -362,7 +362,7 @@ public class WlsDomainConfigTest {
     configureDefaultReplicas(10);
     configureCluster("DockerCluster").withReplicas(10);
 
-    wlsDomainConfig.validate(domainSpec);
+    wlsDomainConfig.validate(domain);
     assertTrue(logRecords.isEmpty());
   }
 


### PR DESCRIPTION
Initial implementation of the new domain model
- includes scoping rules
- implements the classes used by the runtime
- can read either v1 or v2 domain models

Still needs:
- domain watcher / domain job enhancements
- updated schema
- new server startup behavior
- additional fields for configuring pods and services