### PR TITLE
Use additional tests to upgrade helm charts to match scripts

### DIFF
--- a/kubernetes/charts/weblogic-domain/templates/_domain-custom-resource.tpl
+++ b/kubernetes/charts/weblogic-domain/templates/_domain-custom-resource.tpl
@@ -27,6 +27,9 @@ spec:
   image: "{{ .weblogicImage }}"
   # imagePullPolicy defaults to "Always" if image version is :latest
   imagePullPolicy: "IfNotPresent"
+  # Identify which Secret containst the credentials to access the docker repository
+  imagePullSecret:
+    name: {{ .weblogicImagePullSecretName }}
   # Identify which Secret contains the WebLogic Admin credentials (note that there is an example of
   # how to create that Secret at the end of this file)
   adminSecret: 

--- a/kubernetes/charts/weblogic-domain/templates/_traefik-security.tpl
+++ b/kubernetes/charts/weblogic-domain/templates/_traefik-security.tpl
@@ -6,7 +6,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1
     weblogic.domainUID: {{ .Release.Name }}
@@ -37,7 +37,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1
     weblogic.domainUID: {{ .Release.Name }}
@@ -46,9 +46,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/kubernetes/charts/weblogic-domain/templates/_traefik.tpl
+++ b/kubernetes/charts/weblogic-domain/templates/_traefik.tpl
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
   namespace: {{ .Release.Namespace }}
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1
@@ -18,7 +18,7 @@ metadata:
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
   namespace: {{ .Release.Namespace }}
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1
@@ -39,7 +39,7 @@ spec:
         weblogic.domainName: {{ .domainName }}
         weblogic.clusterName: {{ .clusterName }}
     spec:
-      serviceAccountName: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+      serviceAccountName: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
       terminationGracePeriodSeconds: 60
       containers:
       - image: traefik:1.4.5
@@ -82,13 +82,13 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik-cm
+          name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik-cm
 
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik-cm
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik-cm
   namespace: {{ .Release.Namespace }}
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1
@@ -113,7 +113,7 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik
   namespace: {{ .Release.Namespace }}
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1
@@ -135,7 +135,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .clusterName | lower }}-traefik-dashboard
+  name: {{ .Release.Name }}-{{ .clusterName | lower | replace "_" "-" }}-traefik-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
     weblogic.resourceVersion: traefik-load-balancer-v1

--- a/kubernetes/charts/weblogic-domain/templates/_voyager-ingress.tpl
+++ b/kubernetes/charts/weblogic-domain/templates/_voyager-ingress.tpl
@@ -23,7 +23,7 @@ spec:
       nodePort: '{{ .loadBalancerWebPort }}'
       paths:
       - backend:
-          serviceName: {{ .Release.Name }}-cluster-{{ .clusterName | lower }}
+          serviceName: {{ .Release.Name }}-cluster-{{ .clusterName | lower | replace "_" "-" }}
           servicePort: '{{ .managedServerPort }}'
 
 ---

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesBaseTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesBaseTest.java
@@ -14,55 +14,7 @@ import static oracle.kubernetes.operator.VersionConstants.APACHE_LOAD_BALANCER_V
 import static oracle.kubernetes.operator.VersionConstants.DOMAIN_V1;
 import static oracle.kubernetes.operator.VersionConstants.TRAEFIK_LOAD_BALANCER_V1;
 import static oracle.kubernetes.operator.VersionConstants.VOYAGER_LOAD_BALANCER_V1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_GROUP_RBAC;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_APPS_V1BETA1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_EXTENSIONS_V1BETA1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_RBAC_V1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_CLUSTER_ROLE;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_SERVICE_ACCOUNT;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.containsRegexps;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.getThenEmptyConfigMapDataValue;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRole;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRoleBinding;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newConfigMap;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newConfigMapVolumeSource;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newContainer;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newContainerPort;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newDeployment;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newDeploymentSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newDomain;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newDomainSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newEnvVar;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newHTTPGetAction;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newHostPathVolumeSource;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newIntOrString;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newJob;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newJobSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newLabelSelector;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newLocalObjectReferenceList;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newObjectMeta;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPersistentVolume;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPersistentVolumeClaim;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPersistentVolumeClaimSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPersistentVolumeClaimVolumeSource;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPersistentVolumeSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPodSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPodTemplateSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPolicyRule;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newProbe;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newResourceRequirements;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newRoleRef;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newSecretReference;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newSecretVolumeSource;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newService;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newServiceAccount;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newServicePort;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newServiceSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newSubject;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newTCPSocketAction;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newToleration;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newVolume;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newVolumeMount;
+import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.*;
 import static oracle.kubernetes.operator.utils.YamlUtils.yamlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -196,6 +148,7 @@ public abstract class CreateDomainGeneratedFilesBaseTest {
     return newJob()
         .metadata(
             newObjectMeta()
+                .annotations(factory.getExpectedDomainJobAnnotations())
                 .name(getInputs().getDomainUID() + "-create-weblogic-domain-job")
                 .namespace(getInputs().getNamespace()))
         .spec(
@@ -249,8 +202,9 @@ public abstract class CreateDomainGeneratedFilesBaseTest {
                                         .persistentVolumeClaim(
                                             newPersistentVolumeClaimVolumeSource()
                                                 .claimName(
-                                                    getInputs()
-                                                        .getWeblogicDomainPersistentVolumeClaimName())))
+                                                    factory
+                                                        .getWeblogicDomainPersistentVolumeClaimName(
+                                                            getInputs()))))
                                 .addVolumesItem(
                                     newVolume()
                                         .name("weblogic-credentials-volume")
@@ -304,6 +258,7 @@ public abstract class CreateDomainGeneratedFilesBaseTest {
     return newConfigMap()
         .metadata(
             newObjectMeta()
+                .annotations(factory.getExpectedConfigMapAnnotations())
                 .name(getInputs().getDomainUID() + "-create-weblogic-domain-job-cm")
                 .namespace(getInputs().getNamespace())
                 .putLabelsItem(RESOURCE_VERSION_LABEL, DOMAIN_V1)

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -18,7 +18,6 @@ import io.kubernetes.client.models.V1PersistentVolume;
 import oracle.kubernetes.operator.utils.DomainValues;
 import oracle.kubernetes.operator.utils.DomainYamlFactory;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
-import org.junit.BeforeClass;
 
 /**
  * Tests that the all artifacts in the yaml files that create-weblogic-domain.sh creates are correct
@@ -28,17 +27,12 @@ import org.junit.BeforeClass;
 public class CreateDomainGeneratedFilesOptionalFeaturesEnabledTestBase
     extends CreateDomainGeneratedFilesBaseTest {
 
-  @BeforeClass
-  public static void setup() throws Exception {
-    defineDomainYamlFactory(new ScriptedDomainYamlFactory());
-  }
-
   protected static void defineDomainYamlFactory(DomainYamlFactory factory) throws Exception {
     setup(
         factory, withFeaturesEnabled(factory.newDomainValues()).loadBalancer(LOAD_BALANCER_APACHE));
   }
 
-  static DomainValues withFeaturesEnabled(DomainValues values) {
+  protected static DomainValues withFeaturesEnabled(DomainValues values) {
     return values
         .exposeAdminNodePort("true")
         .exposeAdminT3Channel("true")

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesVoyagerTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateDomainGeneratedFilesVoyagerTestBase.java
@@ -10,38 +10,9 @@ import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
 import static oracle.kubernetes.operator.VersionConstants.VOYAGER_LOAD_BALANCER_V1;
 import static oracle.kubernetes.operator.utils.CreateDomainInputs.LOAD_BALANCER_VOYAGER;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_GROUP_RBAC;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_RBAC_V1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_REGISTRATION_V1BETA1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_V1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.API_VERSION_VOYAGER_V1BETA1;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_CLUSTER_ROLE;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_ROLE;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_SERVICE_ACCOUNT;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newAPIService;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newAPIServiceSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRole;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRoleBinding;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newHTTPIngressBackend;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newHTTPIngressPath;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newHTTPIngressRuleValue;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newIngress;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newIngressRule;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newIngressSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newIntOrString;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newObjectMeta;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPolicyRule;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newRoleBinding;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newRoleRef;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newSecret;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newService;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newServicePort;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newServiceReference;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newServiceSpec;
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newSubject;
+import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.*;
 import static oracle.kubernetes.operator.utils.YamlUtils.yamlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import com.appscode.voyager.client.models.V1beta1Ingress;
 import io.kubernetes.client.models.V1Secret;
@@ -144,13 +115,6 @@ public abstract class CreateDomainGeneratedFilesVoyagerTestBase
   @Test
   public void generatesCorrect_loadBalancerService1() {
     assertThat(getActualVoyagerIngressService(), yamlEqualTo(getExpectedVoyagerIngressService()));
-  }
-
-  @Test
-  public void loadBalancerIngressYaml_hasCorrectNumberOfObjects() {
-    assertThat(
-        getVoyagerIngressYaml().getObjectCount(),
-        is(getVoyagerIngressYaml().getExpectedObjectCount()));
   }
 
   private V1Secret getActualVoyagerSecret() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/ScriptedDomainYamlFactory.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/ScriptedDomainYamlFactory.java
@@ -41,6 +41,11 @@ public class ScriptedDomainYamlFactory extends DomainYamlFactory {
     return new YamlGenerator(values).getGeneratedDomainYamlFiles();
   }
 
+  @Override
+  public String getWeblogicDomainPersistentVolumeClaimName(DomainValues inputs) {
+    return inputs.getWeblogicDomainPersistentVolumeClaimName();
+  }
+
   static class YamlGenerator extends YamlGeneratorBase {
     private final DomainValues values;
     private DomainFiles domainFiles;

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesInvalidDNSNameIT.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesInvalidDNSNameIT.java
@@ -1,0 +1,28 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helm;
+
+import oracle.kubernetes.operator.create.CreateDomainGeneratedFilesOptionalFeaturesDisabledTestBase;
+import oracle.kubernetes.operator.utils.DomainYamlFactory;
+import org.junit.BeforeClass;
+
+public class CreateDomainGeneratedFilesInvalidDNSNameIT
+    extends CreateDomainGeneratedFilesOptionalFeaturesDisabledTestBase {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    defineDomainYamlFactory(new HelmDomainYamlFactory());
+  }
+
+  protected static void defineDomainYamlFactory(DomainYamlFactory factory) throws Exception {
+    setup(
+        factory,
+        factory
+            .newDomainValues()
+            .adminServerName("admin_Server")
+            .managedServerNameBase("Managed_server")
+            .clusterName("my_cluster_1"));
+  }
+}

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesInvalidDNSNameVoyagerIT.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesInvalidDNSNameVoyagerIT.java
@@ -1,0 +1,36 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helm;
+
+import static oracle.kubernetes.operator.utils.DomainValues.LOAD_BALANCER_VOYAGER;
+
+import oracle.kubernetes.operator.create.CreateDomainGeneratedFilesVoyagerTestBase;
+import oracle.kubernetes.operator.utils.DomainYamlFactory;
+import org.junit.BeforeClass;
+
+/**
+ * Tests that the all artifacts in the yaml files that create-weblogic-domain.sh creates with
+ * VOYAGER load balancer type are correct when adminServerName, managedServerNameBase or/and
+ * clusterName in create domain inputs file contain invalid DNS characters. The invalid DNS
+ * characters include uppercase letters and underscore "_".
+ */
+public class CreateDomainGeneratedFilesInvalidDNSNameVoyagerIT
+    extends CreateDomainGeneratedFilesVoyagerTestBase {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    defineDomainYamlFactory(new HelmDomainYamlFactory());
+  }
+
+  protected static void defineDomainYamlFactory(DomainYamlFactory factory) throws Exception {
+    setup(
+        factory,
+        withFeaturesEnabled(factory.newDomainValues())
+            .adminServerName("admin_Server")
+            .managedServerNameBase("Managed_server")
+            .clusterName("my_cluster_1")
+            .loadBalancer(LOAD_BALANCER_VOYAGER));
+  }
+}

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesOptionalFeaturesDisabledIT.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesOptionalFeaturesDisabledIT.java
@@ -7,8 +7,6 @@ package oracle.kubernetes.operator.helm;
 import static oracle.kubernetes.operator.utils.YamlUtils.yamlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.kubernetes.client.models.V1ConfigMap;
-import io.kubernetes.client.models.V1Job;
 import io.kubernetes.client.models.V1PersistentVolume;
 import io.kubernetes.client.models.V1PersistentVolumeClaim;
 import oracle.kubernetes.operator.create.CreateDomainGeneratedFilesOptionalFeaturesDisabledTestBase;
@@ -23,48 +21,18 @@ public class CreateDomainGeneratedFilesOptionalFeaturesDisabledIT
     defineDomainYamlFactory(new HelmDomainYamlFactory());
   }
 
-  @Override
-  protected V1Job getExpectedCreateWeblogicDomainJob() {
-    V1Job expected = super.getExpectedCreateWeblogicDomainJob();
-    expected
-        .getMetadata()
-        .putAnnotationsItem("helm.sh/hook", "pre-install")
-        .putAnnotationsItem("helm.sh/hook-delete-policy", "hook-succeeded")
-        .putAnnotationsItem("helm.sh/hook-weight", "0");
-    expected
-        .getSpec()
-        .getTemplate()
-        .getSpec()
-        .getVolumes()
-        .get(1)
-        .getPersistentVolumeClaim()
-        .claimName(getInputs().getWeblogicDomainJobPersistentVolumeClaimName());
-    return expected;
-  }
-
-  @Override
-  protected V1ConfigMap getExpectedCreateWeblogicDomainJobConfigMap() {
-    V1ConfigMap expected = super.getExpectedCreateWeblogicDomainJobConfigMap();
-    expected
-        .getMetadata()
-        .putAnnotationsItem("helm.sh/hook", "pre-install")
-        .putAnnotationsItem("helm.sh/hook-delete-policy", "hook-succeeded")
-        .putAnnotationsItem("helm.sh/hook-weight", "-5");
-    return expected;
-  }
-
   @Test
-  public void generatesCorrect_weblogicDomainJobPersistentVolume() throws Exception {
+  public void generatesCorrect_weblogicDomainJobPersistentVolume() {
     assertThat(
         getActualWeblogicDomainJobPersistentVolume(),
         yamlEqualTo(getExpectedWeblogicDomainJobPersistentVolume()));
   }
 
-  protected V1PersistentVolume getActualWeblogicDomainJobPersistentVolume() {
+  private V1PersistentVolume getActualWeblogicDomainJobPersistentVolume() {
     return getWeblogicDomainPersistentVolumeYaml().getWeblogicDomainJobPersistentVolume();
   }
 
-  protected V1PersistentVolume getExpectedWeblogicDomainJobPersistentVolume() {
+  private V1PersistentVolume getExpectedWeblogicDomainJobPersistentVolume() {
     V1PersistentVolume expected = getExpectedWeblogicDomainPersistentVolume();
     expected.getMetadata().setName(getInputs().getWeblogicDomainJobPersistentVolumeName());
     expected
@@ -72,22 +40,21 @@ public class CreateDomainGeneratedFilesOptionalFeaturesDisabledIT
         .putAnnotationsItem("helm.sh/hook", "pre-install")
         .putAnnotationsItem("helm.sh/hook-delete-policy", "hook-succeeded,hook-failed")
         .putAnnotationsItem("helm.sh/hook-weight", "-5");
-    ;
     return expected;
   }
 
   @Test
-  public void generatesCorrect_weblogicDomainJobPersistentVolumeClaim() throws Exception {
+  public void generatesCorrect_weblogicDomainJobPersistentVolumeClaim() {
     assertThat(
         getActualWeblogicDomainJobPersistentVolumeClaim(),
         yamlEqualTo(getExpectedWeblogicDomainJobPersistentVolumeClaim()));
   }
 
-  protected V1PersistentVolumeClaim getActualWeblogicDomainJobPersistentVolumeClaim() {
+  private V1PersistentVolumeClaim getActualWeblogicDomainJobPersistentVolumeClaim() {
     return getWeblogicDomainPersistentVolumeClaimYaml().getWeblogicDomainJobPersistentVolumeClaim();
   }
 
-  protected V1PersistentVolumeClaim getExpectedWeblogicDomainJobPersistentVolumeClaim() {
+  private V1PersistentVolumeClaim getExpectedWeblogicDomainJobPersistentVolumeClaim() {
     V1PersistentVolumeClaim expected = getExpectedWeblogicDomainPersistentVolumeClaim();
     expected.getMetadata().setName(getInputs().getWeblogicDomainJobPersistentVolumeClaimName());
     expected
@@ -95,7 +62,6 @@ public class CreateDomainGeneratedFilesOptionalFeaturesDisabledIT
         .putAnnotationsItem("helm.sh/hook", "pre-install")
         .putAnnotationsItem("helm.sh/hook-delete-policy", "hook-succeeded,hook-failed")
         .putAnnotationsItem("helm.sh/hook-weight", "-5");
-    ;
     return expected;
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesVoyagerIT.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/CreateDomainGeneratedFilesVoyagerIT.java
@@ -1,0 +1,16 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helm;
+
+import oracle.kubernetes.operator.create.CreateDomainGeneratedFilesVoyagerTestBase;
+import org.junit.BeforeClass;
+
+public class CreateDomainGeneratedFilesVoyagerIT extends CreateDomainGeneratedFilesVoyagerTestBase {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    defineDomainYamlFactory(new HelmDomainYamlFactory());
+  }
+}

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/DomainYamlFactory.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/DomainYamlFactory.java
@@ -4,6 +4,8 @@
 
 package oracle.kubernetes.operator.utils;
 
+import java.util.Map;
+
 public abstract class DomainYamlFactory {
   public DomainValues newDomainValues() throws Exception {
     return createDefaultValues().withTestDefaults();
@@ -12,4 +14,14 @@ public abstract class DomainYamlFactory {
   public abstract DomainValues createDefaultValues() throws Exception;
 
   public abstract GeneratedDomainYamlFiles generate(DomainValues values) throws Exception;
+
+  public abstract String getWeblogicDomainPersistentVolumeClaimName(DomainValues inputs);
+
+  public Map<String, String> getExpectedDomainJobAnnotations() {
+    return null;
+  }
+
+  public Map<String, String> getExpectedConfigMapAnnotations() {
+    return null;
+  }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
@@ -312,11 +312,15 @@ public class ParsedKubernetesYaml {
       if (specAsMap == null) {
         return;
       }
-      String caBundleValueAsBase64EncodedString = (String) specAsMap.get("caBundle");
-      if (caBundleValueAsBase64EncodedString == null) {
-        return;
+      Object caBundle = specAsMap.get("caBundle");
+      if (caBundle == null) return;
+
+      byte[] caBundleAsBytes;
+      if (caBundle instanceof byte[]) caBundleAsBytes = (byte[]) caBundle;
+      else {
+        String caBundleValueAsBase64EncodedString = (String) caBundle;
+        caBundleAsBytes = Base64.decodeBase64(caBundleValueAsBase64EncodedString);
       }
-      byte[] caBundleAsBytes = Base64.decodeBase64(caBundleValueAsBase64EncodedString);
       specAsMap.put("caBundle", caBundleAsBytes);
     }
   }


### PR DESCRIPTION
In preparation for removing the domain chart piecemeal, ensure that it has the same functionality as the scripts, so that nothing is lost.