### PR TITLE
tag operator image to latest for jenkins

### DIFF
--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -22,7 +22,8 @@ function setup_jenkins {
 
     # create a docker image for the operator code being tested
     docker build -t "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}"  --build-arg VERSION=$JAR_VERSION --no-cache=true .
-
+	docker tag "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" wlsldi-v2.docker.oraclecorp.com/weblogic-operator:latest
+	
     docker images
     
     echo "Helm installation starts" 


### PR DESCRIPTION
Tag operator image with latest which will be used later to push to a registry on jenkins. Currently jenkins runs are failing on develop branch, which will fix the issue.