### PR TITLE
Support custom PVC, default domain home and default log home

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -273,11 +273,11 @@ public class BaseTest {
     String scriptsDir =
         "/scratch/acceptance_test_pv/persistentVolume-"
             + domainUid
-            + "/domain/"
-            + domainName
+            + "/domains/"
+            + domainUid
             + "/bin/scripts";
 
-    copyScalingScriptToPod(scriptsDir, domainName, adminPodName, domainNS);
+    copyScalingScriptToPod(scriptsDir, domainUid, adminPodName, domainNS);
     TestUtils.createRBACPoliciesForWLDFScaling();
 
     // deploy opensessionapp
@@ -391,7 +391,7 @@ public class BaseTest {
   }
 
   private void copyScalingScriptToPod(
-      String dirPathToCreate, String domainName, String podName, String domainNS) throws Exception {
+      String dirPathToCreate, String domainUID, String podName, String domainNS) throws Exception {
 
     // create scripts dir under domain pv
     TestUtils.createDirUnderDomainPV(dirPathToCreate);
@@ -399,7 +399,7 @@ public class BaseTest {
     // copy script to pod
     TestUtils.kubectlcp(
         getProjectRoot() + "/src/scripts/scaling/scalingAction.sh",
-        "/shared/domain/" + domainName + "/bin/scripts/scalingAction.sh",
+        "/shared/domains/" + domainUID + "/bin/scripts/scalingAction.sh",
         // "/shared/scalingAction.sh",
         podName,
         domainNS);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -781,6 +781,7 @@ public class Domain {
     initialManagedServerReplicas =
         ((Integer) domainMap.get("initialManagedServerReplicas")).intValue();
     configuredManagedServerCount =
+<<<<<<< HEAD
         ((Integer) domainMap.get("configuredManagedServerCount")).intValue();
     exposeAdminT3Channel = ((Boolean) domainMap.get("exposeAdminT3Channel")).booleanValue();
     exposeAdminNodePort = ((Boolean) domainMap.get("exposeAdminNodePort")).booleanValue();
@@ -796,6 +797,75 @@ public class Domain {
               + "/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/"
               + domainMap.get("createDomainFilesDir"));
     }
+=======
+        ((Integer)
+                inputDomainMap.getOrDefault(
+                    "configuredManagedServerCount", configuredManagedServerCount))
+            .intValue();
+    exposeAdminT3Channel =
+        ((Boolean)
+                inputDomainMap.getOrDefault(
+                    "exposeAdminT3Channel", new Boolean(exposeAdminT3Channel)))
+            .booleanValue();
+    exposeAdminNodePort =
+        ((Boolean)
+                inputDomainMap.getOrDefault(
+                    "exposeAdminNodePort", new Boolean(exposeAdminNodePort)))
+            .booleanValue();
+    t3ChannelPort =
+        ((Integer) inputDomainMap.getOrDefault("t3ChannelPort", t3ChannelPort)).intValue();
+    clusterName = inputDomainMap.getOrDefault("clusterName", clusterName).toString();
+    clusterType = inputDomainMap.getOrDefault("clusterType", clusterType).toString();
+    startupControl = inputDomainMap.getOrDefault("startupControl", startupControl).toString();
+    weblogicDomainStorageReclaimPolicy =
+        inputDomainMap
+            .getOrDefault("weblogicDomainStorageReclaimPolicy", weblogicDomainStorageReclaimPolicy)
+            .toString();
+    weblogicDomainStorageSize =
+        inputDomainMap
+            .getOrDefault("weblogicDomainStorageSize", weblogicDomainStorageSize)
+            .toString();
+    loadBalancer = inputDomainMap.getOrDefault("loadBalancer", loadBalancer).toString();
+    loadBalancerWebPort =
+        ((Integer) inputDomainMap.getOrDefault("loadBalancerWebPort", loadBalancerWebPort))
+            .intValue();
+    loadBalancerDashboardPort =
+        ((Integer)
+                inputDomainMap.getOrDefault("loadBalancerDashboardPort", loadBalancerDashboardPort))
+            .intValue();
+
+    domainMap.put("domainUID", domainUid);
+    domainMap.put("namespace", domainNS);
+    domainMap.put("adminServerName", adminServerName);
+    domainMap.put("managedServerNameBase", managedServerNameBase);
+    domainMap.put("initialManagedServerReplicas", initialManagedServerReplicas);
+    domainMap.put("configuredManagedServerCount", configuredManagedServerCount);
+    domainMap.put("exposeAdminT3Channel", new Boolean(exposeAdminT3Channel));
+    domainMap.put("exposeAdminNodePort", new Boolean(exposeAdminNodePort));
+    domainMap.put("t3ChannelPort", t3ChannelPort);
+    domainMap.put("clusterName", clusterName);
+    domainMap.put("clusterType", clusterType);
+    domainMap.put("startupControl", startupControl);
+    domainMap.put("persistentVolumeClaimName", domainUid + "-pvc");
+    domainMap.put("domainName", inputDomainMap.getOrDefault("domainName", domainUid));
+    domainMap.put(
+        "adminNodePort", inputDomainMap.getOrDefault("adminNodePort", new Integer("30701")));
+    domainMap.put(
+        "loadBalancerVolumePath",
+        inputDomainMap.getOrDefault("loadBalancerVolumePath", new String("")));
+    domainMap.put("weblogicDomainStorageReclaimPolicy", weblogicDomainStorageReclaimPolicy);
+    domainMap.put(
+        "domainPVMountPath", inputDomainMap.getOrDefault("domainPVMountPath", new String("")));
+    domainMap.put(
+        "createDomainScriptsMountPath",
+        inputDomainMap.getOrDefault("createDomainScriptsMountPath", new String("")));
+    domainMap.put(
+        "createDomainScriptName",
+        inputDomainMap.getOrDefault("createDomainScriptName", new String("")));
+    domainMap.put(
+        "createDomainFilesDir",
+        inputDomainMap.getOrDefault("createDomainFilesDir", new String("")));
+>>>>>>> Change default log home to /shared/logs/domainUID and domain home to /shared/domains/domainUID.
 
     if (exposeAdminT3Channel) {
       domainMap.put("t3PublicAddress", TestUtils.getHostName());

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -430,7 +430,7 @@ public class Domain {
 
   public void createDomainOnExistingDirectory() throws Exception {
     String domainStoragePath = domainMap.get("weblogicDomainStoragePath").toString();
-    String domainDir = domainStoragePath + "/domains/" + domainMap.get("domainName").toString();
+    String domainDir = domainStoragePath + "/domains/" + domainMap.get("domainUID").toString();
     logger.info("making sure the domain directory exists");
     if (domainDir != null && !(new File(domainDir).exists())) {
       throw new RuntimeException(

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -543,7 +543,8 @@ public class Domain {
                     + "/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml"));
     Map<String, Object> pvMap = yaml.load(pv_is);
     pv_is.close();
-    pvMap.put("domainUID", domainUid);
+    // Only set the baseName to the domainUID if you want dedicated pv for a domain
+    //  pvMap.put("domainUID", domainUid);
 
     if (domainMap.get("weblogicDomainStorageReclaimPolicy") != null) {
       pvMap.put(
@@ -553,7 +554,8 @@ public class Domain {
     if (domainMap.get("weblogicDomainStorageSize") != null) {
       pvMap.put("weblogicDomainStorageSize", domainMap.get("weblogicDomainStorageSize"));
     }
-    pvMap.put("baseName", domainUid);
+    // Only set the baseName to the domainUID if you want dedicated pv for a domain
+    // pvMap.put("baseName", domainUid);
     pvMap.put("namespace", domainNS);
 
     weblogicDomainStorageReclaimPolicy = (String) pvMap.get("weblogicDomainStorageReclaimPolicy");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -543,8 +543,10 @@ public class Domain {
                     + "/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml"));
     Map<String, Object> pvMap = yaml.load(pv_is);
     pv_is.close();
-    // Only set the baseName to the domainUID if you want dedicated pv for a domain
-    //  pvMap.put("domainUID", domainUid);
+    pvMap.put("domainUID", domainUid);
+
+    // each domain uses its own pv for now
+    domainMap.put("persistentVolumeClaimName", domainUid + "-pvc");
 
     if (domainMap.get("weblogicDomainStorageReclaimPolicy") != null) {
       pvMap.put(
@@ -554,8 +556,7 @@ public class Domain {
     if (domainMap.get("weblogicDomainStorageSize") != null) {
       pvMap.put("weblogicDomainStorageSize", domainMap.get("weblogicDomainStorageSize"));
     }
-    // Only set the baseName to the domainUID if you want dedicated pv for a domain
-    // pvMap.put("baseName", domainUid);
+    pvMap.put("baseName", domainUid);
     pvMap.put("namespace", domainNS);
 
     weblogicDomainStorageReclaimPolicy = (String) pvMap.get("weblogicDomainStorageReclaimPolicy");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -62,7 +62,7 @@ public class Domain {
     createPV();
     createSecret();
     generateInputYaml();
-    callCreateDomainScript();
+    callCreateDomainScript(userProjectsDir + "/weblogic-domains/" + domainUid);
     createLoadBalancer();
   }
 
@@ -437,7 +437,16 @@ public class Domain {
           "FAIL: the domain directory " + domainDir + " does not exist, exiting!");
     }
     logger.info("Run the script to create domain");
-    StringBuffer cmd = new StringBuffer("cd ");
+    try {
+      callCreateDomainScript(userProjectsDir + "/weblogic-domains2/" + domainUid);
+    } catch (RuntimeException re) {
+      re.printStackTrace();
+      logger.info("[SUCCESS] create domain job failed, this is the expected behavior");
+      return;
+    }
+    throw new RuntimeException("FAIL: unexpected result, create domain job did not report error");
+
+    /*    StringBuffer cmd = new StringBuffer("cd ");
     cmd.append(BaseTest.getProjectRoot())
         .append(" && helm install kubernetes/charts/weblogic-domain");
     cmd.append(" --name ")
@@ -454,7 +463,7 @@ public class Domain {
     } else {
       throw new RuntimeException(
           "FAIL: unexpected result, create domain job exit code: " + result.exitValue());
-    }
+    } */
   }
 
   public void verifyAdminConsoleViaLB() throws Exception {
@@ -590,13 +599,13 @@ public class Domain {
     TestUtils.createInputFile(domainMap, generatedInputYamlFile);
   }
 
-  private void callCreateDomainScript() throws Exception {
+  private void callCreateDomainScript(String outputDir) throws Exception {
     StringBuffer cmd = new StringBuffer(BaseTest.getProjectRoot());
     cmd.append(
             "/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh -i ")
         .append(generatedInputYamlFile)
         .append(" -e -v -o ")
-        .append(userProjectsDir + "/weblogic-domains/" + domainUid);
+        .append(outputDir);
     logger.info("Running " + cmd);
     ExecResult result = ExecCommand.exec(cmd.toString());
     if (result.exitValue() != 0) {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -755,6 +755,9 @@ public class Domain {
 
     // read input domain yaml to test
     domainMap = TestUtils.loadYaml(inputYaml);
+    if (domainMap.get("domainName") == null) {
+      domainMap.put("domainName", domainMap.get("domainUID"));
+    }
 
     // read sample domain inputs
     Yaml dyaml = new Yaml();
@@ -781,7 +784,6 @@ public class Domain {
     initialManagedServerReplicas =
         ((Integer) domainMap.get("initialManagedServerReplicas")).intValue();
     configuredManagedServerCount =
-<<<<<<< HEAD
         ((Integer) domainMap.get("configuredManagedServerCount")).intValue();
     exposeAdminT3Channel = ((Boolean) domainMap.get("exposeAdminT3Channel")).booleanValue();
     exposeAdminNodePort = ((Boolean) domainMap.get("exposeAdminNodePort")).booleanValue();
@@ -797,75 +799,6 @@ public class Domain {
               + "/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/"
               + domainMap.get("createDomainFilesDir"));
     }
-=======
-        ((Integer)
-                inputDomainMap.getOrDefault(
-                    "configuredManagedServerCount", configuredManagedServerCount))
-            .intValue();
-    exposeAdminT3Channel =
-        ((Boolean)
-                inputDomainMap.getOrDefault(
-                    "exposeAdminT3Channel", new Boolean(exposeAdminT3Channel)))
-            .booleanValue();
-    exposeAdminNodePort =
-        ((Boolean)
-                inputDomainMap.getOrDefault(
-                    "exposeAdminNodePort", new Boolean(exposeAdminNodePort)))
-            .booleanValue();
-    t3ChannelPort =
-        ((Integer) inputDomainMap.getOrDefault("t3ChannelPort", t3ChannelPort)).intValue();
-    clusterName = inputDomainMap.getOrDefault("clusterName", clusterName).toString();
-    clusterType = inputDomainMap.getOrDefault("clusterType", clusterType).toString();
-    startupControl = inputDomainMap.getOrDefault("startupControl", startupControl).toString();
-    weblogicDomainStorageReclaimPolicy =
-        inputDomainMap
-            .getOrDefault("weblogicDomainStorageReclaimPolicy", weblogicDomainStorageReclaimPolicy)
-            .toString();
-    weblogicDomainStorageSize =
-        inputDomainMap
-            .getOrDefault("weblogicDomainStorageSize", weblogicDomainStorageSize)
-            .toString();
-    loadBalancer = inputDomainMap.getOrDefault("loadBalancer", loadBalancer).toString();
-    loadBalancerWebPort =
-        ((Integer) inputDomainMap.getOrDefault("loadBalancerWebPort", loadBalancerWebPort))
-            .intValue();
-    loadBalancerDashboardPort =
-        ((Integer)
-                inputDomainMap.getOrDefault("loadBalancerDashboardPort", loadBalancerDashboardPort))
-            .intValue();
-
-    domainMap.put("domainUID", domainUid);
-    domainMap.put("namespace", domainNS);
-    domainMap.put("adminServerName", adminServerName);
-    domainMap.put("managedServerNameBase", managedServerNameBase);
-    domainMap.put("initialManagedServerReplicas", initialManagedServerReplicas);
-    domainMap.put("configuredManagedServerCount", configuredManagedServerCount);
-    domainMap.put("exposeAdminT3Channel", new Boolean(exposeAdminT3Channel));
-    domainMap.put("exposeAdminNodePort", new Boolean(exposeAdminNodePort));
-    domainMap.put("t3ChannelPort", t3ChannelPort);
-    domainMap.put("clusterName", clusterName);
-    domainMap.put("clusterType", clusterType);
-    domainMap.put("startupControl", startupControl);
-    domainMap.put("persistentVolumeClaimName", domainUid + "-pvc");
-    domainMap.put("domainName", inputDomainMap.getOrDefault("domainName", domainUid));
-    domainMap.put(
-        "adminNodePort", inputDomainMap.getOrDefault("adminNodePort", new Integer("30701")));
-    domainMap.put(
-        "loadBalancerVolumePath",
-        inputDomainMap.getOrDefault("loadBalancerVolumePath", new String("")));
-    domainMap.put("weblogicDomainStorageReclaimPolicy", weblogicDomainStorageReclaimPolicy);
-    domainMap.put(
-        "domainPVMountPath", inputDomainMap.getOrDefault("domainPVMountPath", new String("")));
-    domainMap.put(
-        "createDomainScriptsMountPath",
-        inputDomainMap.getOrDefault("createDomainScriptsMountPath", new String("")));
-    domainMap.put(
-        "createDomainScriptName",
-        inputDomainMap.getOrDefault("createDomainScriptName", new String("")));
-    domainMap.put(
-        "createDomainFilesDir",
-        inputDomainMap.getOrDefault("createDomainFilesDir", new String("")));
->>>>>>> Change default log home to /shared/logs/domainUID and domain home to /shared/domains/domainUID.
 
     if (exposeAdminT3Channel) {
       domainMap.put("t3PublicAddress", TestUtils.getHostName());

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -21,8 +21,7 @@ public class LoadBalancer {
     this.lbMap = lbMap;
     Path parentDir =
         Files.createDirectories(
-            Paths.get(
-                BaseTest.getUserProjectsDir() + "/weblogic-domains/" + lbMap.get("domainUID")));
+            Paths.get(BaseTest.getUserProjectsDir() + "/loadbalancers/" + lbMap.get("domainUID")));
     // generate input yaml
     TestUtils.createInputFile(lbMap, parentDir + "/lb-inputs.yaml");
 
@@ -33,7 +32,9 @@ public class LoadBalancer {
             + " -i "
             + parentDir
             + "/lb-inputs.yaml -e -o "
-            + BaseTest.getUserProjectsDir();
+            + BaseTest.getUserProjectsDir()
+            + "/loadbalancers/"
+            + lbMap.get("domainUID");
     logger.info("Executing cmd " + cmdLb);
 
     ExecResult result = ExecCommand.exec(cmdLb);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
@@ -39,8 +39,11 @@ public class PersistentVolume {
     logger.info("command result " + result.stdout().trim());
 
     Path parentDir =
-        Files.createDirectories(
-            Paths.get(BaseTest.getUserProjectsDir() + "/pv-pvcs/" + pvMap.get("domainUID")));
+        pvMap.get("domainUID") != null
+            ? Files.createDirectories(
+                Paths.get(BaseTest.getUserProjectsDir() + "/pv-pvcs/" + pvMap.get("domainUID")))
+            : Files.createDirectories(Paths.get(BaseTest.getUserProjectsDir() + "/pv-pvcs/"));
+
     // generate input yaml
     TestUtils.createInputFile(pvMap, parentDir + "/" + pvMap.get("baseName") + "-pv-inputs.yaml");
 
@@ -53,9 +56,7 @@ public class PersistentVolume {
             + "/"
             + pvMap.get("baseName")
             + "-pv-inputs.yaml -e -o "
-            + BaseTest.getUserProjectsDir()
-            + "/pv-pvcs/"
-            + pvMap.get("domainUID");
+            + parentDir;
     logger.info("Executing cmd " + cmdPvPvc);
 
     result = ExecCommand.exec(cmdPvPvc);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
@@ -40,10 +40,9 @@ public class PersistentVolume {
 
     Path parentDir =
         Files.createDirectories(
-            Paths.get(
-                BaseTest.getUserProjectsDir() + "/weblogic-domains/" + pvMap.get("domainUID")));
+            Paths.get(BaseTest.getUserProjectsDir() + "/pv-pvcs/" + pvMap.get("domainUID")));
     // generate input yaml
-    TestUtils.createInputFile(pvMap, parentDir + "/pv-inputs.yaml");
+    TestUtils.createInputFile(pvMap, parentDir + "/" + pvMap.get("baseName") + "-pv-inputs.yaml");
 
     // create PV/PVC
     String cmdPvPvc =
@@ -51,8 +50,12 @@ public class PersistentVolume {
             + "/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh "
             + " -i "
             + parentDir
-            + "/pv-inputs.yaml -e -o "
-            + BaseTest.getUserProjectsDir();
+            + "/"
+            + pvMap.get("baseName")
+            + "-pv-inputs.yaml -e -o "
+            + BaseTest.getUserProjectsDir()
+            + "/pv-pvcs/"
+            + pvMap.get("domainUID");
     logger.info("Executing cmd " + cmdPvPvc);
 
     result = ExecCommand.exec(cmdPvPvc);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -179,7 +179,7 @@ public class TestUtils {
 
   public static boolean checkPVReleased(String domainUid, String namespace) throws Exception {
     StringBuffer cmd = new StringBuffer("kubectl get pv ");
-    cmd.append(domainUid).append("-weblogic-domain-pv -n ").append(namespace);
+    cmd.append(domainUid).append("-pv -n ").append(namespace);
 
     int i = 0;
     while (i < BaseTest.getMaxIterationsPod()) {

--- a/integration-tests/src/test/resources/domain3.yaml
+++ b/integration-tests/src/test/resources/domain3.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 adminServerName: admin-server
-domainName: base_domain
+domainName: domain3
 domainUID: domain3
 clusterName: cluster-1
 configuredManagedServerCount: 4

--- a/integration-tests/src/test/resources/domain4.yaml
+++ b/integration-tests/src/test/resources/domain4.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 adminServerName: admin-server
-domainName: base_domain
+domainName: domain4
 domainUID: domain4
 clusterName: cluster-1
 clusterType: CONFIGURED

--- a/integration-tests/src/test/resources/wldf/wldf.py
+++ b/integration-tests/src/test/resources/wldf/wldf.py
@@ -37,8 +37,8 @@ wn1 = wldfResource.getWatchNotification()
 scriptAct = wn1.createScriptAction('ScriptActionScaleUp')
 scriptAct.setEnabled(true)
 scriptAct.setTimeout(0)
-scriptAct.setWorkingDirectory('/shared/domain/base_domain/bin/scripts/')
-scriptAct.setPathToScript('/shared/domain/base_domain/bin/scripts/scalingAction.sh')
+scriptAct.setWorkingDirectory('/shared/domains/domain3/bin/scripts/')
+scriptAct.setPathToScript('/shared/domains/domain3/bin/scripts/scalingAction.sh')
 props = Properties()
 props.setProperty("INTERNAL_OPERATOR_CERT",  operator_cert_data);
 #props.setProperty("KUBERNETES_SERVICE_HOST", k8s_master_host);

--- a/kubernetes/samples/scripts/common/validate.sh
+++ b/kubernetes/samples/scripts/common/validate.sh
@@ -120,7 +120,6 @@ function validateOutputDir {
       shift
       local in2=${1}
       shift
-      internalValidateInputsFileDoesNotExistOrIsTheSame ${dir} ${in1} ${in2}
       internalValidateGeneratedYamlFilesDoNotExist ${dir} $@
     else
       validationError "${dir} exists but is not a directory."

--- a/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer-inputs.yaml
@@ -11,7 +11,8 @@ adminPort: 7001
 adminServerName: admin-server
 
 # Name of the WebLogic domain to create
-domainName:
+# By default, this is the same as the domainUID
+domainName: domain1
 
 # Unique ID identifying a domain.
 # This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.

--- a/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer-inputs.yaml
@@ -11,7 +11,7 @@ adminPort: 7001
 adminServerName: admin-server
 
 # Name of the WebLogic domain to create
-domainName: base_domain
+domainName:
 
 # Unique ID identifying a domain.
 # This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.

--- a/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh
@@ -63,7 +63,6 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  # lbOutputDir="${outputDir}/weblogic-domains/${domainUID}"
   lbOutputDir=${outputDir}
 
   if [ ! -z "${loadBalancer}" ]; then

--- a/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh
@@ -63,7 +63,8 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  domainOutputDir="${outputDir}/weblogic-domains/${domainUID}"
+  # lbOutputDir="${outputDir}/weblogic-domains/${domainUID}"
+  lbOutputDir=${outputDir}
 
   if [ ! -z "${loadBalancer}" ]; then
     case ${loadBalancer} in
@@ -88,7 +89,7 @@ function initAndValidateOutputDir {
     esac
   fi
   validateOutputDir \
-    ${domainOutputDir} \
+    ${lbOutputDir} \
     ${valuesInputFile} \
     create-load-balancer-inputs.yaml \
     ${fileList}
@@ -102,20 +103,14 @@ function initialize {
   # Validate the required files exist
   validateErrors=false
 
-  if [ -z "${valuesInputFile}" ]; then
-    validationError "You must use the -i option to specify the name of the inputs parameter file (a modified copy of kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balander-inputs.yaml)."
-  else
-    if [ ! -f ${valuesInputFile} ]; then
-      validationError "Unable to locate the input parameters file ${valuesInputFile}"
-    fi
+  echo valuesInputFile ${valuesInputFile}
+
+  if [ ! -f ${valuesInputFile} ]; then
+    validationError "Unable to locate the input parameters file ${valuesInputFile}"
   fi
 
   if [ -z "${outputDir}" ]; then
     validationError "You must use the -o option to specify the name of an existing directory to store the generated yaml files in."
-  else
-    if ! [ -d ${outputDir} ]; then
-      validationError "Unable to locate the directory ${outputDir}. \nThis is the name of the directory to store the generated yaml files in."
-    fi
   fi
 
   traefikSecurityInput="${scriptDir}/traefik-security-template.yaml"
@@ -158,7 +153,6 @@ function initialize {
   # Parse the commonn inputs file
   parseCommonInputs
   validateInputParamsSpecified \
-    domainName \
     adminServerName \
     domainUID \
     clusterName \
@@ -187,25 +181,29 @@ function initialize {
 function createYamlFiles {
 
   # Create a directory for this domain's output files
-  mkdir -p ${domainOutputDir}
+  mkdir -p ${lbOutputDir}
 
   # Make sure the output directory has a copy of the inputs file.
   # The user can either pre-create the output directory, put the inputs
   # file there, and create the domain from it, or the user can put the
   # inputs file some place else and let this script create the output directory
   # (if needed) and copy the inputs file there.
-  copyInputsFileToOutputDirectory ${valuesInputFile} "${domainOutputDir}/create-load-balancer-inputs.yaml"
+  copyInputsFileToOutputDirectory ${valuesInputFile} "${lbOutputDir}/create-load-balancer-inputs.yaml"
 
-  traefikSecurityOutput="${domainOutputDir}/traefik-security.yaml"
-  traefikOutput="${domainOutputDir}/traefik.yaml"
-  apacheOutput="${domainOutputDir}/apache.yaml"
-  apacheSecurityOutput="${domainOutputDir}/apache-security.yaml"
-  voyagerSecurityOutput="${domainOutputDir}/voyager-operator-security.yaml"
-  voyagerOperatorOutput="${domainOutputDir}/voyager-operator.yaml"
-  voyagerIngressOutput="${domainOutputDir}/voyager-ingress.yaml"
+  traefikSecurityOutput="${lbOutputDir}/traefik-security.yaml"
+  traefikOutput="${lbOutputDir}/traefik.yaml"
+  apacheOutput="${lbOutputDir}/apache.yaml"
+  apacheSecurityOutput="${lbOutputDir}/apache-security.yaml"
+  voyagerSecurityOutput="${lbOutputDir}/voyager-operator-security.yaml"
+  voyagerOperatorOutput="${lbOutputDir}/voyager-operator.yaml"
+  voyagerIngressOutput="${lbOutputDir}/voyager-ingress.yaml"
 
   enabledPrefix=""     # uncomment the feature
   disabledPrefix="# "  # comment out the feature
+
+  if [ -z ${domainName} ]; then
+    domainName=$domainUID
+  fi
 
   if [ "${loadBalancer}" = "TRAEFIK" ]; then
     # Traefik file
@@ -297,14 +295,14 @@ function createYamlFiles {
   fi
 
   # Remove any "...yaml-e" files left over from running sed
-  rm -f ${domainOutputDir}/*.yaml-e
+  rm -f ${lbOutputDir}/*.yaml-e
 }
 
 #
 # Deploy Voyager/HAProxy load balancer
 #
 function startupVoyagerLoadBalancer {
-  sh ${scriptDir}/start-voyager-controller.sh -p $domainOutputDir
+  sh ${scriptDir}/start-voyager-controller.sh -p $lbOutputDir
   createVoyagerIngress 
 }
 
@@ -427,29 +425,16 @@ function printSummary {
   # Get the IP address of the kubernetes cluster (into K8S_IP)
   getKubernetesClusterIP
 
-  echo ""
-  echo "Domain ${domainName} was created and will be started by the WebLogic Kubernetes Operator"
-  echo ""
-  if [ "${exposeAdminNodePort}" = true ]; then
-    echo "Administration console access is available at http:${K8S_IP}:${adminNodePort}/console"
-  fi
-  if [ "${exposeAdminT3Channel}" = true ]; then
-    echo "T3 access is available at t3:${K8S_IP}:${t3ChannelPort}"
-  fi
   if [ "${loadBalancer}" = "TRAEFIK" ] || [ "${loadBalancer}" = "VOYAGER" ]; then
-    echo "The load balancer for cluster '${clusterName}' is available at http:${K8S_IP}:${loadBalancerWebPort}/ (add the application path to the URL)"
+    echo "The load balancer for cluster '${clusterName}' is available at http:${K8S_IP}:${loadBalancerWebPort}"
     echo "The load balancer dashboard for cluster '${clusterName}' is available at http:${K8S_IP}:${loadBalancerDashboardPort}"
     echo ""
   elif [ "${loadBalancer}" = "APACHE" ]; then
-    echo "The apache load balancer for '${domainUID}' is available at http:${K8S_IP}:${loadBalancerWebPort}/ (add the application path to the URL)"
+    echo "The Apache load balancer for '${domainUID}' is available at http:${K8S_IP}:${loadBalancerWebPort}"
 
   fi
   echo "The following files were generated:"
-  echo "  ${domainOutputDir}/create-load-balander-inputs.yaml"
-  echo "  ${domainPVOutput}"
-  echo "  ${domainPVCOutput}"
-  echo "  ${createJobOutput}"
-  echo "  ${dcrOutput}"
+  echo "  ${lbOutputDir}/create-load-balander-inputs.yaml"
   if [ "${loadBalancer}" = "TRAEFIK" ]; then
     echo "  ${traefikSecurityOutput}"
     echo "  ${traefikOutput}"

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
@@ -4,6 +4,11 @@
 # The version of this inputs file.  Do not modify.
 version: create-weblogic-sample-domain-pv-pvc-inputs-v1
 
+# Unique ID identifying a domain. 
+# If left empty, the generated pv can be shared by multiple domains
+# This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.
+domainUID:
+
 # The base name of the pv and pvc
 baseName: weblogic-sample-domain
 

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
@@ -4,11 +4,6 @@
 # The version of this inputs file.  Do not modify.
 version: create-weblogic-sample-domain-pv-pvc-inputs-v1
 
-# Unique ID identifying a domain. 
-# If left empty, the generated pv can be shared by multiple domains
-# This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.
-domainUID:
-
 # The base name of the pv and pvc
 baseName: weblogic-sample-domain
 

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
@@ -4,12 +4,8 @@
 # The version of this inputs file.  Do not modify.
 version: create-weblogic-sample-domain-pv-pvc-inputs-v1
 
-# Name of the WebLogic domain to create
-domainName: base_domain
-
-# Unique ID identifying a domain.
-# This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.
-domainUID: domain1
+# The base name of the pv and pvc
+baseName: weblogic-sample-domain
 
 # Persistent volume type for the domain's storage.
 # The value must be 'HOST_PATH' or 'NFS'. 
@@ -22,7 +18,7 @@ weblogicDomainStorageType: HOST_PATH
 
 # Physical path of the domain's persistent storage.
 # The following line must be uncomment and customized:
-#weblogicDomainStoragePath: /scratch/k8s_dir/domain1
+#weblogicDomainStoragePath: /scratch/k8s_dir
 
 # Reclaim policy of the domain's persistent storage
 # The valid values are: 'Retain', 'Delete', and 'Recycle'

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -160,8 +160,13 @@ function createYamlFiles {
 
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${domainPVOutput}
   if [ -z ${domainUID} ]; then
+    domainUIDLabelPrefix="${disabledPrefix}"
+  else
     sed -i -e "s:%DOMAIN_UID%:$domainUID:g" ${domainPVOutput}
+    domainUIDLabelPrefix="${enabledPrefix}"
   fi
+  sed -i -e "s:%DOMAIN_UID_LABEL_PREFIX%:${domainUIDLabelPrefix}:g" ${domainPVOutput}
+
   sed -i -e "s:%BASE_NAME%:$baseName:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_PATH%:${weblogicDomainStoragePath}:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_RECLAIM_POLICY%:${weblogicDomainStorageReclaimPolicy}:g" ${domainPVOutput}
@@ -175,9 +180,12 @@ function createYamlFiles {
   cp ${domainPVCInput} ${domainPVCOutput}
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${domainPVCOutput}
   sed -i -e "s:%BASE_NAME%:${baseName}:g" ${domainPVCOutput}
-  if [ -z ${domainUID} ]; then
+
+  if [ ! -z ${domainUID} ]; then
     sed -i -e "s:%DOMAIN_UID%:$domainUID:g" ${domainPVCOutput}
   fi
+  sed -i -e "s:%DOMAIN_UID_LABEL_PREFIX%:${domainUIDLabelPrefix}:g" ${domainPVCOutput}
+
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_SIZE%:${weblogicDomainStorageSize}:g" ${domainPVCOutput}
 
   # Remove any "...yaml-e" files left over from running sed

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -65,7 +65,7 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  domainOutputDir="${outputDir}/weblogic-domains/${domainUID}"
+  domainOutputDir="${outputDir}/weblogic-domains"
 
   validateOutputDir \
     ${domainOutputDir} \
@@ -114,8 +114,6 @@ function initialize {
   # Parse the commonn inputs file
   parseCommonInputs
   validateInputParamsSpecified \
-    domainName \
-    domainUID \
     weblogicDomainStoragePath \
     weblogicDomainStorageSize \
     namespace \
@@ -164,9 +162,8 @@ function createYamlFiles {
     nfsPrefix="${disabledPrefix}"
   fi
 
-  sed -i -e "s:%DOMAIN_UID%:${domainUID}:g" ${domainPVOutput}
-  sed -i -e "s:%DOMAIN_NAME%:${domainName}:g" ${domainPVOutput}
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${domainPVOutput}
+  sed -i -e "s:%BASE_NAME%:$baseName:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_PATH%:${weblogicDomainStoragePath}:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_RECLAIM_POLICY%:${weblogicDomainStorageReclaimPolicy}:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_SIZE%:${weblogicDomainStorageSize}:g" ${domainPVOutput}
@@ -178,8 +175,7 @@ function createYamlFiles {
 
   cp ${domainPVCInput} ${domainPVCOutput}
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${domainPVCOutput}
-  sed -i -e "s:%DOMAIN_UID%:${domainUID}:g" ${domainPVCOutput}
-  sed -i -e "s:%DOMAIN_NAME%:${domainName}:g" ${domainPVCOutput}
+  sed -i -e "s:%BASE_NAME%:${baseName}:g" ${domainPVCOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_SIZE%:${weblogicDomainStorageSize}:g" ${domainPVCOutput}
 
   # Remove any "...yaml-e" files left over from running sed
@@ -191,7 +187,7 @@ function createYamlFiles {
 #
 function createDomainPV {
   # Check if the persistent volume is already available
-  persistentVolumeName="${domainUID}-weblogic-domain-pv"
+  persistentVolumeName="weblogic-sample-domain-pv"
   checkPvExists ${persistentVolumeName}
   if [ "${PV_EXISTS}" = "false" ]; then
     echo Creating the persistent volume ${persistentVolumeName}
@@ -207,7 +203,7 @@ function createDomainPV {
 #
 function createDomainPVC {
   # Check if the persistent volume claim is already available
-  persistentVolumeClaimName="${domainUID}-weblogic-domain-pvc"
+  persistentVolumeClaimName="weblogic-sample-domain-pvc"
   checkPvcExists ${persistentVolumeClaimName} ${namespace}
   if [ "${PVC_EXISTS}" = "false" ]; then
     echo Creating the persistent volume claim ${persistentVolumeClaimName}

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -65,10 +65,10 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  domainOutputDir="${outputDir}/weblogic-domains"
+  pvPvcOutputDir="${outputDir}/weblogic-domains"
 
   validateOutputDir \
-    ${domainOutputDir} \
+    ${pvPvcOutputDir} \
     ${valuesInputFile} \
     create-pv-pvc-inputs.yaml \
     pv.yaml \
@@ -135,17 +135,17 @@ function initialize {
 function createYamlFiles {
 
   # Create a directory for this domain's output files
-  mkdir -p ${domainOutputDir}
+  mkdir -p ${pvPvcOutputDir}
 
   # Make sure the output directory has a copy of the inputs file.
   # The user can either pre-create the output directory, put the inputs
   # file there, and create the domain from it, or the user can put the
   # inputs file some place else and let this script create the output directory
   # (if needed) and copy the inputs file there.
-  copyInputsFileToOutputDirectory ${valuesInputFile} "${domainOutputDir}/create-pv-pvc-inputs.yaml"
+  copyInputsFileToOutputDirectory ${valuesInputFile} "${pvPvcOutputDir}/create-pv-pvc-inputs.yaml"
 
-  domainPVOutput="${domainOutputDir}/pv.yaml"
-  domainPVCOutput="${domainOutputDir}/pvc.yaml"
+  domainPVOutput="${pvPvcOutputDir}/pv.yaml"
+  domainPVCOutput="${pvPvcOutputDir}/pvc.yaml"
 
   enabledPrefix=""     # uncomment the feature
   disabledPrefix="# "  # comment out the feature
@@ -179,7 +179,7 @@ function createYamlFiles {
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_SIZE%:${weblogicDomainStorageSize}:g" ${domainPVCOutput}
 
   # Remove any "...yaml-e" files left over from running sed
-  rm -f ${domainOutputDir}/*.yaml-e
+  rm -f ${pvPvcOutputDir}/*.yaml-e
 }
 
 #

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -65,7 +65,6 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  domainOutputDir="${outputDir}
 
   validateOutputDir \
     ${outputDir} \

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -159,7 +159,9 @@ function createYamlFiles {
   fi
 
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${domainPVOutput}
-  sed -i -e "s:%DOMAIN_UID%:$domainUID:g" ${domainPVOutput}
+  if [ -z ${domainUID} ]; then
+    sed -i -e "s:%DOMAIN_UID%:$domainUID:g" ${domainPVOutput}
+  fi
   sed -i -e "s:%BASE_NAME%:$baseName:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_PATH%:${weblogicDomainStoragePath}:g" ${domainPVOutput}
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_RECLAIM_POLICY%:${weblogicDomainStorageReclaimPolicy}:g" ${domainPVOutput}
@@ -173,7 +175,9 @@ function createYamlFiles {
   cp ${domainPVCInput} ${domainPVCOutput}
   sed -i -e "s:%NAMESPACE%:$namespace:g" ${domainPVCOutput}
   sed -i -e "s:%BASE_NAME%:${baseName}:g" ${domainPVCOutput}
-  sed -i -e "s:%DOMAIN_UID%:$domainUID:g" ${domainPVCOutput}
+  if [ -z ${domainUID} ]; then
+    sed -i -e "s:%DOMAIN_UID%:$domainUID:g" ${domainPVCOutput}
+  fi
   sed -i -e "s:%WEBLOGIC_DOMAIN_STORAGE_SIZE%:${weblogicDomainStorageSize}:g" ${domainPVCOutput}
 
   # Remove any "...yaml-e" files left over from running sed

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -65,6 +65,7 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
+  domainOutputDir="${outputDir}
 
   validateOutputDir \
     ${outputDir} \

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pv-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pv-template.yaml
@@ -7,6 +7,7 @@ metadata:
   name: %BASE_NAME%-pv
   labels:
     weblogic.resourceVersion: domain-v1
+    %DOMAIN_UID_LABEL_PREFIX%weblogic.domainUID: %DOMAIN_UID%
 spec:
   storageClassName: %BASE_NAME%-storage-class
   capacity:

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pv-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pv-template.yaml
@@ -4,13 +4,11 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: %DOMAIN_UID%-weblogic-domain-pv
+  name: %BASE_NAME%-pv
   labels:
     weblogic.resourceVersion: domain-v1
-    weblogic.domainUID: %DOMAIN_UID%
-    weblogic.domainName: %DOMAIN_NAME%
 spec:
-  storageClassName: %DOMAIN_UID%-weblogic-domain-storage-class
+  storageClassName: %BASE_NAME%-storage-class
   capacity:
     storage: %WEBLOGIC_DOMAIN_STORAGE_SIZE%
   accessModes:

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pvc-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pvc-template.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: %NAMESPACE%
   labels:
     weblogic.resourceVersion: domain-v1
+    %DOMAIN_UID_LABEL_PREFIX%weblogic.domainUID: %DOMAIN_UID%
 spec:
   storageClassName: %BASE_NAME%-storage-class
   accessModes:

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pvc-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/pvc-template.yaml
@@ -4,14 +4,12 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: %DOMAIN_UID%-weblogic-domain-pvc
+  name: %BASE_NAME%-pvc
   namespace: %NAMESPACE%
   labels:
     weblogic.resourceVersion: domain-v1
-    weblogic.domainUID: %DOMAIN_UID%
-    weblogic.domainName: %DOMAIN_NAME%
 spec:
-  storageClassName: %DOMAIN_UID%-weblogic-domain-storage-class
+  storageClassName: %BASE_NAME%-storage-class
   accessModes:
     - ReadWriteMany
   resources:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
@@ -50,13 +50,13 @@ function checkDomainSecret {
 
 function prepareDomainHomeDir { 
   # Do not proceed if the domain already exists
-  domainFolder=${DOMAIN_HOME_DIR}
+  local domainFolder=${DOMAIN_HOME_DIR}
   if [ -d ${domainFolder} ]; then
     fail "The create domain job will not overwrite an existing domain. The domain folder ${domainFolder} already exists"
   fi
 
   # Create the base folders
-  createFolder ${DOMAIN_ROOT_DIR}/domain
+  createFolder ${DOMAIN_ROOT_DIR}/domains
   createFolder ${DOMAIN_LOGS_DIR}
   createFolder ${DOMAIN_ROOT_DIR}/applications
   createFolder ${DOMAIN_ROOT_DIR}/stores

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -99,4 +99,4 @@ createDomainScriptName: create-domain-job.sh
 # the script that is specified by the createDomainScriptName property.
 # The default is the "wlst" subdirectory under the directory where the 
 # create-domain.sh script is located.
-createDomainFilesDir: wlst
+createDomainFilesDir:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -99,4 +99,4 @@ createDomainScriptName: create-domain-job.sh
 # the script that is specified by the createDomainScriptName property.
 # The default is the "wlst" subdirectory under the directory where the 
 # create-domain.sh script is located.
-createDomainFilesDir:
+createDomainFilesDir: wlst

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -12,7 +12,7 @@ adminServerName: admin-server
 
 # Name of the WebLogic domain to create
 # By default, the domainName will be the same as the domainUID
-domainName:
+domainName: domain1
 
 # Unique ID identifying a domain.
 # This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.
@@ -99,4 +99,4 @@ createDomainScriptName: create-domain-job.sh
 # the script that is specified by the createDomainScriptName property.
 # The default is the "wlst" subdirectory under the directory where the 
 # create-domain.sh script is located.
-createDomainFilesDir:
+createDomainFilesDir: wlst

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -84,21 +84,19 @@ namespace: default
 javaOptions: -Dweblogic.StdoutDebugEnabled=false
 
 # Name of the persistent volume claim 
-# The default value is <domainUID>-weblogic-domain-pvc
-persistentVolumeClaimName: 
+persistentVolumeClaimName: weblogic-sample-domain-pvc
 
-# Mount path of the domain persistent volume. The default is /shared.
+# Mount path of the domain persistent volume. 
 domainPVMountPath: /shared
 
 # Mount path of the directory where the create domain scripts are located inside the pod
-# The default is /u01/weblogic.
 createDomainScriptsMountPath: /u01/weblogic
 
-# Script that creates the domain. The default is create-domain-job.sh.
+# Script that creates the domain. 
 createDomainScriptName: create-domain-job.sh
 
 # Directory to get all the create domain scripts and supporting files, including 
 # the script that is specified by the createDomainScriptName property.
 # The default is the "wlst" subdirectory under the directory where the 
 # create-domain.sh script is located.
-createDomainFilesDir:
+createDomainFilesDir: wlst

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -11,7 +11,7 @@ adminPort: 7001
 adminServerName: admin-server
 
 # Name of the WebLogic domain to create
-# By default, the domainName will be the same as the domainUID
+# By default, this is the same as the domainUID
 domainName: domain1
 
 # Unique ID identifying a domain.

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -64,9 +64,9 @@ spec:
             - name: DOMAIN_ROOT_DIR
               value: "%DOMAIN_ROOT_DIR%"
             - name: DOMAIN_HOME_DIR
-              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%"
+              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%"
             - name: DOMAIN_LOGS_DIR
-              value: "%DOMAIN_ROOT_DIR%/logs"
+              value: "%DOMAIN_ROOT_DIR%/logs/%DOMAIN_UID%"
       volumes:
         - name: create-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 apiVersion: batch/v1
 kind: Job
@@ -64,7 +64,7 @@ spec:
             - name: DOMAIN_ROOT_DIR
               value: "%DOMAIN_ROOT_DIR%"
             - name: DOMAIN_HOME_DIR
-              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%"
+              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%"
             - name: DOMAIN_LOGS_DIR
               value: "%DOMAIN_ROOT_DIR%/logs"
       volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -64,7 +64,7 @@ spec:
             - name: DOMAIN_ROOT_DIR
               value: "%DOMAIN_ROOT_DIR%"
             - name: DOMAIN_HOME_DIR
-              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%"
+              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%"
             - name: DOMAIN_LOGS_DIR
               value: "%DOMAIN_ROOT_DIR%/logs/%DOMAIN_UID%"
       volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -64,7 +64,7 @@ spec:
             - name: DOMAIN_ROOT_DIR
               value: "%DOMAIN_ROOT_DIR%"
             - name: DOMAIN_HOME_DIR
-              value: "%DOMAIN_ROOT_DIR%/domain/%DOMAIN_NAME%"
+              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%"
             - name: DOMAIN_LOGS_DIR
               value: "%DOMAIN_ROOT_DIR%/logs"
       volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -64,7 +64,7 @@ spec:
             - name: DOMAIN_ROOT_DIR
               value: "%DOMAIN_ROOT_DIR%"
             - name: DOMAIN_HOME_DIR
-              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%"
+              value: "%DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%"
             - name: DOMAIN_LOGS_DIR
               value: "%DOMAIN_ROOT_DIR%/logs/%DOMAIN_UID%"
       volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -423,6 +423,7 @@ function create_domain_configmap {
     cp ${scriptDir}/common/* ${externalFilesTmpDir}/
   fi
   cp ${domainOutputDir}/create-domain-inputs.yaml ${externalFilesTmpDir}/
+  sed -i -e "s/^domainName:.*/domainName: $domainName/" ${externalFilesTmpDir}/create-domain-inputs.yaml
 
   if [ -f ${externalFilesTmpDir}/prepare.sh ]; then
    sh ${externalFilesTmpDir}/prepare.sh -t ${clusterType} -i ${externalFilesTmpDir}

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -27,7 +27,7 @@ function usage {
   echo usage: ${script} -o dir -i file [-e] [-v] [-h]
   echo "  -o Ouput directory for the generated yaml files, must be specified."
   echo "  -i Parameter input file, must be specified."
-  echo "  -e Also create the resources in the generated yaml files"
+  echo "  -e Also create the resources in the generated yaml files, optional."
   echo "  -v Validate the existence of persistentVolumeClaim, optional."
   echo "  -h Help"
   exit $1
@@ -318,7 +318,7 @@ function createYamlFiles {
 
   # Use the default value if not defined.
   if [ -z "${persistentVolumeClaimName}" ]; then
-    persistentVolumeClaimName=${domainUID}-weblogic-domain-pvc
+    persistentVolumeClaimName=weblogic-sample-domain-pvc
   fi
 
   # Must escape the ':' value in image for sed to properly parse and replace
@@ -400,6 +400,7 @@ function createYamlFiles {
   sed -i -e "s:%ADMIN_NODE_PORT%:${adminNodePort}:g" ${dcrOutput}
   sed -i -e "s:%JAVA_OPTIONS%:${javaOptions}:g" ${dcrOutput}
   sed -i -e "s:%STARTUP_CONTROL%:${startupControl}:g" ${dcrOutput}
+  sed -i -e "s:%DOMAIN_PVC_NAME%:${persistentVolumeClaimName}:g" ${dcrOutput}
  
   # Remove any "...yaml-e" files left over from running sed
   rm -f ${domainOutputDir}/*.yaml-e
@@ -410,6 +411,8 @@ function create_domain_configmap {
   # Use the default files if createDomainFilesDir is not specified
   if [ -z "${createDomainFilesDir}" ]; then
     createDomainFilesDir=${scriptDir}/wlst
+  elif [[ ! ${createDomainFilesDir} == /* ]]; then
+    createDomainFilesDir=${scriptDir}/${createDomainFilesDir}
   fi
 
   # customize the files with domain information

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -74,7 +74,7 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  domainOutputDir="${outputDir}/weblogic-domains/${domainUID}"
+  domainOutputDir="${outputDir}"
 
   validateOutputDir \
     ${domainOutputDir} \

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -75,6 +75,8 @@ fi
 #
 function initAndValidateOutputDir {
   domainOutputDir="${outputDir}"
+  # Create a directory for this domain's output files
+  mkdir -p ${domainOutputDir}
 
   validateOutputDir \
     ${domainOutputDir} \
@@ -202,10 +204,6 @@ function initialize {
 
   if [ -z "${outputDir}" ]; then
     validationError "You must use the -o option to specify the name of an existing directory to store the generated yaml files in."
-  else
-    if ! [ -d ${outputDir} ]; then
-      validationError "Unable to locate the directory ${outputDir}. \nThis is the name of the directory to store the generated yaml files in."
-    fi
   fi
 
   createJobInput="${scriptDir}/create-domain-job-template.yaml"
@@ -272,9 +270,6 @@ function initialize {
 # Function to generate the yaml files for creating a domain
 #
 function createYamlFiles {
-
-  # Create a directory for this domain's output files
-  mkdir -p ${domainOutputDir}
 
   # Make sure the output directory has a copy of the inputs file.
   # The user can either pre-create the output directory, put the inputs

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -532,6 +532,10 @@ function printSummary {
 #
 function createDomainResource {
   kubectl apply -f ${dcrOutput}
+  DCR_AVAIL=`kubectl get domain -n ${namespace} | grep ${domainUID} | wc | awk ' { print $1; } '`
+  if [ "${DCR_AVAIL}" != "1" ]; then
+    fail "The domain custom resource ${domainUID} was not found"
+  fi
 }
 
 #

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -50,7 +50,7 @@ spec:
             - name: DOMAIN_HOME_DIR
               value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%
             - name: DOMAIN_LOGS_DIR
-              value: %DOMAIN_ROOT_DIR%/logs%
+              value: %DOMAIN_ROOT_DIR%/logs
       volumes:
         - name: delete-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 apiVersion: v1
 kind: ConfigMap
@@ -48,7 +48,7 @@ spec:
           args: ["/u01/weblogic/delete-domain-job.sh"]
           env:
             - name: DOMAIN_HOME_DIR
-              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%
+              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%
             - name: DOMAIN_LOGS_DIR
               value: %DOMAIN_ROOT_DIR%/logs
       volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -48,9 +48,9 @@ spec:
           args: ["/u01/weblogic/delete-domain-job.sh"]
           env:
             - name: DOMAIN_HOME_DIR
-              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%
+              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%
             - name: DOMAIN_LOGS_DIR
-              value: %DOMAIN_ROOT_DIR%/logs
+              value: %DOMAIN_ROOT_DIR%/logs/%DOMAIN_UID%
       volumes:
         - name: delete-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -48,7 +48,7 @@ spec:
           args: ["/u01/weblogic/delete-domain-job.sh"]
           env:
             - name: DOMAIN_HOME_DIR
-              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%
+              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_NAME%
             - name: DOMAIN_LOGS_DIR
               value: %DOMAIN_ROOT_DIR%/logs
       volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -48,9 +48,9 @@ spec:
           args: ["/u01/weblogic/delete-domain-job.sh"]
           env:
             - name: DOMAIN_HOME_DIR
-              value: %DOMAIN_ROOT_DIR%/domain/%DOMAIN_NAME%
+              value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%
             - name: DOMAIN_LOGS_DIR
-              value: %DOMAIN_ROOT_DIR%/logs
+              value: %DOMAIN_ROOT_DIR%/logs/%DOMAIN_UID%
       volumes:
         - name: delete-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -50,7 +50,7 @@ spec:
             - name: DOMAIN_HOME_DIR
               value: %DOMAIN_ROOT_DIR%/domains/%DOMAIN_UID%
             - name: DOMAIN_LOGS_DIR
-              value: %DOMAIN_ROOT_DIR%/logs/%DOMAIN_UID%
+              value: %DOMAIN_ROOT_DIR%/logs%
       volumes:
         - name: delete-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/domain-custom-resource-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/domain-custom-resource-template.yaml
@@ -76,7 +76,9 @@ spec:
       value: "-Xms64m -Xmx256m "
   # The number of managed servers to start from clusters not listed by clusterStartup
   # replicas: 1
-
+  storage:
+    predefined:
+      claim: %BASE_NAME%-pvc
   # Uncomment to export the T3Channel as a service
   %EXPOSE_T3_CHANNEL_PREFIX%exportT3Channels:
   %EXPOSE_T3_CHANNEL_PREFIX%- T3Channel

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/domain-custom-resource-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/domain-custom-resource-template.yaml
@@ -78,7 +78,7 @@ spec:
   # replicas: 1
   storage:
     predefined:
-      claim: %BASE_NAME%-pvc
+      claim: %DOMAIN_PVC_NAME%
   # Uncomment to export the T3Channel as a service
   %EXPOSE_T3_CHANNEL_PREFIX%exportT3Channels:
   %EXPOSE_T3_CHANNEL_PREFIX%- T3Channel

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/domain-custom-resource-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/domain-custom-resource-template.yaml
@@ -78,7 +78,7 @@ spec:
   # replicas: 1
   storage:
     predefined:
-      claim: %DOMAIN_PVC_NAME%
+      claim: %BASE_NAME%-pvc
   # Uncomment to export the T3Channel as a service
   %EXPOSE_T3_CHANNEL_PREFIX%exportT3Channels:
   %EXPOSE_T3_CHANNEL_PREFIX%- T3Channel

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
@@ -62,7 +62,7 @@
 #   DOMAIN_DIR     Target location for generated domain. When wdt completes,
 #                  this will contain a directory named after the domain
 #                  defined in the WDT_MODEL_FILE.
-#                  default:  /shared/domain
+#                  default:  /shared/domains
 #
 
 # Initialize globals
@@ -75,7 +75,7 @@ WDT_VAR_FILE=${WDT_VAR_FILE:-"$SCRIPTPATH/create-domain-inputs.yaml"}
 
 WDT_DIR=${WDT_DIR:-/shared/wdt}
 
-DOMAIN_DIR=${DOMAIN_DIR:-/shared/domain}
+DOMAIN_DIR=${DOMAIN_DIR:-/shared/domains}
 
 WDT_INSTALL_ZIP_FILE="${WDT_INSTALL_ZIP_FILE:-weblogic-deploy.zip}"
 WDT_INSTALL_ZIP_URL=${WDT_INSTALL_ZIP_URL:-"https://github.com/oracle/weblogic-deploy-tooling/releases/download/weblogic-deploy-tooling-0.12/$WDT_INSTALL_ZIP_FILE"}

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_configured.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_configured.yaml
@@ -12,7 +12,7 @@ topology:
         '@@PROP:adminServerName@@':
             ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
             Log:
-                FileName: '/shared/logs/@@PROP:adminServerName@@.log'
+                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:adminServerName@@.log'
             NetworkAccessPoint:
                 T3Channel:
                     ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
@@ -29,7 +29,7 @@ topology:
                 Cluster: '@@PROP:clusterName@@'
                 UserPreferredServer: '@@PROP:managedServerNameBase@@1'
             Log:
-                FileName: '/shared/logs/@@PROP:managedServerNameBase@@1.log'
+                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:managedServerNameBase@@1.log'
         '@@PROP:managedServerNameBase@@2':
             Cluster: '@@PROP:clusterName@@'
             ListenAddress: '@@PROP:domainUID@@-@@PROP:managedServerNameBase@@2'
@@ -51,7 +51,7 @@ topology:
                 Cluster: '@@PROP:clusterName@@'
                 UserPreferredServer: '@@PROP:managedServerNameBase@@3'
             Log:
-                FileName: '/shared/logs/@@PROP:managedServerNameBase@@3.log'
+                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:managedServerNameBase@@3.log'
     MigratableTarget:
         '@@PROP:managedServerNameBase@@1 (migratable)':
             Cluster: '@@PROP:clusterName@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
@@ -30,5 +30,7 @@ topology:
             Cluster: '@@PROP:clusterName@@'
             ListenAddress: '@@PROP:domainUID@@-@@PROP:managedServerNameBase@@${id}'
             ListenPort: '@@PROP:managedServerPort@@'
+            Log:
+                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:managedServerNameBase@@${id}.log'
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
@@ -18,7 +18,7 @@ topology:
         '@@PROP:adminServerName@@':
             ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
             Log:
-                FileName: '/shared/logs/@@PROP:adminServerName@@.log'
+                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:adminServerName@@.log'
             NetworkAccessPoint:
                 T3Channel:
                     ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wlst/create-domain.py
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wlst/create-domain.py
@@ -115,6 +115,9 @@ else:
   cmo.setListenPort(server_port)
   cmo.setListenAddress('%s-%s${id}' % (domain_uid, managed_server_name_base_svc))
   cmo.setCluster(cl)
+  create(templateName,'Log')
+  cd('Log/%s' % templateName)
+  set('FileName', '%s/%s${id}.log' % (domain_logs, managed_server_name_base))
   print('Done setting attributes for Server Template: %s' % templateName);
 
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -641,7 +641,7 @@ public abstract class PodStepContext {
     addEnvVar(vars, "SERVER_NAME", getServerName());
     addEnvVar(vars, "DOMAIN_UID", getDomainUID());
     addEnvVar(vars, "NODEMGR_HOME", NODEMGR_HOME);
-    addEnvVar(vars, "LOG_HOME", LOG_HOME);
+    addEnvVar(vars, "LOG_HOME", LOG_HOME + "/" + getDomainUID());
     addEnvVar(
         vars, "SERVICE_NAME", LegalNames.toServerServiceName(getDomainUID(), getServerName()));
     addEnvVar(vars, "AS_SERVICE_NAME", LegalNames.toServerServiceName(getDomainUID(), getAsName()));
@@ -649,7 +649,7 @@ public abstract class PodStepContext {
   }
 
   private String getDomainHome() {
-    return "/shared/domains/" + getDomainName();
+    return "/shared/domains/" + getDomainUID();
   }
 
   // Hide the admin account's user name and password.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -649,7 +649,7 @@ public abstract class PodStepContext {
   }
 
   private String getDomainHome() {
-    return "/shared/domain/" + getDomainName();
+    return "/shared/domains/" + getDomainName();
   }
 
   // Hide the admin account's user name and password.

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -251,7 +251,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     assertThat(
         getCreatedPodSpecContainer().getEnv(),
         allOf(
-            hasEnvVar("item1", "find domain1 at /shared/domain/domain1"),
+            hasEnvVar("item1", "find domain1 at /shared/domains/domain1"),
             hasEnvVar("item2", "ADMIN_SERVER is ADMIN_SERVER:7001")));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -245,13 +245,13 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   @Test
   public void whenDomainHasEnvironmentItemsWithVariables_createAdminPodStartupWithThem() {
     configureAdminServer()
-        .withEnvironmentVariable("item1", "find $(DOMAIN_NAME) at $(DOMAIN_HOME)")
+        .withEnvironmentVariable("item1", "find uid1 at $(DOMAIN_HOME)")
         .withEnvironmentVariable("item2", "$(SERVER_NAME) is $(ADMIN_NAME):$(ADMIN_PORT)");
 
     assertThat(
         getCreatedPodSpecContainer().getEnv(),
         allOf(
-            hasEnvVar("item1", "find domain1 at /shared/domains/domain1"),
+            hasEnvVar("item1", "find uid1 at /shared/domains/uid1"),
             hasEnvVar("item2", "ADMIN_SERVER is ADMIN_SERVER:7001")));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -44,8 +44,8 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   private static final String ITEM2 = "item2";
   private static final String VALUE1 = "value1";
   private static final String VALUE2 = "value2";
-  private static final String RAW_VALUE_1 = "find $(DOMAIN_NAME) at $(DOMAIN_HOME)";
-  private static final String END_VALUE_1 = "find domain1 at /shared/domains/domain1";
+  private static final String RAW_VALUE_1 = "find uid1 at $(DOMAIN_HOME)";
+  private static final String END_VALUE_1 = "find uid1 at /shared/domains/uid1";
   private static final String RAW_VALUE_2 = "$(SERVER_NAME) is not $(ADMIN_NAME):$(ADMIN_PORT)";
   private static final String END_VALUE_2 = "ms1 is not ADMIN_SERVER:7001";
   private static final String CLUSTER_NAME = "test-cluster";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -45,7 +45,7 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   private static final String VALUE1 = "value1";
   private static final String VALUE2 = "value2";
   private static final String RAW_VALUE_1 = "find $(DOMAIN_NAME) at $(DOMAIN_HOME)";
-  private static final String END_VALUE_1 = "find domain1 at /shared/domain/domain1";
+  private static final String END_VALUE_1 = "find domain1 at /shared/domains/domain1";
   private static final String RAW_VALUE_2 = "$(SERVER_NAME) is not $(ADMIN_NAME):$(ADMIN_PORT)";
   private static final String END_VALUE_2 = "ms1 is not ADMIN_SERVER:7001";
   private static final String CLUSTER_NAME = "test-cluster";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -101,7 +101,7 @@ public abstract class PodHelperTestBase {
   private static final int CONFIGURED_DELAY = 21;
   private static final int CONFIGURED_TIMEOUT = 27;
   private static final int CONFIGURED_PERIOD = 35;
-  private static final String DOMAIN_HOME = "/shared/domains/domain1";
+  private static final String DOMAIN_HOME = "/shared/domains/uid1";
   private static final String LOG_HOME = "/shared/logs";
   private static final String NODEMGR_HOME = "/u01/nodemanager";
   private static final String CREDENTIALS_VOLUME_NAME = "weblogic-credentials-volume";
@@ -348,7 +348,7 @@ public abstract class PodHelperTestBase {
             hasEnvVar("ADMIN_PASSWORD", null),
             hasEnvVar("DOMAIN_UID", UID),
             hasEnvVar("NODEMGR_HOME", NODEMGR_HOME),
-            hasEnvVar("LOG_HOME", LOG_HOME),
+            hasEnvVar("LOG_HOME", LOG_HOME + "/" + UID),
             hasEnvVar("SERVICE_NAME", LegalNames.toServerServiceName(UID, getServerName())),
             hasEnvVar("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER))));
   }
@@ -583,7 +583,7 @@ public abstract class PodHelperTestBase {
         .addEnvItem(envItem("ADMIN_PASSWORD", null))
         .addEnvItem(envItem("DOMAIN_UID", UID))
         .addEnvItem(envItem("NODEMGR_HOME", NODEMGR_HOME))
-        .addEnvItem(envItem("LOG_HOME", LOG_HOME))
+        .addEnvItem(envItem("LOG_HOME", LOG_HOME + "/" + UID))
         .addEnvItem(envItem("SERVICE_NAME", LegalNames.toServerServiceName(UID, getServerName())))
         .addEnvItem(envItem("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER)))
         .livenessProbe(createLivenessProbe())

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -101,7 +101,7 @@ public abstract class PodHelperTestBase {
   private static final int CONFIGURED_DELAY = 21;
   private static final int CONFIGURED_TIMEOUT = 27;
   private static final int CONFIGURED_PERIOD = 35;
-  private static final String DOMAIN_HOME = "/shared/domain/domain1";
+  private static final String DOMAIN_HOME = "/shared/domains/domain1";
   private static final String LOG_HOME = "/shared/logs";
   private static final String NODEMGR_HOME = "/u01/nodemanager";
   private static final String CREDENTIALS_VOLUME_NAME = "weblogic-credentials-volume";

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -990,15 +990,20 @@ function create_pv_pvc_non_helm {
     local ADMIN_NODE_PORT="`dom_get $1 ADMIN_NODE_PORT`"
     local MS_PORT="`dom_get $1 MS_PORT`"
 
-    local TMP_DIR="`dom_get $1 TMP_DIR`"
-    local tmp_dir="$TMP_DIR"
+    if [ -z ${domainUID} ]; then
+      tmp_dir=${USER_PROJECTS_DIR}/pv-pvcs
+    else
+      tmp_dir=${USER_PROJECTS_DIR}/pv-pvcs/${domainUID}
+    fi
+
+    mkdir -p $tmp_dir
 
     local inputsPvPvc="$tmp_dir/create-pv-pvc-inputs.yaml"
 
     local DOMAIN_STORAGE_DIR="domain-storage"
 
     cp $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml $inputsPvPvc
-    sed -i -e "s/^domainUID:.*/domainUID: $DOMAIN_UID/" $inputsPvPvc
+    sed -i -e "s/^baseName:.*/baseName: weblogic-sample-domain/" $inputsPvPvc
     sed -i -e "s;^#weblogicDomainStoragePath:.*;weblogicDomainStoragePath: $PV_ROOT/acceptance_test_pv/$DOMAIN_STORAGE_DIR;" $inputsPvPvc
     sed -i -e "s/^namespace:.*/namespace: $NAMESPACE/" $inputsPvPvc
     sed -i -e "s/^weblogicDomainStorageReclaimPolicy:.*/weblogicDomainStorageReclaimPolicy: Recycle/" $inputsPvPvc
@@ -1008,15 +1013,14 @@ function create_pv_pvc_non_helm {
       sed -i -e "s/^#weblogicDomainStorageNFSServer:.*/weblogicDomainStorageNFSServer: $NODEPORT_HOST/" $inputsPvPvc
     fi
 
-    pvPvcOutPutDir=${USER_PROJECTS_DIR}/weblogic-domains
-    trace "Run the script to create the domain into output dir $pvPvcOutPutDir, see \"$outfile\" for tracing."
+    trace "Run the script to create the domain into output dir $tmp_dir, see \"$outfile\" for tracing."
 
     local outfilePvPvc="${tmp_dir}/create-pv-pvc.sh.out"
-    sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh -i $inputsPvPvc -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfilePvPvc}
-    pvOutput="${pvPvcOutPutDir}/pv.yaml"
-    echo Creating the pvresource using ${pvOutput}
+    sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh -i $inputsPvPvc -o ${tmp_dir} 2>&1 | opt_tee ${outfilePvPvc}
+    pvOutput="${tmp_dir}/weblogic-sample-domain-pv.yaml"
+    echo Creating the pv resource using ${pvOutput}
     kubectl apply -f ${pvOutput}
-    pvcOutput="${pvPvcOutPutDir}/pvc.yaml"
+    pvcOutput="${tmp_dir}/weblogic-sample-domain-pvc.yaml"
     echo Creating the pvcresource using ${pvcOutput}
     kubectl apply -f ${pvcOutput}
 }
@@ -1072,8 +1076,8 @@ function create_domain_home_on_pv_non_helm {
     fi
 
     local outfileDomain="${tmp_dir}/create-domain.sh.out"
-    sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh -i $inputsDomain -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfileDomain}
-    dcrOutput="${domainOutPutDir}/domain-custom-resource.yaml"
+    sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh -i $inputsDomain -o ${tmp_dir} 2>&1 | opt_tee ${outfileDomain}
+    dcrOutput="${tmp_dir}/domain-custom-resource.yaml"
     echo Creating the domain custom resource using ${dcrOutput}
     kubectl apply -f ${dcrOutput}
 }
@@ -1095,8 +1099,8 @@ function create_load_balancer_non_helm {
     local LOAD_BALANCER_EXPOSE_ADMIN_PORT="`dom_get $1 LOAD_BALANCER_EXPOSE_ADMIN_PORT`"
     # local LOAD_BALANCER_VOLUME_PATH="/scratch/DockerVolume/ApacheVolume"
 
-    local TMP_DIR="`dom_get $1 TMP_DIR`"
-    local tmp_dir="$TMP_DIR"
+    local tmp_dir="$USER_PROJECTS_DIR/loadbalancers/$DOMAIN_UID"
+    mkdir -p $tmp_dir
 
     local inputsLoadBalancer="$tmp_dir/create-load-balancer-inputs.yaml"
 
@@ -1122,18 +1126,18 @@ function create_load_balancer_non_helm {
     trace "Create and start domain load balancer"
     # Setup load balancer
     local outfileLoadBalancer="${tmp_dir}/create-load-balancer.sh.out"
-    sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh -i $inputsLoadBalancer -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfileLoadBalancer}
+    sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh -i $inputsLoadBalancer -o $tmp_dir 2>&1 | opt_tee ${outfileLoadBalancer}
     if [ "${LB_TYPE}" == "TRAEFIK" ]; then
-      traefikSecurityOutput="${domainOutPutDir}/traefik-security.yaml"
-      traefikOutput="${domainOutPutDir}/traefik.yaml"
+      traefikSecurityOutput="${tmp_dir}/traefik-security.yaml"
+      traefikOutput="${tmp_dir}/traefik.yaml"
       echo Creating the $LB_TYPE load balancer security resource using ${traefikSecurityOutput}
       kubectl apply -f ${traefikSecurityOutput}
       echo Creating the $LB_TYPE load balancer resource using ${traefikOutput}
       kubectl apply -f ${traefikOutput}
 
     elif [ "${LB_TYPE}" == "APACHE" ]; then
-      apacheOutput="${domainOutPutDir}/apache.yaml"
-      apacheSecurityOutput="${domainOutPutDir}/apache-security.yaml"
+      apacheOutput="${tmp_dir}/apache.yaml"
+      apacheSecurityOutput="${tmp_dir}/apache-security.yaml"
       echo Creating the $LB_TYPE load balancer security resource using ${apacheSecurityOutput}
       kubectl apply -f ${apacheSecurityOutput}
       echo Creating the $LB_TYPE load balancer resource using ${apacheOutput}
@@ -1142,9 +1146,9 @@ function create_load_balancer_non_helm {
     elif [ "${LB_TYPE}" == "VOYAGER" ]; then
       # start Voyager operator and ingress controller
       echo Creating Voyager operator and ingress controller
-      sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/start-voyager-controller.sh -p ${domainOutPutDir} 2>&1 | opt_tee ${outfileLoadBalancer}
+      sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/start-voyager-controller.sh -p ${tmp_dir} 2>&1 | opt_tee ${outfileLoadBalancer}
       # start voyager ingress
-      voyagerIngressOutput="${domainOutPutDir}/voyager-ingress.yaml"
+      voyagerIngressOutput="${tmp_dir}/voyager-ingress.yaml"
       echo Creating the $LB_TYPE load balancer resource using ${voyagerIngressOutput}
       createVoyagerIngress $voyagerIngressOutput $NAMESPACE ${DOMAIN_UID}
     fi
@@ -3268,7 +3272,7 @@ function test_suite {
     op_define  oper2   weblogic-operator-2  test2              32001
 
     #          DOM_KEY  OP_KEY  NAMESPACE DOMAIN_UID STARTUP_CONTROL WL_CLUSTER_NAME WL_CLUSTER_TYPE  MS_BASE_NAME   ADMIN_PORT ADMIN_WLST_PORT ADMIN_NODE_PORT MS_PORT LOAD_BALANCER_WEB_PORT LOAD_BALANCER_DASHBOARD_PORT
-    dom_define domain1  oper1   default   domain1    AUTO            cluster-1       DYNAMIC          managed-server 7001       30012           30701           8001    30305                  30315
+    dom_define domain1  oper1   default   domain1    SPECIFIED            cluster-1       DYNAMIC          managed-server 7001       30012           30701           8001    30305                  30315
 
     # TODO: we need to figure out how to support invalid characters in the helm use cases
     # for now, invalid characters are only tested in the none helm cases

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -156,7 +156,7 @@
 #
 #      Local tmp files:      RESULT_ROOT/acceptance_test_tmp/...
 #
-#      PV dirs K8S NFS:      PV_ROOT/acceptance_test_pv/domain-${domain_uid}-storage/...
+#      PV dirs K8S NFS:      PV_ROOT/acceptance_test_pv/domain-storage/...
 #
 #      Archives of above:    PV_ROOT/acceptance_test_pv_archive/...
 #                            RESULT_ROOT/acceptance_test_tmp_archive/...
@@ -995,7 +995,7 @@ function create_pv_pvc_non_helm {
 
     local inputsPvPvc="$tmp_dir/create-pv-pvc-inputs.yaml"
 
-    local DOMAIN_STORAGE_DIR="domain-${DOMAIN_UID}-storage"
+    local DOMAIN_STORAGE_DIR="domain-storage"
 
     cp $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml $inputsPvPvc
     sed -i -e "s/^domainUID:.*/domainUID: $DOMAIN_UID/" $inputsPvPvc
@@ -1008,14 +1008,15 @@ function create_pv_pvc_non_helm {
       sed -i -e "s/^#weblogicDomainStorageNFSServer:.*/weblogicDomainStorageNFSServer: $NODEPORT_HOST/" $inputsPvPvc
     fi
 
-    trace "Run the script to create the domain into output dir $domainOutPutDir, see \"$outfile\" for tracing."
+    pvPvcOutPutDir=${USER_PROJECTS_DIR}/weblogic-domains
+    trace "Run the script to create the domain into output dir $pvPvcOutPutDir, see \"$outfile\" for tracing."
 
     local outfilePvPvc="${tmp_dir}/create-pv-pvc.sh.out"
     sh $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh -i $inputsPvPvc -o $USER_PROJECTS_DIR 2>&1 | opt_tee ${outfilePvPvc}
-    pvOutput="${domainOutPutDir}/pv.yaml"
+    pvOutput="${pvPvcOutPutDir}/pv.yaml"
     echo Creating the pvresource using ${pvOutput}
     kubectl apply -f ${pvOutput}
-    pvcOutput="${domainOutPutDir}/pvc.yaml"
+    pvcOutput="${pvPvcOutPutDir}/pvc.yaml"
     echo Creating the pvcresource using ${pvcOutput}
     kubectl apply -f ${pvcOutput}
 }
@@ -1179,7 +1180,7 @@ function create_domain_pv_pvc_load_balancer {
 
     trace "WLS_JAVA_OPTIONS = \"$WLS_JAVA_OPTIONS\""
 
-    local DOMAIN_STORAGE_DIR="domain-${DOMAIN_UID}-storage"
+    local DOMAIN_STORAGE_DIR="domain-storage"
 
     trace "Create $DOMAIN_UID in $NAMESPACE namespace with load balancer $LB_TYPE"
   

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -1065,7 +1065,7 @@ function create_domain_home_on_pv_non_helm {
     fi
     sed -i -e "s/^javaOptions:.*/javaOptions: $WLS_JAVA_OPTIONS/" $inputsDomain
     sed -i -e "s/^startupControl:.*/startupControl: $STARTUP_CONTROL/"  $inputsDomain
-    sed -i -e "s/^persistentVolumeClaimName:.*/persistentVolumeClaimName: ${DOMAIN_UID}-weblogic-domain-pvc/" $inputsDomain
+    sed -i -e "s/^persistentVolumeClaimName:.*/persistentVolumeClaimName: weblogic-sample-domain-pvc/" $inputsDomain
     # we will test cluster scale up and down in domain1 and domain4 
     if [ "$DOMAIN_UID" == "domain1" ] || [ "$DOMAIN_UID" == "domain4" ] ; then
       sed -i -e "s/^configuredManagedServerCount:.*/configuredManagedServerCount: 3/" $inputsDomain

--- a/src/integration-tests/bash/run.sh
+++ b/src/integration-tests/bash/run.sh
@@ -1105,8 +1105,6 @@ function create_load_balancer_non_helm {
     local inputsLoadBalancer="$tmp_dir/create-load-balancer-inputs.yaml"
 
     cp $PROJECT_ROOT/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer-inputs.yaml $inputsLoadBalancer
-    # accept the default domain name (i.e. don't customize it)
-    local domain_name=`egrep 'domainName' $inputsLoadBalancer | awk '{print $2}'`
 
     sed -i -e "s/^domainUID:.*/domainUID: $DOMAIN_UID/" $inputsLoadBalancer
     sed -i -e "s/^clusterName:.*/clusterName: $WL_CLUSTER_NAME/" $inputsLoadBalancer
@@ -1204,6 +1202,9 @@ function create_domain_pv_pvc_load_balancer {
 
     # accept the default domain name (i.e. don't customize it)
     local domain_name=`egrep 'domainName' $inputs | awk '{print $2}'`
+    if [ -z "${domain_name}" ]; then
+      domain_name=`egrep 'domainUID' $inputs | awk '{print $2}'`
+    fi
 
     trace 'Create the secret with weblogic admin credentials'
     cp $CUSTOM_YAML/weblogic-credentials-template.yaml  $WEBLOGIC_CREDENTIALS_FILE


### PR DESCRIPTION
1) Default domainHome to /shared/domains/domainUID
2) Default logHome to /shared/logs/domainUID
3) Support custom pvc 
4) Support shared pv/vpc - added a new input property for pv/pvc base name
5) Decouple the output location of the pv/pvc, domain, and load balancer scripts
6) Modify the integration test code to work with the new samples - did not change the test logic, which means we still have one pv per domain.

Note: currently there is an intermittent issue in the integration test with the changes. 

Item #1 and #2 are based on the following summary in the slack channel on 10/12/2018.

Tom Moreau [11:35 AM]

Here's a summary of our domain pv decisions (I ran this by Ryan this morning):

1)    the architectural statement (which does not imply large amounts of work for 2.0):   previously, we were focused on one pv per domain.   now we're going to shift the focus - instead of encouraging one pv per domain, we're going to say that the customer creates a pv and can put one or more domains on it (just like the customer can create a namespace and put a bunch of domains in it)   that is, we're going to say that it's a common use case for domains to share a pv, and we should change the operator runtime and samples to reflect this.
2)    this has implications in the default values on the domain resource   domain home - if the domain home is on a pv (we have a switch for this), then the default domain home path will be /shared/domains/\<domain-uid\> (instead of /shared/domain)   log home - the default will be /shared/logs/\<domain-uid\> (instead of /shared/logs)
3)    this has implications on the create domain samples   today we have one sample for creating the pv and other samples to put a domain home on the pv.  they currently put the domain uid in the pv name (i.e. encourage one domain per pv).   instead, we should modify the sample for creating the pv to not put the domain uid in its name.   if a tire kicking customer wants one pv per domain, then they just run the sample to create the pv, and then a sample to create the domain home - they don't change any of the input values.   if the customer want to add more sample domains to the sample pv, then the customer just runs the create domain sample script again, passing in an inputs file that changes the domain uid
4) use case wiki (that I'm working on) - I'll separate out the use cases for creating the pvs from the use cases for creating domains that use them.

@anpanigr @vanajamukkara @maggiehe00 