### PR TITLE
Domain cleanup

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -90,6 +90,11 @@
       <type>jar</type>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.9.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-junit</artifactId>
       <version>2.0.0.0</version>
@@ -118,6 +123,11 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>2.9.6</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.kjetland</groupId>
+      <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+      <version>1.0.31</version>
     </dependency>
   </dependencies>
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/AdminServerConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/AdminServerConfigurator.java
@@ -6,9 +6,12 @@ package oracle.kubernetes.weblogic.domain;
 
 import oracle.kubernetes.weblogic.domain.v1.ExportedNetworkAccessPoint;
 
+@SuppressWarnings("UnusedReturnValue")
 public interface AdminServerConfigurator extends ServerConfigurator {
 
   AdminServerConfigurator withPort(int port);
+
+  AdminServerConfigurator withNodePort(int nodePort);
 
   AdminServerConfigurator withExportedNetworkAccessPoints(String... names);
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -13,12 +13,6 @@ public interface ClusterConfigurator {
 
   ClusterConfigurator withEnvironmentVariable(String name, String value);
 
-  ClusterConfigurator withImage(String imageName);
-
-  ClusterConfigurator withImagePullPolicy(String policy);
-
-  ClusterConfigurator withImagePullSecret(String cluster);
-
   ClusterConfigurator withServerStartState(String cluster);
 
   ClusterConfigurator withServerStartupPolicy(String policy);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -5,6 +5,7 @@
 package oracle.kubernetes.weblogic.domain;
 
 import io.kubernetes.client.models.V1LocalObjectReference;
+import java.util.Arrays;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
 import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
@@ -70,6 +71,18 @@ public abstract class DomainConfigurator {
    */
   public DomainConfigurator withDefaultImagePullSecret(V1LocalObjectReference secretReference) {
     getDomainSpec().setImagePullSecret(secretReference);
+    return this;
+  }
+
+  /**
+   * Sets the image pull secrets for the domain
+   *
+   * @param secretReferences a list of objects referring to secrets
+   * @return this object
+   */
+  public DomainConfigurator withDefaultImagePullSecrets(
+      V1LocalObjectReference... secretReferences) {
+    getDomainSpec().setImagePullSecrets(Arrays.asList(secretReferences));
     return this;
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -5,6 +5,7 @@
 package oracle.kubernetes.weblogic.domain;
 
 import io.kubernetes.client.models.V1LocalObjectReference;
+import io.kubernetes.client.models.V1ObjectMeta;
 import java.util.Arrays;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.weblogic.domain.v1.Domain;
@@ -21,8 +22,12 @@ public abstract class DomainConfigurator {
 
   private Domain domain;
 
+  public DomainConfigurator() {}
+
   protected DomainConfigurator(Domain domain) {
     this.domain = domain;
+    if (domain.getSpec() == null) domain.setSpec(new DomainSpec());
+    if (domain.getMetadata() == null) domain.setMetadata(new V1ObjectMeta());
   }
 
   public abstract DomainConfigurator createFor(Domain domain);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfiguratorFactory.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfiguratorFactory.java
@@ -10,7 +10,7 @@ import oracle.kubernetes.weblogic.domain.v2.DomainV2Configurator;
 
 public class DomainConfiguratorFactory {
 
-  private static DomainConfigurator exemplar = new DomainV2Configurator(null);
+  private static DomainConfigurator exemplar = new DomainV2Configurator();
 
   public static DomainConfigurator forDomain(Domain domain) {
     return exemplar.createFor(domain);
@@ -21,10 +21,10 @@ public class DomainConfiguratorFactory {
   }
 
   public static void selectV1DomainModel() {
-    exemplar = new DomainV1Configurator(null);
+    exemplar = new DomainV1Configurator();
   }
 
   public static void selectV2DomainModel() {
-    exemplar = new DomainV2Configurator(null);
+    exemplar = new DomainV2Configurator();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
@@ -13,12 +13,6 @@ public interface ServerConfigurator {
 
   ServerConfigurator withEnvironmentVariable(String name, String value);
 
-  ServerConfigurator withImage(String imageName);
-
-  ServerConfigurator withImagePullPolicy(String policy);
-
-  ServerConfigurator withImagePullSecret(String secretName);
-
   ServerConfigurator withServerStartState(String state);
 
   ServerConfigurator withServerStartPolicy(String startNever);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/Domain.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/Domain.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.weblogic.domain.v1;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.models.V1ObjectMeta;
@@ -34,6 +35,7 @@ public class Domain {
    */
   @SerializedName("apiVersion")
   @Expose
+  @JsonPropertyDescription("The API version for the Domain. Must be 'weblogic.oracle/v1'")
   private String apiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer
@@ -42,6 +44,7 @@ public class Domain {
    */
   @SerializedName("kind")
   @Expose
+  @JsonPropertyDescription("The type of resourced. Should be 'Domain'")
   private String kind;
   /**
    * Standard object's metadata. More info:
@@ -50,12 +53,16 @@ public class Domain {
   @SerializedName("metadata")
   @Expose
   @Valid
+  @JsonPropertyDescription("The domain meta-data. Must include the name and namespace.")
   private V1ObjectMeta metadata;
+
   /** DomainSpec is a description of a domain. */
   @SerializedName("spec")
   @Expose
   @Valid
+  @JsonPropertyDescription("The actual specification of the domain. Required.")
   private DomainSpec spec;
+
   /**
    * DomainStatus represents information about the status of a domain. Status may trail the actual
    * state of a system.

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
@@ -27,12 +27,15 @@ public class DomainV1Configurator extends DomainConfigurator {
     return new DomainV1Configurator(domain);
   }
 
+  /** Constructs a version 1 domain configurator to use as an examplar */
+  public DomainV1Configurator() {}
+
   /**
    * Constructs a version 1 domain configurator
    *
    * @param domain the domain to be configured
    */
-  public DomainV1Configurator(Domain domain) {
+  public DomainV1Configurator(@Nonnull Domain domain) {
     super(domain);
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
@@ -166,21 +166,6 @@ public class DomainV1Configurator extends DomainConfigurator {
     }
 
     @Override
-    public ServerConfigurator withImage(String imageName) {
-      throw new ConfigurationNotSupportedException("server", "image");
-    }
-
-    @Override
-    public ServerConfigurator withImagePullPolicy(String policy) {
-      throw new ConfigurationNotSupportedException("server", "imagePullPolicy");
-    }
-
-    @Override
-    public ServerConfigurator withImagePullSecret(String secretName) {
-      throw new ConfigurationNotSupportedException("server", "imagePullSecret");
-    }
-
-    @Override
     public ServerConfigurator withServerStartState(String state) {
       return withDesiredState(state);
     }
@@ -258,21 +243,6 @@ public class DomainV1Configurator extends DomainConfigurator {
     public ClusterConfigurator withEnvironmentVariable(String name, String value) {
       clusterStartup.withEnvironmentVariable(name, value);
       return this;
-    }
-
-    @Override
-    public ClusterConfigurator withImage(String imageName) {
-      throw new ConfigurationNotSupportedException("cluster", "image");
-    }
-
-    @Override
-    public ClusterConfigurator withImagePullPolicy(String policy) {
-      throw new ConfigurationNotSupportedException("cluster", "imagePullPolicy");
-    }
-
-    @Override
-    public ClusterConfigurator withImagePullSecret(String secretName) {
-      throw new ConfigurationNotSupportedException("cluster", "imagePullSecret");
     }
 
     @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
@@ -206,6 +206,12 @@ public class DomainV1Configurator extends DomainConfigurator {
     }
 
     @Override
+    public AdminServerConfigurator withNodePort(int nodePort) {
+      super.withNodePort(nodePort);
+      return this;
+    }
+
+    @Override
     public AdminServerConfigurator withExportedNetworkAccessPoints(String... names) {
       getExportT3Channels().addAll(Arrays.asList(names));
       return this;

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpec.java
@@ -29,18 +29,23 @@ import oracle.kubernetes.operator.KubernetesConstants;
 public abstract class ServerSpec {
 
   private static final String ADMIN_MODE_FLAG = "-Dweblogic.management.startupMode=ADMIN";
+  protected DomainSpec domainSpec;
 
-  public String getImage() {
-    return Optional.ofNullable(getConfiguredImage()).orElse(DEFAULT_IMAGE);
+  public ServerSpec(DomainSpec domainSpec) {
+    this.domainSpec = domainSpec;
   }
 
-  protected abstract String getConfiguredImage();
+  public String getImage() {
+    return Optional.ofNullable(domainSpec.getImage()).orElse(DEFAULT_IMAGE);
+  }
 
   public String getImagePullPolicy() {
     return Optional.ofNullable(getConfiguredImagePullPolicy()).orElse(getInferredPullPolicy());
   }
 
-  protected abstract String getConfiguredImagePullPolicy();
+  protected String getConfiguredImagePullPolicy() {
+    return domainSpec.getImagePullPolicy();
+  }
 
   private String getInferredPullPolicy() {
     return useLatestImage() ? ALWAYS_IMAGEPULLPOLICY : IFNOTPRESENT_IMAGEPULLPOLICY;
@@ -55,7 +60,18 @@ public abstract class ServerSpec {
    *
    * @return an object containing the name of a secret. May be null.
    */
-  public abstract V1LocalObjectReference getImagePullSecret();
+  public V1LocalObjectReference getImagePullSecret() {
+    return domainSpec.getImagePullSecret();
+  }
+
+  /**
+   * The secrets used to authenticate to a docker repository when pulling an image.
+   *
+   * @return a list of objects containing the name of secrets. May be empty.
+   */
+  public List<V1LocalObjectReference> getImagePullSecrets() {
+    return domainSpec.getImagePullSecrets();
+  }
 
   /**
    * Returns the environment variables to be defined for this server.

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpecV1Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpecV1Impl.java
@@ -9,14 +9,12 @@ import static oracle.kubernetes.operator.StartupControlConstants.AUTO_STARTUPCON
 import static oracle.kubernetes.operator.StartupControlConstants.SPECIFIED_STARTUPCONTROL;
 
 import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1LocalObjectReference;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 /** The effective configuration for a server configured by the version 1 domain model. */
 public class ServerSpecV1Impl extends ServerSpec {
-  private DomainSpec domainSpec;
   private final String clusterName;
 
   @SuppressWarnings("deprecation")
@@ -31,24 +29,10 @@ public class ServerSpecV1Impl extends ServerSpec {
       String clusterName,
       ServerStartup serverStartup,
       ClusterStartup clusterStartup) {
-    this.domainSpec = domainSpec;
+    super(domainSpec);
     this.clusterName = clusterName;
     this.serverStartup = serverStartup;
     this.clusterStartup = clusterStartup;
-  }
-
-  protected String getConfiguredImage() {
-    return domainSpec.getImage();
-  }
-
-  @Override
-  protected String getConfiguredImagePullPolicy() {
-    return domainSpec.getImagePullPolicy();
-  }
-
-  @Override
-  public V1LocalObjectReference getImagePullSecret() {
-    return domainSpec.getImagePullSecret();
   }
 
   @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
@@ -6,11 +6,10 @@ package oracle.kubernetes.weblogic.domain.v2;
 
 import static java.util.Collections.emptyList;
 
-import com.google.common.base.Strings;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1LocalObjectReference;
 import io.kubernetes.client.models.V1Probe;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,36 +27,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @since 2.0
  */
 public abstract class BaseConfiguration {
-  /**
-   * The WebLogic Docker image.
-   *
-   * <p>Defaults to store/oracle/weblogic:12.2.1.3.
-   */
-  @SerializedName("image")
-  @Expose
-  private String image;
-
-  /**
-   * The image pull policy for the WebLogic Docker image. Legal values are Always, Never and
-   * IfNotPresent.
-   *
-   * <p>Defaults to Always if image ends in :latest, IfNotPresent otherwise.
-   *
-   * <p>More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
-   */
-  @SerializedName("imagePullPolicy")
-  @Expose
-  private String imagePullPolicy;
-
-  /**
-   * Reference to the secret used to authenticate a request for an image pull.
-   *
-   * <p>More info:
-   * https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
-   */
-  @SerializedName("imagePullSecret")
-  @Expose
-  private V1LocalObjectReference imagePullSecret;
 
   /**
    * Environment variables to pass while starting a server.
@@ -67,11 +36,13 @@ public abstract class BaseConfiguration {
   @SerializedName("env")
   @Expose
   @Valid
+  @JsonPropertyDescription("A list of environment variables to add to a server")
   private List<V1EnvVar> env = new ArrayList<>();
 
   /** Desired startup state. Legal values are RUNNING or ADMIN. */
   @SerializedName("serverStartState")
   @Expose
+  @JsonPropertyDescription("The state in which the server is to be started")
   private String serverStartState;
 
   /**
@@ -84,6 +55,9 @@ public abstract class BaseConfiguration {
    */
   @SerializedName("serverStartPolicy")
   @Expose
+  @JsonPropertyDescription(
+      "The strategy for deciding whether to start a server. "
+          + "Legal values are NEVER, ALWAYS, or IF_NEEDED.")
   private String serverStartPolicy;
 
   /**
@@ -94,6 +68,7 @@ public abstract class BaseConfiguration {
    */
   @SerializedName("livenessProbe")
   @Expose
+  @JsonPropertyDescription("Settings for the liveness probe associated with a server")
   private V1Probe livenessProbe = new V1Probe();
 
   /**
@@ -104,6 +79,7 @@ public abstract class BaseConfiguration {
    */
   @SerializedName("readinessProbe")
   @Expose
+  @JsonPropertyDescription("Settings for the readiness probe associated with a server")
   private V1Probe readinessProbe = new V1Probe();
 
   /**
@@ -114,9 +90,6 @@ public abstract class BaseConfiguration {
   void fillInFrom(BaseConfiguration other) {
     if (other == null) return;
 
-    if (image == null) image = other.getImage();
-    if (imagePullPolicy == null) imagePullPolicy = other.getImagePullPolicy();
-    if (imagePullSecret == null) imagePullSecret = other.getImagePullSecret();
     if (serverStartState == null) serverStartState = other.getServerStartState();
     if (serverStartPolicy == null) serverStartPolicy = other.getServerStartPolicy();
 
@@ -156,37 +129,6 @@ public abstract class BaseConfiguration {
    */
   protected boolean hasV2Fields() {
     return serverStartState != null || serverStartPolicy != null || !env.isEmpty();
-  }
-
-  @Nullable
-  public String getImage() {
-    return image;
-  }
-
-  public void setImage(@Nullable String image) {
-    this.image = image;
-  }
-
-  @Nullable
-  public String getImagePullPolicy() {
-    return imagePullPolicy;
-  }
-
-  public void setImagePullPolicy(@Nullable String imagePullPolicy) {
-    this.imagePullPolicy = imagePullPolicy;
-  }
-
-  @Nullable
-  public V1LocalObjectReference getImagePullSecret() {
-    return hasImagePullSecret() ? imagePullSecret : null;
-  }
-
-  private boolean hasImagePullSecret() {
-    return imagePullSecret != null && !Strings.isNullOrEmpty(imagePullSecret.getName());
-  }
-
-  public void setImagePullSecret(@Nullable V1LocalObjectReference imagePullSecret) {
-    this.imagePullSecret = imagePullSecret;
   }
 
   @Nullable
@@ -243,9 +185,6 @@ public abstract class BaseConfiguration {
   @Override
   public String toString() {
     return new ToStringBuilder(this)
-        .append("image", image)
-        .append("imagePullPolicy", imagePullPolicy)
-        .append("imagePullSecret", imagePullSecret)
         .append("serverStartState", serverStartState)
         .append("serverStartPolicy", serverStartPolicy)
         .append("livenessProbe", livenessProbe)
@@ -263,9 +202,6 @@ public abstract class BaseConfiguration {
     BaseConfiguration that = (BaseConfiguration) o;
 
     return new EqualsBuilder()
-        .append(image, that.image)
-        .append(imagePullPolicy, that.imagePullPolicy)
-        .append(imagePullSecret, that.imagePullSecret)
         .append(env, that.env)
         .append(serverStartState, that.serverStartState)
         .append(serverStartPolicy, that.serverStartPolicy)
@@ -277,9 +213,6 @@ public abstract class BaseConfiguration {
   @Override
   public int hashCode() {
     return new HashCodeBuilder(17, 37)
-        .append(image)
-        .append(imagePullPolicy)
-        .append(imagePullSecret)
         .append(env)
         .append(serverStartState)
         .append(serverStartPolicy)

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -9,7 +9,6 @@ import static oracle.kubernetes.operator.VersionConstants.DOMAIN_V2;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_ALWAYS;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_NEVER;
 
-import io.kubernetes.client.models.V1LocalObjectReference;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
 import oracle.kubernetes.weblogic.domain.ClusterConfigurator;
@@ -159,24 +158,6 @@ public class DomainV2Configurator extends DomainConfigurator {
     }
 
     @Override
-    public ServerConfigurator withImage(String imageName) {
-      server.setImage(imageName);
-      return this;
-    }
-
-    @Override
-    public ServerConfigurator withImagePullPolicy(String policy) {
-      server.setImagePullPolicy(policy);
-      return this;
-    }
-
-    @Override
-    public ServerConfigurator withImagePullSecret(String secretName) {
-      server.setImagePullSecret(new V1LocalObjectReference().name(secretName));
-      return this;
-    }
-
-    @Override
     public ServerConfigurator withServerStartState(String state) {
       return withDesiredState(state);
     }
@@ -253,24 +234,6 @@ public class DomainV2Configurator extends DomainConfigurator {
     @Override
     public ClusterConfigurator withEnvironmentVariable(String name, String value) {
       cluster.addEnvironmentVariable(name, value);
-      return this;
-    }
-
-    @Override
-    public ClusterConfigurator withImage(String imageName) {
-      cluster.setImage(imageName);
-      return this;
-    }
-
-    @Override
-    public ClusterConfigurator withImagePullPolicy(String policy) {
-      cluster.setImagePullPolicy(policy);
-      return this;
-    }
-
-    @Override
-    public ClusterConfigurator withImagePullSecret(String secretName) {
-      cluster.setImagePullSecret(new V1LocalObjectReference().name(secretName));
       return this;
     }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -10,6 +10,7 @@ import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_NEVER;
 
 import javax.annotation.Nonnull;
+import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
 import oracle.kubernetes.weblogic.domain.ClusterConfigurator;
 import oracle.kubernetes.weblogic.domain.ConfigurationNotSupportedException;
@@ -25,13 +26,16 @@ public class DomainV2Configurator extends DomainConfigurator {
     return new DomainV2Configurator(domain);
   }
 
-  public DomainV2Configurator(Domain domain) {
+  public DomainV2Configurator() {}
+
+  public DomainV2Configurator(@Nonnull Domain domain) {
     super(domain);
-    if (domain != null && domain.getMetadata() != null) setApiVersion(domain);
+    setApiVersion(domain);
   }
 
   private void setApiVersion(Domain domain) {
     domain.getMetadata().putLabelsItem(RESOURCE_VERSION_LABEL, DOMAIN_V2);
+    domain.setApiVersion(KubernetesConstants.API_VERSION_ORACLE_V2);
   }
 
   @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -79,13 +79,22 @@ public class DomainV2Configurator extends DomainConfigurator {
 
   class AdminServerConfiguratorImpl extends ServerConfiguratorImpl
       implements AdminServerConfigurator {
+    private AdminServer adminServer;
+
     AdminServerConfiguratorImpl(AdminServer adminServer) {
       super(adminServer);
+      this.adminServer = adminServer;
     }
 
     @Override
     public AdminServerConfigurator withPort(int port) {
       getDomainSpec().setAsPort(port);
+      return this;
+    }
+
+    @Override
+    public AdminServerConfigurator withNodePort(int nodePort) {
+      adminServer.setNodePort(nodePort);
       return this;
     }
 
@@ -145,8 +154,7 @@ public class DomainV2Configurator extends DomainConfigurator {
 
     @Override
     public ServerConfigurator withNodePort(int nodePort) {
-      server.setNodePort(nodePort);
-      return this;
+      throw new ConfigurationNotSupportedException("managedServer", "nodePort");
     }
 
     @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
@@ -4,17 +4,16 @@
 
 package oracle.kubernetes.weblogic.domain.v2;
 
-import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_ALWAYS;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_IF_NEEDED;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_NEVER;
 
 import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1LocalObjectReference;
 import io.kubernetes.client.models.V1Probe;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import oracle.kubernetes.weblogic.domain.v1.DomainSpec;
 import oracle.kubernetes.weblogic.domain.v1.ServerSpec;
 
 /** The effective configuration for a server configured by the version 2 domain model. */
@@ -32,7 +31,8 @@ public class ServerSpecV2Impl extends ServerSpec {
    *     them
    */
   public ServerSpecV2Impl(
-      Server server, Integer clusterLimit, BaseConfiguration... configurations) {
+      DomainSpec spec, Server server, Integer clusterLimit, BaseConfiguration... configurations) {
+    super(spec);
     this.server = getBaseConfiguration(server);
     this.clusterLimit = clusterLimit;
     for (BaseConfiguration configuration : configurations) this.server.fillInFrom(configuration);
@@ -40,26 +40,6 @@ public class ServerSpecV2Impl extends ServerSpec {
 
   private Server getBaseConfiguration(Server server) {
     return server != null ? server.getConfiguration() : new Server();
-  }
-
-  @Override
-  public String getImage() {
-    return Optional.ofNullable(getConfiguredImage()).orElse(DEFAULT_IMAGE);
-  }
-
-  @Override
-  protected String getConfiguredImage() {
-    return server.getImage();
-  }
-
-  @Override
-  protected String getConfiguredImagePullPolicy() {
-    return server.getImagePullPolicy();
-  }
-
-  @Override
-  public V1LocalObjectReference getImagePullSecret() {
-    return server.getImagePullSecret();
   }
 
   @Override

--- a/model/src/test/java/oracle/kubernetes/json/GenerateSchema.java
+++ b/model/src/test/java/oracle/kubernetes/json/GenerateSchema.java
@@ -1,0 +1,31 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
+import oracle.kubernetes.weblogic.domain.v1.Domain;
+
+public class GenerateSchema {
+
+  public static void main(String... args) throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper);
+
+    // If using JsonSchema to generate HTML5 GUI:
+    // JsonSchemaGenerator html5 = new JsonSchemaGenerator(objectMapper,
+    // JsonSchemaConfig.html5EnabledSchema() );
+
+    // If you want to configure it manually:
+    // JsonSchemaConfig config = JsonSchemaConfig.create(...);
+    // JsonSchemaGenerator generator = new JsonSchemaGenerator(objectMapper, config);
+
+    JsonNode jsonSchema = jsonSchemaGenerator.generateJsonSchema(Domain.class);
+
+    String jsonSchemaAsString = objectMapper.writeValueAsString(jsonSchema);
+    System.out.println(jsonSchemaAsString);
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -175,7 +175,7 @@ public abstract class DomainTestBase {
   @Test
   public void whenDefaultImagePullSecretSpecified_allServersHaveIt() {
     V1LocalObjectReference secretReference = createSecretReference(PULL_SECRET_NAME);
-    configureDomain(domain).withDefaultImagePullSecret(secretReference);
+    configureDomain(domain).withDefaultImagePullSecrets(secretReference);
 
     assertThat(domain.getAdminServerSpec().getImagePullSecret(), equalTo(secretReference));
     assertThat(

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -317,14 +317,6 @@ public abstract class DomainTestBase {
     assertThat(spec.getNodePort(), nullValue());
   }
 
-  @Test // reverse order of overrides, capture server, need tests for cascading settings
-  public void whenServerConfiguredWithNodePort_returnNodePort() {
-    configureServer(SERVER1).withNodePort(31);
-    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-
-    assertThat(spec.getNodePort(), equalTo(31));
-  }
-
   @Test
   public void whenBothClusterAndServerStateSpecified_managedServerUsesServerState() {
     configureServer(SERVER1).withDesiredState("STAND-BY");

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainStorageTest.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainStorageTest.java
@@ -1,0 +1,86 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v1;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import oracle.kubernetes.weblogic.domain.DomainConfigurator;
+import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
+import org.junit.Test;
+
+public class DomainStorageTest {
+
+  private Domain domain1 = new Domain();
+  private Domain domain2 = new Domain();
+  private Domain domain3 = new Domain();
+
+  @Test
+  public void domainsWithDifferentPredefinedClaims_areNotEqual() {
+    configureDomain(domain1).withPredefinedClaim("claim1");
+    configureDomain(domain2).withPredefinedClaim("claim2");
+
+    assertThat(domain1, not(equalTo(domain2)));
+  }
+
+  @Test
+  public void domainsWithSamePredefinedClaims_areEqual() {
+    configureDomain(domain1).withPredefinedClaim("claim1");
+    configureDomain(domain2).withPredefinedClaim("claim1");
+
+    assertThat(domain1, equalTo(domain2));
+  }
+
+  @Test
+  public void domainsWithDifferentHostPathStorage_areNotEqual() {
+    configureDomain(domain1).withHostPathStorage("/my/path").withStorageSize("100Gi");
+    configureDomain(domain2).withHostPathStorage("/my/path");
+
+    assertThat(domain1, not(equalTo(domain2)));
+  }
+
+  @Test
+  public void domainsWithSameHostPathStorage_areEqual() {
+    configureDomain(domain1).withHostPathStorage("/my/path").withStorageSize("100Gi");
+    configureDomain(domain2).withHostPathStorage("/my/path").withStorageSize("100Gi");
+
+    assertThat(domain1, equalTo(domain2));
+  }
+
+  @Test
+  public void domainsWithDifferentNfsStorage_areNotEqual() {
+    configureDomain(domain1).withNfsStorage("oneHost", "/my/path");
+    configureDomain(domain2).withNfsStorage("anotherHost", "/my/path");
+
+    assertThat(domain1, not(equalTo(domain2)));
+  }
+
+  @Test
+  public void domainsWithSameNfsStorage_areEqual() {
+    configureDomain(domain1)
+        .withNfsStorage("oneHost", "/my/path")
+        .withStorageReclaimPolicy("Delete");
+    configureDomain(domain2)
+        .withNfsStorage("oneHost", "/my/path")
+        .withStorageReclaimPolicy("Delete");
+
+    assertThat(domain1, equalTo(domain2));
+  }
+
+  @Test
+  public void domainsWithPredefinedClaimsAreNotEqualToDomainsWithOperatorCreatedStorage() {
+    configureDomain(domain1).withPredefinedClaim("claim1");
+    configureDomain(domain2).withHostPathStorage("/my/path");
+    configureDomain(domain3).withNfsStorage("oneHost", "/my/path");
+
+    assertThat(domain1, not(equalTo(domain2)));
+    assertThat(domain1, not(equalTo(domain3)));
+  }
+
+  private DomainConfigurator configureDomain(Domain domain) {
+    return DomainConfiguratorFactory.forDomain(domain);
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
@@ -83,6 +83,14 @@ public class DomainV1Test extends DomainTestBase {
     assertThat(domain.getServer(CLUSTER_NAME, SERVER1).shouldStart(0), is(true));
   }
 
+  @Test // reverse order of overrides, capture server, need tests for cascading settings
+  public void whenServerConfiguredWithNodePort_returnNodePort() {
+    configureServer(SERVER1).withNodePort(31);
+    ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getNodePort(), equalTo(31));
+  }
+
   @Test
   public void whenStartAutoAndNamedClusterHasRoomByDefault_shouldStartReturnsTrue() {
     configureDomain(domain).withStartupControl(AUTO_STARTUPCONTROL).withDefaultReplicaCount(3);

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -54,49 +54,8 @@ public class DomainV2Test extends DomainTestBase {
   }
 
   @Test
-  public void whenImageConfiguredOnDomainAndAdminServer_userServerSetting() {
-    configureDomain(domain).withDefaultImage("domain-image");
-    configureAdminServer().withImage("server-image");
-
-    assertThat(domain.getAdminServerSpec().getImage(), equalTo("server-image"));
-  }
-
-  @Test
-  public void whenImageConfiguredOnDomainAndServer_useServerSetting() {
-    configureDomain(domain).withDefaultImage("domain-image");
-    configureServer("server1").withImage("server-image");
-
-    assertThat(domain.getServer("server1", "cluster1").getImage(), equalTo("server-image"));
-  }
-
-  @Test
-  public void whenImageConfiguredOnDomainAndCluster_useClusterSetting() {
-    configureDomain(domain).withDefaultImage("domain-image");
-    configureCluster("cluster1").withImage("cluster-image");
-
-    assertThat(domain.getServer("ms1", "cluster1").getImage(), equalTo("cluster-image"));
-  }
-
-  @Test
   public void whenClusterNotConfigured_useDefaultReplicaCount() {
     assertThat(domain.getReplicaCount("nosuchcluster"), equalTo(DEFAULT_REPLICA_LIMIT));
-  }
-
-  @Test
-  public void whenImagePullPolicyConfiguredOnClusterAndServer_useServerSetting() {
-    configureCluster("cluster1").withImagePullPolicy("always");
-    configureServer("server1").withImagePullPolicy("never");
-
-    assertThat(domain.getServer("server1", "cluster1").getImagePullPolicy(), equalTo("never"));
-  }
-
-  @Test
-  public void whenImagePullSecretConfiguredOnClusterAndServer_useServerSetting() {
-    configureCluster("cluster1").withImagePullSecret("cluster");
-    configureServer("server1").withImagePullSecret("server");
-
-    assertThat(
-        domain.getServer("server1", "cluster1").getImagePullSecret().getName(), equalTo("server"));
   }
 
   @Test
@@ -461,7 +420,8 @@ public class DomainV2Test extends DomainTestBase {
 
     assertThat(serverSpec.getImage(), equalTo(DEFAULT_IMAGE));
     assertThat(serverSpec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
-    assertThat(serverSpec.getImagePullSecret().getName(), equalTo("pull-secret"));
+    assertThat(serverSpec.getImagePullSecrets().get(0).getName(), equalTo("pull-secret1"));
+    assertThat(serverSpec.getImagePullSecrets().get(1).getName(), equalTo("pull-secret2"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
     assertThat(serverSpec.shouldStart(1), is(true));
@@ -475,7 +435,8 @@ public class DomainV2Test extends DomainTestBase {
 
     assertThat(serverSpec.getImage(), equalTo(DEFAULT_IMAGE));
     assertThat(serverSpec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
-    assertThat(serverSpec.getImagePullSecret().getName(), equalTo("pull-secret"));
+    assertThat(serverSpec.getImagePullSecrets().get(0).getName(), equalTo("pull-secret1"));
+    assertThat(serverSpec.getImagePullSecrets().get(1).getName(), equalTo("pull-secret2"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
     assertThat(serverSpec.shouldStart(1), is(true));
@@ -486,8 +447,6 @@ public class DomainV2Test extends DomainTestBase {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
     ServerSpec serverSpec = domain.getAdminServerSpec();
 
-    assertThat(serverSpec.getImage(), equalTo("store/oracle/weblogic:latest"));
-    assertThat(serverSpec.getImagePullSecret().getName(), equalTo("pull-secret"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value1")));
   }
 

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -250,6 +250,13 @@ public class DomainV2Test extends DomainTestBase {
   }
 
   @Test
+  public void whenAdminServerConfiguredWithNodePort_returnNodePort() {
+    configureAdminServer().withNodePort(31);
+
+    assertThat(domain.getAdminServerSpec().getNodePort(), equalTo(31));
+  }
+
+  @Test
   public void whenExportT3ChannelsDefinedWithLabels_returnChannelNames() {
     AdminServerConfigurator configurator = configureDomain(domain).configureAdminServer("");
     configurator
@@ -447,6 +454,7 @@ public class DomainV2Test extends DomainTestBase {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
     ServerSpec serverSpec = domain.getAdminServerSpec();
 
+    assertThat(serverSpec.getNodePort(), equalTo(7001));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value1")));
   }
 
@@ -456,7 +464,6 @@ public class DomainV2Test extends DomainTestBase {
     ServerSpec serverSpec = domain.getServer("server1", "cluster1");
 
     assertThat(serverSpec.getImage(), equalTo(DEFAULT_IMAGE));
-    assertThat(serverSpec.getNodePort(), equalTo(7001));
     assertThat(
         serverSpec.getEnvironmentVariables(),
         containsInAnyOrder(

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-3.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-3.yaml
@@ -19,8 +19,11 @@ spec:
   asPort: 8001
   # The WebLogic Domain Name
 
+  # the T3 endpoints to export. Each entry is an endpoint name,
+  # optionally with labels and annotations to be added to the generated external channel service.
+  # An endpoint without any labels or endpoints must have the empty value: a pair of braces.
   exportedNetworkAccessPoints:
-    channelA:
+    channelA: {}
     channelB:
       labels:
         age: 23

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -31,8 +31,9 @@ spec:
   # imagePullPolicy defaults to "Always" if image version is :latest
   imagePullPolicy: IfNotPresent
   # Identify which Secret contains the credentials for pulling the image
-  imagePullSecret:
-    name: pull-secret
+  imagePullSecrets:
+  - name: pull-secret1
+  - name: pull-secret2
   env:
   - name: var1
     value: value0
@@ -46,7 +47,6 @@ spec:
         path: /local/path
 
   adminServer:
-    image: "store/oracle/weblogic:latest"
     env:
     - name: var1
       value: value1

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -47,6 +47,8 @@ spec:
         path: /local/path
 
   adminServer:
+    # The Admin Server's NodePort (optional)
+    nodePort: 7001
     env:
     - name: var1
       value: value1
@@ -55,8 +57,6 @@ spec:
   managedServers:
     # the name of the server to apply these rules to
   - serverName: server1
-    # The Admin Server's NodePort
-    nodePort: 7001
     # an (optional) list of environment variable to be set on the server
     env:
     - name: JAVA_OPTIONS

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -14,7 +14,6 @@ import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1ExecAction;
 import io.kubernetes.client.models.V1Handler;
 import io.kubernetes.client.models.V1Lifecycle;
-import io.kubernetes.client.models.V1LocalObjectReference;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1PersistentVolume;
 import io.kubernetes.client.models.V1PersistentVolumeClaim;
@@ -588,10 +587,14 @@ public abstract class PodStepContext {
                             .name(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
                             .defaultMode(ALL_READ_AND_EXECUTE)));
 
+    /**/
+    podSpec.setImagePullSecrets(getServerSpec().getImagePullSecrets());
+    /*/
     V1LocalObjectReference imagePullSecret = getServerSpec().getImagePullSecret();
     if (imagePullSecret != null) {
       podSpec.addImagePullSecretsItem(imagePullSecret);
     }
+    /**/
     if (getClaimName() != null) {
       podSpec.addVolumesItem(
           new V1Volume()

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -19,6 +19,7 @@ import static oracle.kubernetes.operator.helpers.PodHelperTestBase.VolumeMountMa
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
@@ -252,13 +253,13 @@ public abstract class PodHelperTestBase {
 
   @Test
   public void whenPodCreatedWithoutPullSecret_doNotAddToPod() {
-    assertThat(getCreatedPod().getSpec().getImagePullSecrets(), nullValue());
+    assertThat(getCreatedPod().getSpec().getImagePullSecrets(), empty());
   }
 
   @Test
   public void whenPodCreatedWithPullSecret_addToPod() {
     V1LocalObjectReference imagePullSecret = new V1LocalObjectReference().name("secret");
-    configureDomain().withDefaultImagePullSecret(imagePullSecret);
+    configureDomain().withDefaultImagePullSecrets(imagePullSecret);
 
     assertThat(getCreatedPod().getSpec().getImagePullSecrets(), hasItem(imagePullSecret));
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -329,6 +329,7 @@ public class ManagedServersUpStepTest {
 
   @Test
   public void serverStartupInfo_containsWlsServerStartupAndConfig() {
+    assumeTrue(DomainConfiguratorFactory.useDomainV1());
     configureServerToStart("wls1").withNodePort(17);
     addWlsServer("wls1");
 
@@ -413,6 +414,7 @@ public class ManagedServersUpStepTest {
 
   @Test
   public void whenClusterStartupDefinedForServerNotRunning_addServerStartup() {
+    assumeTrue(DomainConfiguratorFactory.useDomainV1());
     configureServerToStart("ms1").withNodePort(23);
     configureCluster("cluster1");
     addWlsCluster("cluster1", "ms1");


### PR DESCRIPTION
Moves the image fields from BaseConfiguration to the domain spec.
Adds unit tests for DomainStorage
Restricts nodePort to the admin server in v2
Reflects the above changes in the domain resource samples