### PR TITLE
Add operator role, rolebinding and fix keytool path

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-general.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-general.tpl
@@ -4,7 +4,7 @@
 {{- define "operator.operatorClusterRoleGeneral" }}
 ---
 kind: "ClusterRole"
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 metadata:
   name: {{ list .Release.Namespace "weblogic-operator-clusterrole-general" | join "-" | quote }}
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
@@ -4,7 +4,7 @@
 {{- define "operator.operatorClusterRoleNamespace" }}
 ---
 kind: "ClusterRole"
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 metadata:
   name: {{ list .Release.Namespace "weblogic-operator-clusterrole-namespace" | join "-" | quote }}
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
@@ -12,13 +12,7 @@ metadata:
     weblogic.operatorName: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["services", "configmaps", "pods", "podtemplates", "events", "persistentvolumeclaims"]
+  resources: ["services", "configmaps", "pods", "podtemplates", "secrets", "events", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 - apiGroups: [""]
   resources: ["pods/logs"]
@@ -35,4 +29,7 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["podsecuritypolicies", "networkpolicies"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
 {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-namespace.tpl
@@ -12,8 +12,11 @@ metadata:
     weblogic.operatorName: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [""]
-  resources: ["services", "configmaps", "pods", "podtemplates", "secrets", "events", "persistentvolumeclaims"]
+  resources: ["services", "configmaps", "pods", "podtemplates", "events", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["pods/logs"]
   verbs: ["get", "list"]

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-nonresource.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-nonresource.tpl
@@ -4,7 +4,7 @@
 {{- define "operator.operatorClusterRoleNonResource" }}
 ---
 kind: "ClusterRole"
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 metadata:
   name: {{ list .Release.Namespace "weblogic-operator-clusterrole-nonresource" | join "-" | quote }}
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-auth-delegator.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-auth-delegator.tpl
@@ -3,7 +3,7 @@
 
 {{- define "operator.clusterRoleBindingAuthDelegator" }}
 ---
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRoleBinding"
 metadata:
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-discovery.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-discovery.tpl
@@ -3,7 +3,7 @@
 
 {{- define "operator.clusterRoleBindingDiscovery" }}
 ---
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRoleBinding"
 metadata:
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-general.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-general.tpl
@@ -3,7 +3,7 @@
 
 {{- define "operator.clusterRoleBindingGeneral" }}
 ---
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRoleBinding"
 metadata:
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-nonresource.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrolebinding-nonresource.tpl
@@ -3,7 +3,7 @@
 
 {{- define "operator.clusterRoleBindingNonResource" }}
 ---
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRoleBinding"
 metadata:
   labels:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
@@ -1,0 +1,18 @@
+# Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+{{- define "operator.operatorRole" }}
+---
+kind: "Role"
+apiVersion: "rbac.authorization.k8s.io/v1beta1"
+metadata:
+  name: "weblogic-operator-role"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    weblogic.resourceVersion: "operator-v1"
+    weblogic.operatorName: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets", "configmaps", "events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+{{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
@@ -4,7 +4,7 @@
 {{- define "operator.operatorRole" }}
 ---
 kind: "Role"
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 metadata:
   name: "weblogic-operator-role"
   namespace: {{ .Release.Namespace | quote }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-rolebinding-namespace.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-rolebinding-namespace.tpl
@@ -4,7 +4,7 @@
 {{- define "operator.operatorRoleBindingNamespace" }}
 ---
 kind: "RoleBinding"
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 metadata:
   name: "weblogic-operator-rolebinding-namespace"
   namespace: {{ .domainNamespace | quote }}
@@ -19,5 +19,5 @@ subjects:
 roleRef:
   kind: "ClusterRole"
   name: {{ list .Release.Namespace "weblogic-operator-clusterrole-namespace" | join "-" | quote }}
-  apiGroup: ""
+  apiGroup: "rbac.authorization.k8s.io"
 {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-rolebinding.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-rolebinding.tpl
@@ -1,0 +1,23 @@
+# Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+{{- define "operator.operatorRoleBinding" }}
+---
+kind: "RoleBinding"
+apiVersion: "rbac.authorization.k8s.io/v1beta1"
+metadata:
+  name: "weblogic-operator-rolebinding"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    weblogic.resourceVersion: "operator-v1"
+    weblogic.operatorName: {{ .Release.Namespace | quote }}
+subjects:
+- kind: "ServiceAccount"
+  name: {{ .serviceAccount | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  apiGroup: ""
+roleRef:
+  kind: "Role"
+  name: "weblogic-operator-role"
+  apiGroup: ""
+{{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-rolebinding.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-rolebinding.tpl
@@ -4,7 +4,7 @@
 {{- define "operator.operatorRoleBinding" }}
 ---
 kind: "RoleBinding"
-apiVersion: "rbac.authorization.k8s.io/v1beta1"
+apiVersion: "rbac.authorization.k8s.io/v1"
 metadata:
   name: "weblogic-operator-rolebinding"
   namespace: {{ .Release.Namespace | quote }}
@@ -19,5 +19,5 @@ subjects:
 roleRef:
   kind: "Role"
   name: "weblogic-operator-role"
-  apiGroup: ""
+  apiGroup: "rbac.authorization.k8s.io"
 {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator.tpl
@@ -9,6 +9,8 @@
 {{- include "operator.clusterRoleBindingAuthDelegator" . }}
 {{- include "operator.clusterRoleBindingDiscovery" . }}
 {{- include "operator.clusterRoleBindingNonResource" . }}
+{{- include "operator.operatorRole" . }}
+{{- include "operator.operatorRoleBinding" . }}
 {{- include "operator.operatorConfigMap" . }}
 {{- include "operator.operatorSecrets" . }}
 {{- include "operator.operatorDeployment" . }}

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -12,6 +12,7 @@ import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
 import static oracle.kubernetes.operator.VersionConstants.OPERATOR_V1;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRole;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRoleBinding;
+import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newClusterRoleRef;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newConfigMap;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newConfigMapVolumeSource;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newContainer;
@@ -43,16 +44,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.models.V1ServiceSpec;
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
-import io.kubernetes.client.models.V1beta1RoleBinding;
 import oracle.kubernetes.operator.utils.GeneratedOperatorObjects;
+import oracle.kubernetes.operator.utils.KubernetesArtifactUtils;
 import oracle.kubernetes.operator.utils.OperatorValues;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 import org.apache.commons.codec.binary.Base64;
@@ -356,11 +358,11 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedWeblogicOperatorClusterRole()));
   }
 
-  private V1beta1ClusterRole getActualWeblogicOperatorClusterRole() {
+  private V1ClusterRole getActualWeblogicOperatorClusterRole() {
     return getGeneratedFiles().getWeblogicOperatorClusterRole();
   }
 
-  private V1beta1ClusterRole getExpectedWeblogicOperatorClusterRole() {
+  private V1ClusterRole getExpectedWeblogicOperatorClusterRole() {
     return newClusterRole()
         .metadata(
             newObjectMeta()
@@ -448,7 +450,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedWeblogicOperatorClusterRoleNonResource()));
   }
 
-  private V1beta1ClusterRole getExpectedWeblogicOperatorClusterRoleNonResource() {
+  private V1ClusterRole getExpectedWeblogicOperatorClusterRoleNonResource() {
     return newClusterRole()
         .metadata(
             newObjectMeta()
@@ -478,9 +480,9 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                         .namespace(getInputs().getNamespace())
                         .apiGroup(""))
                 .roleRef(
-                    newRoleRef()
+                    newClusterRoleRef()
                         .name(getInputs().getNamespace() + "-weblogic-operator-clusterrole-general")
-                        .apiGroup("rbac.authorization.k8s.io"))));
+                        .apiGroup(KubernetesArtifactUtils.API_GROUP_RBAC))));
   }
 
   @Test
@@ -490,11 +492,11 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedOperatorRoleBindingNonResource()));
   }
 
-  private V1beta1ClusterRoleBinding getActualOperatorRoleBindingNonResource() {
+  private V1ClusterRoleBinding getActualOperatorRoleBindingNonResource() {
     return getGeneratedFiles().getOperatorRoleBindingNonResource();
   }
 
-  private V1beta1ClusterRoleBinding getExpectedOperatorRoleBindingNonResource() {
+  private V1ClusterRoleBinding getExpectedOperatorRoleBindingNonResource() {
     return newClusterRoleBinding()
         .metadata(
             newObjectMeta()
@@ -510,9 +512,9 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                 .namespace(getInputs().getNamespace())
                 .apiGroup(""))
         .roleRef(
-            newRoleRef()
+            newClusterRoleRef()
                 .name(getInputs().getNamespace() + "-weblogic-operator-clusterrole-nonresource")
-                .apiGroup("rbac.authorization.k8s.io"));
+                .apiGroup(KubernetesArtifactUtils.API_GROUP_RBAC));
   }
 
   @Test
@@ -522,7 +524,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedOperatorRoleBindingDiscovery()));
   }
 
-  private V1beta1ClusterRoleBinding getExpectedOperatorRoleBindingDiscovery() {
+  private V1ClusterRoleBinding getExpectedOperatorRoleBindingDiscovery() {
     return newClusterRoleBinding()
         .metadata(
             newObjectMeta()
@@ -536,7 +538,10 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                 .name(getInputs().getServiceAccount())
                 .namespace(getInputs().getNamespace())
                 .apiGroup(""))
-        .roleRef(newRoleRef().name("system:discovery").apiGroup("rbac.authorization.k8s.io"));
+        .roleRef(
+            newClusterRoleRef()
+                .name("system:discovery")
+                .apiGroup(KubernetesArtifactUtils.API_GROUP_RBAC));
   }
 
   @Test
@@ -546,7 +551,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedOperatorRoleBindingAuthDelegator()));
   }
 
-  private V1beta1ClusterRoleBinding getExpectedOperatorRoleBindingAuthDelegator() {
+  private V1ClusterRoleBinding getExpectedOperatorRoleBindingAuthDelegator() {
     return newClusterRoleBinding()
         .metadata(
             newObjectMeta()
@@ -561,7 +566,10 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                 .name(getInputs().getServiceAccount())
                 .namespace(getInputs().getNamespace())
                 .apiGroup(""))
-        .roleRef(newRoleRef().name("system:auth-delegator").apiGroup("rbac.authorization.k8s.io"));
+        .roleRef(
+            newClusterRoleRef()
+                .name("system:auth-delegator")
+                .apiGroup(KubernetesArtifactUtils.API_GROUP_RBAC));
   }
 
   @Test
@@ -571,23 +579,13 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedWeblogicOperatorNamespaceRole()));
   }
 
-  private V1beta1ClusterRole getExpectedWeblogicOperatorNamespaceRole() {
+  private V1ClusterRole getExpectedWeblogicOperatorNamespaceRole() {
     return newClusterRole()
         .metadata(
             newObjectMeta()
                 .name(getInputs().getNamespace() + "-weblogic-operator-clusterrole-namespace")
                 .putLabelsItem(RESOURCE_VERSION_LABEL, OPERATOR_V1)
                 .putLabelsItem(OPERATORNAME_LABEL, getInputs().getNamespace()))
-        .addRulesItem(
-            newPolicyRule()
-                .addApiGroupsItem("")
-                .resources(singletonList("secrets"))
-                .verbs(asList("get", "list", "watch")))
-        .addRulesItem(
-            newPolicyRule()
-                .addApiGroupsItem("storage.k8s.io")
-                .addResourcesItem("storageclasses")
-                .verbs(asList("get", "list", "watch")))
         .addRulesItem(
             newPolicyRule()
                 .addApiGroupsItem("")
@@ -609,6 +607,11 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                         "patch",
                         "delete",
                         "deletecollection")))
+        .addRulesItem(
+            newPolicyRule()
+                .addApiGroupsItem("")
+                .resources(singletonList("secrets"))
+                .verbs(asList("get", "list", "watch")))
         .addRulesItem(
             newPolicyRule()
                 .addApiGroupsItem("")
@@ -660,7 +663,12 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                         "update",
                         "patch",
                         "delete",
-                        "deletecollection")));
+                        "deletecollection")))
+        .addRulesItem(
+            newPolicyRule()
+                .addApiGroupsItem("storage.k8s.io")
+                .addResourcesItem("storageclasses")
+                .verbs(asList("get", "list", "watch")));
   }
 
   @Test
@@ -673,7 +681,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
     }
   }
 
-  private V1beta1RoleBinding getExpectedWeblogicOperatorRoleBinding(String namespace) {
+  private V1RoleBinding getExpectedWeblogicOperatorRoleBinding(String namespace) {
     return newRoleBinding()
         .metadata(
             newObjectMeta()
@@ -688,9 +696,66 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                 .namespace(getInputs().getNamespace())
                 .apiGroup(""))
         .roleRef(
-            newRoleRef()
+            newClusterRoleRef()
                 .name(getInputs().getNamespace() + "-weblogic-operator-clusterrole-namespace")
-                .apiGroup(""));
+                .apiGroup(KubernetesArtifactUtils.API_GROUP_RBAC));
+  }
+
+  @Test
+  public void generatesCorrect_weblogicOperatorRole() {
+    assertThat(
+        getGeneratedFiles().getWeblogicOperatorRole(),
+        yamlEqualTo(getExpectedWeblogicOperatorRole()));
+  }
+
+  private V1ClusterRole getExpectedWeblogicOperatorRole() {
+    return newClusterRole()
+        .metadata(
+            newObjectMeta()
+                .name(getInputs().getNamespace() + "-weblogic-operator-role")
+                .putLabelsItem(RESOURCE_VERSION_LABEL, OPERATOR_V1)
+                .putLabelsItem(OPERATORNAME_LABEL, getInputs().getNamespace()))
+        .addRulesItem(
+            newPolicyRule()
+                .addApiGroupsItem("")
+                .resources(asList("secrets", "configmaps", "events"))
+                .verbs(
+                    asList(
+                        "get",
+                        "list",
+                        "watch",
+                        "create",
+                        "update",
+                        "patch",
+                        "delete",
+                        "deletecollection")));
+  }
+
+  @Test
+  public void generatesCorrect_weblogicOperatorRoleBinding() {
+    assertThat(
+        getGeneratedFiles().getWeblogicOperatorRoleBinding(),
+        yamlEqualTo(getExpectedWeblogicOperatorRoleBinding()));
+  }
+
+  private V1RoleBinding getExpectedWeblogicOperatorRoleBinding() {
+    return newRoleBinding()
+        .metadata(
+            newObjectMeta()
+                .name("weblogic-operator-rolebinding")
+                .namespace(getInputs().getNamespace())
+                .putLabelsItem(RESOURCE_VERSION_LABEL, OPERATOR_V1)
+                .putLabelsItem(OPERATORNAME_LABEL, getInputs().getNamespace()))
+        .addSubjectsItem(
+            newSubject()
+                .kind("ServiceAccount")
+                .name(getInputs().getServiceAccount())
+                .namespace(getInputs().getNamespace())
+                .apiGroup(""))
+        .roleRef(
+            newRoleRef()
+                .name("weblogic-operator-role")
+                .apiGroup(KubernetesArtifactUtils.API_GROUP_RBAC));
   }
 
   @SuppressWarnings("unused")

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -28,6 +28,7 @@ import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPodSpe
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPodTemplateSpec;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newPolicyRule;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newProbe;
+import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newRole;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newRoleBinding;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newRoleRef;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newSecret;
@@ -48,6 +49,7 @@ import io.kubernetes.client.models.V1ClusterRole;
 import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1Role;
 import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1Service;
@@ -708,11 +710,12 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedWeblogicOperatorRole()));
   }
 
-  private V1ClusterRole getExpectedWeblogicOperatorRole() {
-    return newClusterRole()
+  private V1Role getExpectedWeblogicOperatorRole() {
+    return newRole()
         .metadata(
             newObjectMeta()
-                .name(getInputs().getNamespace() + "-weblogic-operator-role")
+                .name("weblogic-operator-role")
+                .namespace(getInputs().getNamespace())
                 .putLabelsItem(RESOURCE_VERSION_LABEL, OPERATOR_V1)
                 .putLabelsItem(OPERATORNAME_LABEL, getInputs().getNamespace()))
         .addRulesItem(

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/OperatorChartIT.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/OperatorChartIT.java
@@ -16,9 +16,9 @@ public class OperatorChartIT extends OperatorChartITBase {
   private static final InstallArgs NO_VALUES_INSTALL_ARGS = newInstallArgs(Collections.emptyMap());
 
   @Test
-  public void whenChartsGenerated_haveOneRoleBinding() throws Exception {
+  public void whenChartsGenerated_haveTwoRoleBindings() throws Exception {
     ProcessedChart chart = getChart(NO_VALUES_INSTALL_ARGS);
 
-    assertThat(chart.getDocuments("RoleBinding"), hasSize(1));
+    assertThat(chart.getDocuments("RoleBinding"), hasSize(2));
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/GeneratedOperatorObjects.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/GeneratedOperatorObjects.java
@@ -5,14 +5,15 @@
 package oracle.kubernetes.operator.utils;
 
 import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1Role;
+import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServiceAccount;
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
-import io.kubernetes.client.models.V1beta1RoleBinding;
 
 /**
  * Generates the operator yaml files for a set of valid operator input params. Creates and managed
@@ -30,7 +31,7 @@ public class GeneratedOperatorObjects {
     this.securityYaml = securityYaml;
   }
 
-  public V1beta1ClusterRole getWeblogicOperatorClusterRole() {
+  public V1ClusterRole getWeblogicOperatorClusterRole() {
     return securityYaml.getWeblogicOperatorClusterRole();
   }
 
@@ -70,31 +71,39 @@ public class GeneratedOperatorObjects {
     return securityYaml.getOperatorServiceAccount();
   }
 
-  public V1beta1ClusterRole getWeblogicOperatorClusterRoleNonResource() {
+  public V1ClusterRole getWeblogicOperatorClusterRoleNonResource() {
     return securityYaml.getWeblogicOperatorClusterRoleNonResource();
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBinding() {
+  public V1ClusterRoleBinding getOperatorRoleBinding() {
     return securityYaml.getOperatorRoleBinding();
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBindingNonResource() {
+  public V1ClusterRoleBinding getOperatorRoleBindingNonResource() {
     return securityYaml.getOperatorRoleBindingNonResource();
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBindingDiscovery() {
+  public V1ClusterRoleBinding getOperatorRoleBindingDiscovery() {
     return securityYaml.getOperatorRoleBindingDiscovery();
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBindingAuthDelegator() {
+  public V1ClusterRoleBinding getOperatorRoleBindingAuthDelegator() {
     return securityYaml.getOperatorRoleBindingAuthDelegator();
   }
 
-  public V1beta1ClusterRole getWeblogicOperatorNamespaceRole() {
+  public V1ClusterRole getWeblogicOperatorNamespaceRole() {
     return securityYaml.getWeblogicOperatorNamespaceRole();
   }
 
-  public V1beta1RoleBinding getWeblogicOperatorRoleBinding(String namespace) {
+  public V1RoleBinding getWeblogicOperatorRoleBinding(String namespace) {
     return securityYaml.getWeblogicOperatorRoleBinding(namespace);
+  }
+
+  public V1Role getWeblogicOperatorRole() {
+    return securityYaml.getWeblogicOperatorRole();
+  }
+
+  public V1RoleBinding getWeblogicOperatorRoleBinding() {
+    return securityYaml.getWeblogicOperatorRoleBinding();
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/KubernetesArtifactUtils.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/KubernetesArtifactUtils.java
@@ -15,6 +15,8 @@ import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.models.ApiregistrationV1beta1ServiceReference;
 import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.models.ExtensionsV1beta1DeploymentSpec;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.models.V1Container;
@@ -44,8 +46,11 @@ import io.kubernetes.client.models.V1PersistentVolumeSpec;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodSpec;
 import io.kubernetes.client.models.V1PodTemplateSpec;
+import io.kubernetes.client.models.V1PolicyRule;
 import io.kubernetes.client.models.V1Probe;
 import io.kubernetes.client.models.V1ResourceRequirements;
+import io.kubernetes.client.models.V1RoleBinding;
+import io.kubernetes.client.models.V1RoleRef;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1SecretReference;
 import io.kubernetes.client.models.V1SecretVolumeSource;
@@ -53,18 +58,13 @@ import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.models.V1ServicePort;
 import io.kubernetes.client.models.V1ServiceSpec;
+import io.kubernetes.client.models.V1Subject;
 import io.kubernetes.client.models.V1TCPSocketAction;
 import io.kubernetes.client.models.V1Toleration;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
 import io.kubernetes.client.models.V1beta1APIService;
 import io.kubernetes.client.models.V1beta1APIServiceSpec;
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
-import io.kubernetes.client.models.V1beta1PolicyRule;
-import io.kubernetes.client.models.V1beta1RoleBinding;
-import io.kubernetes.client.models.V1beta1RoleRef;
-import io.kubernetes.client.models.V1beta1Subject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -195,26 +195,30 @@ public class KubernetesArtifactUtils {
     return new V1beta1IngressSpec();
   }
 
-  public static V1beta1ClusterRole newClusterRole() {
-    return (new V1beta1ClusterRole()).apiVersion(API_VERSION_RBAC_V1BETA1).kind(KIND_CLUSTER_ROLE);
+  public static V1ClusterRole newClusterRole() {
+    return (new V1ClusterRole()).apiVersion(API_VERSION_RBAC_V1).kind(KIND_CLUSTER_ROLE);
   }
 
-  public static V1beta1ClusterRoleBinding newClusterRoleBinding() {
-    return (new V1beta1ClusterRoleBinding())
-        .apiVersion(API_VERSION_RBAC_V1BETA1)
+  public static V1ClusterRoleBinding newClusterRoleBinding() {
+    return (new V1ClusterRoleBinding())
+        .apiVersion(API_VERSION_RBAC_V1)
         .kind(KIND_CLUSTER_ROLE_BINDING);
   }
 
-  public static V1beta1RoleBinding newRoleBinding() {
-    return (new V1beta1RoleBinding()).apiVersion(API_VERSION_RBAC_V1BETA1).kind(KIND_ROLE_BINDING);
+  public static V1RoleBinding newRoleBinding() {
+    return (new V1RoleBinding()).apiVersion(API_VERSION_RBAC_V1).kind(KIND_ROLE_BINDING);
   }
 
-  public static V1beta1RoleRef newRoleRef() {
-    return (new V1beta1RoleRef()).kind(KIND_CLUSTER_ROLE);
+  public static V1RoleRef newRoleRef() {
+    return (new V1RoleRef()).apiGroup(API_GROUP_RBAC).kind(KIND_ROLE);
   }
 
-  public static V1beta1Subject newSubject() {
-    return new V1beta1Subject();
+  public static V1RoleRef newClusterRoleRef() {
+    return (new V1RoleRef()).apiGroup(API_GROUP_RBAC).kind(KIND_CLUSTER_ROLE);
+  }
+
+  public static V1Subject newSubject() {
+    return new V1Subject();
   }
 
   public static V1ObjectMeta newObjectMeta() {
@@ -301,8 +305,8 @@ public class KubernetesArtifactUtils {
     return new V1LocalObjectReference();
   }
 
-  public static V1beta1PolicyRule newPolicyRule() {
-    return new V1beta1PolicyRule();
+  public static V1PolicyRule newPolicyRule() {
+    return new V1PolicyRule();
   }
 
   public static V1ResourceRequirements newResourceRequirements() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/KubernetesArtifactUtils.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/KubernetesArtifactUtils.java
@@ -49,6 +49,7 @@ import io.kubernetes.client.models.V1PodTemplateSpec;
 import io.kubernetes.client.models.V1PolicyRule;
 import io.kubernetes.client.models.V1Probe;
 import io.kubernetes.client.models.V1ResourceRequirements;
+import io.kubernetes.client.models.V1Role;
 import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1RoleRef;
 import io.kubernetes.client.models.V1Secret;
@@ -193,6 +194,10 @@ public class KubernetesArtifactUtils {
 
   public static V1beta1IngressSpec newIngressSpec() {
     return new V1beta1IngressSpec();
+  }
+
+  public static V1Role newRole() {
+    return (new V1Role()).apiVersion(API_VERSION_RBAC_V1).kind(KIND_ROLE);
   }
 
   public static V1ClusterRole newClusterRole() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedApacheSecurityYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedApacheSecurityYaml.java
@@ -4,8 +4,8 @@
 
 package oracle.kubernetes.operator.utils;
 
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import java.nio.file.Path;
 
 /**
@@ -25,11 +25,11 @@ public class ParsedApacheSecurityYaml extends ParsedKubernetesYaml {
     this.inputs = inputs;
   }
 
-  public V1beta1ClusterRole getApacheClusterRole() {
+  public V1ClusterRole getApacheClusterRole() {
     return getClusterRoles().find(getApacheName());
   }
 
-  public V1beta1ClusterRoleBinding getApacheClusterRoleBinding() {
+  public V1ClusterRoleBinding getApacheClusterRoleBinding() {
     return getClusterRoleBindings().find(getApacheName());
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
@@ -442,13 +442,13 @@ public class ParsedKubernetesYaml {
     }
   }
 
-  private static class RoleHandler extends TypeHandler<V1ClusterRoleBinding> {
+  private static class RoleHandler extends TypeHandler<V1Role> {
     private RoleHandler() {
       super(V1Role.class);
     }
 
     @Override
-    protected V1ObjectMeta getMetadata(V1ClusterRoleBinding instance) {
+    protected V1ObjectMeta getMetadata(V1Role instance) {
       return instance.getMetadata();
     }
   }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
@@ -15,6 +15,7 @@ import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_JOB;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_NAMESPACE;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_PERSISTENT_VOLUME;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_PERSISTENT_VOLUME_CLAIM;
+import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_ROLE;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_ROLE_BINDING;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_SECRET;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.KIND_SERVICE;
@@ -23,19 +24,20 @@ import static oracle.kubernetes.operator.utils.YamlUtils.newYaml;
 
 import com.appscode.voyager.client.models.V1beta1Ingress;
 import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1ConfigMap;
 import io.kubernetes.client.models.V1Job;
 import io.kubernetes.client.models.V1Namespace;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1PersistentVolume;
 import io.kubernetes.client.models.V1PersistentVolumeClaim;
+import io.kubernetes.client.models.V1Role;
+import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.models.V1beta1APIService;
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
-import io.kubernetes.client.models.V1beta1RoleBinding;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -71,6 +73,7 @@ public class ParsedKubernetesYaml {
     kindToHandler.put(KIND_NAMESPACE, new NamespaceHandler());
     kindToHandler.put(KIND_PERSISTENT_VOLUME, new PersistentVolumeHandler());
     kindToHandler.put(KIND_PERSISTENT_VOLUME_CLAIM, new PersistentVolumeClaimHandler());
+    kindToHandler.put(KIND_ROLE, new RoleHandler());
     kindToHandler.put(KIND_ROLE_BINDING, new RoleBindingHandler());
     kindToHandler.put(KIND_SECRET, new SecretHandler());
     kindToHandler.put(KIND_SERVICE, new ServiceHandler());
@@ -132,12 +135,12 @@ public class ParsedKubernetesYaml {
     return (TypeHandler<V1ConfigMap>) getHandler(KIND_CONFIG_MAP);
   }
 
-  TypeHandler<V1beta1ClusterRole> getClusterRoles() {
-    return (TypeHandler<V1beta1ClusterRole>) getHandler(KIND_CLUSTER_ROLE);
+  TypeHandler<V1ClusterRole> getClusterRoles() {
+    return (TypeHandler<V1ClusterRole>) getHandler(KIND_CLUSTER_ROLE);
   }
 
-  TypeHandler<V1beta1ClusterRoleBinding> getClusterRoleBindings() {
-    return (TypeHandler<V1beta1ClusterRoleBinding>) getHandler(KIND_CLUSTER_ROLE_BINDING);
+  TypeHandler<V1ClusterRoleBinding> getClusterRoleBindings() {
+    return (TypeHandler<V1ClusterRoleBinding>) getHandler(KIND_CLUSTER_ROLE_BINDING);
   }
 
   TypeHandler<ExtensionsV1beta1Deployment> getDeployments() {
@@ -168,8 +171,12 @@ public class ParsedKubernetesYaml {
     return (TypeHandler<V1PersistentVolumeClaim>) getHandler(KIND_PERSISTENT_VOLUME_CLAIM);
   }
 
-  TypeHandler<V1beta1RoleBinding> getRoleBindings() {
-    return (TypeHandler<V1beta1RoleBinding>) getHandler(KIND_ROLE_BINDING);
+  TypeHandler<V1Role> getRoles() {
+    return (TypeHandler<V1Role>) getHandler(KIND_ROLE);
+  }
+
+  TypeHandler<V1RoleBinding> getRoleBindings() {
+    return (TypeHandler<V1RoleBinding>) getHandler(KIND_ROLE_BINDING);
   }
 
   TypeHandler<V1Secret> getSecrets() {
@@ -336,24 +343,24 @@ public class ParsedKubernetesYaml {
     }
   }
 
-  private static class ClusterRoleHandler extends TypeHandler<V1beta1ClusterRole> {
+  private static class ClusterRoleHandler extends TypeHandler<V1ClusterRole> {
     private ClusterRoleHandler() {
-      super(V1beta1ClusterRole.class);
+      super(V1ClusterRole.class);
     }
 
     @Override
-    protected V1ObjectMeta getMetadata(V1beta1ClusterRole instance) {
+    protected V1ObjectMeta getMetadata(V1ClusterRole instance) {
       return instance.getMetadata();
     }
   }
 
-  private static class ClusterRoleBindingHandler extends TypeHandler<V1beta1ClusterRoleBinding> {
+  private static class ClusterRoleBindingHandler extends TypeHandler<V1ClusterRoleBinding> {
     private ClusterRoleBindingHandler() {
-      super(V1beta1ClusterRoleBinding.class);
+      super(V1ClusterRoleBinding.class);
     }
 
     @Override
-    protected V1ObjectMeta getMetadata(V1beta1ClusterRoleBinding instance) {
+    protected V1ObjectMeta getMetadata(V1ClusterRoleBinding instance) {
       return instance.getMetadata();
     }
   }
@@ -435,13 +442,24 @@ public class ParsedKubernetesYaml {
     }
   }
 
-  private static class RoleBindingHandler extends TypeHandler<V1beta1RoleBinding> {
-    private RoleBindingHandler() {
-      super(V1beta1RoleBinding.class);
+  private static class RoleHandler extends TypeHandler<V1ClusterRoleBinding> {
+    private RoleHandler() {
+      super(V1Role.class);
     }
 
     @Override
-    protected V1ObjectMeta getMetadata(V1beta1RoleBinding instance) {
+    protected V1ObjectMeta getMetadata(V1ClusterRoleBinding instance) {
+      return instance.getMetadata();
+    }
+  }
+
+  private static class RoleBindingHandler extends TypeHandler<V1RoleBinding> {
+    private RoleBindingHandler() {
+      super(V1RoleBinding.class);
+    }
+
+    @Override
+    protected V1ObjectMeta getMetadata(V1RoleBinding instance) {
       return instance.getMetadata();
     }
   }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedTraefikSecurityYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedTraefikSecurityYaml.java
@@ -4,8 +4,8 @@
 
 package oracle.kubernetes.operator.utils;
 
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import java.nio.file.Path;
 import oracle.kubernetes.operator.helpers.LegalNames;
 
@@ -28,11 +28,11 @@ public class ParsedTraefikSecurityYaml extends ParsedKubernetesYaml {
     this.inputs = inputs;
   }
 
-  public V1beta1ClusterRole getTraefikClusterRole() {
+  public V1ClusterRole getTraefikClusterRole() {
     return getClusterRoles().find(getTraefikScope());
   }
 
-  public V1beta1ClusterRoleBinding getTraefikDashboardClusterRoleBinding() {
+  public V1ClusterRoleBinding getTraefikDashboardClusterRoleBinding() {
     return getClusterRoleBindings().find(getTraefikScope());
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedVoyagerOperatorSecurityYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedVoyagerOperatorSecurityYaml.java
@@ -4,10 +4,10 @@
 
 package oracle.kubernetes.operator.utils;
 
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
+import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1ServiceAccount;
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
-import io.kubernetes.client.models.V1beta1RoleBinding;
 import java.nio.file.Path;
 
 /** Parses a generated voyager-operator-security.yaml file into a set of typed k8s java objects */
@@ -25,27 +25,27 @@ public class ParsedVoyagerOperatorSecurityYaml extends ParsedKubernetesYaml {
     return getServiceAccounts().find(getVoyagerOperatorName());
   }
 
-  public V1beta1ClusterRole getVoyagerClusterRole() {
+  public V1ClusterRole getVoyagerClusterRole() {
     return getClusterRoles().find(getVoyagerOperatorName());
   }
 
-  public V1beta1ClusterRoleBinding getVoyagerClusterRoleBinding() {
+  public V1ClusterRoleBinding getVoyagerClusterRoleBinding() {
     return getClusterRoleBindings().find(getVoyagerOperatorName());
   }
 
-  public V1beta1RoleBinding getVoyagerAuthenticationReaderRoleBinding() {
+  public V1RoleBinding getVoyagerAuthenticationReaderRoleBinding() {
     return getRoleBindings().find("voyager-apiserver-extension-server-authentication-reader");
   }
 
-  public V1beta1ClusterRoleBinding getVoyagerAuthDelegatorClusterRoleBinding() {
+  public V1ClusterRoleBinding getVoyagerAuthDelegatorClusterRoleBinding() {
     return getClusterRoleBindings().find("voyager-apiserver-auth-delegator");
   }
 
-  public V1beta1ClusterRole getVoyagerAppsCodeEditClusterRole() {
+  public V1ClusterRole getVoyagerAppsCodeEditClusterRole() {
     return getClusterRoles().find("appscode:voyager:edit");
   }
 
-  public V1beta1ClusterRole getVoyagerAppsCodeViewClusterRole() {
+  public V1ClusterRole getVoyagerAppsCodeViewClusterRole() {
     return getClusterRoles().find("appscode:voyager:view");
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedWeblogicOperatorSecurityYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedWeblogicOperatorSecurityYaml.java
@@ -4,11 +4,12 @@
 
 package oracle.kubernetes.operator.utils;
 
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1Role;
+import io.kubernetes.client.models.V1RoleBinding;
 import io.kubernetes.client.models.V1ServiceAccount;
-import io.kubernetes.client.models.V1beta1ClusterRole;
-import io.kubernetes.client.models.V1beta1ClusterRoleBinding;
-import io.kubernetes.client.models.V1beta1RoleBinding;
 import java.nio.file.Path;
 
 /** Parses a generated weblogic-operator-security.yaml file into a set of typed k8s java objects */
@@ -35,42 +36,50 @@ public class ParsedWeblogicOperatorSecurityYaml extends ParsedKubernetesYaml {
     return getServiceAccounts().find(inputs.getServiceAccount());
   }
 
-  public V1beta1ClusterRole getWeblogicOperatorClusterRole() {
+  public V1ClusterRole getWeblogicOperatorClusterRole() {
     return getClusterRoles().find(inputs.getNamespace() + "-weblogic-operator-clusterrole-general");
   }
 
-  public V1beta1ClusterRole getWeblogicOperatorClusterRoleNonResource() {
+  public V1ClusterRole getWeblogicOperatorClusterRoleNonResource() {
     return getClusterRoles()
         .find(inputs.getNamespace() + "-weblogic-operator-clusterrole-nonresource");
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBinding() {
+  public V1ClusterRoleBinding getOperatorRoleBinding() {
     return getClusterRoleBindings()
         .find(inputs.getNamespace() + "-weblogic-operator-clusterrolebinding-general");
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBindingNonResource() {
+  public V1ClusterRoleBinding getOperatorRoleBindingNonResource() {
     return getClusterRoleBindings()
         .find(inputs.getNamespace() + "-weblogic-operator-clusterrolebinding-nonresource");
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBindingDiscovery() {
+  public V1ClusterRoleBinding getOperatorRoleBindingDiscovery() {
     return getClusterRoleBindings()
         .find(inputs.getNamespace() + "-weblogic-operator-clusterrolebinding-discovery");
   }
 
-  public V1beta1ClusterRoleBinding getOperatorRoleBindingAuthDelegator() {
+  public V1ClusterRoleBinding getOperatorRoleBindingAuthDelegator() {
     return getClusterRoleBindings()
         .find(inputs.getNamespace() + "-weblogic-operator-clusterrolebinding-auth-delegator");
   }
 
-  public V1beta1ClusterRole getWeblogicOperatorNamespaceRole() {
+  public V1ClusterRole getWeblogicOperatorNamespaceRole() {
     return getClusterRoles()
         .find(inputs.getNamespace() + "-weblogic-operator-clusterrole-namespace");
   }
 
-  public V1beta1RoleBinding getWeblogicOperatorRoleBinding(String namespace) {
+  public V1RoleBinding getWeblogicOperatorRoleBinding(String namespace) {
     return getRoleBindings().find("weblogic-operator-rolebinding-namespace", namespace);
+  }
+
+  public V1Role getWeblogicOperatorRole() {
+    return getRoles().find("weblogic-operator-role");
+  }
+
+  public V1RoleBinding getWeblogicOperatorRoleBinding() {
+    return getRoleBindings().find("weblogic-operator-rolebinding");
   }
 
   public int getExpectedObjectCount() {

--- a/src/scripts/initialize-internal-operator-identity.sh
+++ b/src/scripts/initialize-internal-operator-identity.sh
@@ -41,7 +41,7 @@ function generateInternalIdentity {
   OP_CSR="${TEMP_DIR}/${OP_PREFIX}.csr"
   OP_CERT_PEM="${TEMP_DIR}/${OP_PREFIX}.cert.pem"
   OP_KEY_PEM="${TEMP_DIR}/${OP_PREFIX}.key.pem"
-  KEYTOOL=/usr/java/jdk1.8.0_141/bin/keytool
+  KEYTOOL=${JAVA_HOME}/bin/keytool
 
   # generate a keypair for the operator's internal service, putting it in a keystore
   $KEYTOOL \


### PR DESCRIPTION
There are two fixes here to get the script working that generates the internal keys and certificates for the operator's REST interface:

1) The path to keytool was wrong
2) The operator didn't have permission to create CMs and Secrets in its own namespace