### PR TITLE
Restore output dir hierarchy in samples

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -63,7 +63,7 @@ public class Domain {
     createPV();
     createSecret();
     generateInputYaml();
-    callCreateDomainScript(userProjectsDir + "/weblogic-domains/" + domainUid);
+    callCreateDomainScript(userProjectsDir);
     createLoadBalancer();
   }
 
@@ -450,7 +450,7 @@ public class Domain {
     }
     logger.info("Run the script to create domain");
     try {
-      callCreateDomainScript(userProjectsDir + "/weblogic-domains2/" + domainUid);
+      callCreateDomainScript(userProjectsDir + "2");
     } catch (RuntimeException re) {
       re.printStackTrace();
       logger.info("[SUCCESS] create domain job failed, this is the expected behavior");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -32,9 +32,7 @@ public class LoadBalancer {
             + " -i "
             + parentDir
             + "/lb-inputs.yaml -e -o "
-            + BaseTest.getUserProjectsDir()
-            + "/loadbalancers/"
-            + lbMap.get("domainUID");
+            + BaseTest.getUserProjectsDir();
     logger.info("Executing cmd " + cmdLb);
 
     ExecResult result = ExecCommand.exec(cmdLb);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -21,7 +21,7 @@ public class LoadBalancer {
     this.lbMap = lbMap;
     Path parentDir =
         Files.createDirectories(
-            Paths.get(BaseTest.getUserProjectsDir() + "/loadbalancers/" + lbMap.get("domainUID")));
+            Paths.get(BaseTest.getUserProjectsDir() + "/load-balancers/" + lbMap.get("domainUID")));
     // generate input yaml
     TestUtils.createInputFile(lbMap, parentDir + "/lb-inputs.yaml");
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
@@ -56,7 +56,7 @@ public class PersistentVolume {
             + "/"
             + pvMap.get("baseName")
             + "-pv-inputs.yaml -e -o "
-            + parentDir;
+            + BaseTest.getUserProjectsDir();
     logger.info("Executing cmd " + cmdPvPvc);
 
     result = ExecCommand.exec(cmdPvPvc);

--- a/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-load-balancer/create-load-balancer.sh
@@ -63,7 +63,7 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  lbOutputDir=${outputDir}
+  lbOutputDir=${outputDir}/load-balancers/${domainUID}
 
   if [ ! -z "${loadBalancer}" ]; then
     case ${loadBalancer} in

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/README.md
@@ -20,7 +20,7 @@ Run the create script, pointing it at your inputs file and an output directory:
   -o /path/to/output-directory
 ```
 
-By default, the script generates two yaml files, namely `weblogic-sample-pv.yaml` and `weblogic-sample-pvc.yaml`, in the `/path/to/output-directory` directory. These two yaml files can be used to create the Kubernetes resources using the `kubectl create -f` command.
+The `create-pv-pvc.sh` script will create a subdirectory `pv-pvcs` under the given `/path/to/output-directory` directory. By default, the script generates two yaml files, namely `weblogic-sample-pv.yaml` and `weblogic-sample-pvc.yaml`, in the `/path/to/output-directory` directory/pv-pvcs`. These two yaml files can be used to create the Kubernetes resources using the `kubectl create -f` command.
 
 ```
   kubectl create -f weblogic-sample-pv.yaml

--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc.sh
@@ -65,21 +65,22 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
+  pvOutputDir="$outputDir/pv-pvcs"
 
   if [ -z ${domainUID} ]; then
-    pvOutput="${outputDir}/${baseName}-pv.yaml"
-    pvcOutput="${outputDir}/${baseName}-pvc.yaml"
+    pvOutput="${pvOutputDir}/${baseName}-pv.yaml"
+    pvcOutput="${pvOutputDir}/${baseName}-pvc.yaml"
     persistentVolumeName=${baseName}-pv
     persistentVolumeClaimName=${baseName}-pvc
   else
-    pvOutput="${outputDir}/${domainUID}-${baseName}-pv.yaml"
-    pvcOutput="${outputDir}/${domainUID}-${baseName}-pvc.yaml"
+    pvOutput="${pvOutputDir}/${domainUID}-${baseName}-pv.yaml"
+    pvcOutput="${pvOutputDir}/${domainUID}-${baseName}-pvc.yaml"
     persistentVolumeName=${domainUID}-${baseName}-pv
     persistentVolumeClaimName=${domainUID}-${baseName}-pvc
   fi
 
   validateOutputDir \
-    ${outputDir} \
+    ${pvOutputDir} \
     ${valuesInputFile} \
     create-pv-pvc-inputs.yaml \
     ${pvOutput} \
@@ -143,14 +144,14 @@ function initialize {
 function createYamlFiles {
 
   # Create a directory for this domain's output files
-  mkdir -p ${outputDir}
+  mkdir -p ${pvOutputDir}
 
   # Make sure the output directory has a copy of the inputs file.
   # The user can either pre-create the output directory, put the inputs
   # file there, and create the domain from it, or the user can put the
   # inputs file some place else and let this script create the output directory
   # (if needed) and copy the inputs file there.
-  copyInputsFileToOutputDirectory ${valuesInputFile} "${outputDir}/create-pv-pvc-inputs.yaml"
+  copyInputsFileToOutputDirectory ${valuesInputFile} "${pvOutputDir}/create-pv-pvc-inputs.yaml"
 
   enabledPrefix=""     # uncomment the feature
   disabledPrefix="# "  # comment out the feature
@@ -200,7 +201,7 @@ function createYamlFiles {
   sed -i -e "s:%SAMPLE_STORAGE_SIZE%:${weblogicDomainStorageSize}:g" ${pvcOutput}
 
   # Remove any "...yaml-e" files left over from running sed
-  rm -f ${outputDir}/*.yaml-e
+  rm -f ${pvOutputDir}/*.yaml-e
 }
 
 #

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -74,7 +74,7 @@ fi
 # for the generated yaml files for this domain.
 #
 function initAndValidateOutputDir {
-  domainOutputDir="${outputDir}"
+  domainOutputDir="${outputDir}/weblogic-domains/${domainUID}"
   # Create a directory for this domain's output files
   mkdir -p ${domainOutputDir}
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -435,6 +435,8 @@ function create_domain_configmap {
   fi
 
   kubectl label configmap ${cmName} -n $namespace weblogic.resourceVersion=domain-v1 weblogic.domainUID=$domainUID weblogic.domainName=$domainName
+
+  rm -rf $externalFilesTmpDir
 }
 
 #


### PR DESCRIPTION
The samples keep the following output dir hierarchy with this change:
    "\<user-specified-outputdir\>\/weblogic-domains/\<domainUID\>" for domain artifacts.
    "\<user-specified-outputdir\>/pv-pvcs" for pv/pvcs
    "\<user-specified-outputdir\>/load-balancers/\<domainUID\>" for load balancers 

@anpanigr @vanajamukkara @maggiehe00 
                         
Signed-off-by: doxiao <dongbo.xiao@oracle.com>