### PR TITLE
Fix scaling test

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ExportedNetworkAccessPoint.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ExportedNetworkAccessPoint.java
@@ -9,6 +9,9 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class ExportedNetworkAccessPoint {
 
@@ -36,5 +39,32 @@ public class ExportedNetworkAccessPoint {
 
   public Map<String, String> getAnnotations() {
     return Collections.unmodifiableMap(annotations);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("labels", labels)
+        .append("annotations", annotations)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ExportedNetworkAccessPoint that = (ExportedNetworkAccessPoint) o;
+
+    return new EqualsBuilder()
+        .append(labels, that.labels)
+        .append(annotations, that.annotations)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37).append(labels).append(annotations).toHashCode();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
@@ -4,4 +4,77 @@
 
 package oracle.kubernetes.weblogic.domain.v2;
 
-public class AdminServer extends Server {}
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import oracle.kubernetes.weblogic.domain.v1.ExportedNetworkAccessPoint;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class AdminServer extends Server {
+
+  public static final AdminServer NULL_ADMIN_SERVER = new AdminServer();
+
+  /**
+   * List of T3 network access points to export, along with label and annotations to apply to
+   * corresponding channel services.
+   *
+   * @since 2.0
+   */
+  @JsonPropertyDescription("T3 network access points to export")
+  private Map<String, ExportedNetworkAccessPoint> exportedNetworkAccessPoints = new HashMap<>();
+
+  /**
+   * Configures an exported T3 network access point.
+   *
+   * @param name the name of the NAP
+   */
+  ExportedNetworkAccessPoint addExportedNetworkAccessPoint(String name) {
+    if (exportedNetworkAccessPoints == null) exportedNetworkAccessPoints = new HashMap<>();
+
+    ExportedNetworkAccessPoint exportedNetworkAccessPoint = new ExportedNetworkAccessPoint();
+    exportedNetworkAccessPoints.put(name, exportedNetworkAccessPoint);
+    return exportedNetworkAccessPoint;
+  }
+
+  public List<String> getExportedNetworkAccessPointNames() {
+    return new ArrayList<>(exportedNetworkAccessPoints.keySet());
+  }
+
+  public ExportedNetworkAccessPoint getExportedNetworkAccessPoint(String napName) {
+    return exportedNetworkAccessPoints.get(napName);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .appendSuper(super.toString())
+        .append("exportedNetworkAccessPoints", exportedNetworkAccessPoints)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    AdminServer that = (AdminServer) o;
+
+    return new EqualsBuilder()
+        .appendSuper(super.equals(o))
+        .append(exportedNetworkAccessPoints, that.exportedNetworkAccessPoints)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .appendSuper(super.hashCode())
+        .append(exportedNetworkAccessPoints)
+        .toHashCode();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
@@ -154,7 +154,7 @@ public abstract class BaseConfiguration {
   }
 
   private void addEnvVar(V1EnvVar var) {
-    if (env == null) env = new ArrayList<>();
+    if (env == null) setEnv(new ArrayList<>());
     env.add(var);
   }
 
@@ -187,8 +187,12 @@ public abstract class BaseConfiguration {
     return new ToStringBuilder(this)
         .append("serverStartState", serverStartState)
         .append("serverStartPolicy", serverStartPolicy)
-        .append("livenessProbe", livenessProbe)
-        .append("readinessProbe", readinessProbe)
+        .append("livenessProbe.initialDelaySeconds", livenessProbe.getInitialDelaySeconds())
+        .append("livenessProbe.timeoutSeconds", livenessProbe.getTimeoutSeconds())
+        .append("livenessProbe.periodSeconds", livenessProbe.getPeriodSeconds())
+        .append("readinessProbeProbe.initialDelaySeconds", readinessProbe.getInitialDelaySeconds())
+        .append("readinessProbe.timeoutSeconds", readinessProbe.getTimeoutSeconds())
+        .append("readinessProbe.periodSeconds", readinessProbe.getPeriodSeconds())
         .append("env", env)
         .toString();
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
@@ -7,6 +7,9 @@ package oracle.kubernetes.weblogic.domain.v2;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * An element representing a cluster in the domain configuration.
@@ -43,5 +46,38 @@ public class Cluster extends BaseConfiguration {
 
   public void setReplicas(Integer replicas) {
     this.replicas = replicas;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .appendSuper(super.toString())
+        .append("clusterName", clusterName)
+        .append("replicas", replicas)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Cluster cluster = (Cluster) o;
+
+    return new EqualsBuilder()
+        .appendSuper(super.equals(o))
+        .append(clusterName, cluster.clusterName)
+        .append(replicas, cluster.replicas)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .appendSuper(super.hashCode())
+        .append(clusterName)
+        .append(replicas)
+        .toHashCode();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -101,29 +101,19 @@ public class DomainV2Configurator extends DomainConfigurator {
     @Override
     public AdminServerConfigurator withExportedNetworkAccessPoints(String... names) {
       for (String name : names) {
-        getDomainSpec().addExportedNetworkAccessPoint(name);
+        adminServer.addExportedNetworkAccessPoint(name);
       }
       return this;
     }
 
     @Override
     public ExportedNetworkAccessPoint configureExportedNetworkAccessPoint(String channelName) {
-      return getDomainSpec().addExportedNetworkAccessPoint(channelName);
+      return adminServer.addExportedNetworkAccessPoint(channelName);
     }
   }
 
   private AdminServer getOrCreateAdminServer(String adminServerName) {
-    AdminServer adminServer = getDomainSpec().getAdminServer();
-    if (adminServer != null) return adminServer;
-
-    return createAdminServer(adminServerName);
-  }
-
-  private AdminServer createAdminServer(String adminServerName) {
-    getDomainSpec().setAsName(adminServerName);
-    AdminServer adminServer = new AdminServer();
-    getDomainSpec().setAdminServer(adminServer);
-    return adminServer;
+    return getDomainSpec().getOrCreateAdminServer(adminServerName);
   }
 
   @Override

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -48,16 +48,19 @@ public abstract class DomainTestBase {
   private static final String AS_NAME = "admin";
   protected static final String CLUSTER_NAME = "cluster1";
   protected static final String SERVER1 = "ms1";
-  protected final Domain domain =
-      new Domain()
-          .withMetadata(new V1ObjectMeta().namespace(NS))
-          .withSpec(
-              new DomainSpec()
-                  .withAdminSecret(SECRET)
-                  .withAsName(AS_NAME)
-                  .withAsPort(AS_PORT)
-                  .withDomainName(DOMAIN_NAME)
-                  .withDomainUID(DOMAIN_UID));
+  protected final Domain domain = createDomain();
+
+  protected static Domain createDomain() {
+    return new Domain()
+        .withMetadata(new V1ObjectMeta().namespace(NS))
+        .withSpec(
+            new DomainSpec()
+                .withAdminSecret(SECRET)
+                .withAsName(AS_NAME)
+                .withAsPort(AS_PORT)
+                .withDomainName(DOMAIN_NAME)
+                .withDomainUID(DOMAIN_UID));
+  }
 
   protected abstract DomainConfigurator configureDomain(Domain domain);
 

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/AdminServerTest.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/AdminServerTest.java
@@ -1,0 +1,62 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class AdminServerTest extends BaseConfigurationTestBase {
+  private AdminServer server1;
+  private AdminServer server2;
+
+  public AdminServerTest() {
+    super(new AdminServer(), new AdminServer());
+    server1 = getInstance1();
+    server2 = getInstance2();
+  }
+
+  @Test
+  public void whenExportedAccessPointsAreTheSame_objectsAreEqual() {
+    server1
+        .addExportedNetworkAccessPoint("nap1")
+        .addLabel("label1", "value1")
+        .addAnnotation("annotation1", "value2");
+    server1.addExportedNetworkAccessPoint("nap2");
+    server2.addExportedNetworkAccessPoint("nap2");
+    server2
+        .addExportedNetworkAccessPoint("nap1")
+        .addAnnotation("annotation1", "value2")
+        .addLabel("label1", "value1");
+
+    assertThat(server1, equalTo(server1));
+  }
+
+  @Test
+  public void whenExportedAccessPointsDifferByName_objectsAreNotEqual() {
+    server1.addExportedNetworkAccessPoint("nap1");
+    server2.addExportedNetworkAccessPoint("nap2");
+
+    assertThat(server1, not(equalTo(server2)));
+  }
+
+  @Test
+  public void whenExportedAccessPointsDifferByLabel_objectsAreNotEqual() {
+    server1.addExportedNetworkAccessPoint("nap1").addLabel("a", "b");
+    server2.addExportedNetworkAccessPoint("nap1").addLabel("a", "c");
+
+    assertThat(server1, not(equalTo(server2)));
+  }
+
+  @Test
+  public void whenExportedAccessPointsDifferByAnnotation_objectsAreNotEqual() {
+    server1.addExportedNetworkAccessPoint("nap1").addAnnotation("a", "b");
+    server2.addExportedNetworkAccessPoint("nap1").addAnnotation("a", "c");
+
+    assertThat(server1, not(equalTo(server2)));
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/BaseConfigurationTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/BaseConfigurationTestBase.java
@@ -1,0 +1,87 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2; // Copyright 2018, Oracle Corporation and/or its
+// affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import io.kubernetes.client.models.V1EnvVar;
+import java.util.Arrays;
+import org.junit.Test;
+
+public abstract class BaseConfigurationTestBase {
+  private BaseConfiguration instance1;
+  private BaseConfiguration instance2;
+
+  BaseConfigurationTestBase(BaseConfiguration instance1, BaseConfiguration instance2) {
+    this.instance1 = instance1;
+    this.instance2 = instance2;
+  }
+
+  @SuppressWarnings("unchecked")
+  <T extends BaseConfiguration> T getInstance1() {
+    return (T) instance1;
+  }
+
+  @SuppressWarnings("unchecked")
+  <T extends BaseConfiguration> T getInstance2() {
+    return (T) instance2;
+  }
+
+  @Test
+  public void whenEnvironmentsAreTheSame_objectsAreEqual() {
+    instance1.setEnv(Arrays.asList(env("a", "b"), env("c", "d")));
+    instance2.addEnvironmentVariable("a", "b");
+    instance2.addEnvironmentVariable("c", "d");
+
+    assertThat(instance1, equalTo(instance2));
+  }
+
+  @Test
+  public void whenEnvironmentsDiffer_objectsAreNotEqual() {
+    instance1.setEnv(Arrays.asList(env("a", "b"), env("c", "d")));
+    instance2.addEnvironmentVariable("a", "b");
+
+    assertThat(instance1, not(equalTo(instance2)));
+  }
+
+  @Test
+  public void whenServerStartStatesAreSame_objectsAreEqual() {
+    instance1.setServerStartState("ADMIN");
+    instance2.setServerStartState("ADMIN");
+
+    assertThat(instance1, equalTo(instance2));
+  }
+
+  @Test
+  public void whenServerStartStatesDiffer_objectsAreNotEqual() {
+    instance1.setServerStartState("ADMIN");
+
+    assertThat(instance1, not(equalTo(instance2)));
+  }
+
+  @Test
+  public void whenServerStartPolicyAreSame_objectsAreEqual() {
+    instance1.setServerStartPolicy("IF_NEEDED");
+    instance2.setServerStartPolicy("IF_NEEDED");
+
+    assertThat(instance1, equalTo(instance2));
+  }
+
+  @Test
+  public void whenServerStartPoliciesDiffer_objectsAreNotEqual() {
+    instance1.setServerStartPolicy("NEVER");
+
+    assertThat(instance1, not(equalTo(instance2)));
+  }
+
+  private V1EnvVar env(String name, String value) {
+    return new V1EnvVar().name(name).value(value);
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/ClusterTest.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/ClusterTest.java
@@ -1,0 +1,53 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class ClusterTest extends BaseConfigurationTestBase {
+  private final Cluster cluster1;
+  private final Cluster cluster2;
+
+  public ClusterTest() {
+    super(new Cluster(), new Cluster());
+    cluster1 = getInstance1();
+    cluster2 = getInstance2();
+  }
+
+  @Test
+  public void whenNamesAreTheSame_objectsAreEqual() {
+    cluster1.setClusterName("one");
+    cluster2.setClusterName("one");
+
+    assertThat(cluster1, equalTo(cluster2));
+  }
+
+  @Test
+  public void whenNamesDiffer_objectsAreNotEqual() {
+    cluster1.setClusterName("one");
+    cluster2.setClusterName("two");
+
+    assertThat(cluster1, not(equalTo(cluster2)));
+  }
+
+  @Test
+  public void whenReplicasAreTheSame_objectsAreEqual() {
+    cluster1.setReplicas(3);
+    cluster2.setReplicas(3);
+
+    assertThat(cluster1, equalTo(cluster2));
+  }
+
+  @Test
+  public void whenReplicasDiffer_objectsAreNotEqual() {
+    cluster1.setReplicas(3);
+
+    assertThat(cluster1, not(equalTo(cluster2)));
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -417,6 +418,26 @@ public class DomainV2Test extends DomainTestBase {
     assertThat(spec.getReadinessProbe().getInitialDelaySeconds(), equalTo(INITIAL_DELAY));
     assertThat(spec.getReadinessProbe().getTimeoutSeconds(), equalTo(TIMEOUT));
     assertThat(spec.getReadinessProbe().getPeriodSeconds(), equalTo(PERIOD));
+  }
+
+  @Test
+  public void whenDomainsAreConfiguredAlike_objectsAreEqual() {
+    Domain domain1 = createDomain();
+
+    configureDomain(domain).configureCluster("cls1");
+    configureDomain(domain1).configureCluster("cls1");
+
+    assertThat(domain, equalTo(domain1));
+  }
+
+  @Test
+  public void whenDomainsHaveDifferentClusters_objectsAreNotEqual() {
+    Domain domain1 = createDomain();
+
+    configureDomain(domain).configureCluster("cls1").withReplicas(2);
+    configureDomain(domain1).configureCluster("cls1").withReplicas(3);
+
+    assertThat(domain, not(equalTo(domain1)));
   }
 
   @Test

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-3.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-3.yaml
@@ -19,17 +19,18 @@ spec:
   asPort: 8001
   # The WebLogic Domain Name
 
+  adminServer:
   # the T3 endpoints to export. Each entry is an endpoint name,
   # optionally with labels and annotations to be added to the generated external channel service.
   # An endpoint without any labels or endpoints must have the empty value: a pair of braces.
-  exportedNetworkAccessPoints:
-    channelA: {}
-    channelB:
-      labels:
-        age: 23
-        color: red
-      annotations:
-        time: midnight
+    exportedNetworkAccessPoints:
+      channelA: {}
+      channelB:
+        labels:
+          age: 23
+          color: red
+        annotations:
+          time: midnight
 
   domainName: base_domain
   # The domainUID must be unique across the entire Kubernetes Cluster.   Each WebLogic Domain must


### PR DESCRIPTION
The scaling test was failing because the equals() method on the Domain has ignoring v2 properties. The change also corrects the location of the exportedNetworkAccessPoints property, moving it from the domain to the adminServer.