### PR TITLE
Make default replica count configurable in v2

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -39,12 +39,9 @@ public abstract class DomainConfigurator {
    */
   public abstract AdminServerConfigurator configureAdminServer(String adminServerName);
 
-  /**
-   * Sets the default number of replicas to be run in a cluster.
-   *
-   * @param replicas a non-negative number
-   */
-  public abstract void withDefaultReplicaCount(int replicas);
+  public void withDefaultReplicaCount(int replicas) {
+    getDomainSpec().setReplicas(replicas);
+  }
 
   /**
    * Sets the default image for the domain.

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
@@ -29,4 +29,6 @@ public interface EffectiveConfigurationFactory {
   Map<String, String> getChannelServiceLabels(String channel);
 
   Map<String, String> getChannelServiceAnnotations(String channel);
+
+  Integer getDefaultReplicaLimit();
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainSpec.java
@@ -203,11 +203,8 @@ public class DomainSpec extends BaseConfiguration {
 
   /**
    * The desired number of running managed servers in each WebLogic cluster that is not explicitly
-   * configured in clusterStartup.
-   *
-   * @deprecated as of 2.0 defaults to Domain.DEFAULT_REPLICA_LIMIT
+   * configured in a cluster specification.
    */
-  @Deprecated
   @SerializedName("replicas")
   @Expose
   private Integer replicas;
@@ -762,7 +759,9 @@ public class DomainSpec extends BaseConfiguration {
   @SuppressWarnings("DeprecatedIsStillUsed")
   @Deprecated
   public Integer getReplicas() {
-    return replicas != null ? replicas : Domain.DEFAULT_REPLICA_LIMIT;
+    return replicas != null
+        ? replicas
+        : getEffectiveConfigurationFactory("weblogic.oracle/v1").getDefaultReplicaLimit();
   }
 
   /**
@@ -941,7 +940,9 @@ public class DomainSpec extends BaseConfiguration {
   }
 
   private int getReplicaCountFor(Cluster cluster) {
-    return hasReplicaCount(cluster) ? cluster.getReplicas() : Domain.DEFAULT_REPLICA_LIMIT;
+    return hasReplicaCount(cluster)
+        ? cluster.getReplicas()
+        : Optional.ofNullable(replicas).orElse(0);
   }
 
   private boolean hasReplicaCount(Cluster cluster) {
@@ -1007,6 +1008,11 @@ public class DomainSpec extends BaseConfiguration {
     @Override
     public Map<String, String> getChannelServiceAnnotations(String channel) {
       return Collections.emptyMap();
+    }
+
+    @Override
+    public Integer getDefaultReplicaLimit() {
+      return 2;
     }
 
     @SuppressWarnings("deprecation")
@@ -1079,6 +1085,11 @@ public class DomainSpec extends BaseConfiguration {
       ExportedNetworkAccessPoint accessPoint = getExportedNetworkAccessPoint(napName);
 
       return accessPoint == null ? Collections.emptyMap() : accessPoint.getAnnotations();
+    }
+
+    @Override
+    public Integer getDefaultReplicaLimit() {
+      return 0;
     }
 
     private Cluster getOrCreateCluster(String clusterName) {

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Configurator.java
@@ -46,11 +46,6 @@ public class DomainV1Configurator extends DomainConfigurator {
   }
 
   @Override
-  public void withDefaultReplicaCount(int replicas) {
-    getDomainSpec().setReplicas(replicas);
-  }
-
-  @Override
   public DomainConfigurator withPredefinedClaim(String claimName) {
     getDomainSpec().setStorage(DomainStorage.createPredefinedClaim(claimName));
     return this;

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -44,11 +44,6 @@ public class DomainV2Configurator extends DomainConfigurator {
   }
 
   @Override
-  public void withDefaultReplicaCount(int replicas) {
-    throw new ConfigurationNotSupportedException("domain", "defaultReplicas");
-  }
-
-  @Override
   public void withDefaultReadinessProbeSettings(
       Integer initialDelay, Integer timeout, Integer period) {
     ((BaseConfiguration) getDomainSpec()).setReadinessProbe(initialDelay, timeout, period);

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -279,11 +279,6 @@ public abstract class DomainTestBase {
   }
 
   @Test
-  public void whenNoReplicaCountSpecified_useDefaultValue() {
-    assertThat(domain.getReplicaCount("cluster1"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
-  }
-
-  @Test
   public void whenNoReplicaCountSpecified_canChangeIt() {
     domain.setReplicaCount("cluster1", 7);
 

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
@@ -251,4 +251,9 @@ public class DomainV1Test extends DomainTestBase {
     assertThat(probe.getFailureThreshold(), nullValue());
     assertThat(probe.getPeriodSeconds(), nullValue());
   }
+
+  @Test
+  public void whenNoReplicaCountSpecified_useDefaultValue() {
+    assertThat(domain.getReplicaCount("cluster1"), equalTo(Domain.DEFAULT_REPLICA_LIMIT));
+  }
 }

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-2.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-2.yaml
@@ -32,10 +32,16 @@ spec:
   # to be started to get to the cluster's replica count..
   serverStartPolicy: NEVER
 
+  # Specifies the number of replicas for any clusters which do not specify their own count:
+  replicas: 3
+
   # Configured storage using host-path style
   storage:
     generated:
       reclaimPolicy: Delete
       hostPath:
         path: /other/path
+
+  clusters:
+    - name: cluster1
 

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -26,6 +26,8 @@ spec:
   # The domainUID is also used to identify the Persistent Volume that belongs to/with this Domain.
   domainUID: test-domain
 
+  replicas: 2
+
   # The Operator currently does not support other images
   image: "store/oracle/weblogic:12.2.1.3"
   # imagePullPolicy defaults to "Always" if image version is :latest

--- a/operator/src/test/java/oracle/kubernetes/operator/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/rest/RestBackendImplTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 @SuppressWarnings("SameParameterValue")
 public class RestBackendImplTest {
 
+  private static final int REPLICA_LIMIT = 4;
   private static final String DOMAIN = "domain";
   private static final String NS = "namespace1";
   private static final String UID = "uid1";
@@ -140,7 +141,7 @@ public class RestBackendImplTest {
   }
 
   private ClusterConfigurator configureCluster(String clusterName) {
-    return configurator.configureCluster(clusterName);
+    return configureDomain().configureCluster(clusterName);
   }
 
   @Test
@@ -161,12 +162,15 @@ public class RestBackendImplTest {
 
   @Test
   public void whenNoPerClusterReplicaSettingAndDefaultMatchesRequest_doNothing() {
-    if (DomainConfiguratorFactory.useDomainV1())
-      configurator.withDefaultReplicaCount(Domain.DEFAULT_REPLICA_LIMIT);
+    configureDomain().withDefaultReplicaCount(REPLICA_LIMIT);
 
-    restBackend.scaleCluster(UID, "cluster1", Domain.DEFAULT_REPLICA_LIMIT);
+    restBackend.scaleCluster(UID, "cluster1", REPLICA_LIMIT);
 
     assertThat(getUpdatedDomain(), nullValue());
+  }
+
+  private DomainConfigurator configureDomain() {
+    return configurator;
   }
 
   private static class SecurityControl {


### PR DESCRIPTION
This restores the ability to configure the default replica count at the domain level, initializing it to 0.