### PR TITLE
OWLS-69372, Add option to disable operator and server Pod liveness probes.

### DIFF
--- a/model/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
+++ b/model/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
@@ -28,6 +28,7 @@ public interface KubernetesConstants {
   String CONTAINER_NAME = "weblogic-server";
 
   String DOMAIN_CONFIG_MAP_NAME = "weblogic-domain-cm";
+  String DOMAIN_DEBUG_CONFIG_MAP_NAME = "weblogic-domain-debug-cm";
   String API_VERSION_ORACLE_V2 = "weblogic.oracle/v2";
   String INTROSPECTOR_CONFIG_MAP_NAME_SUFFIX = "-weblogic-domain-introspect-cm";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -593,7 +593,15 @@ public abstract class PodStepContext implements StepContextConstants {
                     .configMap(
                         new V1ConfigMapVolumeSource()
                             .name(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
-                            .defaultMode(ALL_READ_AND_EXECUTE)));
+                            .defaultMode(ALL_READ_AND_EXECUTE)))
+            .addVolumesItem(
+                new V1Volume()
+                    .name(DEBUG_SCRIPTS_VOLUME)
+                    .configMap(
+                        new V1ConfigMapVolumeSource()
+                            .name(KubernetesConstants.DOMAIN_DEBUG_CONFIG_MAP_NAME)
+                            .defaultMode(ALL_READ_AND_EXECUTE)
+                            .optional(Boolean.TRUE)));
 
     if (isEnableDomainIntrospectorJob()) {
       podSpec.addVolumesItem(
@@ -636,6 +644,8 @@ public abstract class PodStepContext implements StepContextConstants {
             .addVolumeMountsItem(volumeMount(STORAGE_VOLUME, STORAGE_MOUNT_PATH))
             .addVolumeMountsItem(readOnlyVolumeMount(SECRETS_VOLUME, SECRETS_MOUNT_PATH))
             .addVolumeMountsItem(readOnlyVolumeMount(SCRIPTS_VOLUME, SCRIPTS_MOUNTS_PATH))
+            .addVolumeMountsItem(
+                readOnlyVolumeMount(DEBUG_SCRIPTS_VOLUME, DEBUG_SCRIPTS_MOUNTS_PATH))
             .readinessProbe(createReadinessProbe(tuningParameters.getPodTuning()))
             .livenessProbe(createLivenessProbe(tuningParameters.getPodTuning()));
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextConstants.java
@@ -4,10 +4,12 @@ public interface StepContextConstants {
 
   static final String SECRETS_VOLUME = "weblogic-credentials-volume";
   static final String SCRIPTS_VOLUME = "weblogic-domain-cm-volume";
+  static final String DEBUG_SCRIPTS_VOLUME = "weblogic-domain-debug-cm-volume";
   static final String SIT_CONFIG_MAP_VOLUME_SUFFIX = "-weblogic-domain-introspect-cm-volume";
   static final String STORAGE_VOLUME = "weblogic-domain-storage-volume";
   static final String SECRETS_MOUNT_PATH = "/weblogic-operator/secrets";
   static final String SCRIPTS_MOUNTS_PATH = "/weblogic-operator/scripts";
+  static final String DEBUG_SCRIPTS_MOUNTS_PATH = "/weblogic-operator/debug-scripts";
   static final String STORAGE_MOUNT_PATH = "/shared";
   static final String NODEMGR_HOME = "/u01/nodemanager";
   static final String DEFAULT_LOG_HOME = "/shared/logs";

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -14,12 +14,16 @@ DH=${DOMAIN_HOME?}
 
 STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
+# if the successful-liveness file is available, treat failures as success
+#
+RETVAL=$(test -f /weblogic-operator/debug-scripts/successful-liveness ; echo $?)
+
 if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
   echo "Error: WebLogic NodeManager process not found."
-  exit 1
+  exit $RETVAL
 fi
 if [ -f ${STATEFILE} ] && [ `grep -c "FAILED_NOT_RESTARTABLE" ${STATEFILE}` -eq 1 ]; then
   echo "Error: WebLogic Server state is FAILED_NOT_RESTARTABLE."
-  exit 1
+  exit $RETVAL
 fi
 exit 0

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -270,6 +270,8 @@ public abstract class PodHelperTestBase {
         containsInAnyOrder(
             writableVolumeMount("weblogic-domain-storage-volume", "/shared"),
             readOnlyVolumeMount("weblogic-credentials-volume", "/weblogic-operator/secrets"),
+            readOnlyVolumeMount(
+                "weblogic-domain-debug-cm-volume", "/weblogic-operator/debug-scripts"),
             readOnlyVolumeMount("weblogic-domain-cm-volume", "/weblogic-operator/scripts")));
   }
 


### PR DESCRIPTION
changes for supporting debugging by helping to prevent crash rollback

In this case 'the option' is implemented as a ConfigMap that the user can create with a particular entry