### PR TITLE
Move env, livenessProbe and readinessProbe under serverPod

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v1/ServerSpec.java
@@ -11,7 +11,6 @@ import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEP
 import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1LocalObjectReference;
 import io.kubernetes.client.models.V1PodSecurityContext;
-import io.kubernetes.client.models.V1Probe;
 import io.kubernetes.client.models.V1ResourceRequirements;
 import io.kubernetes.client.models.V1SecurityContext;
 import io.kubernetes.client.models.V1Volume;
@@ -23,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.weblogic.domain.v2.ProbeTuning;
 
 /** Represents the effective configuration for a server, as seen by the operator runtime. */
 @SuppressWarnings("WeakerAccess")
@@ -139,13 +139,13 @@ public abstract class ServerSpec {
   }
 
   @Nonnull
-  public V1Probe getLivenessProbe() {
-    return new V1Probe();
+  public ProbeTuning getLivenessProbe() {
+    return new ProbeTuning();
   }
 
   @Nonnull
-  public V1Probe getReadinessProbe() {
-    return new V1Probe();
+  public ProbeTuning getReadinessProbe() {
+    return new ProbeTuning();
   }
 
   @Nonnull

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
@@ -7,7 +7,6 @@ package oracle.kubernetes.weblogic.domain.v2;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1Probe;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -118,16 +117,16 @@ public abstract class BaseConfiguration {
     serverPod.setLivenessProbe(initialDelay, timeout, period);
   }
 
-  V1Probe getLivenessProbe() {
-    return serverPod.getLivenessProbe();
+  ProbeTuning getLivenessProbe() {
+    return serverPod.getLivenessProbeTuning();
   }
 
   void setReadinessProbe(Integer initialDelay, Integer timeout, Integer period) {
-    serverPod.setReadinessProbe(initialDelay, timeout, period);
+    serverPod.setReadinessProbeTuning(initialDelay, timeout, period);
   }
 
-  V1Probe getReadinessProbe() {
-    return serverPod.getReadinessProbe();
+  ProbeTuning getReadinessProbe() {
+    return serverPod.getReadinessProbeTuning();
   }
 
   @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
@@ -4,18 +4,13 @@
 
 package oracle.kubernetes.weblogic.domain.v2;
 
-import static java.util.Collections.emptyList;
-
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1Probe;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import javax.annotation.Nullable;
-import javax.validation.Valid;
 import oracle.kubernetes.json.Description;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -29,16 +24,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  */
 public abstract class BaseConfiguration {
 
-  /**
-   * Environment variables to pass while starting a server.
-   *
-   * @since 2.0
-   */
-  @SerializedName("env")
-  @Expose
-  @Valid
-  @Description("A list of environment variables to add to a server")
-  private List<V1EnvVar> env = new ArrayList<>();
+  @Description("Configuration affecting the server pod")
+  private ServerPod serverPod = new ServerPod();
 
   /** Desired startup state. Legal values are RUNNING or ADMIN. */
   @SerializedName("serverStartState")
@@ -62,28 +49,6 @@ public abstract class BaseConfiguration {
   private String serverStartPolicy;
 
   /**
-   * Defines the settings for the liveness probe. Any that are not specified will default to the
-   * runtime liveness probe tuning settings.
-   *
-   * @since 2.0
-   */
-  @SerializedName("livenessProbe")
-  @Expose
-  @Description("Settings for the liveness probe associated with a server")
-  private V1Probe livenessProbe = new V1Probe();
-
-  /**
-   * Defines the settings for the readiness probe. Any that are not specified will default to the
-   * runtime readiness probe tuning settings.
-   *
-   * @since 2.0
-   */
-  @SerializedName("readinessProbe")
-  @Expose
-  @Description("Settings for the readiness probe associated with a server")
-  private V1Probe readinessProbe = new V1Probe();
-
-  /**
    * Fills in any undefined settings in this configuration from another configuration.
    *
    * @param other the other configuration which can override this one
@@ -94,9 +59,7 @@ public abstract class BaseConfiguration {
     if (serverStartState == null) serverStartState = other.getServerStartState();
     if (overrideStartPolicyFrom(other)) serverStartPolicy = other.getServerStartPolicy();
 
-    for (V1EnvVar var : getV1EnvVars(other)) addIfMissing(var);
-    copyValues(livenessProbe, other.livenessProbe);
-    copyValues(readinessProbe, other.readinessProbe);
+    serverPod.fillInFrom(other.serverPod);
   }
 
   private boolean overrideStartPolicyFrom(BaseConfiguration other) {
@@ -112,37 +75,13 @@ public abstract class BaseConfiguration {
     return Objects.equals(getServerStartPolicy(), ConfigurationConstants.START_NEVER);
   }
 
-  private List<V1EnvVar> getV1EnvVars(BaseConfiguration configuration) {
-    return Optional.ofNullable(configuration.getEnv()).orElse(emptyList());
-  }
-
-  private void addIfMissing(V1EnvVar var) {
-    if (!hasEnvVar(var.getName())) addEnvVar(var);
-  }
-
-  private boolean hasEnvVar(String name) {
-    if (env == null) return false;
-    for (V1EnvVar var : env) {
-      if (var.getName().equals(name)) return true;
-    }
-    return false;
-  }
-
-  private void copyValues(V1Probe toProbe, V1Probe fromProbe) {
-    if (toProbe.getInitialDelaySeconds() == null)
-      toProbe.setInitialDelaySeconds(fromProbe.getInitialDelaySeconds());
-    if (toProbe.getTimeoutSeconds() == null)
-      toProbe.setTimeoutSeconds(fromProbe.getTimeoutSeconds());
-    if (toProbe.getPeriodSeconds() == null) toProbe.setPeriodSeconds(fromProbe.getPeriodSeconds());
-  }
-
   /**
    * Returns true if any version 2 configuration fields are specified.
    *
    * @return whether there is version 2 configuration field in this instance
    */
   protected boolean hasV2Fields() {
-    return serverStartState != null || serverStartPolicy != null || !env.isEmpty();
+    return serverStartState != null || serverStartPolicy != null || serverPod.hasV2Fields();
   }
 
   @Nullable
@@ -156,20 +95,15 @@ public abstract class BaseConfiguration {
 
   @Nullable
   public List<V1EnvVar> getEnv() {
-    return env;
+    return serverPod.getEnv();
   }
 
   public void setEnv(@Nullable List<V1EnvVar> env) {
-    this.env = env;
+    serverPod.setEnv(env);
   }
 
   void addEnvironmentVariable(String name, String value) {
-    addEnvVar(new V1EnvVar().name(name).value(value));
-  }
-
-  private void addEnvVar(V1EnvVar var) {
-    if (env == null) setEnv(new ArrayList<>());
-    env.add(var);
+    serverPod.addEnvVar(new V1EnvVar().name(name).value(value));
   }
 
   void setServerStartPolicy(String serverStartPolicy) {
@@ -181,19 +115,19 @@ public abstract class BaseConfiguration {
   }
 
   void setLivenessProbe(Integer initialDelay, Integer timeout, Integer period) {
-    livenessProbe.initialDelaySeconds(initialDelay).timeoutSeconds(timeout).periodSeconds(period);
+    serverPod.setLivenessProbe(initialDelay, timeout, period);
   }
 
   V1Probe getLivenessProbe() {
-    return livenessProbe;
+    return serverPod.getLivenessProbe();
   }
 
   void setReadinessProbe(Integer initialDelay, Integer timeout, Integer period) {
-    readinessProbe.initialDelaySeconds(initialDelay).timeoutSeconds(timeout).periodSeconds(period);
+    serverPod.setReadinessProbe(initialDelay, timeout, period);
   }
 
   V1Probe getReadinessProbe() {
-    return readinessProbe;
+    return serverPod.getReadinessProbe();
   }
 
   @Override
@@ -201,13 +135,7 @@ public abstract class BaseConfiguration {
     return new ToStringBuilder(this)
         .append("serverStartState", serverStartState)
         .append("serverStartPolicy", serverStartPolicy)
-        .append("livenessProbe.initialDelaySeconds", livenessProbe.getInitialDelaySeconds())
-        .append("livenessProbe.timeoutSeconds", livenessProbe.getTimeoutSeconds())
-        .append("livenessProbe.periodSeconds", livenessProbe.getPeriodSeconds())
-        .append("readinessProbeProbe.initialDelaySeconds", readinessProbe.getInitialDelaySeconds())
-        .append("readinessProbe.timeoutSeconds", readinessProbe.getTimeoutSeconds())
-        .append("readinessProbe.periodSeconds", readinessProbe.getPeriodSeconds())
-        .append("env", env)
+        .append("serverPod", serverPod)
         .toString();
   }
 
@@ -220,22 +148,18 @@ public abstract class BaseConfiguration {
     BaseConfiguration that = (BaseConfiguration) o;
 
     return new EqualsBuilder()
-        .append(env, that.env)
+        .append(serverPod, that.serverPod)
         .append(serverStartState, that.serverStartState)
         .append(serverStartPolicy, that.serverStartPolicy)
-        .append(livenessProbe, that.livenessProbe)
-        .append(readinessProbe, that.readinessProbe)
         .isEquals();
   }
 
   @Override
   public int hashCode() {
     return new HashCodeBuilder(17, 37)
-        .append(env)
+        .append(serverPod)
         .append(serverStartState)
         .append(serverStartPolicy)
-        .append(livenessProbe)
-        .append(readinessProbe)
         .toHashCode();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ProbeTuning.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ProbeTuning.java
@@ -1,0 +1,86 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import com.google.gson.annotations.SerializedName;
+import oracle.kubernetes.json.Description;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class ProbeTuning {
+  @Description("The number of seconds before the first check is performed")
+  private Integer initialDelaySeconds = null;
+
+  @Description("The number of seconds between checks")
+  @SerializedName("periodSeconds")
+  private Integer periodSeconds = null;
+
+  @Description("The number of seconds with no response that indicates a failure")
+  @SerializedName("timeoutSeconds")
+  private Integer timeoutSeconds = null;
+
+  public ProbeTuning() {}
+
+  public Integer getInitialDelaySeconds() {
+    return initialDelaySeconds;
+  }
+
+  public ProbeTuning initialDelaySeconds(Integer initialDelaySeconds) {
+    this.initialDelaySeconds = initialDelaySeconds;
+    return this;
+  }
+
+  public Integer getPeriodSeconds() {
+    return periodSeconds;
+  }
+
+  public ProbeTuning periodSeconds(Integer periodSeconds) {
+    this.periodSeconds = periodSeconds;
+    return this;
+  }
+
+  public Integer getTimeoutSeconds() {
+    return timeoutSeconds;
+  }
+
+  public ProbeTuning timeoutSeconds(Integer timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("initialDelaySeconds", initialDelaySeconds)
+        .append("periodSeconds", periodSeconds)
+        .append("timeoutSeconds", timeoutSeconds)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ProbeTuning that = (ProbeTuning) o;
+
+    return new EqualsBuilder()
+        .append(initialDelaySeconds, that.initialDelaySeconds)
+        .append(periodSeconds, that.periodSeconds)
+        .append(timeoutSeconds, that.timeoutSeconds)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(initialDelaySeconds)
+        .append(periodSeconds)
+        .append(timeoutSeconds)
+        .toHashCode();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
@@ -1,0 +1,163 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static java.util.Collections.emptyList;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1Probe;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import oracle.kubernetes.json.Description;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+class ServerPod {
+
+  /**
+   * Environment variables to pass while starting a server.
+   *
+   * @since 2.0
+   */
+  @SerializedName("env")
+  @Expose
+  @Valid
+  @Description("A list of environment variables to add to a server")
+  private List<V1EnvVar> env = new ArrayList<>();
+
+  /**
+   * Defines the settings for the liveness probe. Any that are not specified will default to the
+   * runtime liveness probe tuning settings.
+   *
+   * @since 2.0
+   */
+  @SerializedName("livenessProbe")
+  @Expose
+  @Description("Settings for the liveness probe associated with a server")
+  private V1Probe livenessProbe = new V1Probe();
+
+  /**
+   * Defines the settings for the readiness probe. Any that are not specified will default to the
+   * runtime readiness probe tuning settings.
+   *
+   * @since 2.0
+   */
+  @SerializedName("readinessProbe")
+  @Expose
+  @Description("Settings for the readiness probe associated with a server")
+  private V1Probe readinessProbe = new V1Probe();
+
+  V1Probe getReadinessProbe() {
+    return this.readinessProbe;
+  }
+
+  void setReadinessProbe(Integer initialDelay, Integer timeout, Integer period) {
+    this.readinessProbe
+        .initialDelaySeconds(initialDelay)
+        .timeoutSeconds(timeout)
+        .periodSeconds(period);
+  }
+
+  boolean hasV2Fields() {
+    return !this.env.isEmpty();
+  }
+
+  void fillInFrom(ServerPod serverPod1) {
+    for (V1EnvVar var : serverPod1.getV1EnvVars()) addIfMissing(var);
+    copyValues(livenessProbe, serverPod1.livenessProbe);
+    copyValues(readinessProbe, serverPod1.readinessProbe);
+  }
+
+  private List<V1EnvVar> getV1EnvVars() {
+    return Optional.ofNullable(getEnv()).orElse(emptyList());
+  }
+
+  private void addIfMissing(V1EnvVar var) {
+    if (!hasEnvVar(var.getName())) addEnvVar(var);
+  }
+
+  private boolean hasEnvVar(String name) {
+    if (env == null) return false;
+    for (V1EnvVar var : env) {
+      if (var.getName().equals(name)) return true;
+    }
+    return false;
+  }
+
+  private static void copyValues(V1Probe toProbe, V1Probe fromProbe) {
+    if (toProbe.getInitialDelaySeconds() == null)
+      toProbe.setInitialDelaySeconds(fromProbe.getInitialDelaySeconds());
+    if (toProbe.getTimeoutSeconds() == null)
+      toProbe.setTimeoutSeconds(fromProbe.getTimeoutSeconds());
+    if (toProbe.getPeriodSeconds() == null) toProbe.setPeriodSeconds(fromProbe.getPeriodSeconds());
+  }
+
+  List<V1EnvVar> getEnv() {
+    return this.env;
+  }
+
+  void addEnvVar(V1EnvVar var) {
+    if (this.env == null) setEnv(new ArrayList<>());
+    this.env.add(var);
+  }
+
+  void setEnv(@Nullable List<V1EnvVar> env) {
+    this.env = env;
+  }
+
+  V1Probe getLivenessProbe() {
+    return this.livenessProbe;
+  }
+
+  void setLivenessProbe(Integer initialDelay, Integer timeout, Integer period) {
+    this.livenessProbe
+        .initialDelaySeconds(initialDelay)
+        .timeoutSeconds(timeout)
+        .periodSeconds(period);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("env", env)
+        .append("livenessProbe.initialDelaySeconds", livenessProbe.getInitialDelaySeconds())
+        .append("livenessProbe.timeoutSeconds", livenessProbe.getTimeoutSeconds())
+        .append("livenessProbe.periodSeconds", livenessProbe.getPeriodSeconds())
+        .append("readinessProbeProbe.initialDelaySeconds", readinessProbe.getInitialDelaySeconds())
+        .append("readinessProbe.timeoutSeconds", readinessProbe.getTimeoutSeconds())
+        .append("readinessProbe.periodSeconds", readinessProbe.getPeriodSeconds())
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ServerPod that = (ServerPod) o;
+
+    return new EqualsBuilder()
+        .append(env, that.env)
+        .append(livenessProbe, that.livenessProbe)
+        .append(readinessProbe, that.readinessProbe)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(env)
+        .append(livenessProbe)
+        .append(readinessProbe)
+        .toHashCode();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
@@ -9,7 +9,6 @@ import static java.util.Collections.emptyList;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1Probe;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +41,7 @@ class ServerPod {
   @SerializedName("livenessProbe")
   @Expose
   @Description("Settings for the liveness probe associated with a server")
-  private V1Probe livenessProbe = new V1Probe();
+  private ProbeTuning livenessProbeTuning = new ProbeTuning();
 
   /**
    * Defines the settings for the readiness probe. Any that are not specified will default to the
@@ -53,14 +52,25 @@ class ServerPod {
   @SerializedName("readinessProbe")
   @Expose
   @Description("Settings for the readiness probe associated with a server")
-  private V1Probe readinessProbe = new V1Probe();
+  private ProbeTuning readinessProbeTuning = new ProbeTuning();
 
-  V1Probe getReadinessProbe() {
-    return this.readinessProbe;
+  ProbeTuning getReadinessProbeTuning() {
+    return this.readinessProbeTuning;
   }
 
-  void setReadinessProbe(Integer initialDelay, Integer timeout, Integer period) {
-    this.readinessProbe
+  void setReadinessProbeTuning(Integer initialDelay, Integer timeout, Integer period) {
+    this.readinessProbeTuning
+        .initialDelaySeconds(initialDelay)
+        .timeoutSeconds(timeout)
+        .periodSeconds(period);
+  }
+
+  ProbeTuning getLivenessProbeTuning() {
+    return this.livenessProbeTuning;
+  }
+
+  void setLivenessProbe(Integer initialDelay, Integer timeout, Integer period) {
+    this.livenessProbeTuning
         .initialDelaySeconds(initialDelay)
         .timeoutSeconds(timeout)
         .periodSeconds(period);
@@ -72,8 +82,8 @@ class ServerPod {
 
   void fillInFrom(ServerPod serverPod1) {
     for (V1EnvVar var : serverPod1.getV1EnvVars()) addIfMissing(var);
-    copyValues(livenessProbe, serverPod1.livenessProbe);
-    copyValues(readinessProbe, serverPod1.readinessProbe);
+    copyValues(livenessProbeTuning, serverPod1.livenessProbeTuning);
+    copyValues(readinessProbeTuning, serverPod1.readinessProbeTuning);
   }
 
   private List<V1EnvVar> getV1EnvVars() {
@@ -92,12 +102,11 @@ class ServerPod {
     return false;
   }
 
-  private static void copyValues(V1Probe toProbe, V1Probe fromProbe) {
+  private static void copyValues(ProbeTuning toProbe, ProbeTuning fromProbe) {
     if (toProbe.getInitialDelaySeconds() == null)
-      toProbe.setInitialDelaySeconds(fromProbe.getInitialDelaySeconds());
-    if (toProbe.getTimeoutSeconds() == null)
-      toProbe.setTimeoutSeconds(fromProbe.getTimeoutSeconds());
-    if (toProbe.getPeriodSeconds() == null) toProbe.setPeriodSeconds(fromProbe.getPeriodSeconds());
+      toProbe.initialDelaySeconds(fromProbe.getInitialDelaySeconds());
+    if (toProbe.getTimeoutSeconds() == null) toProbe.timeoutSeconds(fromProbe.getTimeoutSeconds());
+    if (toProbe.getPeriodSeconds() == null) toProbe.periodSeconds(fromProbe.getPeriodSeconds());
   }
 
   List<V1EnvVar> getEnv() {
@@ -113,27 +122,12 @@ class ServerPod {
     this.env = env;
   }
 
-  V1Probe getLivenessProbe() {
-    return this.livenessProbe;
-  }
-
-  void setLivenessProbe(Integer initialDelay, Integer timeout, Integer period) {
-    this.livenessProbe
-        .initialDelaySeconds(initialDelay)
-        .timeoutSeconds(timeout)
-        .periodSeconds(period);
-  }
-
   @Override
   public String toString() {
     return new ToStringBuilder(this)
         .append("env", env)
-        .append("livenessProbe.initialDelaySeconds", livenessProbe.getInitialDelaySeconds())
-        .append("livenessProbe.timeoutSeconds", livenessProbe.getTimeoutSeconds())
-        .append("livenessProbe.periodSeconds", livenessProbe.getPeriodSeconds())
-        .append("readinessProbeProbe.initialDelaySeconds", readinessProbe.getInitialDelaySeconds())
-        .append("readinessProbe.timeoutSeconds", readinessProbe.getTimeoutSeconds())
-        .append("readinessProbe.periodSeconds", readinessProbe.getPeriodSeconds())
+        .append("livenessProbe", livenessProbeTuning)
+        .append("readinessProbe", readinessProbeTuning)
         .toString();
   }
 
@@ -147,8 +141,8 @@ class ServerPod {
 
     return new EqualsBuilder()
         .append(env, that.env)
-        .append(livenessProbe, that.livenessProbe)
-        .append(readinessProbe, that.readinessProbe)
+        .append(livenessProbeTuning, that.livenessProbeTuning)
+        .append(readinessProbeTuning, that.readinessProbeTuning)
         .isEquals();
   }
 
@@ -156,8 +150,8 @@ class ServerPod {
   public int hashCode() {
     return new HashCodeBuilder(17, 37)
         .append(env)
-        .append(livenessProbe)
-        .append(readinessProbe)
+        .append(livenessProbeTuning)
+        .append(readinessProbeTuning)
         .toHashCode();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
@@ -9,7 +9,6 @@ import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_NEVER;
 
 import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1Probe;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -85,13 +84,13 @@ public abstract class ServerSpecV2Impl extends ServerSpec {
 
   @Nonnull
   @Override
-  public V1Probe getLivenessProbe() {
+  public ProbeTuning getLivenessProbe() {
     return server.getLivenessProbe();
   }
 
   @Nonnull
   @Override
-  public V1Probe getReadinessProbe() {
+  public ProbeTuning getReadinessProbe() {
     return server.getReadinessProbe();
   }
 }

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v1/DomainV1Test.java
@@ -17,10 +17,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-import io.kubernetes.client.models.V1Probe;
 import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainTestBase;
+import oracle.kubernetes.weblogic.domain.v2.ProbeTuning;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -235,20 +235,20 @@ public class DomainV1Test extends DomainTestBase {
   @Test
   public void livenessProbeSettings_returnsNullValues() {
     ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-    V1Probe probe = spec.getLivenessProbe();
+    ProbeTuning probe = spec.getLivenessProbe();
 
     assertThat(probe.getInitialDelaySeconds(), nullValue());
-    assertThat(probe.getFailureThreshold(), nullValue());
+    assertThat(probe.getTimeoutSeconds(), nullValue());
     assertThat(probe.getPeriodSeconds(), nullValue());
   }
 
   @Test
   public void readinessProbeSettings_returnsNullValues() {
     ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
-    V1Probe probe = spec.getReadinessProbe();
+    ProbeTuning probe = spec.getReadinessProbe();
 
     assertThat(probe.getInitialDelaySeconds(), nullValue());
-    assertThat(probe.getFailureThreshold(), nullValue());
+    assertThat(probe.getTimeoutSeconds(), nullValue());
     assertThat(probe.getPeriodSeconds(), nullValue());
   }
 

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -606,6 +606,26 @@ public class DomainV2Test extends DomainTestBase {
   }
 
   @Test
+  public void whenDomain2ReadFromYaml_serverConfiguresReadinessProbe() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_2);
+    ServerSpec serverSpec = domain.getServer("server2", "cluster1");
+
+    assertThat(serverSpec.getReadinessProbe().getInitialDelaySeconds(), equalTo(10));
+    assertThat(serverSpec.getReadinessProbe().getTimeoutSeconds(), equalTo(15));
+    assertThat(serverSpec.getReadinessProbe().getPeriodSeconds(), equalTo(20));
+  }
+
+  @Test
+  public void whenDomain2ReadFromYaml_serverConfiguresLivenessProbe() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_2);
+    ServerSpec serverSpec = domain.getServer("server2", "cluster1");
+
+    assertThat(serverSpec.getLivenessProbe().getInitialDelaySeconds(), equalTo(20));
+    assertThat(serverSpec.getLivenessProbe().getTimeoutSeconds(), equalTo(5));
+    assertThat(serverSpec.getLivenessProbe().getPeriodSeconds(), equalTo(18));
+  }
+
+  @Test
   public void whenDomain3ReadFromYaml_PredefinedStorageDefinesClaimName() throws IOException {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_3);
 

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-2.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-2.yaml
@@ -43,5 +43,21 @@ spec:
         path: /other/path
 
   clusters:
-    - name: cluster1
+    - clusterName: cluster1
+      serverPod:
+        readinessProbe:
+          initialDelaySeconds: 10
+          timeoutSeconds: 15
+          periodSeconds: 20
+        livenessProbe:
+          initialDelaySeconds: 20
+          timeoutSeconds: 5
+          periodSeconds: 20
+
+  managedServers:
+    - serverName: server2
+      serverPod:
+        livenessProbe:
+          periodSeconds: 18
+
 

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -36,9 +36,11 @@ spec:
   imagePullSecrets:
   - name: pull-secret1
   - name: pull-secret2
-  env:
-  - name: var1
-    value: value0
+
+  serverPod:
+    env:
+    - name: var1
+      value: value0
 
   # Configured storage using nfs style
   storage:
@@ -51,20 +53,23 @@ spec:
   adminServer:
     # The Admin Server's NodePort (optional)
     nodePort: 7001
-    env:
-    - name: var1
-      value: value1
+    serverPod:
+      env:
+      - name: var1
+        value: value1
 
   # list of configurations per named server.
   managedServers:
     # the name of the server to apply these rules to
   - serverName: server1
     # an (optional) list of environment variable to be set on the server
-    env:
-    - name: JAVA_OPTIONS
-      value: "-server"
-    - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+    serverPod:
+      env:
+      - name: JAVA_OPTIONS
+        value: "-server"
+      - name: USER_MEM_ARGS
+        value: "-Xms64m -Xmx256m "
+        
   - serverName: server2
     serverStartState: ADMIN
 
@@ -75,8 +80,9 @@ spec:
   - clusterName: cluster2
     desiredState: "RUNNING"
     replicas: 5
-    env:
-    - name: JAVA_OPTIONS
-      value: "-verbose"
-    - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+    serverPod:
+      env:
+      - name: JAVA_OPTIONS
+        value: "-verbose"
+      - name: USER_MEM_ARGS
+        value: "-Xms64m -Xmx256m "


### PR DESCRIPTION
OWLS-69904: This change moves the already-implemented fields under a new serverPod element. 