### PR TITLE
OWLS-69262 part1: add weblogicConfigurationOverridesSecretNames to domain spec

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -165,6 +165,15 @@ public abstract class DomainConfigurator {
   }
 
   /**
+   * Sets the WebLogic configuration overrides secret names for the domain
+   *
+   * @param secretNames a list of secret names
+   * @return this object
+   */
+  public abstract DomainConfigurator withWeblogicConfigurationOverridesSecretNames(
+      String... secretNames);
+
+  /**
    * Sets the default settings for the readiness probe. Any settings left null will default to the
    * tuning parameters.
    *

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -155,6 +155,16 @@ public class DomainSpec extends BaseConfiguration {
   private DomainStorage storage;
 
   /**
+   * The additional WebLogic Configuration secrets.
+   *
+   * @since 2.0
+   */
+  @Description("A list of names of the secrets for the WebLogic configurations.")
+  @SerializedName("weblogicConfigurationOverridesSecretNames")
+  @Expose
+  private List<String> weblogicConfigurationOverridesSecretNames;
+
+  /**
    * The configuration for the admin server.
    *
    * @since 2.0
@@ -490,6 +500,23 @@ public class DomainSpec extends BaseConfiguration {
     return storage;
   }
 
+  private boolean hasWeblogicConfigurationOverridesSecretNames() {
+    return weblogicConfigurationOverridesSecretNames != null
+        && weblogicConfigurationOverridesSecretNames.size() != 0;
+  }
+
+  @Nullable
+  public List<String> getWeblogicConfigurationOverridesSecretNames() {
+    if (hasWeblogicConfigurationOverridesSecretNames())
+      return weblogicConfigurationOverridesSecretNames;
+    else return Collections.emptyList();
+  }
+
+  public void setWeblogicConfigurationOverridesSecretNames(
+      @Nullable List<String> overridesSecretNames) {
+    this.weblogicConfigurationOverridesSecretNames = overridesSecretNames;
+  }
+
   /**
    * Returns the name of the persistent volume claim for the logs and PV-based domain.
    *
@@ -527,7 +554,10 @@ public class DomainSpec extends BaseConfiguration {
             .append("adminServer", adminServer)
             .append("managedServers", managedServers)
             .append("clusters", clusters)
-            .append("replicas", replicas);
+            .append("replicas", replicas)
+            .append(
+                "weblogicConfigurationOverridesSecretNames",
+                weblogicConfigurationOverridesSecretNames);
 
     return builder.toString();
   }
@@ -549,7 +579,8 @@ public class DomainSpec extends BaseConfiguration {
             .append(adminServer)
             .append(managedServers)
             .append(clusters)
-            .append(replicas);
+            .append(replicas)
+            .append(weblogicConfigurationOverridesSecretNames);
 
     return builder.toHashCode();
   }
@@ -575,7 +606,10 @@ public class DomainSpec extends BaseConfiguration {
             .append(adminServer, rhs.adminServer)
             .append(managedServers, rhs.managedServers)
             .append(clusters, rhs.clusters)
-            .append(replicas, rhs.replicas);
+            .append(replicas, rhs.replicas)
+            .append(
+                weblogicConfigurationOverridesSecretNames,
+                rhs.weblogicConfigurationOverridesSecretNames);
 
     return builder.isEquals();
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -159,7 +159,7 @@ public class DomainSpec extends BaseConfiguration {
    *
    * @since 2.0
    */
-  @Description("A list of names of the secrets for the WebLogic configurations.")
+  @Description("A list of names of the secrets for optional WebLogic configuration overrides.")
   @SerializedName("weblogicConfigurationOverridesSecretNames")
   @Expose
   private List<String> weblogicConfigurationOverridesSecretNames;

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -155,7 +155,7 @@ public class DomainSpec extends BaseConfiguration {
   private DomainStorage storage;
 
   /**
-   * The additional WebLogic Configuration secrets.
+   * The list of names of the Kubernetes secrets used in the WebLogic Configuration overrides.
    *
    * @since 2.0
    */

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -9,6 +9,7 @@ import static oracle.kubernetes.operator.VersionConstants.DOMAIN_V2;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_ALWAYS;
 import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_NEVER;
 
+import java.util.Arrays;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
@@ -73,6 +74,18 @@ public class DomainV2Configurator extends DomainConfigurator {
   @Override
   public DomainConfigurator withAdditionalVolumeMount(String name, String path) {
     ((BaseConfiguration) getDomainSpec()).addAdditionalVolumeMount(name, path);
+    return this;
+  }
+
+  @Override
+  /**
+   * Sets the WebLogic configuration overrides secret names for the domain
+   *
+   * @param secretNames a list of secret names
+   * @return this object
+   */
+  public DomainConfigurator withWeblogicConfigurationOverridesSecretNames(String... secretNames) {
+    getDomainSpec().setWeblogicConfigurationOverridesSecretNames(Arrays.asList(secretNames));
     return this;
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
@@ -84,6 +84,15 @@ public abstract class ServerSpec {
     }
   }
 
+  /**
+   * The secret names used in WebLogic configuration overrides
+   *
+   * @return a list of secret names. May be empty.
+   */
+  public List<String> getWeblogicConfigurationOverridesSecretNames() {
+    return domainSpec.getWeblogicConfigurationOverridesSecretNames();
+  }
+
   @SuppressWarnings("SameParameterValue")
   private V1EnvVar getOrCreateVar(List<V1EnvVar> env, String name) {
     for (V1EnvVar var : env) {

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -498,6 +498,9 @@ public class DomainV2Test extends DomainTestBase {
     assertThat(serverSpec.getImagePullSecrets().get(0).getName(), equalTo("pull-secret1"));
     assertThat(serverSpec.getImagePullSecrets().get(1).getName(), equalTo("pull-secret2"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
+    assertThat(
+        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
     assertThat(serverSpec.shouldStart(1), is(true));
   }
@@ -512,6 +515,9 @@ public class DomainV2Test extends DomainTestBase {
     assertThat(serverSpec.getImagePullPolicy(), equalTo(IFNOTPRESENT_IMAGEPULLPOLICY));
     assertThat(serverSpec.getImagePullSecrets().get(0).getName(), equalTo("pull-secret1"));
     assertThat(serverSpec.getImagePullSecrets().get(1).getName(), equalTo("pull-secret2"));
+    assertThat(
+        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
     assertThat(serverSpec.shouldStart(1), is(true));
@@ -538,6 +544,9 @@ public class DomainV2Test extends DomainTestBase {
             envVar("JAVA_OPTIONS", "-server"),
             envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
             envVar("var1", "value0")));
+    assertThat(
+        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
   }
 
   @Test
@@ -552,6 +561,9 @@ public class DomainV2Test extends DomainTestBase {
             envVar("JAVA_OPTIONS", "-Dweblogic.management.startupMode=ADMIN -verbose"),
             envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
             envVar("var1", "value0")));
+    assertThat(
+        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
   }
 
   @Test

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -48,6 +48,9 @@ spec:
         server: thatServer
         path: /local/path
 
+  # configured wls configuration overrides secret names
+  weblogicConfigurationOverridesSecretNames: [overrides-secret-1, overrides-secret-2]
+
   adminServer:
     # The Admin Server's NodePort (optional)
     nodePort: 7001


### PR DESCRIPTION
1) Add weblogicConfigurationOverridesSecretNames to domain spec.
2) add unit tests

Note: part2 will be done in another PR, which will update domain introspector job to mount the specified secrets. Part2 needs to be done in the introspector branch or in develop branch after the introspector branch is merged.

Questions @rjeberhard @moreaut @mriccell : shall we shorten the attribute name  weblogicConfigurationOverridesSecretNames? We have another long name in the domain spec: weblogicConfigurationOverridesConfigMapName, which I think can be shortened as well.