### PR TITLE
Support more options for schema generation

### DIFF
--- a/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/ExternalSchema.java
+++ b/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/ExternalSchema.java
@@ -1,0 +1,28 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.json.mojo;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+class ExternalSchema {
+
+  private String url;
+  private String cache;
+
+  ExternalSchema(String url, String cache) {
+    this.url = url;
+    this.cache = cache;
+  }
+
+  URL getUrl() throws MalformedURLException {
+    return new URL(url);
+  }
+
+  URL getCacheURL(String baseDir) throws MalformedURLException {
+    return new File(new File(baseDir), cache).toURI().toURL();
+  }
+}

--- a/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/Main.java
+++ b/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/Main.java
@@ -5,13 +5,46 @@
 package oracle.kubernetes.json.mojo;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import org.apache.maven.plugin.MojoExecutionException;
 
 public interface Main {
 
-  /** Specify the Kubernetes version to support. */
-  void setKubernetesVersion(String version) throws MojoExecutionException;
+  /**
+   * Defines an external schema URL to be used for object definitions
+   *
+   * @param schemaURL the schema URL
+   * @param cacheUrl a file url specifying a local cache of the schema
+   * @throws IOException if there is a problem using the URLs
+   */
+  void defineSchemaUrlAndContents(URL schemaURL, URL cacheUrl) throws IOException;
+
+  /**
+   * Specifies that deprecated fields should be included when generating a schema. If false, they
+   * will be ignored.
+   *
+   * @param includeDeprecated true if deprecated fields should be included
+   */
+  void setIncludeDeprecated(boolean includeDeprecated);
+
+  /**
+   * Specifies that the "additionalProperties" property will be added to the schema for each object
+   * and set to false, to forbid any unspecified properties
+   *
+   * @param includeAdditionalProperties true if unspecified properties should cause validation to
+   *     fail
+   */
+  void setIncludeAdditionalProperties(boolean includeAdditionalProperties);
+
+  /**
+   * Specifies that object fields will be implemented as references using the $ref field, and any
+   * not defined in an external schema will be added to "definitions." If false, they will be
+   * represented as inline definitions.
+   *
+   * @param supportObjectReferences true if objects are to be represented as references
+   */
+  void setSupportObjectReferences(boolean supportObjectReferences);
 
   /**
    * Specify the classpath for the class whose schema is to be built

--- a/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/MainImpl.java
+++ b/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/MainImpl.java
@@ -15,15 +15,20 @@ import org.apache.maven.plugin.MojoExecutionException;
 public class MainImpl implements Main {
   private SchemaGenerator generator = new SchemaGenerator();
   private ClassLoader classLoader;
-  private String rootClassName;
 
   @Override
-  public void setKubernetesVersion(String version) throws MojoExecutionException {
-    try {
-      generator.useKubernetesVersion(version);
-    } catch (IOException e) {
-      throw new MojoExecutionException("Unable to set Kubernetes version", e);
-    }
+  public void setIncludeDeprecated(boolean includeDeprecated) {
+    generator.setIncludeDeprecated(includeDeprecated);
+  }
+
+  @Override
+  public void setIncludeAdditionalProperties(boolean includeAdditionalProperties) {
+    generator.setIncludeAdditionalProperties(includeAdditionalProperties);
+  }
+
+  @Override
+  public void setSupportObjectReferences(boolean supportObjectReferences) {
+    generator.setSupportObjectReferences(supportObjectReferences);
   }
 
   @Override
@@ -36,6 +41,12 @@ public class MainImpl implements Main {
     return classLoader.getResource(name);
   }
 
+  @Override
+  public void defineSchemaUrlAndContents(URL schemaURL, URL cacheUrl) throws IOException {
+    generator.addExternalSchema(schemaURL, cacheUrl);
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override
   public void generateSchema(String className, File outputFile) throws MojoExecutionException {
     outputFile.getParentFile().mkdirs();

--- a/json-schema-maven-plugin/src/test/java/oracle/kubernetes/json/mojo/TestMain.java
+++ b/json-schema-maven-plugin/src/test/java/oracle/kubernetes/json/mojo/TestMain.java
@@ -5,30 +5,28 @@
 package oracle.kubernetes.json.mojo;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.apache.maven.plugin.MojoExecutionException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TestMain implements Main {
-  private String version;
   private URL[] classpath;
-  private IOException badKubernetesVersionException;
   private URL classpathResource;
   private String className;
   private File outputFile;
   private String resourceName;
+  private boolean includeDeprecated;
+  private Map<URL, URL> schemas = new HashMap<>();
+  private boolean includeAdditionalProperties;
+  private boolean supportObjectReferences;
 
   TestMain() throws MalformedURLException {
     classpathResource = new URL("file:abc");
   }
 
-  String getVersion() {
-    return version;
-  }
-
-  void reportBadKubernetesException() {
-    badKubernetesVersionException = new IOException();
+  boolean isIncludeDeprecated() {
+    return includeDeprecated;
   }
 
   URL[] getClasspath() {
@@ -51,9 +49,36 @@ public class TestMain implements Main {
     return outputFile;
   }
 
+  URL getCacheFor(URL schemaUrl) {
+    return schemas.get(schemaUrl);
+  }
+
+  boolean isIncludeAdditionalProperties() {
+    return includeAdditionalProperties;
+  }
+
+  boolean isSupportObjectReferences() {
+    return supportObjectReferences;
+  }
+
   @Override
-  public void setKubernetesVersion(String version) {
-    this.version = version;
+  public void setSupportObjectReferences(boolean supportObjectReferences) {
+    this.supportObjectReferences = supportObjectReferences;
+  }
+
+  @Override
+  public void defineSchemaUrlAndContents(URL schemaURL, URL cacheUrl) {
+    schemas.put(schemaURL, cacheUrl);
+  }
+
+  @Override
+  public void setIncludeDeprecated(boolean includeDeprecated) {
+    this.includeDeprecated = includeDeprecated;
+  }
+
+  @Override
+  public void setIncludeAdditionalProperties(boolean includeAdditionalProperties) {
+    this.includeAdditionalProperties = includeAdditionalProperties;
   }
 
   @Override
@@ -68,9 +93,8 @@ public class TestMain implements Main {
   }
 
   @Override
-  public void generateSchema(String className, File outputFile) throws MojoExecutionException {
+  public void generateSchema(String className, File outputFile) {
     this.className = className;
     this.outputFile = outputFile;
-    if (badKubernetesVersionException != null) throw new MojoExecutionException("bad version");
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ProbeTuning.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ProbeTuning.java
@@ -24,6 +24,12 @@ public class ProbeTuning {
 
   public ProbeTuning() {}
 
+  void copyValues(ProbeTuning fromProbe) {
+    if (initialDelaySeconds == null) initialDelaySeconds(fromProbe.initialDelaySeconds);
+    if (timeoutSeconds == null) timeoutSeconds(fromProbe.timeoutSeconds);
+    if (periodSeconds == null) periodSeconds(fromProbe.periodSeconds);
+  }
+
   public Integer getInitialDelaySeconds() {
     return initialDelaySeconds;
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
@@ -105,8 +105,8 @@ class ServerPod {
 
   void fillInFrom(ServerPod serverPod1) {
     for (V1EnvVar var : serverPod1.getV1EnvVars()) addIfMissing(var);
-    copyValues(livenessProbeTuning, serverPod1.livenessProbeTuning);
-    copyValues(readinessProbeTuning, serverPod1.readinessProbeTuning);
+    livenessProbeTuning.copyValues(serverPod1.livenessProbeTuning);
+    readinessProbeTuning.copyValues(serverPod1.readinessProbeTuning);
     for (V1Volume var : serverPod1.getAdditionalVolumes()) addIfMissing(var);
     for (V1VolumeMount var : serverPod1.getAdditionalVolumeMounts()) addIfMissing(var);
   }
@@ -147,13 +147,6 @@ class ServerPod {
 
   private void addIfMissing(V1VolumeMount var) {
     if (!hasVolumeMountName(var.getName())) addAdditionalVolumeMount(var);
-  }
-
-  private static void copyValues(ProbeTuning toProbe, ProbeTuning fromProbe) {
-    if (toProbe.getInitialDelaySeconds() == null)
-      toProbe.initialDelaySeconds(fromProbe.getInitialDelaySeconds());
-    if (toProbe.getTimeoutSeconds() == null) toProbe.timeoutSeconds(fromProbe.getTimeoutSeconds());
-    if (toProbe.getPeriodSeconds() == null) toProbe.periodSeconds(fromProbe.getPeriodSeconds());
   }
 
   List<V1EnvVar> getEnv() {


### PR DESCRIPTION
With this change, it is now possible to configure the plugin to:

- disable the "additionalProperties" field (required for K8s CRD validation)
- generate object fields in-line rather than using the $ref field (required for K8s CRD validation)
- specify the name and location of the file to generate (needed to generate one for validation and one for the website) 