### PR TITLE
Shorten weblogicConfigurationOverridesSecretNames 

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -170,8 +170,7 @@ public abstract class DomainConfigurator {
    * @param secretNames a list of secret names
    * @return this object
    */
-  public abstract DomainConfigurator withWeblogicConfigurationOverridesSecretNames(
-      String... secretNames);
+  public abstract DomainConfigurator withConfigOverrideSecrets(String... secretNames);
 
   /**
    * Sets the default settings for the readiness probe. Any settings left null will default to the

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -160,9 +160,9 @@ public class DomainSpec extends BaseConfiguration {
    * @since 2.0
    */
   @Description("A list of names of the secrets for optional WebLogic configuration overrides.")
-  @SerializedName("weblogicConfigurationOverridesSecretNames")
+  @SerializedName("configOverrideSecrets")
   @Expose
-  private List<String> weblogicConfigurationOverridesSecretNames;
+  private List<String> configOverrideSecrets;
 
   /**
    * The configuration for the admin server.
@@ -500,21 +500,18 @@ public class DomainSpec extends BaseConfiguration {
     return storage;
   }
 
-  private boolean hasWeblogicConfigurationOverridesSecretNames() {
-    return weblogicConfigurationOverridesSecretNames != null
-        && weblogicConfigurationOverridesSecretNames.size() != 0;
+  private boolean hasConfigOverrideSecrets() {
+    return configOverrideSecrets != null && configOverrideSecrets.size() != 0;
   }
 
   @Nullable
-  public List<String> getWeblogicConfigurationOverridesSecretNames() {
-    if (hasWeblogicConfigurationOverridesSecretNames())
-      return weblogicConfigurationOverridesSecretNames;
+  public List<String> getConfigOverrideSecrets() {
+    if (hasConfigOverrideSecrets()) return configOverrideSecrets;
     else return Collections.emptyList();
   }
 
-  public void setWeblogicConfigurationOverridesSecretNames(
-      @Nullable List<String> overridesSecretNames) {
-    this.weblogicConfigurationOverridesSecretNames = overridesSecretNames;
+  public void setConfigOverrideSecrets(@Nullable List<String> overridesSecretNames) {
+    this.configOverrideSecrets = overridesSecretNames;
   }
 
   /**
@@ -555,9 +552,7 @@ public class DomainSpec extends BaseConfiguration {
             .append("managedServers", managedServers)
             .append("clusters", clusters)
             .append("replicas", replicas)
-            .append(
-                "weblogicConfigurationOverridesSecretNames",
-                weblogicConfigurationOverridesSecretNames);
+            .append("configOverrideSecrets", configOverrideSecrets);
 
     return builder.toString();
   }
@@ -580,7 +575,7 @@ public class DomainSpec extends BaseConfiguration {
             .append(managedServers)
             .append(clusters)
             .append(replicas)
-            .append(weblogicConfigurationOverridesSecretNames);
+            .append(configOverrideSecrets);
 
     return builder.toHashCode();
   }
@@ -607,9 +602,7 @@ public class DomainSpec extends BaseConfiguration {
             .append(managedServers, rhs.managedServers)
             .append(clusters, rhs.clusters)
             .append(replicas, rhs.replicas)
-            .append(
-                weblogicConfigurationOverridesSecretNames,
-                rhs.weblogicConfigurationOverridesSecretNames);
+            .append(configOverrideSecrets, rhs.configOverrideSecrets);
 
     return builder.isEquals();
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -84,8 +84,8 @@ public class DomainV2Configurator extends DomainConfigurator {
    * @param secretNames a list of secret names
    * @return this object
    */
-  public DomainConfigurator withWeblogicConfigurationOverridesSecretNames(String... secretNames) {
-    getDomainSpec().setWeblogicConfigurationOverridesSecretNames(Arrays.asList(secretNames));
+  public DomainConfigurator withConfigOverrideSecrets(String... secretNames) {
+    getDomainSpec().setConfigOverrideSecrets(Arrays.asList(secretNames));
     return this;
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
@@ -89,8 +89,8 @@ public abstract class ServerSpec {
    *
    * @return a list of secret names. May be empty.
    */
-  public List<String> getWeblogicConfigurationOverridesSecretNames() {
-    return domainSpec.getWeblogicConfigurationOverridesSecretNames();
+  public List<String> getConfigOverrideSecrets() {
+    return domainSpec.getConfigOverrideSecrets();
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -499,7 +499,7 @@ public class DomainV2Test extends DomainTestBase {
     assertThat(serverSpec.getImagePullSecrets().get(1).getName(), equalTo("pull-secret2"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
     assertThat(
-        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        serverSpec.getConfigOverrideSecrets(),
         containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
     assertThat(serverSpec.shouldStart(1), is(true));
@@ -516,7 +516,7 @@ public class DomainV2Test extends DomainTestBase {
     assertThat(serverSpec.getImagePullSecrets().get(0).getName(), equalTo("pull-secret1"));
     assertThat(serverSpec.getImagePullSecrets().get(1).getName(), equalTo("pull-secret2"));
     assertThat(
-        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        serverSpec.getConfigOverrideSecrets(),
         containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
     assertThat(serverSpec.getEnvironmentVariables(), contains(envVar("var1", "value0")));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
@@ -545,7 +545,7 @@ public class DomainV2Test extends DomainTestBase {
             envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
             envVar("var1", "value0")));
     assertThat(
-        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        serverSpec.getConfigOverrideSecrets(),
         containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
   }
 
@@ -562,7 +562,7 @@ public class DomainV2Test extends DomainTestBase {
             envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
             envVar("var1", "value0")));
     assertThat(
-        serverSpec.getWeblogicConfigurationOverridesSecretNames(),
+        serverSpec.getConfigOverrideSecrets(),
         containsInAnyOrder("overrides-secret-1", "overrides-secret-2"));
   }
 

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -49,7 +49,7 @@ spec:
         path: /local/path
 
   # configured wls configuration overrides secret names
-  weblogicConfigurationOverridesSecretNames: [overrides-secret-1, overrides-secret-2]
+  configOverrideSecrets: [overrides-secret-1, overrides-secret-2]
 
   adminServer:
     # The Admin Server's NodePort (optional)


### PR DESCRIPTION
Change weblogicConfigurationOverridesSecretNames  to configOverrideSecrets.

Signed-off-by: doxiao <dongbo.xiao@oracle.com>