### PR TITLE
fix weblogic-kubernetes-operator image path

### DIFF
--- a/kubernetes/create-weblogic-operator-inputs.yaml
+++ b/kubernetes/create-weblogic-operator-inputs.yaml
@@ -22,7 +22,7 @@ targetNamespaces: default
 # The docker image containing the operator code.
 # Ensure that the image is built or published to an appropriate registry
 # See https://github.com/oracle/weblogic-kubernetes-operator/blob/master/site/installation.md
-weblogicOperatorImage: weblogic-kubernetes-operator:1.1
+weblogicOperatorImage: oracle/weblogic-kubernetes-operator:1.1
 
 # The image pull policy for the operator docker image.
 weblogicOperatorImagePullPolicy: IfNotPresent


### PR DESCRIPTION
On Docker hub the image available under: oracle/weblogic-kubernetes-operator path.