### PR TITLE
fix curl command to send request to different domains

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -318,7 +318,11 @@ public class Domain {
       testAppUrl.append(webappName).append("/");
       // curl cmd to call webapp
       StringBuffer curlCmd = new StringBuffer("curl --silent ");
-      curlCmd.append(" -H 'host:").append(domainUid).append(".org' ").append(testAppUrl.toString());
+      curlCmd
+          .append(" -H 'host: ")
+          .append(domainUid)
+          .append(".org' ")
+          .append(testAppUrl.toString());
 
       // curl cmd to get response code
       StringBuffer curlCmdResCode = new StringBuffer(curlCmd.toString());

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -315,19 +315,22 @@ public class Domain {
       if (loadBalancer.equals("APACHE")) {
         testAppUrl.append("weblogic/");
       }
-      testAppUrl.append(webappName).append("/"); // curl cmd to call webapp
-      StringBuffer curlCmd = new StringBuffer("curl --silent --show-error --noproxy ");
-      curlCmd
-          .append(TestUtils.getHostName())
-          .append(" ")
-          .append(testAppUrl.toString()); // curl cmd to get response code
+      testAppUrl.append(webappName).append("/");
+      // curl cmd to call webapp
+      StringBuffer curlCmd = new StringBuffer("curl --silent ");
+      curlCmd.append(" -H 'host:").append(domainUid).append(".org' ").append(testAppUrl.toString());
+
+      // curl cmd to get response code
       StringBuffer curlCmdResCode = new StringBuffer(curlCmd.toString());
-      curlCmdResCode.append(
-          " --write-out %{http_code} -o /dev/null"); // call webapp iteratively till its
-      // deployed/ready
-      callWebAppAndWaitTillReady(
-          curlCmdResCode
-              .toString()); // execute curl and look for the managed server name in response
+      curlCmdResCode.append(" --write-out %{http_code} -o /dev/null");
+
+      logger.info("Curd cmd with response code " + curlCmdResCode);
+      logger.info("Curd cmd " + curlCmd);
+
+      // call webapp iteratively till its deployed/ready
+      callWebAppAndWaitTillReady(curlCmdResCode.toString());
+
+      // execute curl and look for the managed server name in response
       callWebAppAndCheckForServerNameInResponse(curlCmd.toString(), verifyLoadBalance);
       // logger.info("curlCmd "+curlCmd);
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -113,7 +113,8 @@ public class TestUtils {
     if (System.getenv("K8S_NODEPORT_HOST") != null) {
       return System.getenv("K8S_NODEPORT_HOST");
     } else {
-      ExecResult result = ExecCommand.exec("hostname | awk -F. '{print $1}'");
+      // ExecResult result = ExecCommand.exec("hostname | awk -F. '{print $1}'");
+      ExecResult result = ExecCommand.exec("hostname");
       return result.stdout().trim();
     }
   }


### PR DESCRIPTION
changed curl command to send request to different domains using the below format for traefik host routing ingress..
curl --silent -H 'host: domain1.org' http://${HOSTNAME}:30305/testwebapp/

Now the request is sent to the correct domain. earlier the webapp request was not sent to the correct domain and the test was failing with 
[ERROR] test5CreateConfiguredDomainInTest2NS(oracle.kubernetes.operator.ITOperator) Time elapsed: 626.775 s <<< ERROR!
java.lang.RuntimeException: FAILURE: Load balancer can not reach server domain4-managed-server1

now its failing with below error because of the issue - https://jira.oraclecorp.com/jira/browse/OWLS-70125
[ERROR] test5CreateConfiguredDomainInTest2NS(oracle.kubernetes.operator.ITOperator)  Time elapsed: 1,316.09 s  <<< ERROR!
java.lang.RuntimeException: FAILURE: testwebapp did not return 200 status code, got 503
	at oracle.kubernetes.operator.utils.Domain.callWebAppAndWaitTillReady(Domain.java:700)

Here is the jenkins run - http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/372/consoleFull