### PR TITLE
Monitor failing test

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -417,8 +417,10 @@ public class DomainPresenceInfo {
     @Override
     public ServerKubernetesObjects putIfAbsent(String key, ServerKubernetesObjects value) {
       ServerKubernetesObjects result = delegate.putIfAbsent(key, value);
+      DomainPresenceMonitor.putIfAbsent(key, result);
       if (result == null) {
         Domain d = domain.get();
+        DomainPresenceMonitor.putIfAbsentDomain(d);
         if (d != null) {
           ServerKubernetesObjectsManager.register(d.getSpec().getDomainUID(), key, value);
         }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceMonitor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceMonitor.java
@@ -1,0 +1,48 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import oracle.kubernetes.weblogic.domain.v2.Domain;
+
+class DomainPresenceMonitor {
+
+  private static String serverNameAsKey;
+  private static ServerKubernetesObjects result;
+  private static Domain domain;
+  private static String serverName;
+
+  static void clear() {
+    serverNameAsKey = null;
+    domain = null;
+    serverName = null;
+  }
+
+  static String getExplanation() {
+    StringBuilder sb = new StringBuilder();
+    if (serverNameAsKey != null)
+      format(sb, "putIfAbsent called with %s and returned %s", serverNameAsKey, result);
+    if (domain != null) format(sb, "Domain was not null");
+    if (serverName != null) format(sb, "registered with key %s", serverName);
+
+    return sb.toString();
+  }
+
+  private static void format(StringBuilder sb, String pattern, Object... values) {
+    sb.append(String.format(pattern, values)).append("\n");
+  }
+
+  static void putIfAbsent(String key, ServerKubernetesObjects result) {
+    DomainPresenceMonitor.serverNameAsKey = key;
+    DomainPresenceMonitor.result = result;
+  }
+
+  static void putIfAbsentDomain(Domain domain) {
+    DomainPresenceMonitor.domain = domain;
+  }
+
+  static void registered(String registeredName) {
+    DomainPresenceMonitor.serverName = registeredName;
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceMonitor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceMonitor.java
@@ -11,12 +11,13 @@ class DomainPresenceMonitor {
   private static String serverNameAsKey;
   private static ServerKubernetesObjects result;
   private static Domain domain;
-  private static String serverName;
+  private static String registeredName;
+  private static String unregisteredName;
 
   static void clear() {
     serverNameAsKey = null;
     domain = null;
-    serverName = null;
+    registeredName = null;
   }
 
   static String getExplanation() {
@@ -24,7 +25,8 @@ class DomainPresenceMonitor {
     if (serverNameAsKey != null)
       format(sb, "putIfAbsent called with %s and returned %s", serverNameAsKey, result);
     if (domain != null) format(sb, "Domain was not null");
-    if (serverName != null) format(sb, "registered with key %s", serverName);
+    if (registeredName != null) format(sb, "registered with key %s", registeredName);
+    if (unregisteredName != null) format(sb, "unregistered with key %s", unregisteredName);
 
     return sb.toString();
   }
@@ -43,6 +45,10 @@ class DomainPresenceMonitor {
   }
 
   static void registered(String registeredName) {
-    DomainPresenceMonitor.serverName = registeredName;
+    DomainPresenceMonitor.registeredName = registeredName;
+  }
+
+  static void unregistered(String unregisteredName) {
+    DomainPresenceMonitor.unregisteredName = unregisteredName;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsManager.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsManager.java
@@ -30,6 +30,7 @@ public class ServerKubernetesObjectsManager {
   }
 
   static void register(String domainUID, String serverName, ServerKubernetesObjects sko) {
+    DomainPresenceMonitor.registered(serverName);
     serverMap.put(LegalNames.toServerName(domainUID, serverName), sko);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsManager.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsManager.java
@@ -35,6 +35,7 @@ public class ServerKubernetesObjectsManager {
   }
 
   static void unregister(String domainUID, String serverName) {
+    DomainPresenceMonitor.unregistered(serverName);
     serverMap.remove(LegalNames.toServerName(domainUID, serverName));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
@@ -16,6 +16,7 @@ import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.models.V1ObjectMeta;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.weblogic.domain.v2.Domain;
@@ -38,6 +39,13 @@ public class ServerKubernetesObjectsLookupTest {
         protected void failed(Throwable e, Description description) {
           super.failed(e, description);
           System.out.println("Tell Russell\n" + DomainPresenceMonitor.getExplanation());
+          try {
+            Memento serverMap =
+                StaticStubSupport.preserve(ServerKubernetesObjectsManager.class, "serverMap");
+            Map<String, ServerKubernetesObjects> map = serverMap.getOriginalValue();
+            System.out.println("   " + map);
+          } catch (NoSuchFieldException ignored) {
+          }
         }
       };
 
@@ -50,6 +58,7 @@ public class ServerKubernetesObjectsLookupTest {
     mementos.add(
         StaticStubSupport.install(
             ServerKubernetesObjectsManager.class, "serverMap", new ConcurrentHashMap<>()));
+    DomainPresenceMonitor.clear();
   }
 
   @After

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjectsLookupTest.java
@@ -22,11 +22,24 @@ import oracle.kubernetes.weblogic.domain.v2.Domain;
 import oracle.kubernetes.weblogic.domain.v2.DomainSpec;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public class ServerKubernetesObjectsLookupTest {
 
   private List<Memento> mementos = new ArrayList<>();
+
+  @Rule
+  public TestWatcher watcher =
+      new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+          super.failed(e, description);
+          System.out.println("Tell Russell\n" + DomainPresenceMonitor.getExplanation());
+        }
+      };
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
Added logic to monitor the behavior of the test that is failing in wercker. It should have virtually no impact in production (just calling some setters).

An earlier version of this did fail - only enough to rule out some possible sources of error. I have added some more logic in hopes of figuring out what is going on.