### PR TITLE
changes in what to run in QUICKTEST and add debug for liveness probe test

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -148,6 +148,7 @@ public class BaseTest {
    */
   public void testAdminServerExternalService(Domain domain) throws Exception {
     logger.info("Inside testAdminServerExternalService");
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     domain.verifyAdminServerExternalService(getUsername(), getPassword());
     logger.info("Done - testAdminServerExternalService");
   }
@@ -159,6 +160,7 @@ public class BaseTest {
    */
   public void testAdminT3Channel(Domain domain) throws Exception {
     logger.info("Inside testAdminT3Channel");
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     Map<String, Object> domainMap = domain.getDomainMap();
     // check if the property is set to true
     Boolean exposeAdmint3Channel = (Boolean) domainMap.get("exposeAdminT3Channel");
@@ -185,6 +187,7 @@ public class BaseTest {
    */
   public void testDomainLifecyle(Operator operator, Domain domain) throws Exception {
     logger.info("Inside testDomainLifecyle");
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     domain.destroy();
     domain.create();
     operator.verifyExternalRESTService();
@@ -203,6 +206,7 @@ public class BaseTest {
    */
   public void testClusterScaling(Operator operator, Domain domain) throws Exception {
     logger.info("Inside testClusterScaling");
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     Map<String, Object> domainMap = domain.getDomainMap();
     String domainUid = domain.getDomainUid();
     String domainNS = domainMap.get("namespace").toString();
@@ -320,6 +324,7 @@ public class BaseTest {
    */
   public void testOperatorLifecycle(Operator operator, Domain domain) throws Exception {
     logger.info("Inside testOperatorLifecycle");
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     operator.destroy();
     operator.create();
     operator.verifyExternalRESTService();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -187,7 +187,6 @@ public class BaseTest {
    */
   public void testDomainLifecyle(Operator operator, Domain domain) throws Exception {
     logger.info("Inside testDomainLifecyle");
-    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     domain.destroy();
     domain.create();
     operator.verifyExternalRESTService();
@@ -324,7 +323,6 @@ public class BaseTest {
    */
   public void testOperatorLifecycle(Operator operator, Domain domain) throws Exception {
     logger.info("Inside testOperatorLifecycle");
-    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
     operator.destroy();
     operator.create();
     operator.verifyExternalRESTService();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -263,6 +263,7 @@ public class BaseTest {
    */
   public void testWLDFScaling(Operator operator, Domain domain) throws Exception {
     logger.info("Inside testWLDFScaling");
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
 
     Map<String, Object> domainMap = domain.getDomainMap();
     String domainUid = domain.getDomainUid();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -88,7 +88,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS");
   }
 
-  @Test
+  // @Test
   public void test1CreateFirstOperatorAndDomain() throws Exception {
 
     logTestBegin("test1CreateFirstOperatorAndDomain");
@@ -97,7 +97,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test1CreateFirstOperatorAndDomain");
   }
 
-  @Test
+  // @Test
   public void test2CreateAnotherDomainInDefaultNS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -115,7 +115,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test2CreateAnotherDomainInDefaultNS");
   }
 
-  @Test
+  // @Test
   public void test3CreateDomainInTest1NS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -132,7 +132,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test3CreateDomainInTest1NS");
   }
 
-  @Test
+  // @Test
   public void test4CreateAnotherOperatorManagingTest2NS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -144,7 +144,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test4CreateAnotherOperatorManagingTest2NS");
   }
 
-  @Test
+  // @Test
   public void test5CreateConfiguredDomainInTest2NS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -183,7 +183,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test5CreateConfiguredDomainInTest2NS");
   }
 
-  @Test
+  // @Test
   public void test6CreateDomainWithStartPolicyAdminOnly() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -199,7 +199,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test6CreateDomainWithStartPolicyAdminOnly");
   }
 
-  @Test
+  // @Test
   public void test7CreateDomainPVReclaimPolicyRecycle() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -238,7 +238,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test8WlsLivenessProbe");
   }
 
-  @Test
+  // @Test
   public void test9CreateDomainOnExistingDir() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -273,7 +273,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - testACreateDomainApacheLB");
   }
 
-  @Test
+  // @Test
   public void testBCreateDomainWithDefaultValuesInSampleInputs() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -88,7 +88,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS");
   }
 
-  // @Test
+  @Test
   public void test1CreateFirstOperatorAndDomain() throws Exception {
 
     logTestBegin("test1CreateFirstOperatorAndDomain");
@@ -97,7 +97,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test1CreateFirstOperatorAndDomain");
   }
 
-  // @Test
+  @Test
   public void test2CreateAnotherDomainInDefaultNS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -115,10 +115,8 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test2CreateAnotherDomainInDefaultNS");
   }
 
-  // @Test
+  @Test
   public void test3CreateDomainInTest1NS() throws Exception {
-    Assume.assumeFalse(
-        System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
 
     logTestBegin("test3CreateDomainInTest1NS");
     logger.info("Creating Domain domain3 & verifing the domain creation");
@@ -132,7 +130,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test3CreateDomainInTest1NS");
   }
 
-  // @Test
+  @Test
   public void test4CreateAnotherOperatorManagingTest2NS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -144,7 +142,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test4CreateAnotherOperatorManagingTest2NS");
   }
 
-  // @Test
+  @Test
   public void test5CreateConfiguredDomainInTest2NS() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -183,7 +181,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test5CreateConfiguredDomainInTest2NS");
   }
 
-  // @Test
+  @Test
   public void test6CreateDomainWithStartPolicyAdminOnly() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -199,7 +197,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test6CreateDomainWithStartPolicyAdminOnly");
   }
 
-  // @Test
+  @Test
   public void test7CreateDomainPVReclaimPolicyRecycle() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -219,8 +217,6 @@ public class ITOperator extends BaseTest {
 
   @Test
   public void test8WlsLivenessProbe() throws Exception {
-    Assume.assumeFalse(
-        System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
 
     logTestBegin("test8WlsLivenessProbe");
     logger.info("Checking if operator1 is running, if not creating");
@@ -238,7 +234,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - test8WlsLivenessProbe");
   }
 
-  // @Test
+  @Test
   public void test9CreateDomainOnExistingDir() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
@@ -273,7 +269,7 @@ public class ITOperator extends BaseTest {
     logger.info("SUCCESS - testACreateDomainApacheLB");
   }
 
-  // @Test
+  @Test
   public void testBCreateDomainWithDefaultValuesInSampleInputs() throws Exception {
     Assume.assumeFalse(
         System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -126,7 +126,7 @@ public class ITOperator extends BaseTest {
     }
     // create domain3
     Domain domain3 = testDomainCreation(domain3YamlFile);
-    
+
     logger.info("SUCCESS - test3CreateDomainInTest1NS");
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -296,7 +296,7 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain & verifing the domain creation");
     // create domain1
     Domain domain = testDomainCreation(domainYamlFile);
-    if (System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true")) {
+    if (System.getenv("WERCKER") != null && System.getenv("WERCKER").equalsIgnoreCase("true")) {
       testDomainLifecyle(operator, domain);
       testOperatorLifecycle(operator, domain);
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -296,7 +296,9 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain & verifing the domain creation");
     // create domain1
     Domain domain = testDomainCreation(domainYamlFile);
-    if (System.getenv("WERCKER") != null && System.getenv("WERCKER").equalsIgnoreCase("true")) {
+    if (System.getenv("QUICKTEST") == null
+        || (System.getenv("QUICKTEST") != null
+            && !System.getenv("QUICKTEST").equalsIgnoreCase("true"))) {
       testDomainLifecyle(operator, domain);
       testOperatorLifecycle(operator, domain);
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -118,6 +118,8 @@ public class ITOperator extends BaseTest {
 
   @Test
   public void test3CreateDomainInTest1NS() throws Exception {
+    Assume.assumeFalse(
+        System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true"));
 
     logTestBegin("test3CreateDomainInTest1NS");
     logger.info("Creating Domain domain3 & verifing the domain creation");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -94,6 +94,7 @@ public class ITOperator extends BaseTest {
     logTestBegin("test1CreateFirstOperatorAndDomain");
     testCreateOperatorManagingDefaultAndTest1NS();
     domain1 = testAllUseCasesForADomain(operator1, domain1YamlFile);
+    testWLDFScaling(operator1, domain1);
     logger.info("SUCCESS - test1CreateFirstOperatorAndDomain");
   }
 
@@ -125,8 +126,7 @@ public class ITOperator extends BaseTest {
     }
     // create domain3
     Domain domain3 = testDomainCreation(domain3YamlFile);
-
-    testWLDFScaling(operator1, domain3);
+    
     logger.info("SUCCESS - test3CreateDomainInTest1NS");
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -94,7 +94,6 @@ public class ITOperator extends BaseTest {
     logTestBegin("test1CreateFirstOperatorAndDomain");
     testCreateOperatorManagingDefaultAndTest1NS();
     domain1 = testAllUseCasesForADomain(operator1, domain1YamlFile);
-    testWLDFScaling(operator1, domain1);
     logger.info("SUCCESS - test1CreateFirstOperatorAndDomain");
   }
 
@@ -128,7 +127,7 @@ public class ITOperator extends BaseTest {
     }
     // create domain3
     Domain domain3 = testDomainCreation(domain3YamlFile);
-
+    testWLDFScaling(operator1, domain3);
     logger.info("SUCCESS - test3CreateDomainInTest1NS");
   }
 
@@ -297,9 +296,11 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain & verifing the domain creation");
     // create domain1
     Domain domain = testDomainCreation(domainYamlFile);
-    // testDomainLifecyle(operator, domain);
-    // testClusterScaling(operator, domain);
-    // testOperatorLifecycle(operator, domain);
+    if (System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true")) {
+      testDomainLifecyle(operator, domain);
+      testOperatorLifecycle(operator, domain);
+    }
+    testClusterScaling(operator, domain);
     return domain;
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -297,9 +297,9 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain & verifing the domain creation");
     // create domain1
     Domain domain = testDomainCreation(domainYamlFile);
-    testDomainLifecyle(operator, domain);
-    testClusterScaling(operator, domain);
-    testOperatorLifecycle(operator, domain);
+    // testDomainLifecyle(operator, domain);
+    // testClusterScaling(operator, domain);
+    // testOperatorLifecycle(operator, domain);
     return domain;
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -230,7 +230,9 @@ public class TestUtils {
 
     // kill server process 3 times
     for (int i = 0; i < 3; i++) {
-      kubectlexecNoCheck(podName, namespace, "/shared/killserver.sh");
+      ExecResult result = kubectlexecNoCheck(podName, namespace, "/shared/killserver.sh");
+      logger.info("result exitValue " + result.exitValue());
+      logger.info("result stdout " + result.stdout() + " stderr " + result.stderr());
       Thread.sleep(2 * 1000);
     }
     // one more time so that liveness probe restarts
@@ -241,6 +243,7 @@ public class TestUtils {
     while (true) {
       long currentTime = System.currentTimeMillis();
       int finalRestartCnt = getPodRestartCount(podName, namespace);
+      logger.info("initialRestartCnt " + initialRestartCnt + " finalRestartCnt" + finalRestartCnt);
       if ((finalRestartCnt - initialRestartCnt) == 1) {
         logger.info("WLS liveness probe test is successful.");
         break;
@@ -301,6 +304,8 @@ public class TestUtils {
         .append(" ")
         .append(scriptPath);
 
+    ExecResult result = ExecCommand.exec("kubectl get pods -n " + namespace);
+    logger.info("get pods before killing the server " + result.stdout() + "\n " + result.stderr());
     logger.info("Command to call kubectl sh file " + cmdKubectlSh);
     return ExecCommand.exec(cmdKubectlSh.toString());
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -231,8 +231,9 @@ public class TestUtils {
     // kill server process 3 times
     for (int i = 0; i < 3; i++) {
       ExecResult result = kubectlexecNoCheck(podName, namespace, "/shared/killserver.sh");
-      logger.info("result exitValue " + result.exitValue());
-      logger.info("result stdout " + result.stdout() + " stderr " + result.stderr());
+      logger.info("kill server process command exitValue " + result.exitValue());
+      logger.info(
+          "kill server process command result " + result.stdout() + " stderr " + result.stderr());
       Thread.sleep(2 * 1000);
     }
     // one more time so that liveness probe restarts
@@ -243,7 +244,7 @@ public class TestUtils {
     while (true) {
       long currentTime = System.currentTimeMillis();
       int finalRestartCnt = getPodRestartCount(podName, namespace);
-      logger.info("initialRestartCnt " + initialRestartCnt + " finalRestartCnt" + finalRestartCnt);
+      logger.info("initialRestartCnt " + initialRestartCnt + " finalRestartCnt " + finalRestartCnt);
       if ((finalRestartCnt - initialRestartCnt) == 1) {
         logger.info("WLS liveness probe test is successful.");
         break;
@@ -531,11 +532,11 @@ public class TestUtils {
                 + " to try renew the lease. "
                 + "Some of the potential reasons for this failure are that another run"
                 + "may have obtained the lease, the lease may have been externally "
-                + "deleted, or the caller of run.sh may have forgotten to obtain the"
-                + "lease before calling run.sh (using 'lease.sh -o \"$LEASE_ID\"'). "
+                + "deleted, or the caller of the test may have forgotten to obtain the "
+                + "lease before calling the test (using 'lease.sh -o \"$LEASE_ID\"'). "
                 + "To force delete a lease no matter who owns the lease,"
                 + "call 'lease.sh -f' or 'kubernetes delete cm acceptance-test-lease'"
-                + "(this should only be done when sure there's no current run.sh "
+                + "(this should only be done when sure there's no current java tests "
                 + "that owns the lease).  To view the current lease holder,"
                 + "use 'lease.sh -s'.  To disable this lease check, do not set"
                 + "the LEASE_ID environment variable.");

--- a/wercker.yml
+++ b/wercker.yml
@@ -192,7 +192,7 @@ integration-test-java:
         yum clean all
 
         # store the artifacts so we can download them easily
-        tar czvf ${WERCKER_REPORT_ARTIFACTS_DIR}/integration-test-data.tar.gz /pipeline/output/*
+        tar czvf ${WERCKER_REPORT_ARTIFACTS_DIR}/integration-test-data.tar.gz /pipeline/output/* /scratch/*
       }
 
       cleanup_and_store

--- a/wercker.yml
+++ b/wercker.yml
@@ -178,6 +178,11 @@ integration-test-java:
     goals: clean verify
     version: 3.5.2
     profiles: java-integration-tests
+    
+  - script:
+    name: copy pv archive 
+    code: |
+      cp /scratch/acceptance_test_pv_archive /pipeline/output/
 
   after-steps:
   - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -192,7 +192,7 @@ integration-test-java:
         yum clean all
 
         # store the artifacts so we can download them easily
-        tar czvf ${WERCKER_REPORT_ARTIFACTS_DIR}/integration-test-data.tar.gz /pipeline/output/* /scratch/*
+        tar czvf ${WERCKER_REPORT_ARTIFACTS_DIR}/integration-test-data.tar.gz /pipeline/output/*
       }
 
       cleanup_and_store


### PR DESCRIPTION
Below changes are made

adding more frequently failing liveness probe test to QUICKTEST with more debug messages
removed domain lifecycle and operator lifecycle tests from QUICKTEST as they never failed

Ready to merge