### PR TITLE
Handle named servers according to their cluster association

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -4,13 +4,7 @@
 
 package oracle.kubernetes.operator.steps;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import javax.annotation.Nonnull;
 import oracle.kubernetes.operator.DomainStatusUpdater;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
@@ -100,14 +94,18 @@ public class ManagedServersUpStep extends Step {
       LOGGER.fine(SERVERS_UP_MSG, factory.domain.getDomainUID(), getRunningServers(info));
     }
 
-    for (WlsServerConfig serverConfig : info.getScan().getServerConfigs().values()) {
-      factory.addServerIfNeeded(serverConfig, null);
-    }
+    Set<String> clusteredServers = new HashSet<>();
 
     for (WlsClusterConfig clusterConfig : info.getScan().getClusterConfigs().values()) {
       for (WlsServerConfig serverConfig : clusterConfig.getServerConfigs()) {
         factory.addServerIfNeeded(serverConfig, clusterConfig);
+        clusteredServers.add(serverConfig.getName());
       }
+    }
+
+    for (WlsServerConfig serverConfig : info.getScan().getServerConfigs().values()) {
+      if (!clusteredServers.contains(serverConfig.getName()))
+        factory.addServerIfNeeded(serverConfig, null);
     }
 
     info.setServerStartupInfo(factory.getStartupInfos());

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServerConfig.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.wlsconfig;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /** Contains configuration of a WLS server that belongs to a dynamic cluster */
 public class WlsDynamicServerConfig extends WlsServerConfig {
@@ -118,24 +119,6 @@ public class WlsDynamicServerConfig extends WlsServerConfig {
 
   @Override
   public String toString() {
-    return "WlsDynamicServerConfig{"
-        + "name='"
-        + name
-        + '\''
-        + ", listenPort="
-        + listenPort
-        + ", listenAddress='"
-        + listenAddress
-        + '\''
-        + ", sslListenPort="
-        + sslListenPort
-        + ", sslPortEnabled="
-        + sslPortEnabled
-        + ", machineName='"
-        + machineName
-        + '\''
-        + ", networkAccessPoints="
-        + networkAccessPoints
-        + '}';
+    return new ToStringBuilder(this).toString();
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
@@ -7,6 +7,9 @@ package oracle.kubernetes.operator.wlsconfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /** Contains configuration of a WebLogic server */
 public class WlsServerConfig {
@@ -257,25 +260,47 @@ public class WlsServerConfig {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+
+    if (o == null || getClass() != o.getClass()) return false;
+
+    WlsServerConfig that = (WlsServerConfig) o;
+
+    return new EqualsBuilder()
+        .append(sslPortEnabled, that.sslPortEnabled)
+        .append(name, that.name)
+        .append(listenPort, that.listenPort)
+        .append(listenAddress, that.listenAddress)
+        .append(sslListenPort, that.sslListenPort)
+        .append(machineName, that.machineName)
+        .append(networkAccessPoints, that.networkAccessPoints)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(name)
+        .append(listenPort)
+        .append(listenAddress)
+        .append(sslListenPort)
+        .append(sslPortEnabled)
+        .append(machineName)
+        .append(networkAccessPoints)
+        .toHashCode();
+  }
+
+  @Override
   public String toString() {
-    return "WlsServerConfig{"
-        + "name='"
-        + name
-        + '\''
-        + ", listenPort="
-        + listenPort
-        + ", listenAddress='"
-        + listenAddress
-        + '\''
-        + ", sslListenPort="
-        + sslListenPort
-        + ", sslPortEnabled="
-        + sslPortEnabled
-        + ", machineName='"
-        + machineName
-        + '\''
-        + ", networkAccessPoints="
-        + networkAccessPoints
-        + '}';
+    return new ToStringBuilder(this)
+        .append("name", name)
+        .append("listenPort", listenPort)
+        .append("listenAddress", listenAddress)
+        .append("sslListenPort", sslListenPort)
+        .append("sslPortEnabled", sslPortEnabled)
+        .append("machineName", machineName)
+        .append("networkAccessPoints", networkAccessPoints)
+        .toString();
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -9,18 +9,8 @@ import static oracle.kubernetes.operator.WebLogicConstants.ADMIN_STATE;
 import static oracle.kubernetes.operator.steps.ManagedServersUpStep.SERVERS_UP_MSG;
 import static oracle.kubernetes.operator.steps.ManagedServersUpStepTest.TestStepFactory.getServerStartupInfo;
 import static oracle.kubernetes.operator.steps.ManagedServersUpStepTest.TestStepFactory.getServers;
-import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_ALWAYS;
-import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_IF_NEEDED;
-import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.START_NEVER;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants.*;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import com.meterware.simplestub.Memento;
@@ -28,11 +18,7 @@ import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import oracle.kubernetes.TestUtils;
@@ -53,7 +39,6 @@ import oracle.kubernetes.weblogic.domain.v2.Domain;
 import oracle.kubernetes.weblogic.domain.v2.DomainSpec;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -428,7 +413,6 @@ public class ManagedServersUpStepTest {
   }
 
   @Test
-  @Ignore
   public void whenWlsClusterNotInDomainSpec_recordServerAndClusterConfigs() {
     setCluster1Replicas(3);
     addWlsServers("ms1", "ms2", "ms3", "ms4", "ms5");
@@ -440,6 +424,17 @@ public class ManagedServersUpStepTest {
     assertThat(getServerStartupInfo("ms1").getClusterName(), equalTo("cluster1"));
     assertThat(getServerStartupInfo("ms1").getEnvironment(), empty());
     assertThat(getServerStartupInfo("ms1").getNodePort(), nullValue());
+  }
+
+  @Test
+  public void whenWlsClusterNotInDomainSpec_startUpToLimit() {
+    setCluster1Replicas(3);
+    addWlsServers("ms1", "ms2", "ms3", "ms4", "ms5");
+    addWlsCluster("cluster1", "ms1", "ms2", "ms3", "ms4", "ms5");
+
+    invokeStep();
+
+    assertThat(getServers(), containsInAnyOrder("ms1", "ms2", "ms3"));
   }
 
   @Test


### PR DESCRIPTION
WlsDomainConfig.getServerConfigs() returns all managed servers, whether or not they are part of a cluster. There is currently no way to obtain only those that are not clustered. This leads the ManagedServersUpStep to check those servers twice: once as though they are not clustered, and once as though they are clustered. 

When the serverStartPolicy is IF_NEEDED, that leads named managed servers always to be run, which is incorrect.

This change has the step process the clusters first, recording the servers found locally, in order to avoid checking them as though they are not clustered. It fixes both OWLS-70348 and OWLS-70351.

Note: the introspector branch will provide a new method that returns only the non-clustered servers. At that point, the additional logic will no longer be needed in the ManagedServersUpStep.