### PR TITLE
Fix situational config file loading error found in admin server log

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -698,7 +698,7 @@ class SitConfigGenerator(Generator):
       nap_name=nap.getName()
       self.writeln("<d:network-access-point>")
       self.indent()
-      self.writeln("<d:name f:combine-mode=\"replace\">" + nap_name + "</d:name>")
+      self.writeln("<d:name>" + nap_name + "</d:name>")
       self.writeln("<d:listen-address f:combine-mode=\"replace\">" + listen_address + "</d:listen-address>")
       self.undent()
       self.writeln("</d:network-access-point>")


### PR DESCRIPTION
Fixes error found in admin server log file:
<Error loading the situational config files: weblogic.descriptor.DescriptorException: Unmarshaller failed: com.bea.xml.XmlException: javax.management.InvalidAttributeValueException: The Name attribute cannot be modified after the MBean domain1:Name=AdminServer,Location=managed-server3,Type=ServerConfig has been created.>

by removing  'combine-mode="replace"'
from <network-access-point><name> attribute in the situational config file generated in the introspect domain job.