### PR TITLE
OWLS-69882: Add support for an admin server administration node port …

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/AdminServerConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/AdminServerConfigurator.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.weblogic.domain;
 
+import oracle.kubernetes.weblogic.domain.v2.AdminService;
 import oracle.kubernetes.weblogic.domain.v2.ExportedNetworkAccessPoint;
 
 @SuppressWarnings("UnusedReturnValue")
@@ -16,4 +17,6 @@ public interface AdminServerConfigurator extends ServerConfigurator {
   AdminServerConfigurator withExportedNetworkAccessPoints(String... names);
 
   ExportedNetworkAccessPoint configureExportedNetworkAccessPoint(String channelName);
+
+  AdminService configureAdminService();
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
@@ -26,6 +26,9 @@ public class AdminServer extends Server {
   @Description("T3 network access points to export")
   private Map<String, ExportedNetworkAccessPoint> exportedNetworkAccessPoints = new HashMap<>();
 
+  @Description("")
+  private AdminService adminService;
+
   /**
    * Configures an exported T3 network access point.
    *
@@ -52,6 +55,7 @@ public class AdminServer extends Server {
     return new ToStringBuilder(this)
         .appendSuper(super.toString())
         .append("exportedNetworkAccessPoints", exportedNetworkAccessPoints)
+        .append("adminService", adminService)
         .toString();
   }
 
@@ -66,6 +70,7 @@ public class AdminServer extends Server {
     return new EqualsBuilder()
         .appendSuper(super.equals(o))
         .append(exportedNetworkAccessPoints, that.exportedNetworkAccessPoints)
+        .append(adminService, that.adminService)
         .isEquals();
   }
 
@@ -74,6 +79,15 @@ public class AdminServer extends Server {
     return new HashCodeBuilder(17, 37)
         .appendSuper(super.hashCode())
         .append(exportedNetworkAccessPoints)
+        .append(adminService)
         .toHashCode();
+  }
+
+  public AdminService getAdminService() {
+    return adminService;
+  }
+
+  public void setAdminService(AdminService adminService) {
+    this.adminService = adminService;
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
@@ -26,7 +26,9 @@ public class AdminServer extends Server {
   @Description("T3 network access points to export")
   private Map<String, ExportedNetworkAccessPoint> exportedNetworkAccessPoints = new HashMap<>();
 
-  @Description("")
+  @Description(
+      "Configures which of the admin server's WebLogic admin channels should be exposed outside"
+          + " the Kubernetes cluster via a node port service.")
   private AdminService adminService;
 
   /**

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
@@ -1,3 +1,7 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
 package oracle.kubernetes.weblogic.domain.v2;
 
 import com.google.gson.annotations.SerializedName;

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
@@ -1,0 +1,78 @@
+package oracle.kubernetes.weblogic.domain.v2;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class AdminService {
+  /** */
+  @SerializedName("labels")
+  private Map<String, String> labels = new HashMap<>();
+  /** */
+  @SerializedName("annotations")
+  private Map<String, String> annotations = new HashMap<>();
+  /** */
+  @SerializedName("channels")
+  private Map<String, Channel> channels = new HashMap<>();
+
+  public AdminService addLabel(String name, String value) {
+    labels.put(name, value);
+    return this;
+  }
+
+  public Map<String, String> getLabels() {
+    return Collections.unmodifiableMap(labels);
+  }
+
+  public AdminService addAnnotation(String name, String value) {
+    annotations.put(name, value);
+    return this;
+  }
+
+  public Map<String, String> getAnnotations() {
+    return Collections.unmodifiableMap(annotations);
+  }
+
+  public AdminService addChannel(String name, Channel port) {
+    channels.put(name, port);
+    return this;
+  }
+
+  public Map<String, Channel> getChannels() {
+    return channels;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("labels", labels)
+        .append("annotations", annotations)
+        .append("channles", channels)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(labels).append(annotations).append(channels).toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (!(o instanceof AdminService)) {
+      return false;
+    }
+    AdminService as = (AdminService) o;
+    return new EqualsBuilder()
+        .append(labels, as.labels)
+        .append(annotations, as.annotations)
+        .append(channels, as.channels)
+        .isEquals();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Channel.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Channel.java
@@ -1,0 +1,47 @@
+package oracle.kubernetes.weblogic.domain.v2;
+
+import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class Channel {
+  public Channel() {}
+
+  public Channel(int nodePort) {
+    this.nodePort = nodePort;
+  }
+
+  @SerializedName("nodePort")
+  private int nodePort;
+
+  public int getNodePort() {
+    return nodePort;
+  }
+
+  public void setNodePort(int nodePort) {
+    this.nodePort = nodePort;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this).append("nodePort", nodePort).toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(nodePort).toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (!(o instanceof Channel)) {
+      return false;
+    }
+    Channel ch = (Channel) o;
+    return new EqualsBuilder().append(nodePort, ch.nodePort).isEquals();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Channel.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Channel.java
@@ -1,3 +1,7 @@
+// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
 package oracle.kubernetes.weblogic.domain.v2;
 
 import com.google.gson.annotations.SerializedName;

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -148,6 +148,14 @@ public class DomainV2Configurator extends DomainConfigurator {
     public ExportedNetworkAccessPoint configureExportedNetworkAccessPoint(String channelName) {
       return adminServer.addExportedNetworkAccessPoint(channelName);
     }
+
+    @Override
+    public AdminService configureAdminService() {
+      if (adminServer.getAdminService() == null) {
+        adminServer.setAdminService(new AdminService());
+      }
+      return adminServer.getAdminService();
+    }
   }
 
   private AdminServer getOrCreateAdminServer(String adminServerName) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -1003,6 +1003,11 @@ public class DomainProcessorImpl implements DomainProcessor {
             dom.getDomainUID(), dom.getMetadata().getNamespace(), null));
     resources.add(JobHelper.createDomainIntrospectorJobStep(PodHelper.createAdminPodStep(null)));
     resources.add(new BeforeAdminServiceStep(null));
+
+    if (dom.getSpec().getAdminServer().getAdminService() != null) {
+      resources.add(ServiceHelper.createForAdminServiceStep(null));
+    }
+
     resources.add(ServiceHelper.createForServerStep(null));
     resources.add(new WatchPodReadyAdminStep(Main.podWatchers, null));
     resources.add(new ExternalAdminChannelsStep(next));

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -14,6 +14,7 @@ public class LegalNames {
   private static final String CLUSTER_SERVICE_PATTERN = "%s-cluster-%s";
   private static final String NAP_PATTERN = "%s-%s-extchannel-%s";
   private static final String DOMAIN_INTROSPECTOR_JOB_PATTERN = "%s-introspect-domain-job";
+  private static final String ADMIN_SERVICE_PATTERN = "%s-%s-admin";
 
   public static String toIngressName(String domainUID, String clusterName) {
     return toDNS1123LegalName(String.format(INGRESS_PATTERN, domainUID, clusterName));
@@ -43,6 +44,9 @@ public class LegalNames {
     return toDNS1123LegalName(String.format(DOMAIN_INTROSPECTOR_JOB_PATTERN, domainUID));
   }
 
+  static String toAdminServiceName(String domainUID, String serverName) {
+    return toDNS1123LegalName(String.format(ADMIN_SERVICE_PATTERN, domainUID, serverName));
+  }
   /**
    * Converts value to nearest DNS-1123 legal name, which can be used as a Kubernetes identifier
    *

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -851,9 +851,11 @@ public class ServiceHelper {
       if (serverConfig != null) {
         if ("default".equals(channel)) {
           return serverConfig.getListenPort();
-        } else if ("defaultSecure".equals(channel)) {
+        } else if ("defaultSecure".equals(channel) && serverConfig.isSslPortEnabled()) {
           return serverConfig.getSslListenPort();
-        } else {
+        } /*else if("adminSecure".equals(channel) && serverConfig.isAdminPortEnabled()){
+            return serverConfig.getAdminPort();
+          }*/ else {
           for (NetworkAccessPoint nap : serverConfig.getNetworkAccessPoints()) {
             if (nap.getName().equals(channel)) {
               return nap.getListenPort();

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -862,7 +862,7 @@ public class ServiceHelper {
           return -1;
         }
       }
-      //what to do if severConfig == null
+      // what to do if severConfig == null
       return -1;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -767,6 +767,7 @@ public class ServiceHelper {
 
     ForAdminServiceStepContext(Step conflictStep, Packet packet) {
       super(conflictStep, packet);
+      this.packet = packet;
     }
 
     @Override
@@ -847,18 +848,22 @@ public class ServiceHelper {
 
     private int searchAdminChannelPort(String channel) {
       WlsServerConfig serverConfig = (WlsServerConfig) packet.get(ADMIN_SERVER_CONFIG);
-      if ("default".equals(channel)) {
-        return serverConfig.getListenPort();
-      } else if ("defaultSecure".equals(channel)) {
-        return serverConfig.getSslListenPort();
-      } else {
-        for (NetworkAccessPoint nap : serverConfig.getNetworkAccessPoints()) {
-          if (nap.getName().equals(channel)) {
-            return nap.getListenPort();
+      if (serverConfig != null) {
+        if ("default".equals(channel)) {
+          return serverConfig.getListenPort();
+        } else if ("defaultSecure".equals(channel)) {
+          return serverConfig.getSslListenPort();
+        } else {
+          for (NetworkAccessPoint nap : serverConfig.getNetworkAccessPoints()) {
+            if (nap.getName().equals(channel)) {
+              return nap.getListenPort();
+            }
           }
+          return -1;
         }
-        return -1;
       }
+      //what to do if severConfig == null
+      return -1;
     }
 
     private AdminService getAdminService() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -36,9 +36,12 @@ import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
+import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
+import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.v2.AdminService;
 import oracle.kubernetes.weblogic.domain.v2.Domain;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
@@ -723,6 +726,143 @@ public class ServiceHelper {
     @Override
     protected void removeServiceFromRecord() {
       sko.getChannels().remove(getChannelName());
+    }
+  }
+
+  /**
+   * Create asynchronous step for admin service
+   *
+   * @param next
+   * @return
+   */
+  public static Step createForAdminServiceStep(Step next) {
+    return new ForAdminServiceStep(next);
+  }
+
+  private static class ForAdminServiceStep extends ServiceHelperStep {
+    ForAdminServiceStep(Step next) {
+      super(next);
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      DomainPresenceInfo info = packet.getSPI(DomainPresenceInfo.class);
+      Scan scan = ScanCache.INSTANCE.lookupScan(info.getNamespace(), info.getDomainUID());
+      WlsDomainConfig config = scan != null ? scan.getWlsDomainConfig() : null;
+      packet.put(
+          ForAdminServiceStepContext.ADMIN_SERVER_CONFIG,
+          config.getServerConfig(config.getAdminServerName()));
+      return super.apply(packet);
+    }
+
+    @Override
+    protected ServiceStepContext createContext(Packet packet) {
+      return new ForAdminServiceStepContext(this, packet);
+    }
+  }
+
+  private static class ForAdminServiceStepContext extends ServerServiceStepContext {
+    private static final String ADMIN_SERVER_CONFIG = "adminserverConfig";
+    private Packet packet;
+
+    ForAdminServiceStepContext(Step conflictStep, Packet packet) {
+      super(conflictStep, packet);
+    }
+
+    @Override
+    protected String createServiceName() {
+      return LegalNames.toAdminServiceName(getDomainUID(), getServerName());
+    }
+
+    @Override
+    protected String getSpecType() {
+      return "NodePort";
+    }
+
+    @Override
+    protected V1ServicePort createServicePort() {
+      return new V1ServicePort().nodePort(1);
+    }
+
+    @Override
+    protected V1Service getServiceFromRecord() {
+      return sko.getService().get();
+    }
+
+    @Override
+    protected void addServiceToRecord(V1Service service) {
+      sko.getService().set(service);
+    }
+
+    @Override
+    protected void removeServiceFromRecord() {
+      sko.getService().set(null);
+    }
+
+    @Override
+    protected String getServiceCreatedMessageKey() {
+      return ADMIN_SERVICE_CREATED;
+    }
+
+    @Override
+    protected String getServiceReplaceMessageKey() {
+      return ADMIN_SERVICE_REPLACED;
+    }
+
+    @Override
+    protected V1ServiceSpec createServiceSpec() {
+      V1ServiceSpec spec = super.createServiceSpec();
+      List<V1ServicePort> ports = new ArrayList<>();
+      AdminService adminService = getAdminService();
+
+      for (String channel : adminService.getChannels().keySet()) {
+        int port = searchAdminChannelPort(channel);
+        if (port != -1) {
+          V1ServicePort servicePort =
+              new V1ServicePort()
+                  .name(channel)
+                  .port(port)
+                  .nodePort(adminService.getChannels().get(channel).getNodePort());
+
+          ports.add(servicePort);
+        }
+      }
+      spec.setPorts(ports);
+      return spec;
+    }
+
+    @Override
+    protected V1ObjectMeta createMetadata() {
+      V1ObjectMeta metadata = super.createMetadata();
+
+      AdminService adminService = getAdminService();
+      for (String label : adminService.getLabels().keySet()) {
+        metadata.putLabelsItem(label, adminService.getLabels().get(label));
+      }
+      for (String annotation : adminService.getAnnotations().keySet()) {
+        metadata.putAnnotationsItem(annotation, adminService.getAnnotations().get(annotation));
+      }
+      return metadata;
+    }
+
+    private int searchAdminChannelPort(String channel) {
+      WlsServerConfig serverConfig = (WlsServerConfig) packet.get(ADMIN_SERVER_CONFIG);
+      if ("default".equals(channel)) {
+        return serverConfig.getListenPort();
+      } else if ("defaultSecure".equals(channel)) {
+        return serverConfig.getSslListenPort();
+      } else {
+        for (NetworkAccessPoint nap : serverConfig.getNetworkAccessPoints()) {
+          if (nap.getName().equals(channel)) {
+            return nap.getListenPort();
+          }
+        }
+        return -1;
+      }
+    }
+
+    private AdminService getAdminService() {
+      return getDomain().getSpec().getAdminServer().getAdminService();
     }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -120,7 +120,7 @@ public class ServiceHelperTest {
         .addToPacket(SERVER_NAME, TEST_SERVER_NAME)
         .addToPacket(PORT, TEST_PORT)
         .addDomainPresenceInfo(domainPresenceInfo);
-      registerWlsDomainConfigScan();
+    registerWlsDomainConfigScan();
   }
 
   @After
@@ -797,33 +797,20 @@ public class ServiceHelperTest {
   }
 
   private void registerWlsDomainConfigScan() {
-      ScanCache.INSTANCE.registerScan(
-              domainPresenceInfo.getNamespace(),
-              domainPresenceInfo.getDomainUID(),
-              new Scan(createWlsDomainConfig(),
-              new DateTime())
-      );
+    ScanCache.INSTANCE.registerScan(
+        domainPresenceInfo.getNamespace(),
+        domainPresenceInfo.getDomainUID(),
+        new Scan(createWlsDomainConfig(), new DateTime()));
   }
-  private WlsDomainConfig createWlsDomainConfig() {
-      Map<String, WlsServerConfig> wlsServerConfigs = new HashMap<>();
-      wlsServerConfigs.put(ADMIN_SERVER, new WlsServerConfig(
-              ADMIN_SERVER,
-              TEST_PORT,
-              null,
-              null,
-              false,
-              null,
-              null
 
-      ));
-      WlsDomainConfig wlsDomainConfig = new WlsDomainConfig(
-              DOMAIN_NAME,
-              new HashMap<>(),
-              wlsServerConfigs,
-              null,
-              null
-      );
-      wlsDomainConfig.setAdminServerName(ADMIN_SERVER);
-      return wlsDomainConfig;
+  private WlsDomainConfig createWlsDomainConfig() {
+    Map<String, WlsServerConfig> wlsServerConfigs = new HashMap<>();
+    wlsServerConfigs.put(
+        ADMIN_SERVER, new WlsServerConfig(ADMIN_SERVER, TEST_PORT, null, null, false, null, null));
+
+    WlsDomainConfig wlsDomainConfig =
+        new WlsDomainConfig(DOMAIN_NAME, new HashMap<>(), wlsServerConfigs, null, null);
+    wlsDomainConfig.setAdminServerName(ADMIN_SERVER);
+    return wlsDomainConfig;
   }
 }


### PR DESCRIPTION
Changes to support administration node port:

- Updated AdminServer schema with AdminService object that contains:
      Map of annotations,
      Map of labels,
      Map with channels to be exposed.

- Updated Operator runtime to create such nodePort service.

This PR depends on https://github.com/oracle/weblogic-kubernetes-operator/pull/561
