### PR TITLE
shutdown domain in all cases on jenkins and more

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -125,9 +125,10 @@ public class ITOperator extends BaseTest {
 
     logTestBegin("test1CreateFirstOperatorAndDomain");
     logger.info("Creating Operator & waiting for the script to complete execution");
-    Domain domain1 = null;
     // create operator1
     operator1 = TestUtils.createOperator(op1YamlFile);
+    Domain domain1 = null;
+    boolean testCompletedSuccessfully = false;
     try {
       domain1 = testDomainCreation(domain1YamlFile);
       domain1.verifyDomainCreated();
@@ -135,9 +136,11 @@ public class ITOperator extends BaseTest {
       testAdvancedUseCasesForADomain(operator1, domain1);
 
       if (!SMOKETEST) domain1.testWlsLivenessProbe();
+      testCompletedSuccessfully = true;
     } finally {
 
-      if (domain1 != null && JENKINS) domain1.shutdownUsingServerStartPolicy();
+      if (domain1 != null && (JENKINS || testCompletedSuccessfully))
+        domain1.shutdownUsingServerStartPolicy();
     }
 
     logger.info("SUCCESS - test1CreateFirstOperatorAndDomain");
@@ -150,7 +153,7 @@ public class ITOperator extends BaseTest {
     logTestBegin("test2CreateAnotherDomainInDefaultNS");
     logger.info("Creating Domain domain2 & verifing the domain creation");
     Domain domain2 = null;
-
+    boolean testCompletedSuccessfully = false;
     if (operator1 == null) {
       operator1 = TestUtils.createOperator(op1YamlFile);
     }
@@ -159,8 +162,9 @@ public class ITOperator extends BaseTest {
       domain2 = testDomainCreation(domain2YamlFile);
       domain2.verifyDomainCreated();
       testBasicUseCases(domain2);
+      testCompletedSuccessfully = true;
     } finally {
-      if (domain2 != null && JENKINS) {
+      if (domain2 != null && (JENKINS || testCompletedSuccessfully)) {
         logger.info("Destroy domain2");
         domain2.destroy();
       }
@@ -178,14 +182,16 @@ public class ITOperator extends BaseTest {
       operator1 = TestUtils.createOperator(op1YamlFile);
     }
     Domain domain3 = null;
+    boolean testCompletedSuccessfully = false;
     try {
       // create domain3
       domain3 = testDomainCreation(domain3YamlFile);
       domain3.verifyDomainCreated();
       testBasicUseCases(domain3);
       testWLDFScaling(operator1, domain3);
+      testCompletedSuccessfully = true;
     } finally {
-      if (domain3 != null && JENKINS) {
+      if (domain3 != null && (JENKINS || testCompletedSuccessfully)) {
         domain3.destroy();
       }
     }
@@ -217,7 +223,7 @@ public class ITOperator extends BaseTest {
     }
 
     Domain domain4 = null, domain5 = null;
-
+    boolean testCompletedSuccessfully = false;
     try {
       domain4 = testDomainCreation(domain4YamlFile);
       domain4.verifyDomainCreated();
@@ -244,12 +250,13 @@ public class ITOperator extends BaseTest {
 
       logger.info("Verify no impact on domain5");
       domain5.verifyDomainCreated();
+      testCompletedSuccessfully = true;
       logger.info("SUCCESS - test5CreateConfiguredDomainInTest2NS");
     } finally {
-      if (domain4 != null && JENKINS) {
+      if (domain4 != null && (JENKINS || testCompletedSuccessfully)) {
         domain4.destroy();
       }
-      if (domain5 != null && JENKINS) {
+      if (domain5 != null && (JENKINS || testCompletedSuccessfully)) {
         domain5.destroy();
       }
     }
@@ -267,12 +274,13 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain domain6 & verifing the domain creation");
     // create domain6
     Domain domain6 = null;
-
+    boolean testCompletedSuccessfully = false;
     try {
       domain6 = testDomainCreation(domain6YamlFile);
       domain6.verifyDomainCreated();
+      testCompletedSuccessfully = true;
     } finally {
-      if (domain6 != null && JENKINS) domain6.destroy();
+      if (domain6 != null && (JENKINS || testCompletedSuccessfully)) domain6.destroy();
     }
 
     logger.info("SUCCESS - test6CreateDomainWithStartPolicyAdminOnly");
@@ -290,6 +298,7 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain domain7 & verifing the domain creation");
     // create domain7
     Domain domain7 = null;
+
     try {
       domain7 = testDomainCreation(domain7YamlFile);
       domain7.verifyDomainCreated();
@@ -315,7 +324,7 @@ public class ITOperator extends BaseTest {
       domain8 = testDomainCreation(domain8YamlFile);
       domain8.verifyDomainCreated();
     } finally {
-      if (domain8 != null && JENKINS) {
+      if (domain8 != null) {
         // create domain on existing dir
         domain8.destroy();
       }
@@ -334,15 +343,16 @@ public class ITOperator extends BaseTest {
     if (operator1 == null) {
       operator1 = TestUtils.createOperator(op1YamlFile);
     }
-
+    boolean testCompletedSuccessfully = false;
     // create domain9
     Domain domain9 = null;
     try {
       domain9 = testDomainCreation(domain9YamlFile);
       domain9.verifyDomainCreated();
       domain9.verifyAdminConsoleViaLB();
+      testCompletedSuccessfully = true;
     } finally {
-      if (domain9 != null && JENKINS) domain9.destroy();
+      if (domain9 != null && (JENKINS || testCompletedSuccessfully)) domain9.destroy();
     }
     logger.info("SUCCESS - testACreateDomainApacheLB");
   }
@@ -359,13 +369,15 @@ public class ITOperator extends BaseTest {
 
     // create domain10
     Domain domain10 = null;
+    boolean testCompletedSuccessfully = false;
     try {
       domain10 = testDomainCreation(domain10YamlFile);
       domain10.verifyDomainCreated();
       testBasicUseCases(domain10);
       testAdvancedUseCasesForADomain(operator1, domain10);
+      testCompletedSuccessfully = true;
     } finally {
-      if (domain10 != null && JENKINS) domain10.destroy();
+      if (domain10 != null && (JENKINS || testCompletedSuccessfully)) domain10.destroy();
     }
 
     logger.info("SUCCESS - testBCreateDomainWithDefaultValuesInSampleInputs");
@@ -381,6 +393,7 @@ public class ITOperator extends BaseTest {
       operatorForDel1 = TestUtils.createOperator(opForDelYamlFile1);
     }
     Domain domain = null;
+    boolean testCompletedSuccessfully = false;
     try {
       domain = testDomainCreation(domain1ForDelValueYamlFile);
       domain.verifyDomainCreated();
@@ -390,8 +403,9 @@ public class ITOperator extends BaseTest {
       TestUtils.deleteWeblogicDomainResources(domain.getDomainUid());
 
       TestUtils.verifyAfterDeletion(domain);
+      testCompletedSuccessfully = true;
     } finally {
-      if (domain != null && JENKINS) domain.destroy();
+      if (domain != null && (JENKINS || testCompletedSuccessfully)) domain.destroy();
     }
     logger.info("SUCCESS - testDeleteOneDomain");
   }
@@ -406,6 +420,7 @@ public class ITOperator extends BaseTest {
       operatorForDel2 = TestUtils.createOperator(opForDelYamlFile2);
     }
     Domain domainDel1 = null, domainDel2 = null;
+    boolean testCompletedSuccessfully = false;
     try {
       domainDel1 = testDomainCreation(domain2ForDelValueYamlFile);
       domainDel1.verifyDomainCreated();
@@ -422,9 +437,10 @@ public class ITOperator extends BaseTest {
 
       TestUtils.verifyAfterDeletion(domainDel1);
       TestUtils.verifyAfterDeletion(domainDel2);
+      testCompletedSuccessfully = true;
     } finally {
-      if (domainDel1 != null && JENKINS) domainDel1.destroy();
-      if (domainDel2 != null && JENKINS) domainDel2.destroy();
+      if (domainDel1 != null && (JENKINS || testCompletedSuccessfully)) domainDel1.destroy();
+      if (domainDel2 != null && (JENKINS || testCompletedSuccessfully)) domainDel2.destroy();
     }
     logger.info("SUCCESS - testDeleteTwoDomains");
   }
@@ -438,12 +454,14 @@ public class ITOperator extends BaseTest {
       operator1 = TestUtils.createOperator(op1YamlFile);
     }
     Domain domain11 = null;
+    boolean testCompletedSuccessfully = false;
     try {
       // cp py
       copyCreateDomainScript();
       domain11 = testDomainCreation(domain11YamlFile);
       domain11.verifyDomainCreated();
       testBasicUseCases(domain11);
+      testCompletedSuccessfully = true;
       logger.info("SUCCESS - testAutoSitConfigOverrides");
     } finally {
 
@@ -457,7 +475,7 @@ public class ITOperator extends BaseTest {
         throw new RuntimeException(cmd + " failed");
       }
 
-      if (domain11 != null && JENKINS) {
+      if (domain11 != null && (JENKINS || testCompletedSuccessfully)) {
         domain11.destroy();
       }
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -393,20 +393,24 @@ public class ITOperator extends BaseTest {
       operatorForDel1 = TestUtils.createOperator(opForDelYamlFile1);
     }
     Domain domain = null;
-    boolean testCompletedSuccessfully = false;
     try {
       domain = testDomainCreation(domain1ForDelValueYamlFile);
       domain.verifyDomainCreated();
       TestUtils.verifyBeforeDeletion(domain);
-
-      logger.info("About to delete domain: " + domain.getDomainUid());
-      TestUtils.deleteWeblogicDomainResources(domain.getDomainUid());
-
-      TestUtils.verifyAfterDeletion(domain);
-      testCompletedSuccessfully = true;
-    } finally {
-      if (domain != null && (JENKINS || testCompletedSuccessfully)) domain.destroy();
+    } catch (Exception ex) {
+      if (domain != null && JENKINS) {
+        try {
+          domain.destroy();
+        } catch (Exception ignore) {
+        }
+      }
+      throw ex;
     }
+
+    logger.info("About to delete domain: " + domain.getDomainUid());
+    TestUtils.deleteWeblogicDomainResources(domain.getDomainUid());
+
+    TestUtils.verifyAfterDeletion(domain);
     logger.info("SUCCESS - testDeleteOneDomain");
   }
 
@@ -420,7 +424,7 @@ public class ITOperator extends BaseTest {
       operatorForDel2 = TestUtils.createOperator(opForDelYamlFile2);
     }
     Domain domainDel1 = null, domainDel2 = null;
-    boolean testCompletedSuccessfully = false;
+
     try {
       domainDel1 = testDomainCreation(domain2ForDelValueYamlFile);
       domainDel1.verifyDomainCreated();
@@ -429,19 +433,29 @@ public class ITOperator extends BaseTest {
 
       TestUtils.verifyBeforeDeletion(domainDel1);
       TestUtils.verifyBeforeDeletion(domainDel2);
+    } catch (Exception ex) {
 
-      final String domainUidsToBeDeleted =
-          domainDel1.getDomainUid() + "," + domainDel2.getDomainUid();
-      logger.info("About to delete domains: " + domainUidsToBeDeleted);
-      TestUtils.deleteWeblogicDomainResources(domainUidsToBeDeleted);
-
-      TestUtils.verifyAfterDeletion(domainDel1);
-      TestUtils.verifyAfterDeletion(domainDel2);
-      testCompletedSuccessfully = true;
-    } finally {
-      if (domainDel1 != null && (JENKINS || testCompletedSuccessfully)) domainDel1.destroy();
-      if (domainDel2 != null && (JENKINS || testCompletedSuccessfully)) domainDel2.destroy();
+      if (domainDel1 != null && JENKINS) {
+        try {
+          domainDel1.destroy();
+        } catch (Exception ignore) {
+        }
+      }
+      if (domainDel2 != null && JENKINS) {
+        try {
+          domainDel2.destroy();
+        } catch (Exception ignore) {
+        }
+      }
+      throw ex;
     }
+    final String domainUidsToBeDeleted =
+        domainDel1.getDomainUid() + "," + domainDel2.getDomainUid();
+    logger.info("About to delete domains: " + domainUidsToBeDeleted);
+    TestUtils.deleteWeblogicDomainResources(domainUidsToBeDeleted);
+
+    TestUtils.verifyAfterDeletion(domainDel1);
+    TestUtils.verifyAfterDeletion(domainDel2);
     logger.info("SUCCESS - testDeleteTwoDomains");
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -45,6 +45,7 @@ public class ITOperator extends BaseTest {
   private static final String domain3ForDelValueYamlFile = "domain_del_3.yaml";
   private static String domain9YamlFile = "domain9.yaml";
   private static String domain10YamlFile = "domain10.yaml";
+  private static String domain11YamlFile = "domain11.yaml";
 
   // property file used to configure constants for integration tests
   private static String appPropsFile = "OperatorIT.properties";
@@ -329,6 +330,56 @@ public class ITOperator extends BaseTest {
 
     TestUtils.verifyAfterDeletion(domainDel1);
     TestUtils.verifyAfterDeletion(domainDel2);
+  }
+
+  @Test
+  public void testAutoSitConfigOverrides() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
+    logTestBegin("testAutoSitConfigOverrides");
+    try {
+      // cp py
+      StringBuffer cmd = new StringBuffer("cd ");
+      cmd.append(BaseTest.getProjectRoot())
+          .append(
+              "/integration-tests/src/test/resources/domain-home-on-pv && cp create-domain.py create-domain.py.bak");
+      logger.info("Running " + cmd);
+
+      ExecResult result = ExecCommand.exec(cmd.toString());
+      if (result.exitValue() != 0) {
+        throw new RuntimeException(cmd + " failed");
+      }
+
+      cmd = new StringBuffer("cd ");
+      cmd.append(BaseTest.getProjectRoot())
+          .append(
+              "/integration-tests/src/test/resources/domain-home-on-pv && cp create-domain-auto-sit-config.py create-domain.py");
+      logger.info("Running " + cmd);
+      result = ExecCommand.exec(cmd.toString());
+      if (result.exitValue() != 0) {
+        throw new RuntimeException(cmd + " failed");
+      }
+
+      if (operator1 == null) {
+        operator1 = TestUtils.createOperator(op1YamlFile);
+      }
+
+      testAllUseCasesForADomain(operator1, domain11YamlFile);
+
+      logger.info("SUCCESS - test1CreateFirstOperatorAndDomain");
+    } finally {
+      StringBuffer cmd = new StringBuffer("cd ");
+      cmd.append(BaseTest.getProjectRoot())
+          .append(
+              "/integration-tests/src/test/resources/domain-home-on-pv && cp create-domain.py.bak create-domain.py");
+      logger.info("Running " + cmd);
+
+      ExecResult result = ExecCommand.exec(cmd.toString());
+      if (result.exitValue() != 0) {
+        throw new RuntimeException(cmd + " failed");
+      }
+    }
+    // cp py back
+
   }
 
   private void testCreateOperatorManagingDefaultAndTest1NS() throws Exception {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -863,9 +863,9 @@ public class Domain {
     }
 
     domainMap.put("domainHome", "/shared/domains/" + domainUid);
-    domainMap.put(
-        "createDomainFilesDir",
-        BaseTest.getProjectRoot() + "/integration-tests/src/test/resources/domain-home-on-pv");
+    /* domainMap.put(
+    "createDomainFilesDir",
+    BaseTest.getProjectRoot() + "/integration-tests/src/test/resources/domain-home-on-pv"); */
     String imageName = "store/oracle/weblogic";
     if (System.getenv("IMAGE_NAME_WEBLOGIC") != null) {
       imageName = System.getenv("IMAGE_NAME_WEBLOGIC");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -612,7 +612,7 @@ public class Domain {
     weblogicDomainStorageSize = (String) pvMap.get("weblogicDomainStorageSize");
 
     // test NFS for domain5 on JENKINS
-    if (domainUid.equals("domain5")
+    if (domainUid.equals("domain6")
         && (System.getenv("JENKINS") != null
             && System.getenv("JENKINS").equalsIgnoreCase("true"))) {
       pvMap.put("weblogicDomainStorageType", "NFS");
@@ -863,7 +863,9 @@ public class Domain {
     }
 
     domainMap.put("domainHome", "/shared/domains/" + domainUid);
-
+    domainMap.put(
+        "createDomainFilesDir",
+        BaseTest.getProjectRoot() + "/integration-tests/src/test/resources/domain-home-on-pv");
     String imageName = "store/oracle/weblogic";
     if (System.getenv("IMAGE_NAME_WEBLOGIC") != null) {
       imageName = System.getenv("IMAGE_NAME_WEBLOGIC");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -487,9 +487,9 @@ public class TestUtils {
 
   public static Domain createDomain(String inputYaml) throws Exception {
     logger.info("Creating domain with yaml, waiting for the script to complete execution");
-    Domain domain = new Domain(inputYaml);
-    domain.verifyDomainCreated();
-    return domain;
+    return new Domain(inputYaml);
+    /* domain.verifyDomainCreated();
+    return domain; */
   }
 
   public static Map<String, Object> loadYaml(String yamlFile) throws Exception {

--- a/integration-tests/src/test/resources/OperatorIT.properties
+++ b/integration-tests/src/test/resources/OperatorIT.properties
@@ -5,5 +5,5 @@ baseDir=/scratch
 #wls admin user
 username=weblogic
 password=welcome1
-maxIterationsPod=50
+maxIterationsPod=25
 waitTimePod=10

--- a/integration-tests/src/test/resources/domain-home-on-pv/create-domain-auto-sit-config.py
+++ b/integration-tests/src/test/resources/domain-home-on-pv/create-domain-auto-sit-config.py
@@ -1,0 +1,149 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+def getEnvVar(var):
+  val=os.environ.get(var)
+  if val==None:
+    print "ERROR: Env var ",var, " not set."
+    sys.exit(1)
+  return val
+
+# This python script is used to create a WebLogic domain
+
+domain_uid                   = getEnvVar("DOMAIN_UID")
+server_port                  = int(getEnvVar("MANAGED_SERVER_PORT"))
+domain_path                  = getEnvVar("DOMAIN_HOME")
+cluster_name                 = getEnvVar("CLUSTER_NAME")
+admin_server_name            = getEnvVar("ADMIN_SERVER_NAME")
+admin_server_name_svc        = getEnvVar("ADMIN_SERVER_NAME_SVC")
+admin_port                   = int(getEnvVar("ADMIN_PORT"))
+domain_name                  = getEnvVar("DOMAIN_NAME")
+t3_channel_port              = int(getEnvVar("T3_CHANNEL_PORT"))
+t3_public_address            = getEnvVar("T3_PUBLIC_ADDRESS")
+number_of_ms                 = int(getEnvVar("CONFIGURED_MANAGED_SERVER_COUNT"))
+cluster_type                 = getEnvVar("CLUSTER_TYPE")
+managed_server_name_base     = getEnvVar("MANAGED_SERVER_NAME_BASE")
+managed_server_name_base_svc = getEnvVar("MANAGED_SERVER_NAME_BASE_SVC")
+domain_logs                  = getEnvVar("DOMAIN_LOGS_DIR")
+script_dir                   = getEnvVar("CREATE_DOMAIN_SCRIPT_DIR")
+production_mode_enabled      = getEnvVar("PRODUCTION_MODE_ENABLED")
+
+# Read the domain secrets from the common python file
+execfile('%s/read-domain-secret.py' % script_dir)
+
+print('domain_path        : [%s]' % domain_path);
+print('domain_name        : [%s]' % domain_name);
+print('admin_server_name  : [%s]' % admin_server_name);
+print('admin_username     : [%s]' % admin_username);
+print('admin_port         : [%s]' % admin_port);
+print('cluster_name       : [%s]' % cluster_name);
+print('server_port        : [%s]' % server_port);
+# Open default domain template
+# ============================
+readTemplate("/u01/oracle/wlserver/common/templates/wls/wls.jar")
+
+set('Name', domain_name)
+setOption('DomainName', domain_name)
+
+# Configure the Administration Server
+# ===================================
+cd('/Servers/AdminServer')
+# Give incorrect listenaddress, introspector overrides with sit-config
+set('ListenAddress', 'junk')
+set('ListenPort', admin_port)
+set('Name', admin_server_name)
+create('AdminServer','Log')
+cd('/Servers/AdminServer/Log/AdminServer')
+# Give incorrect filelog, introspector overrides with sit-config
+set('FileName', 'dirdoesnotexist')
+
+create('T3Channel', 'NetworkAccessPoint')
+cd('/Servers/%s/NetworkAccessPoints/T3Channel' % admin_server_name)
+set('PublicPort', t3_channel_port)
+set('PublicAddress', t3_public_address)
+# Give incorrect listenaddress, introspector overrides with sit-config
+set('ListenAddress', 'junk')
+set('ListenPort', t3_channel_port)
+
+
+# Set the admin user's username and password
+# ==========================================
+cd('/Security/%s/User/weblogic' % domain_name)
+cmo.setName(admin_username)
+cmo.setPassword(admin_password)
+
+# Write the domain and close the domain template
+# ==============================================
+setOption('OverwriteDomain', 'true')
+
+# Create a cluster
+# ======================
+cd('/')
+cl=create(cluster_name, 'Cluster')
+
+if cluster_type == "CONFIGURED":
+
+  # Create managed servers
+  for index in range(0, number_of_ms):
+    cd('/')
+
+    msIndex = index+1
+    name = '%s%s' % (managed_server_name_base, msIndex)
+    name_svc = '%s%s' % (managed_server_name_base_svc, msIndex)
+
+    create(name, 'Server')
+    cd('/Servers/%s/' % name )
+    print('managed server name is %s' % name);
+    set('ListenAddress', '%s-%s' % (domain_uid, name_svc))
+    set('ListenPort', server_port)
+    set('NumOfRetriesBeforeMSIMode', 0)
+    set('RetryIntervalBeforeMSIMode', 1)
+    set('Cluster', cluster_name)
+
+else:
+  print('Configuring Dynamic Cluster %s' % cluster_name)
+
+  templateName = cluster_name + "-template"
+  print('Creating Server Template: %s' % templateName)
+  st1=create(templateName, 'ServerTemplate')
+  print('Done creating Server Template: %s' % templateName)
+  cd('/ServerTemplates/%s' % templateName)
+  cmo.setListenPort(server_port)
+  cmo.setListenAddress('%s-%s${id}' % (domain_uid, managed_server_name_base_svc))
+  cmo.setCluster(cl)
+  print('Done setting attributes for Server Template: %s' % templateName);
+
+
+  cd('/Clusters/%s' % cluster_name)
+  create(cluster_name, 'DynamicServers')
+  cd('DynamicServers/%s' % cluster_name)
+  set('ServerTemplate', st1)
+  set('ServerNamePrefix', managed_server_name_base)
+  set('DynamicClusterSize', number_of_ms)
+  set('MaxDynamicClusterSize', number_of_ms)
+  set('CalculatedListenPorts', false)
+  set('Id', 1)
+
+  print('Done setting attributes for Dynamic Cluster: %s' % cluster_name);
+
+# Write Domain
+# ============
+writeDomain(domain_path)
+closeTemplate()
+print 'Domain Created'
+
+# Update Domain
+readDomain(domain_path)
+cd('/')
+if production_mode_enabled == "true":
+  cmo.setProductionModeEnabled(true)
+else: 
+  cmo.setProductionModeEnabled(false)
+updateDomain()
+closeDomain()
+print 'Domain Updated'
+print 'Done'
+
+# Exit WLST
+# =========
+exit()

--- a/integration-tests/src/test/resources/domain-home-on-pv/create-domain-script.sh
+++ b/integration-tests/src/test/resources/domain-home-on-pv/create-domain-script.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+# Include common utility functions
+source ${CREATE_DOMAIN_SCRIPT_DIR}/utility.sh
+
+export DOMAIN_HOME=${DOMAIN_HOME_DIR}
+
+# Create the domain
+wlst.sh -skipWLSModuleScanning ${CREATE_DOMAIN_SCRIPT_DIR}/create-domain.py
+
+

--- a/integration-tests/src/test/resources/domain-home-on-pv/create-domain.py
+++ b/integration-tests/src/test/resources/domain-home-on-pv/create-domain.py
@@ -1,0 +1,149 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+def getEnvVar(var):
+  val=os.environ.get(var)
+  if val==None:
+    print "ERROR: Env var ",var, " not set."
+    sys.exit(1)
+  return val
+
+# This python script is used to create a WebLogic domain
+
+domain_uid                   = getEnvVar("DOMAIN_UID")
+server_port                  = int(getEnvVar("MANAGED_SERVER_PORT"))
+domain_path                  = getEnvVar("DOMAIN_HOME")
+cluster_name                 = getEnvVar("CLUSTER_NAME")
+admin_server_name            = getEnvVar("ADMIN_SERVER_NAME")
+admin_server_name_svc        = getEnvVar("ADMIN_SERVER_NAME_SVC")
+admin_port                   = int(getEnvVar("ADMIN_PORT"))
+domain_name                  = getEnvVar("DOMAIN_NAME")
+t3_channel_port              = int(getEnvVar("T3_CHANNEL_PORT"))
+t3_public_address            = getEnvVar("T3_PUBLIC_ADDRESS")
+number_of_ms                 = int(getEnvVar("CONFIGURED_MANAGED_SERVER_COUNT"))
+cluster_type                 = getEnvVar("CLUSTER_TYPE")
+managed_server_name_base     = getEnvVar("MANAGED_SERVER_NAME_BASE")
+managed_server_name_base_svc = getEnvVar("MANAGED_SERVER_NAME_BASE_SVC")
+domain_logs                  = getEnvVar("DOMAIN_LOGS_DIR")
+script_dir                   = getEnvVar("CREATE_DOMAIN_SCRIPT_DIR")
+production_mode_enabled      = getEnvVar("PRODUCTION_MODE_ENABLED")
+
+# Read the domain secrets from the common python file
+execfile('%s/read-domain-secret.py' % script_dir)
+
+print('domain_path        : [%s]' % domain_path);
+print('domain_name        : [%s]' % domain_name);
+print('admin_server_name  : [%s]' % admin_server_name);
+print('admin_username     : [%s]' % admin_username);
+print('admin_port         : [%s]' % admin_port);
+print('cluster_name       : [%s]' % cluster_name);
+print('server_port        : [%s]' % server_port);
+# Open default domain template
+# ============================
+readTemplate("/u01/oracle/wlserver/common/templates/wls/wls.jar")
+
+set('Name', domain_name)
+setOption('DomainName', domain_name)
+
+# Configure the Administration Server
+# ===================================
+cd('/Servers/AdminServer')
+# Give incorrect listenaddress, introspector overrides with sit-config
+set('ListenAddress', 'junk')
+set('ListenPort', admin_port)
+set('Name', admin_server_name)
+create('AdminServer','Log')
+cd('/Servers/AdminServer/Log/AdminServer')
+# Give incorrect filelog, introspector overrides with sit-config
+set('FileName', 'dirdoesnotexist')
+
+create('T3Channel', 'NetworkAccessPoint')
+cd('/Servers/%s/NetworkAccessPoints/T3Channel' % admin_server_name)
+set('PublicPort', t3_channel_port)
+set('PublicAddress', t3_public_address)
+# Give incorrect listenaddress, introspector overrides with sit-config
+set('ListenAddress', 'junk')
+set('ListenPort', t3_channel_port)
+
+
+# Set the admin user's username and password
+# ==========================================
+cd('/Security/%s/User/weblogic' % domain_name)
+cmo.setName(admin_username)
+cmo.setPassword(admin_password)
+
+# Write the domain and close the domain template
+# ==============================================
+setOption('OverwriteDomain', 'true')
+
+# Create a cluster
+# ======================
+cd('/')
+cl=create(cluster_name, 'Cluster')
+
+if cluster_type == "CONFIGURED":
+
+  # Create managed servers
+  for index in range(0, number_of_ms):
+    cd('/')
+
+    msIndex = index+1
+    name = '%s%s' % (managed_server_name_base, msIndex)
+    name_svc = '%s%s' % (managed_server_name_base_svc, msIndex)
+
+    create(name, 'Server')
+    cd('/Servers/%s/' % name )
+    print('managed server name is %s' % name);
+    set('ListenAddress', '%s-%s' % (domain_uid, name_svc))
+    set('ListenPort', server_port)
+    set('NumOfRetriesBeforeMSIMode', 0)
+    set('RetryIntervalBeforeMSIMode', 1)
+    set('Cluster', cluster_name)
+
+else:
+  print('Configuring Dynamic Cluster %s' % cluster_name)
+
+  templateName = cluster_name + "-template"
+  print('Creating Server Template: %s' % templateName)
+  st1=create(templateName, 'ServerTemplate')
+  print('Done creating Server Template: %s' % templateName)
+  cd('/ServerTemplates/%s' % templateName)
+  cmo.setListenPort(server_port)
+  cmo.setListenAddress('%s-%s${id}' % (domain_uid, managed_server_name_base_svc))
+  cmo.setCluster(cl)
+  print('Done setting attributes for Server Template: %s' % templateName);
+
+
+  cd('/Clusters/%s' % cluster_name)
+  create(cluster_name, 'DynamicServers')
+  cd('DynamicServers/%s' % cluster_name)
+  set('ServerTemplate', st1)
+  set('ServerNamePrefix', managed_server_name_base)
+  set('DynamicClusterSize', number_of_ms)
+  set('MaxDynamicClusterSize', number_of_ms)
+  set('CalculatedListenPorts', false)
+  set('Id', 1)
+
+  print('Done setting attributes for Dynamic Cluster: %s' % cluster_name);
+
+# Write Domain
+# ============
+writeDomain(domain_path)
+closeTemplate()
+print 'Domain Created'
+
+# Update Domain
+readDomain(domain_path)
+cd('/')
+if production_mode_enabled == "true":
+  cmo.setProductionModeEnabled(true)
+else: 
+  cmo.setProductionModeEnabled(false)
+updateDomain()
+closeDomain()
+print 'Domain Updated'
+print 'Done'
+
+# Exit WLST
+# =========
+exit()

--- a/integration-tests/src/test/resources/domain11.yaml
+++ b/integration-tests/src/test/resources/domain11.yaml
@@ -1,0 +1,5 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+domainUID: domain11
+namespace: default


### PR DESCRIPTION
Changes made to shutdown the domain even if the test fails on jenkins. 
Run cleanup.sh at the end for jenkins
Leave the domain running if the test fails on standalone mode
Reduced the number of iterations for pod/server status checking(which means from ~8 mins to ~4 mins) as there are issues which need to be fixed, there is no point in waiting longer time. 
Other changes for testing automatic sit config overrides which are not enabled in the test

wercker ran fine, Quick test ran fine on jenkins, testing full test suite on jenkins.
http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/609/console

full test suite run 
http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/610/consoleFull

@rjeberhard so far so good on the full test suite run on jenkins, you can merge these changes before PR#577

READY TO MERGE