### PR TITLE
Speed up mock server pod shutdown

### DIFF
--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -211,16 +211,3 @@ else
   startWLS
   waitUntilShutdown
 fi
-
-#
-# Wait forever.   Kubernetes will monitor this pod via liveness and readyness probes.
-#
-
-if [ "${MOCK_WLS}" != 'true' ] && [ "${SERVER_OUT_IN_POD_LOG}" == 'true' ] ; then
-  trace "Showing the server out file from ${SERVER_OUT_FILE}"
-  tail -F -n +0 ${SERVER_OUT_FILE} || exitOrLoop
-else
-  trace "Wait indefinitely so that the Kubernetes pod does not exit and try to restart"
-  while true; do sleep 60; done
-fi
-

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -18,6 +18,7 @@ trace "Stop server ${SERVER_NAME}"
 checkEnv SERVER_NAME || exit 1
 
 if [ "${MOCK_WLS}" == 'true' ]; then
+  touch /u01/doShutdown
   exit 0
 fi
 


### PR DESCRIPTION
Speed up the performance of shutting down the mocked servers by
having stopServer.sh create a marker file that says that stopServer.sh was called,
and by having startServer.sh poll every 5 seconds and exit as soon as it finds the marker file.

(v.s. startServer.sh looping forever, so that the pod never stops naturally thus kubernetes
has to wait until its timeout is reached then kill the pod)
