### PR TITLE
Support maxUnavailable

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -12,6 +12,8 @@ import io.kubernetes.client.models.V1SecurityContext;
 public interface ClusterConfigurator {
   ClusterConfigurator withReplicas(int replicas);
 
+  ClusterConfigurator withMaxUnavailable(int maxUnavailable);
+
   ClusterConfigurator withDesiredState(String state);
 
   ClusterConfigurator withEnvironmentVariable(String name, String value);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
@@ -22,6 +22,8 @@ public interface EffectiveConfigurationFactory {
 
   void setReplicaCount(String clusterName, int replicaCount);
 
+  int getMaxUnavailable(String clusterName);
+
   boolean isShuttingDown();
 
   List<String> getExportedNetworkAccessPointNames();

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
@@ -27,6 +27,11 @@ public class Cluster extends BaseConfiguration {
   @Range(minimum = 0)
   private Integer replicas;
 
+  @Description(
+      "The maximum number of cluster membrers that can be temporarily unavailable. Defaults to 1.")
+  @Range(minimum = 1)
+  private Integer maxUnavailable;
+
   public String getClusterName() {
     return clusterName;
   }
@@ -48,12 +53,21 @@ public class Cluster extends BaseConfiguration {
     this.replicas = replicas;
   }
 
+  public Integer getMaxUnavailable() {
+    return maxUnavailable;
+  }
+
+  public void setMaxUnavailable(Integer maxUnavailable) {
+    this.maxUnavailable = maxUnavailable;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
         .appendSuper(super.toString())
         .append("clusterName", clusterName)
         .append("replicas", replicas)
+        .append("maxUnavailable", maxUnavailable)
         .toString();
   }
 
@@ -69,6 +83,7 @@ public class Cluster extends BaseConfiguration {
         .appendSuper(super.equals(o))
         .append(clusterName, cluster.clusterName)
         .append(replicas, cluster.replicas)
+        .append(maxUnavailable, cluster.maxUnavailable)
         .isEquals();
   }
 
@@ -78,6 +93,7 @@ public class Cluster extends BaseConfiguration {
         .appendSuper(super.hashCode())
         .append(clusterName)
         .append(replicas)
+        .append(maxUnavailable)
         .toHashCode();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
@@ -214,6 +214,26 @@ public class Domain {
   }
 
   /**
+   * Returns the maximum number of unavailable replicas for the specified cluster.
+   *
+   * @param clusterName the name of the cluster
+   * @return the result of applying any configurations for this value
+   */
+  public int getMaxUnavailable(String clusterName) {
+    return getEffectiveConfigurationFactory().getMaxUnavailable(clusterName);
+  }
+
+  /**
+   * Returns the minimum number of replicas for the specified cluster.
+   *
+   * @param clusterName the name of the cluster
+   * @return the result of applying any configurations for this value
+   */
+  public int getMinAvailable(String clusterName) {
+    return Math.max(getReplicaCount(clusterName) - getMaxUnavailable(clusterName), 0);
+  }
+
+  /**
    * DomainSpec is a description of a domain.
    *
    * @return Specification

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -684,6 +684,14 @@ public class DomainSpec extends BaseConfiguration {
     return cluster != null && cluster.getReplicas() != null;
   }
 
+  private int getMaxUnavailableFor(Cluster cluster) {
+    return hasMaxUnavailable(cluster) ? cluster.getMaxUnavailable() : 1;
+  }
+
+  private boolean hasMaxUnavailable(Cluster cluster) {
+    return cluster != null && cluster.getMaxUnavailable() != null;
+  }
+
   private AdminServer getAdminServer() {
     return Optional.ofNullable(adminServer).orElse(AdminServer.NULL_ADMIN_SERVER);
   }
@@ -732,6 +740,11 @@ public class DomainSpec extends BaseConfiguration {
     @Override
     public void setReplicaCount(String clusterName, int replicaCount) {
       getOrCreateCluster(clusterName).setReplicas(replicaCount);
+    }
+
+    @Override
+    public int getMaxUnavailable(String clusterName) {
+      return getMaxUnavailableFor(getCluster(clusterName));
     }
 
     @Override

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -382,6 +382,12 @@ public class DomainV2Configurator extends DomainConfigurator {
     }
 
     @Override
+    public ClusterConfigurator withMaxUnavailable(int maxUnavailable) {
+      cluster.setMaxUnavailable(maxUnavailable);
+      return this;
+    }
+
+    @Override
     public ClusterConfigurator withDesiredState(String state) {
       cluster.setServerStartState(state);
       return this;

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -302,6 +302,34 @@ public abstract class DomainTestBase {
   }
 
   @Test
+  public void afterReplicaCountMaxUnavailableSetForCluster_canReadMinAvailable() {
+    configureCluster("cluster1").withReplicas(5).withMaxUnavailable(2);
+
+    assertThat(domain.getMinAvailable("cluster1"), equalTo(3));
+  }
+
+  @Test
+  public void afterReplicaCountSetForCluster_canReadMinAvailable() {
+    configureCluster("cluster1").withReplicas(5);
+
+    assertThat(domain.getMinAvailable("cluster1"), equalTo(4));
+  }
+
+  @Test
+  public void afterReplicaCountMaxUnavailableSetForCluster_zeroMin() {
+    configureCluster("cluster1").withReplicas(3).withMaxUnavailable(10);
+
+    assertThat(domain.getMinAvailable("cluster1"), equalTo(0));
+  }
+
+  @Test
+  public void afterMaxUnavailableSetForCluster_canReadIt() {
+    configureCluster("cluster1").withMaxUnavailable(5);
+
+    assertThat(domain.getMaxUnavailable("cluster1"), equalTo(5));
+  }
+
+  @Test
   public void whenServerNotConfigured_nodePortIsNull() {
     ServerSpec spec = domain.getServer(SERVER1, CLUSTER_NAME);
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
@@ -35,8 +35,6 @@ import oracle.kubernetes.weblogic.domain.v2.ServerStatus;
 public class RollingHelper {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
-  private static final int MINIMUM_FOR_CLUSTER = 2;
-
   private RollingHelper() {}
 
   /**
@@ -222,7 +220,7 @@ public class RollingHelper {
 
           // then add as many as possible next() entries leaving at least minimum cluster
           // availability
-          while (countReady-- > MINIMUM_FOR_CLUSTER) {
+          while (countReady-- > dom.getMinAvailable(clusterName)) {
             current = it.next();
             serverConfig = (WlsServerConfig) current.packet.get(ProcessingConstants.SERVER_SCAN);
             servers.add(serverConfig != null ? serverConfig.getName() : dom.getSpec().getAsName());


### PR DESCRIPTION
Proposal: implement Cluster.maxUnavailable, but have it just be an Integer (the absolute number of servers) rather than IntOrString.  We would therefore drop support for values like, "10%" and instead only support an absolute number.

The default would be 1.

We would still defer (probably forever) supporting maxSurge.