### PR TITLE
Correct volumeMount config in domain-home-in-image sample plus a cleanup

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/create-pv-pvc-inputs.yaml
@@ -26,7 +26,7 @@ weblogicDomainStorageType: HOST_PATH
 
 # Physical path of the persistent storage.
 # The following line must be uncomment and customized:
-weblogicDomainStoragePath: /scratch/k8s_dir
+#weblogicDomainStoragePath: /scratch/k8s_dir
 
 # Reclaim policy of the persistent storage
 # The valid values are: 'Retain', 'Delete', and 'Recycle'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -88,12 +88,14 @@ function validateDomainSecret {
 
   # Verify the secret contains a username
   SECRET=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep username: | wc | awk ' { print $1; }'`
+  USERNAME=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep username: | awk ' { print $1; }'`
   if [ "${SECRET}" != "1" ]; then
     validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does contain a username"
   fi
 
   # Verify the secret contains a password
   SECRET=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep password: | wc | awk ' { print $1; }'`
+  PASSWORD=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep password: | awk ' { print $1; }'`
   if [ "${SECRET}" != "1" ]; then
     validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does contain a password"
   fi
@@ -349,6 +351,13 @@ function createDomainHome {
   cp ${domainPropertiesOutput} ./docker-images/OracleWebLogic/samples/12213-domain-home-in-image/properties/docker_build
 
   cd docker-images/OracleWebLogic/samples/12213-domain-home-in-image
+  
+  sed -i -e "s|myuser|${USERNAME}|g" properties/docker_build/domain_security.properties
+  sed -i -e "s|mypassword1|${PASSWORD}|g" properties/docker_build/domain_security.properties
+
+  sed -i -e "s|myuser|${USERNAME}|g" properties/docker_run/security.properties
+  sed -i -e "s|mypassword1|${PASSWORD}|g" properties/docker_run/security.properties
+
   ./build.sh
 
   if [ "$?" != "0" ]; then

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -88,14 +88,12 @@ function validateDomainSecret {
 
   # Verify the secret contains a username
   SECRET=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep username: | wc | awk ' { print $1; }'`
-  USERNAME=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep username: | awk ' { print $1; }'`
   if [ "${SECRET}" != "1" ]; then
     validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does contain a username"
   fi
 
   # Verify the secret contains a password
   SECRET=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep password: | wc | awk ' { print $1; }'`
-  PASSWORD=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}'| grep password: | awk ' { print $1; }'`
   if [ "${SECRET}" != "1" ]; then
     validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does contain a password"
   fi
@@ -352,12 +350,6 @@ function createDomainHome {
 
   cd docker-images/OracleWebLogic/samples/12213-domain-home-in-image
   
-  sed -i -e "s|myuser|${USERNAME}|g" properties/docker_build/domain_security.properties
-  sed -i -e "s|mypassword1|${PASSWORD}|g" properties/docker_build/domain_security.properties
-
-  sed -i -e "s|myuser|${USERNAME}|g" properties/docker_run/security.properties
-  sed -i -e "s|mypassword1|${PASSWORD}|g" properties/docker_run/security.properties
-
   ./build.sh
 
   if [ "$?" != "0" ]; then

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -349,7 +349,6 @@ function createDomainHome {
   cp ${domainPropertiesOutput} ./docker-images/OracleWebLogic/samples/12213-domain-home-in-image/properties/docker_build
 
   cd docker-images/OracleWebLogic/samples/12213-domain-home-in-image
-  
   ./build.sh
 
   if [ "$?" != "0" ]; then

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/domain-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/domain-template.yaml
@@ -44,6 +44,18 @@ spec:
   # - "ADMIN_ONLY" will start up only the administration server (no managed servers will be started)
   # - "IF_NEEDED" will start all non-clustered servers, including the administration server and clustered servers up to the replica count
   serverStartPolicy: "%SERVER_START_POLICY%"
+  env:
+  - name: JAVA_OPTIONS
+    value: "%JAVA_OPTIONS%"
+  - name: USER_MEM_ARGS
+    value: "-Xms64m -Xmx256m "
+  volumes:
+  - name: runtime-properties
+    hostPath:
+      path: "%RUNTIME_PROPERTIES%"
+  volumeMounts:
+  - mountPath: "/u01/oracle/properties"
+    name: runtime-properties
   # adminServer is used to configure the desired behavior for starting the administration server.
   adminServer:
   # serverStartState legal values are "RUNNING" or "ADMIN"
@@ -56,35 +68,11 @@ spec:
     %EXPOSE_T3_CHANNEL_PREFIX%exportedNetworkAccessPoints:
     %EXPOSE_T3_CHANNEL_PREFIX%  T3Channel: {}
     # an (optional) list of environment variable to be set on the server
-    env:
-    - name: JAVA_OPTIONS
-      value: "%JAVA_OPTIONS%"
-    - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
-    volumes:
-    - name: runtime-properties
-      hostPath:
-        path: "%RUNTIME_PROPERTIES%"
-    volumeMounts:
-    - name: runtime-properties
-      mountPath: "/u01/oracle/properties"
   # clusters is used to configure the desired behavior for starting member servers of a cluster.  
   # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
   clusters:
     %CLUSTER_NAME%:
       serverStartState: "RUNNING"
       replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
-      env:
-      - name: JAVA_OPTIONS
-        value: "%JAVA_OPTIONS%"
-      - name: USER_MEM_ARGS
-        value: "-Xms64m -Xmx256m "
-      volumes:
-      - name: runtime-properties
-        hostPath:
-          path: "%RUNTIME_PROPERTIES%"
-      volumeMounts:
-      - name: runtime-properties
-        mountPath: "/u01/oracle/properties"
   # The number of managed servers to start from clusters not listed in clusters
   # replicas: 1


### PR DESCRIPTION
1) Correct the volumeMount configuration in domain-home-in-image
2) Revert an intentional change (introduced in PR#583) in create-pv-pvc inputs file.