### PR TITLE
Add support for javaOptions field

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
@@ -30,6 +30,16 @@ class ServerPod {
   private List<V1EnvVar> env = new ArrayList<>();
 
   /**
+   * A shortcut for setting the JAVA_OPTIONS environment variable.
+   *
+   * @since 2.0
+   */
+  @Valid
+  @Description(
+      "Values to add to the JAVA_OPTIONS environment variable. Ignored if the JAVA_OPTIONS variable is set explicitly as part of 'env'")
+  private String javaOptions;
+
+  /**
    * Defines the settings for the liveness probe. Any that are not specified will default to the
    * runtime liveness probe tuning settings.
    *
@@ -159,6 +169,7 @@ class ServerPod {
 
   void fillInFrom(ServerPod serverPod1) {
     for (V1EnvVar var : serverPod1.getV1EnvVars()) addIfMissing(var);
+    Optional.ofNullable(serverPod1.javaOptions).ifPresent(this::addJavaOptionsIfMissing);
     livenessProbe.copyValues(serverPod1.livenessProbe);
     readinessProbe.copyValues(serverPod1.readinessProbe);
     for (V1Volume var : serverPod1.getAdditionalVolumes()) addIfMissing(var);
@@ -171,6 +182,11 @@ class ServerPod {
     copyValues(resources, serverPod1.resources);
     copyValues(podSecurityContext, serverPod1.podSecurityContext);
     copyValues(containerSecurityContext, serverPod1.containerSecurityContext);
+  }
+
+  private void addJavaOptionsIfMissing(String javaOptions) {
+    if (!hasEnvVar("JAVA_OPTIONS"))
+      addEnvVar(new V1EnvVar().name("JAVA_OPTIONS").value(javaOptions));
   }
 
   @SuppressWarnings("Duplicates")

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -1216,6 +1216,24 @@ public class DomainV2Test extends DomainTestBase {
   }
 
   @Test
+  public void whenDomain3ReadFromYaml_managedServerHasJavaOptionFromDomain() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_3);
+
+    assertThat(
+        domain.getServer("server1", null).getEnvironmentVariables(),
+        contains(envVar("JAVA_OPTIONS", "-add-this")));
+  }
+
+  @Test
+  public void whenDomain3ReadFromYaml_adminServerHasOverridenJavaOption() throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_3);
+
+    assertThat(
+        domain.getAdminServerSpec().getEnvironmentVariables(),
+        contains(envVar("JAVA_OPTIONS", "-server")));
+  }
+
+  @Test
   public void whenDomainReadFromYaml_DomainRestartVersion() throws IOException {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
     assertThat(domain.getAdminServerSpec().getDomainRestartVersion(), is("1"));

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-3.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample-3.yaml
@@ -16,6 +16,8 @@ spec:
   # The Admin Server's ListenPort
   asPort: 8001
 
+  serverPod:
+    javaOptions: "-add-this"
   adminServer:
   # the T3 endpoints to export. Each entry is an endpoint name,
   # optionally with labels and annotations to be added to the generated external channel service.
@@ -29,6 +31,9 @@ spec:
         annotations:
           time: midnight
     serverPod:
+      env:
+      - name: JAVA_OPTIONS
+        value: "-server"
       nodeSelector:
         os: linux
       serviceLabels:


### PR DESCRIPTION
Adds the functionality that we had in 1.1 and which is documented in the wiki. It provides an alternative way to set the JAVA_OPTIONS environment variable.