### PR TITLE
Add customization of base image in domain-home-in-image sample

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -68,7 +68,7 @@ The following parameters can be provided in the inputs file.
 | `adminPort` | Port number for the Administration Server inside the Kubernetes cluster. | `7001` |
 | `adminNodePort` | Port number of the Administration Server outside the Kubernetes cluster. | `30701` |
 | `adminServerName` | Name of the Administration Server. | `admin-server` |
-| `baseImage` | The image that is used to build the domain-home-in-image Docker image. | `oracle/weblogic:12.2.1.3-developer` |
+| `baseImage` | The image that is used to build the domain-home-in-image Docker image. If not specified, use the built-in base image `oracle/weblogic:12.2.1.3-developer`. | `oracle/weblogic:12.2.1.3-developer` |
 | `clusterName` | Name of the WebLogic cluster instance to generate for the domain. | `cluster-1` |
 | `clusterType` | Type of the WebLogic Cluster. Legal values are `CONFIGURED` or `DYNAMIC`. | `DYNAMIC` |
 | `configuredManagedServerCount` | Number of Managed Server instances to generate for the domain. | `2` |

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -68,6 +68,7 @@ The following parameters can be provided in the inputs file.
 | `adminPort` | Port number for the Administration Server inside the Kubernetes cluster. | `7001` |
 | `adminNodePort` | Port number of the Administration Server outside the Kubernetes cluster. | `30701` |
 | `adminServerName` | Name of the Administration Server. | `admin-server` |
+| `baseImage` | The image that is used to build the domain-home-in-image Docker image. | `oracle/weblogic:12.2.1.3-developer` |
 | `clusterName` | Name of the WebLogic cluster instance to generate for the domain. | `cluster-1` |
 | `clusterType` | Type of the WebLogic Cluster. Legal values are `CONFIGURED` or `DYNAMIC`. | `DYNAMIC` |
 | `configuredManagedServerCount` | Number of Managed Server instances to generate for the domain. | `2` |

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -73,3 +73,7 @@ namespace: default
 #Java Option for Weblogic Server
 javaOptions: -Dweblogic.StdoutDebugEnabled=false
 
+#Base image used to build the domain home in image Docker image
+#By default, it is oracle/weblogic:12.2.1.3-developer
+baseImage:
+

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -74,6 +74,6 @@ namespace: default
 javaOptions: -Dweblogic.StdoutDebugEnabled=false
 
 #Base image used to build the domain home in image Docker image
-#By default, it is oracle/weblogic:12.2.1.3-developer
-baseImage:
+#If not specified, use the built-in base image oracle/weblogic:12.2.1.3-developer
+baseImage: oracle/weblogic:12.2.1.3-developer
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -311,6 +311,10 @@ function createDomainHome {
   sed -i -e "s|myuser|${username}|g" properties/docker_build/domain_security.properties
   sed -i -e "s|mypassword1|${password}|g" properties/docker_build/domain_security.properties
 
+  if [ ! -z $baseImage ]; then
+    sed -i -e "s|oracle/weblogic:12.2.1.3-developer|${baseImage}|g" Dockerfile
+  fi
+
   ./build.sh
 
   if [ "$?" != "0" ]; then


### PR DESCRIPTION
Right now, the domain-home-in-image Docker project uses unpatched WebLogic 12.2.1.3 image oracle/weblogic:12.2.1.3-developer.  This option allows us to test with 19c or patched 12.2.1.3 image.