### PR TITLE
Fix bug in override secret mount path

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -235,7 +235,8 @@ public abstract class JobStepContext implements StepContextConstants {
     List<String> configOverrideSecrets = getConfigOverrideSecrets();
     for (String secretName : configOverrideSecrets) {
       container.addVolumeMountsItem(
-          readOnlyVolumeMount(secretName + "-volume", OVERRIDE_SECRETS_MOUNT_PATH));
+          readOnlyVolumeMount(
+              secretName + "-volume", OVERRIDE_SECRETS_MOUNT_PATH + '/' + secretName));
     }
     return container;
   }

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -789,6 +789,13 @@ class CustomSitConfigIntrospector(SecretManager):
 
 
   def addSecretsFromDirectory(self, secret_path, secret_name):
+    if not os.path.isdir(secret_path):
+      # The operator pod somehow put a file where we
+      # only expected to find a directory mount.
+      self.env.addError("Internal Error:  Secret path'" 
+                        + secret_path + "'" +
+                        + " is not a directory.")
+      return
     for the_file in os.listdir(secret_path):
       the_file_path = os.path.join(secret_path, the_file)
       if os.path.isfile(the_file_path):


### PR DESCRIPTION
Fix a problem found by @vanajamukkara where custom override secret macros such as ${secret:mysecretname.username} could not be resolved because the Operator pod was not mounting a path named 'mysecretname' in the expected location for the introspector job.   

For example, an override secret named 'secret-name' with key 'secret-key' was showing up in '/weblogic-operator/config-overrides/secret-key' instead of the expected '/weblogic-operator/config-overrides/secret-name/secret-key'.

This fix passes local ad-hoc testing.