### PR TITLE
OWLS-70593: OPERATOR: CUSTOM OVERRIDE CONFIG MAP DOES NOT TAKE EFFECT WHEN DYNAMICALLY ADDED

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/BaseConfiguration.java
@@ -111,11 +111,11 @@ public abstract class BaseConfiguration {
     serverPod.addEnvVar(new V1EnvVar().name(name).value(value));
   }
 
-  void setServerStartPolicy(String serverStartPolicy) {
+  public void setServerStartPolicy(String serverStartPolicy) {
     this.serverStartPolicy = serverStartPolicy;
   }
 
-  protected String getServerStartPolicy() {
+  public String getServerStartPolicy() {
     return serverStartPolicy;
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -440,7 +440,7 @@ public class DomainSpec extends BaseConfiguration {
 
   @Nullable
   @Override
-  protected String getServerStartPolicy() {
+  public String getServerStartPolicy() {
     return Optional.ofNullable(super.getServerStartPolicy()).orElse(START_IF_NEEDED);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -204,11 +204,6 @@ public class JobHelper {
       }
     }
 
-    // Start Admin Server?
-    if (!spec.getAdminServer().getServerStartPolicy().equals(ConfigurationConstants.START_NEVER)) {
-      return true;
-    }
-
     return false;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -175,31 +175,39 @@ public class JobHelper {
     List<ManagedServer> servers = spec.getManagedServers();
 
     // Are we starting a cluster?
+    // NOTE: clusterServerStartPolicy == null indicates default policy
     for (Cluster cluster : clusters) {
       int replicaCount = cluster.getReplicas();
+      String clusterServerStartPolicy = cluster.getServerStartPolicy();
       LOGGER.fine(
           "Start Policy: "
-              + cluster.getServerStartPolicy()
+              + clusterServerStartPolicy
               + ", replicaCount: "
               + replicaCount
               + " for cluster: "
               + cluster);
-      if (!cluster.getServerStartPolicy().equals(ConfigurationConstants.START_NEVER)
+      if ((clusterServerStartPolicy == null
+              || !clusterServerStartPolicy.equals(ConfigurationConstants.START_NEVER))
           && replicaCount > 0) {
         return true;
       }
     }
 
     // If Domain level Server Start Policy = ALWAYS, IF_NEEDED or ADMIN_ONLY then we most likely
-    // will
-    // start a server pod
-    if (!dom.getSpec().getServerStartPolicy().equals(ConfigurationConstants.START_NEVER)) {
+    // will start a server pod
+    // NOTE: domainServerStartPolicy == null indicates default policy
+    String domainServerStartPolicy = dom.getSpec().getServerStartPolicy();
+    if (domainServerStartPolicy == null
+        || !domainServerStartPolicy.equals(ConfigurationConstants.START_NEVER)) {
       return true;
     }
 
     // Are we starting any explicitly specified individual server?
+    // NOTE: serverStartPolicy == null indicates default policy
     for (ManagedServer server : servers) {
-      if (!server.getServerStartPolicy().equals(ConfigurationConstants.START_NEVER)) {
+      String serverStartPolicy = server.getServerStartPolicy();
+      if (serverStartPolicy == null
+          || !serverStartPolicy.equals(ConfigurationConstants.START_NEVER)) {
         return true;
       }
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -128,7 +128,7 @@ public class ManagedServersUpStep extends Step {
     Collection<String> runningList = new ArrayList<>();
     for (Map.Entry<String, ServerKubernetesObjects> entry : info.getServers().entrySet()) {
       ServerKubernetesObjects sko = entry.getValue();
-      if (sko != null && sko.getPod() != null) {
+      if (sko != null && sko.getPod().get() != null) {
         runningList.add(entry.getKey());
       }
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -30,6 +30,7 @@ import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.weblogic.domain.v2.Cluster;
+import oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants;
 import oracle.kubernetes.weblogic.domain.v2.Domain;
 import oracle.kubernetes.weblogic.domain.v2.DomainSpec;
 import org.hamcrest.Matcher;
@@ -158,6 +159,7 @@ public class DomainIntrospectorJobTest {
     Cluster cluster = new Cluster();
     cluster.setClusterName("cluster-1");
     cluster.setReplicas(1);
+    cluster.setServerStartPolicy(ConfigurationConstants.START_IF_NEEDED);
     DomainSpec spec =
         new DomainSpec()
             .withDomainUID(UID)
@@ -166,6 +168,7 @@ public class DomainIntrospectorJobTest {
             .withCluster(cluster)
             .withImage(LATEST_IMAGE)
             .withDomainHomeInImage(false);
+    spec.setServerStartPolicy(ConfigurationConstants.START_IF_NEEDED);
 
     List<String> overrideSecrets = new ArrayList<>();
     overrideSecrets.add(OVERRIDE_SECRET_1);


### PR DESCRIPTION
Fix for 'running servers' count for doing introspection job.  Also added some logic for looking at 'Server Start' policy for best effort in determining if we're  going from zero to one or more managed server pods.