### PR TITLE
Add an option to not alway clone the docker images project plus bug-fixing

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -43,8 +43,8 @@ usage: create-domain.sh -o dir -i file -u username -p password [-s] [-e] [-h]
   -u Username used in building the Docker image for WebLogic domain in image.
   -p Password used in building the Docker image for WebLogic domain in image.
   -e Also create the resources in the generated YAML files, optional.
-  -s Save what has been previously cloned https://github.com/oracle/docker-images.git, optional. 
-     The default is false, which means this script will always remove existing project and clone again.
+  -k Keep what has been previously cloned from https://github.com/oracle/docker-images.git, optional. 
+     If not specified, this script will always remove existing project and clone again.
   -h Help
 
 ```

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -37,12 +37,14 @@ The usage of the create script is as follows:
 
 ```
 $ sh create-domain.sh -h
-usage: create-domain.sh -o dir -i file -u username -p password [-e] [-h]
+usage: create-domain.sh -o dir -i file -u username -p password [-s] [-e] [-h]
   -i Parameter inputs file, must be specified.
   -o Ouput directory for the generated properties and YAML files, must be specified.
   -u Username used in building the Docker image for WebLogic domain in image.
   -p Password used in building the Docker image for WebLogic domain in image.
   -e Also create the resources in the generated YAML files, optional.
+  -s Save what has been previously cloned https://github.com/oracle/docker-images.git, optional. 
+     The default is false, which means this script will always remove existing project and clone again.
   -h Help
 
 ```

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -20,14 +20,14 @@ source ${scriptDir}/../../common/utility.sh
 source ${scriptDir}/../../common/validate.sh
 
 function usage {
-  echo usage: ${script} -o dir -i file -u username -p password [-s] [-e] [-h]
+  echo usage: ${script} -o dir -i file -u username -p password [-k] [-e] [-h]
   echo "  -i Parameter inputs file, must be specified."
   echo "  -o Ouput directory for the generated properties and YAML files, must be specified."
   echo "  -u Username used in building the Docker image for WebLogic domain in image."
   echo "  -p Password used in building the Docker image for WebLogic domain in image."
   echo "  -e Also create the resources in the generated YAML files, optional."
-  echo "  -s Save what has been previously cloned https://github.com/oracle/docker-images.git, optional. "
-  echo "     The default is false, which means this script will always remove existing project and clone again."
+  echo "  -k Keep what has been previously from cloned https://github.com/oracle/docker-images.git, optional. "
+  echo "     If not specified, this script will always remove existing project directory and clone again."
   echo "  -h Help"
   exit $1
 }
@@ -37,7 +37,7 @@ function usage {
 #
 executeIt=false
 cloneIt=true
-while getopts "evhsi:o:u:p:" opt; do
+while getopts "evhki:o:u:p:" opt; do
   case $opt in
     i) valuesInputFile="${OPTARG}"
     ;;
@@ -49,7 +49,7 @@ while getopts "evhsi:o:u:p:" opt; do
     ;;
     p) password="${OPTARG}"
     ;;
-    s) cloneIt=false;
+    k) cloneIt=false;
     ;;
     h) usage 0
     ;;
@@ -152,7 +152,7 @@ function initialize {
 # Function to get the dependency docker sample
 #
 function getDockerSample {
-  rm -rf {scriptDir}/docker-images
+  rm -rf ${scriptDir}/docker-images
   git clone https://github.com/oracle/docker-images.git
 }
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/domain-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/domain-template.yaml
@@ -17,7 +17,7 @@ spec:
   # If the domain home is in the image
   domainHomeInImage: true
   # The Operator currently does not support other images
-  image: "12213-domain-home-in-image:latest"
+  image: %IMAGE_NAME%
   # imagePullPolicy defaults to "Never"
   imagePullPolicy: "Never"
   # Identify which Secret contains the WebLogic Admin credentials (note that there is an example of
@@ -26,9 +26,9 @@ spec:
     name: %WEBLOGIC_CREDENTIALS_SECRET_NAME%
   # Whether to include the server out file into the pod's stdout, default is true
   includeServerOutInPodLog: %INCLUDE_SERVER_OUT_IN_POD_LOG%
-  # serverStartPolicy legal values are "NEVER", "ALWAYS", "IF_NEEDED", or "ADMIN_ONLY"
+  # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
   # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
-  # - "ALWAYS" will start up all defined servers
+  # - "NEVER" will not start any servers in the domain 
   # - "ADMIN_ONLY" will start up only the administration server (no managed servers will be started)
   # - "IF_NEEDED" will start all non-clustered servers, including the administration server and clustered servers up to the replica count
   serverStartPolicy: "%SERVER_START_POLICY%"
@@ -58,3 +58,4 @@ spec:
       replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
   # The number of managed servers to start from clusters not listed in clusters
   # replicas: 1
+


### PR DESCRIPTION
1) add a command line option to keep using the previously cloned project dir. This allows customers to re-generate the images after modifying the WDT model files.
2) Fix hard-coded image value in the domain yaml file
3) Correct credentials override for WDT case.

@anpanigr 