### PR TITLE
Fixes for WebLogic Server and Node Manager .log and .out locations

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
@@ -306,6 +306,10 @@ public class Domain {
         .orElse(String.format(LOG_HOME_DEFAULT_PATTERN, getDomainUID()));
   }
 
+  public boolean getLogHomeEnabled() {
+    return spec.getLogHomeEnabled();
+  }
+
   public boolean isIncludeServerOutInPodLog() {
     return spec.getIncludeServerOutInPodLog();
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -97,6 +97,7 @@ public abstract class JobStepContext implements StepContextConstants {
   }
 
   String getEffectiveLogHome() {
+    if (!getDomain().getLogHomeEnabled()) return "";
     String logHome = getLogHome();
     if (logHome == null || "".equals(logHome.trim())) {
       // logHome not specified, use default value

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -158,6 +158,7 @@ public abstract class PodStepContext implements StepContextConstants {
   }
 
   String getEffectiveLogHome() {
+    if (!getDomain().getLogHomeEnabled()) return "";
     String logHome = getLogHome();
     if (logHome == null || "".equals(logHome.trim())) {
       // logHome not specified, use default value

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -797,7 +797,7 @@ class SitConfigGenerator(Generator):
     self.writeln("</d:security-configuration>")
 
   def customizeDomainLogPath(self):
-    self.customizeLog(self.env.getDomain().getName())
+    self.customizeLog(self.env.getDomain().getName(), self.env.getDomain(), true)
 
   def customizeServers(self):
     for server in self.env.getDomain().getServers():
@@ -824,7 +824,7 @@ class SitConfigGenerator(Generator):
       self.writeln("<d:listen-address f:combine-mode=\"replace\">" + listen_address + "</d:listen-address>")
       self.undent()
       self.writeln("</d:network-access-point>")
-    self.customizeLog(name)
+    self.customizeLog(name, server, false)
     self.undent()
     self.writeln("</d:server>")
 
@@ -840,18 +840,33 @@ class SitConfigGenerator(Generator):
     self.indent()
     self.writeln("<d:name>" + name + "</d:name>")
     self.writeln("<d:listen-address f:combine-mode=\"replace\">" + listen_address + "</d:listen-address>")
-    self.customizeLog(server_name_prefix + "${id}")
+    self.customizeLog(server_name_prefix + "${id}", template, false)
     self.undent()
     self.writeln("</d:server-template>")
 
-  def customizeLog(self, name):
+  def customizeLog(self, name, bean, isDomainBean):
     logs_dir = self.env.getDomainLogHome()
-    if logs_dir is not None:
-      self.writeln("<d:log f:combine-mode=\"replace\">")
-      self.indent()
-      self.writeln("<d:file-name>" + logs_dir + "/" + name + ".log</d:file-name>")
-      self.undent()
-      self.writeln("</d:log>")
+    if logs_dir is None or len(logs_dir) == 0:
+      return
+
+    logaction=''
+    fileaction=''
+    if bean.getLog() is None:
+      if not isDomainBean:
+        # don't know why, but don't need to "add" a missing domain log bean, and adding it causes trouble
+        logaction=' f:combine-mode="add"'
+      fileaction=' f:combine-mode="add"'
+    else:
+      if bean.getLog().getFileName() is None:
+        fileaction=' f:combine-mode="add"'
+      else:
+        fileaction=' f:combine-mode="replace"'
+
+    self.writeln("<d:log" + logaction + ">")
+    self.indent()
+    self.writeln("<d:file-name" + fileaction + ">" + logs_dir + "/" + name + ".log</d:file-name>")
+    self.undent()
+    self.writeln("</d:log>")
 
 class CustomSitConfigIntrospector(SecretManager):
 

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -60,7 +60,6 @@ checkEnv DOMAIN_UID \
          DOMAIN_HOME \
          JAVA_HOME \
          NODEMGR_HOME \
-         LOG_HOME \
          WL_HOME \
          MW_HOME \
          || exit 1

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -327,7 +327,7 @@ public abstract class PodHelperTestBase {
             hasEnvVar("DOMAIN_UID", UID),
             hasEnvVar("NODEMGR_HOME", NODEMGR_HOME),
             hasEnvVar("SERVER_OUT_IN_POD_LOG", Boolean.toString(INCLUDE_SERVER_OUT_IN_POD_LOG)),
-            hasEnvVar("LOG_HOME", LOG_HOME + "/" + UID),
+            hasEnvVar("LOG_HOME", ""),
             hasEnvVar("SERVICE_NAME", LegalNames.toServerServiceName(UID, getServerName())),
             hasEnvVar("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER))));
   }
@@ -335,12 +335,14 @@ public abstract class PodHelperTestBase {
   @Test
   public void whenPodCreated_withLogHomeSpecified_hasLogHomeEnvVariable() {
     final String MY_LOG_HOME = "/shared/mylogs";
+    domainPresenceInfo.getDomain().getSpec().setLogHomeEnabled(true);
     domainPresenceInfo.getDomain().getSpec().setLogHome("/shared/mylogs");
     assertThat(getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("LOG_HOME", MY_LOG_HOME)));
   }
 
   @Test
   public void whenPodCreated_withoutLogHomeSpecified_hasDefaultLogHomeEnvVariable() {
+    domainPresenceInfo.getDomain().getSpec().setLogHomeEnabled(true);
     domainPresenceInfo.getDomain().getSpec().setLogHome(null);
     assertThat(
         getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("LOG_HOME", LOG_HOME + "/" + UID)));
@@ -462,7 +464,8 @@ public abstract class PodHelperTestBase {
     testSupport.verifyCompletionThrowable(ApiException.class);
   }
 
-  @Test
+  // TBD This test fails - don't know why.
+  // @Test
   public void whenCompliantPodExists_recordIt() {
     initializeExistingPod(createPodModel());
     testSupport.runSteps(getStepFactory(), terminalStep);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -464,8 +464,7 @@ public abstract class PodHelperTestBase {
     testSupport.verifyCompletionThrowable(ApiException.class);
   }
 
-  // TBD This test fails - don't know why.
-  // @Test
+  @Test
   public void whenCompliantPodExists_recordIt() {
     initializeExistingPod(createPodModel());
     testSupport.runSteps(getStepFactory(), terminalStep);
@@ -563,7 +562,7 @@ public abstract class PodHelperTestBase {
         .addEnvItem(envItem("NODEMGR_HOME", NODEMGR_HOME))
         .addEnvItem(
             envItem("SERVER_OUT_IN_POD_LOG", Boolean.toString(INCLUDE_SERVER_OUT_IN_POD_LOG)))
-        .addEnvItem(envItem("LOG_HOME", LOG_HOME + "/" + UID))
+        .addEnvItem(envItem("LOG_HOME", ""))
         .addEnvItem(envItem("SERVICE_NAME", LegalNames.toServerServiceName(UID, getServerName())))
         .addEnvItem(envItem("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER)))
         .livenessProbe(createLivenessProbe())

--- a/src/integration-tests/introspector/introspectDomainProxy.sh
+++ b/src/integration-tests/introspector/introspectDomainProxy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2018, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+/weblogic-operator/scripts/introspectDomain.sh
+
+# the introspectTest.sh script looks for this exact line:
+echo "INTROSPECT_DOMAIN_EXIT=$?"
+
+echo In "$0" SLEEPING
+
+while [ 1 -eq 1 ]; do 
+  sleep 10
+done

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -336,6 +336,7 @@ function deployTestScriptConfigMap() {
   cp ${SOURCEPATH}/operator/src/main/resources/scripts/traceUtils* ${test_home}/test-scripts || exit 1
   cp ${SCRIPTPATH}/createDomain.sh ${test_home}/test-scripts || exit 1
   cp ${SCRIPTPATH}/createTestRoot.sh ${test_home}/test-scripts || exit 1
+  cp ${SCRIPTPATH}/introspectDomainProxy.sh ${test_home}/test-scripts || exit 1
 
   if [ "$CREATE_DOMAIN" = "true" ]; then
     rm -f ${test_home}/scripts/createDomain.py
@@ -454,6 +455,7 @@ function deployCreateDomainJob() {
 #   - this emulates what the operator pod would do prior to start wl-pods
 #
 
+# Alternatively, run deployIntrospectJobPod() instead.
 function deployIntrospectJob() {
   local introspect_output_cm_name=${DOMAIN_UID}-weblogic-domain-introspect-cm
 
@@ -482,6 +484,105 @@ function deployIntrospectJob() {
 
   createConfigMapFromDir $introspect_output_cm_name ${test_home}/jobfiles 
 
+}
+
+# Here we emulate the introspect job by directly starting an introspect pod and monitoring it.
+# deployIntrospectJob() does about the same thing, but starts a pod via a job
+# (Running a pod directly is helpful for debugging.)
+
+function deployIntrospectJobPod() {
+  local introspect_output_cm_name=${DOMAIN_UID}-weblogic-domain-introspect-cm
+  local target_yaml=${test_home}/wl-introspect-pod.yaml
+  local pod_name=${DOMAIN_UID}--introspect-domain-pod
+  local job_name=$pod_name
+
+  trace "Info: Run introspection job, parse its output to files, and put files in configmap '$introspect_output_cm_name'."
+
+  # delete anything left over from a previous invocation of this function
+
+  kubectl -n $NAMESPACE delete cm $introspect_output_cm_name \
+    --ignore-not-found  \
+    2>&1 | tracePipe "Info: kubectl output: "
+
+  if [ -f "${target_yaml}" ]; then
+    kubectl -n $NAMESPACE delete -f ${target_yaml} \
+      --ignore-not-found \
+      2>&1 | tracePipe "Info: kubectl output: "
+    rm -f ${target_yaml}
+  fi
+
+  trace "Info: Deploying job pod '$pod_name' and waiting for it to be ready."
+
+  (
+    export SERVER_NAME=introspect
+    export JOB_NAME=${DOMAIN_UID}--introspect-domain-pod
+    export JOB_SCRIPT=/test-scripts/introspectDomainProxy.sh
+    export SERVICE_NAME=`toDNS1123Legal ${DOMAIN_UID}-${server_name}`
+    export AS_SERVICE_NAME=`toDNS1123Legal ${DOMAIN_UID}-${ADMIN_NAME}`
+    if [ "${SERVER_NAME}" = "${ADMIN_NAME}" ]; then
+      export LOCAL_SERVER_DEFAULT_PORT=$ADMIN_PORT
+    else
+      export LOCAL_SERVER_DEFAULT_PORT=$MANAGED_SERVER_PORT
+    fi
+    ${SCRIPTPATH}/util_subst.sh -g wl-introspect-pod.yamlt ${target_yaml}  || exit 1
+  ) || exit 1
+
+  kubectl create -f ${target_yaml} \
+    2>&1 | tracePipe "Info: kubectl output: " || exit 1
+
+  # Wait for pod to come up successfully
+
+  # TBD make the following a helper fn since this is the second place
+  #     we wait for a pod to start, and the code is exactly the same...
+  local status="0/1"
+  local startsecs=$SECONDS
+  local maxsecs=180
+  tracen "Info: Waiting up to $maxsecs seconds for pod '$pod_name' readiness"
+  while [ "${status}" != "1/1" ] ; do
+    if [ $((SECONDS - startsecs)) -gt $maxsecs ]; then
+      echo
+      trace "Error: pod $pod_name failed to start within $maxsecs seconds.  kubectl describe:"
+      kubectl -n $NAMESPACE describe pod $pod_name
+      trace "Error: pod $pod_name failed to start within $maxsecs seconds.  kubectl log:"
+      kubectl -n $NAMESPACE logs $pod_name
+      exit 1
+    fi
+    echo -n "."
+    sleep 1
+    status=`kubectl -n $NAMESPACE get pods 2>&1 | egrep $pod_name | awk '{print $2}'`
+  done
+  echo "  ($((SECONDS - startsecs)) seconds)"
+
+  local startSecs=$SECONDS
+  local maxsecs=30
+  local exitString=""
+  tracen "Info: Waiting up to $maxsecs seconds for pod '$pod_name' to run the introspectDomain.py script."
+  printdots_start
+  while [ $((SECONDS - startSecs)) -lt $maxsecs ] && [ "$exitString" = "" ]; do
+    exitString="`kubectl -n $NAMESPACE logs $pod_name 2>&1 | grep INTROSPECT_DOMAIN_EXIT`"
+    sleep 1
+  done
+  printdots_end
+  if [ "$exitString" = "" ]; then
+    trace "Error: Introspector timed out, see 'kubectl -n $NAMESPACE logs $pod_name'."
+    exit 1
+  fi
+  if [ ! "$exitString" = "INTROSPECT_DOMAIN_EXIT=0" ]; then
+    trace "Error: Introspector pod script failed, see 'kubectl -n $NAMESPACE logs $pod_name'."
+    exit 1
+  fi
+
+  # parse job pod's output files
+
+  kubectl -n $NAMESPACE logs $pod_name > ${test_home}/job-${DOMAIN_UID}-introspect-domain-pod-job.out 
+
+  ${SCRIPTPATH}/util_fsplit.sh \
+    ${test_home}/job-${DOMAIN_UID}-introspect-domain-pod-job.out \
+    ${test_home}/jobfiles || exit 1
+
+  # put the outputfile in a cm
+
+  createConfigMapFromDir $introspect_output_cm_name ${test_home}/jobfiles 
 }
 
 #############################################################################
@@ -664,7 +765,8 @@ if [ ! "$RERUN_INTROSPECT_ONLY" = "true" ]; then
   createTestRootPVDir
   deployWebLogic_PV_PVC_and_Secret
   deployCreateDomainJob
-  deployIntrospectJob
+  #deployIntrospectJob
+  deployIntrospectJobPod
   deployPod ${ADMIN_NAME?}
   deploySinglePodService ${ADMIN_NAME?} ${ADMIN_PORT?} 30701
   deployPod ${MANAGED_SERVER_NAME_BASE?}1

--- a/src/integration-tests/introspector/wl-introspect-pod.yamlt
+++ b/src/integration-tests/introspector/wl-introspect-pod.yamlt
@@ -1,0 +1,67 @@
+# Copyright 2018, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    weblogic.createdByOperator: "true"
+    weblogic.domainUID: ${DOMAIN_UID}
+    weblogic.resourceVersion: domain-v2
+  name: ${JOB_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  containers:
+  - command:
+    - ${JOB_SCRIPT}
+    env:
+    - name: NAMESPACE
+      value: "${NAMESPACE}"
+    - name: DOMAIN_UID
+      value: "${DOMAIN_UID}"
+    - name: DOMAIN_HOME
+      value: "${DOMAIN_HOME}"
+    - name: NODEMGR_HOME
+      value: "${NODEMGR_HOME}"
+    - name: LOG_HOME
+      value: "${LOG_HOME}"
+    - name: CREDENTIALS_SECRET_NAME
+      value: "${WEBLOGIC_CREDENTIALS_SECRET_NAME}"
+    image: "${WEBLOGIC_IMAGE_NAME}:${WEBLOGIC_IMAGE_TAG}"
+    imagePullPolicy: ${WEBLOGIC_IMAGE_PULL_POLICY}
+    name: weblogic-server
+    volumeMounts:
+    - name: weblogic-credentials-volume
+      mountPath: /weblogic-operator/secrets
+      readOnly: true
+    - name: weblogic-domain-cm-volume
+      mountPath: /weblogic-operator/scripts
+      readOnly: true
+    - name: ${DOMAIN_UID}-mycustom-overrides-cm-volume
+      mountPath: /weblogic-operator/config-overrides
+      readOnly: true
+    - name: test-script-cm-volume
+      mountPath: /test-scripts
+      readOnly: true
+    ${PVCOMMENT}- mountPath: /shared
+    ${PVCOMMENT}  name: weblogic-domain-storage-volume
+  volumes:
+  - name: weblogic-credentials-volume
+    secret:
+      defaultMode: 420
+      secretName:  ${WEBLOGIC_CREDENTIALS_SECRET_NAME}
+  - name: weblogic-domain-cm-volume
+    configMap:
+      defaultMode: 365
+      name: weblogic-domain-cm
+  - name: ${DOMAIN_UID}-mycustom-overrides-cm-volume
+    configMap:
+      defaultMode: 365
+      name: ${DOMAIN_UID}-mycustom-overrides-cm
+  - name: test-script-cm-volume
+    configMap:
+      defaultMode: 365
+      name: test-script-cm
+  ${PVCOMMENT}- name: weblogic-domain-storage-volume
+  ${PVCOMMENT}  persistentVolumeClaim:
+  ${PVCOMMENT}    claimName: ${DOMAIN_UID}-weblogic-domain-pvc


### PR DESCRIPTION
This check-in has two fixes:

- A: Adds missing support for putting logs in their default locations when logHomeEnabled is false (logHomeEnabled flag was being ignored)
- B: Generates correct sit-cfg overrides when original Log settings aren't set -- e.g. use "add" sit-cfg verb instead of "replace" (log files would end up in their default location instead of getting overridden)

Work-around, if not applying this check-in:

- Set 'logHome' to a location that has write-permission (helps with problem A above, not problem B)

Changes in this check-in:

- modify Operator to set LOG_HOME env var to '' when logHomeEnabled is false,
- modify startNodeManager.sh script to call mkdir ${DOMAIN_HOME}/servers/${SERVER_NAME}/logs instead of mkdir ${LOG_HOME} when LOG_HOME is '',
- modify startNodeManager.sh script to skip calling mkdir all-together when running inside an introspector pod,
- modify introspectDomain.py to skip creating sit-cfg overrides for log dirs if LOG_HOME is '' or null (it use to check for null, and did not check for ''),
- modify introspectDomain.py to use 'add' sit-config verbs instead of 'replace' if original log 'file-name' setting isn't explicitly set in the config.xml

Test status:

- Passes QUICKTEST integration testing when running locally.

- Passes Ad Hoc Testing
  - for both when setting log file-name on domain/server/server-template in config.xml, and when _not_ setting it:
    - For logHomeEnabled=true
      - confirm sit-cfg override works (log files for domain/server/server-template are in logHome)
      - also confirm NM log is in logHome too
      - also confirm .out from servers & node-manager end up in logHome too
    - For logHomeEnabled=false
      - verified sit-cfg isn't created
      - verified domain/server/server-tamplate/nodemanager logs end up at their respective default locations
      - verified server .out files end up in ${DOMAIN_HOME}/servers/${SERVER_NAME}/logs