### PR TITLE
Fix javadoc to get successful mvn javadoc:javadoc in 2.0-rc1 branch

### DIFF
--- a/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/Main.java
+++ b/json-schema-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/Main.java
@@ -56,6 +56,7 @@ public interface Main {
   /**
    * Returns a resource from the classpath, corresponding to the specified name.
    *
+   * @param name Name of the resource to be returned
    * @return a url to the specified resource, or null if none is found
    */
   URL getResource(String name);
@@ -65,6 +66,7 @@ public interface Main {
    *
    * @param className the root class for the schema
    * @param outputFile the file to generate
+   * @throws MojoExecutionException If an exception occurred during the schema generation
    */
   void generateSchema(String className, File outputFile) throws MojoExecutionException;
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -76,7 +76,7 @@ public interface ClusterConfigurator {
    * Add security constraints at container level, if the same constraint is also defined at pod
    * level then container constraint take precedence
    *
-   * @param podSecurityContext
+   * @param podSecurityContext pod-level security attributes to be added to this ClusterConfigurator
    * @return this object
    */
   ClusterConfigurator withPodSecurityContext(V1PodSecurityContext podSecurityContext);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -45,15 +45,17 @@ public abstract class DomainConfigurator {
   }
 
   /**
-   * @param domainHomeInImage
-   * @return
+   * Specifies whether the domain home is stored in the image
+   *
+   * @param domainHomeInImage boolean indicating if the domain home is stored in the image
+   * @return this object
    */
   public DomainConfigurator withDomainHomeInImage(boolean domainHomeInImage) {
     getDomainSpec().setDomainHomeInImage(domainHomeInImage);
     return this;
   }
 
-  /** Defines a name for the domain's admin server. */
+  /** @return An AdminServerConfigurator object for configuring an admin server */
   public abstract AdminServerConfigurator configureAdminServer();
 
   public void withDefaultReplicaCount(int replicas) {
@@ -169,6 +171,7 @@ public abstract class DomainConfigurator {
    * Sets the default server start policy ("ALWAYS", "NEVER" or "IF_NEEDED") for the domain.
    *
    * @param startPolicy the new default policy
+   * @return this object
    */
   public abstract DomainConfigurator withDefaultServerStartPolicy(String startPolicy);
 
@@ -260,7 +263,7 @@ public abstract class DomainConfigurator {
    * Add security constraints at container level, if the same constraint is also defined at pod
    * level then container constraint take precedence
    *
-   * @param podSecurityContext
+   * @param podSecurityContext pod-level security attributes to be added to this DomainConfigurator
    * @return this object
    */
   public abstract DomainConfigurator withPodSecurityContext(

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
@@ -72,7 +72,7 @@ public interface ServerConfigurator {
    * Add security constraints at container level, if the same constraint is also defined at pod
    * level then container constraint take precedence
    *
-   * @param podSecurityContext
+   * @param podSecurityContext pod-level security attributes to be added to this ServerConfigurator
    * @return this object
    */
   ServerConfigurator withPodSecurityContext(V1PodSecurityContext podSecurityContext);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -170,8 +170,8 @@ public class DomainSpec extends BaseConfiguration {
   /**
    * Adds a Cluster to the DomainSpec
    *
-   * @param cluster
-   * @return
+   * @param cluster The cluster to be added to this DomainSpec
+   * @return this object
    */
   public DomainSpec withCluster(Cluster cluster) {
     clusters.add(cluster);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ManagedServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ManagedServerSpecV2Impl.java
@@ -10,9 +10,9 @@ public class ManagedServerSpecV2Impl extends ServerSpecV2Impl {
    *
    * @param spec the domain specification
    * @param server the server whose configuration is to be returned
+   * @param cluster the cluster that this managed server belongs to
    * @param clusterLimit the number of servers desired for the cluster, or null if not a clustered
    *     server
-   * @param configurations the additional configurations to search for values if the server lacks
    */
   public ManagedServerSpecV2Impl(
       DomainSpec spec, Server server, Cluster cluster, Integer clusterLimit) {

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -49,6 +49,7 @@ public class PodWatcher extends Watcher<V1Pod>
    * @param factory thread factory
    * @param ns Namespace
    * @param initialResourceVersion Initial resource version or empty string
+   * @param tuning Watch tuning parameters
    * @param listener Callback for watch events
    * @param isStopping Stop signal
    * @return Pod watcher for the namespace

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CRDHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CRDHelper.java
@@ -35,6 +35,7 @@ public class CRDHelper {
   /**
    * Factory for {@link Step} that creates Domain CRD
    *
+   * @param version Version of the Kubernetes API Server
    * @param next Next step
    * @return Step for creating Domain custom resource definition
    */

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -520,6 +520,7 @@ public class CallBuilder {
    *
    * @param name Name
    * @param namespace Namespace
+   * @param deleteOptions Delete options
    * @param responseStep Response step for when call completes
    * @return Asynchronous step
    */
@@ -823,6 +824,7 @@ public class CallBuilder {
    *
    * @param name Name
    * @param namespace Namespace
+   * @param deleteOptions Delete options
    * @param responseStep Response step for when call completes
    * @return Asynchronous step
    */

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -249,6 +249,7 @@ public class ConfigMapHelper {
   /**
    * Factory for {@link Step} that creates config map containing sit config
    *
+   * @param next Next step
    * @return Step for creating config map containing sit config
    */
   public static Step createSitConfigMapStep(Step next) {
@@ -425,6 +426,8 @@ public class ConfigMapHelper {
   /**
    * Factory for {@link Step} that deletes introspector config map
    *
+   * @param domainUID The unique identifier assigned to the Weblogic domain when it was registered
+   * @param namespace Namespace
    * @param next Next processing step
    * @return Step for deleting introspector config map
    */

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -53,6 +53,7 @@ public class DomainPresenceInfo {
    * Create presence for a domain
    *
    * @param namespace Namespace
+   * @param domainUID The unique identifier assigned to the Weblogic domain when it was registered
    */
   public DomainPresenceInfo(String namespace, String domainUID) {
     this.domain = new AtomicReference<>(null);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -110,6 +110,7 @@ public class JobHelper {
   /**
    * Factory for {@link Step} that creates WebLogic domain introspector job
    *
+   * @param tuning Watch tuning parameters
    * @param next Next processing step
    * @return Step for creating job
    */
@@ -218,8 +219,10 @@ public class JobHelper {
   /**
    * Factory for {@link Step} that deletes WebLogic domain introspector job
    *
+   * @param domainUID The unique identifier assigned to the Weblogic domain when it was registered
+   * @param namespace Namespace
    * @param next Next processing step
-   * @return Step for deleting server pod
+   * @return Step for deleting the domain introsepctor jod
    */
   public static Step deleteDomainIntrospectorJobStep(
       String domainUID, String namespace, Step next) {
@@ -270,6 +273,7 @@ public class JobHelper {
   /**
    * Factory for {@link Step} that reads WebLogic domain introspector job results from pod's log
    *
+   * @param tuning Watch tuning parameters
    * @param next Next processing step
    * @return Step for reading WebLogic domain introspector pod log
    */

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -748,8 +748,8 @@ public class ServiceHelper {
   /**
    * Create asynchronous step for admin service
    *
-   * @param next
-   * @return
+   * @param next Next processing step
+   * @return Step for creating admin service
    */
   public static Step createForAdminServiceStep(Step next) {
     return new ForAdminServiceStep(next);

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -60,9 +60,10 @@ public class WlsDomainConfig implements WlsDomain {
    * Constructor
    *
    * @param name Name of this WLS domain
+   * @param adminServerName Name of the admin server in this WLS domain
    * @param wlsClusterConfigs A Map containing clusters configured in this WLS domain
    * @param wlsServerConfigs A Map containing servers configured in the WLS domain
-   * @param serverTemplates A Map containing server templates configued in this WLS domain
+   * @param wlsServerTemplates A Map containing server templates configued in this WLS domain
    * @param wlsMachineConfigs A Map containing machines configured in the WLS domain
    */
   public WlsDomainConfig(


### PR DESCRIPTION
Fixed javadoc warnings and errors to get mvn javadoc:javadoc to run successfully on 2.0-rc1 branch