### PR TITLE
a fix for domains created with 'setOption('ServerStartMode','prod')' …

### DIFF
--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -159,7 +159,7 @@ cat <<EOF > ${nm_props_file}
   LogLimit=0
   DomainsDirRemoteSharingEnabled=true
   PropertiesVersion=12.2.1
-  AuthenticationEnabled=true
+  AuthenticationEnabled=false
   NodeManagerHome=${NODEMGR_HOME}
   JavaHome=${JAVA_HOME}
   LogLevel=FINEST


### PR DESCRIPTION
…which causes WLST nmConnect logins to fail