### PR TITLE
integration test should not always use /shared/logs/domain1 as logHome

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -942,6 +942,7 @@ public class Domain {
     }
 
     domainMap.put("domainHome", "/shared/domains/" + domainUid);
+    domainMap.put("logHome", "/shared/logs/" + domainUid);
     domainMap.put(
         "createDomainFilesDir",
         BaseTest.getProjectRoot() + "/integration-tests/src/test/resources/domain-home-on-pv");


### PR DESCRIPTION
integration test should override default logHome value of /shared/logs/domain1 from kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml