### PR TITLE
discard client on watch failure; extend socket timeout

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
@@ -126,7 +126,13 @@ abstract class Watcher<T> {
                 .withResourceVersion(resourceVersion.toString())
                 .withTimeoutSeconds(tuning.watchLifetime))) {
       while (watch.hasNext()) {
-        Watch.Response<T> item = watch.next();
+        Watch.Response<T> item;
+        try {
+          item = watch.next();
+        } catch (Throwable e) {
+          watch.discardClient();
+          throw e;
+        }
 
         if (isStopping()) setIsDraining(true);
         if (isDraining()) continue;

--- a/operator/src/main/java/oracle/kubernetes/operator/builders/WatchI.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/builders/WatchI.java
@@ -14,4 +14,6 @@ import java.util.Iterator;
  * @param <T> the generic object type
  */
 public interface WatchI<T>
-    extends Iterable<Watch.Response<T>>, Iterator<Watch.Response<T>>, java.io.Closeable {}
+    extends Iterable<Watch.Response<T>>, Iterator<Watch.Response<T>>, java.io.Closeable {
+  default void discardClient() {}
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/builders/WatchImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/builders/WatchImpl.java
@@ -8,6 +8,7 @@ import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.util.Watch;
 import java.io.IOException;
 import java.util.Iterator;
+import javax.annotation.Nonnull;
 import oracle.kubernetes.operator.helpers.Pool;
 
 /**
@@ -15,7 +16,7 @@ import oracle.kubernetes.operator.helpers.Pool;
  */
 public class WatchImpl<T> implements WatchI<T> {
   private final Pool<ApiClient> pool;
-  private final ApiClient client;
+  private ApiClient client;
   private Watch<T> impl;
 
   WatchImpl(Pool<ApiClient> pool, ApiClient client, Watch<T> impl) {
@@ -31,6 +32,12 @@ public class WatchImpl<T> implements WatchI<T> {
   }
 
   @Override
+  public void discardClient() {
+    client = pool.take();
+  }
+
+  @Override
+  @Nonnull
   public Iterator<Watch.Response<T>> iterator() {
     return impl.iterator();
   }


### PR DESCRIPTION
When a watch fails, the client is sometimes rendered unusable, but we have been returning it to the pool, so that subsequent watch calls also fail. This is a short-term fix for that. When the exception is detected, we force the watch implementation to get a new client to be returned to the pool in place of the bad one.

A cleaner fix will move the responsibility for the client pooling to the Watcher itself.