### PR TITLE
Develop server lifecle site doc pod obsolete fix

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
@@ -105,6 +105,7 @@ class ServerPod {
 
   /**
    * The labels to be attached to pods.
+   * The label names must not start with 'weblogic.'.
    *
    * @since 2.0
    */
@@ -121,6 +122,7 @@ class ServerPod {
 
   /**
    * The labels to be attached to Service.
+   * The label names must not start with 'weblogic.'.
    *
    * @since 2.0
    */

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerPod.java
@@ -104,8 +104,7 @@ class ServerPod {
   private List<V1VolumeMount> volumeMounts = new ArrayList<>();
 
   /**
-   * The labels to be attached to pods.
-   * The label names must not start with 'weblogic.'.
+   * The labels to be attached to pods. The label names must not start with 'weblogic.'.
    *
    * @since 2.0
    */
@@ -121,8 +120,7 @@ class ServerPod {
   private Map<String, String> podAnnotations = new HashMap<>();
 
   /**
-   * The labels to be attached to Service.
-   * The label names must not start with 'weblogic.'.
+   * The labels to be attached to Service. The label names must not start with 'weblogic.'.
    *
    * @since 2.0
    */

--- a/site/server-lifecycle.md
+++ b/site/server-lifecycle.md
@@ -131,7 +131,7 @@ The `restartVersion` property on the domain resource lets you force the operator
 The operator runtime does rolling restarts of clustered servers so that service is maintained.
 
 ### Properties that cause servers to be restarted
-The operator will restart servers when any of the follow properties on the domain resource that affect the server, are changed:
+The operator will restart servers when any of the follow properties on the domain resource that affect the server are changed:
 * `annotations`
 * `containerSecurityContext`
 * `domainHome`
@@ -145,15 +145,14 @@ The operator will restart servers when any of the follow properties on the domai
 * `logHomeEnabled`
 * `logHome`
 * `livenessProbe`
+* `nodeSelector`
 * `podSecurityContext`
 * `readinessProbe`
+* `resources`
 * `restartVersion`
 * `serverStartState`
 * `volumes`
 * `volumeMounts`
-
-**Note**: The operator does not restart affected servers when `nodeSelector` or `resources` is changed on the domain resource.
-In these cases, you can use `restartVersion` to force the operator to restart the servers.
 
 ### Rolling restarts
 


### PR DESCRIPTION
Make the site doc in server-lifecycle.md that talks about when the operator automatically rolls pods match the operator runtime.

Add domain resource schema doc to say that customer supplied pod and service label names can't start with 'weblogic.'.
