### PR TITLE
Doc updates bad param and explicitly remove 1.x - fixes #731

### DIFF
--- a/site/helm-charts.md
+++ b/site/helm-charts.md
@@ -4,6 +4,15 @@
 
 The WebLogic Kubernetes Operator uses Helm to create and deploy any necessary resources and then run the operator in a Kubernetes cluster. Helm helps you manage Kubernetes applications. Helm charts help you define and install applications into the Kubernetes cluster. The operator's Helm chart is located in the `kubernetes/charts/weblogic-operator` directory.
 
+> If you have an old version of the operator installed on your cluster you must remove
+  it before installing this version.  You should remove the deployment (for example `kubectl delete deploy weblogic-operator -n your-namespace`) and the custom
+  resource definition (for example `kubectl delete crd domain`).  If you do not remove
+  the custom resource definition you may see errors like this: 
+  
+    `Error from server (BadRequest): error when creating "/scratch/output/uidomain/weblogic-domains/uidomain/domain.yaml": 
+    the API version in the data (weblogic.oracle/v2) does not match the expected API version (weblogic.oracle/v1`
+
+
 ## Install Helm and Tiller
 
 Helm has two parts: a client (helm) and a server (tiller). Tiller runs inside of your Kubernetes cluster, and manages releases (installations) of your charts.  See https://github.com/kubernetes/helm/blob/master/docs/install.md for detailed instructions on installing helm and tiller.

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -178,7 +178,7 @@ $ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -u username -p 
 You need to provide the WebLogic administration username and password in the `-u` and `-p` options
 respectively, as shown in the example.  If you specify the `-e` option, the script will generate the 
 Kubernetes YAML files *and* apply them to your cluster.  If you omit the `-e` option, the 
-script will jsut generate the YAML files, but will not take any action on your cluster.
+script will just generate the YAML files, but will not take any action on your cluster.
 
 c.	Confirm that the operator started the servers for the domain:
 * Use `kubectl` to show that the domain resource was created:

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -172,8 +172,13 @@ domain namespace (`sample-domain1-ns`) and the `domainHomeImageBase` (`oracle/we
 For example, assuming you named your copy `my-inputs.yaml`:
 ```
 $ cd kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image
-$ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -e
+$ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -u username -p password -e
 ```
+
+You need to provide the WebLogic administration username and password in the `-u` and `-p` options
+respectively, as shown in the example.  If you specify the `-e` option, the script will generate the 
+Kubernetes YAML files *and* apply them to your cluster.  If you omit the `-e` option, the 
+script will jsut generate the YAML files, but will not take any action on your cluster.
 
 c.	Confirm that the operator started the servers for the domain:
 * Use `kubectl` to show that the domain resource was created:

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -4,6 +4,14 @@ Use this quick start guide to create a WebLogic deployment in a Kubernetes clust
 These instructions assume that you are already familiar with Kubernetes.  If you need more detailed instructions, please
 refer to the [User guide](user-guide.md).
 
+> If you have an old version of the operator installed on your cluster you must remove
+  it before installing this version.  You should remove the deployment (for example `kubectl delete deploy weblogic-operator -n your-namespace`) and the custom
+  resource definition (for example `kubectl delete crd domain`).  If you do not remove
+  the custom resource definition you may see errors like this: 
+  
+    `Error from server (BadRequest): error when creating "/scratch/output/uidomain/weblogic-domains/uidomain/domain.yaml": 
+    the API version in the data (weblogic.oracle/v2) does not match the expected API version (weblogic.oracle/v1`
+
 ## Prerequisites
 For this exercise, you’ll need a Kubernetes cluster. If you need help setting one up, check out our [cheat sheet](k8s_setup.md).
 
@@ -164,7 +172,7 @@ domain namespace (`sample-domain1-ns`) and the `domainHomeImageBase` (`oracle/we
 For example, assuming you named your copy `my-inputs.yaml`:
 ```
 $ cd kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image
-$ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -e -v
+$ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -e
 ```
 
 c.	Confirm that the operator started the servers for the domain:


### PR DESCRIPTION
This PR updates the documentation to fix two issues reported by @bollinenisravan  

1. The quickstart listed `-v` as an option on the create-domain script in domain-in-image, but it is not a valid option in that script.

2. If you do not remove the 1.x CRD, create domain will fail with a version incompatibility error:

`Error from server (BadRequest): error when creating "/scratch/output/uidomain/weblogic-domains/uidomain/domain.yaml": the API version in the data (weblogic.oracle/v2) does not match the expected API version (weblogic.oracle/v1)`

