### PR TITLE
WIP:  Issue #721 fix.  When domain resource 'domainHome' is not set and 'domainHomeInImage' is 'true' look for a single WebLogic domain under '/u01/oracle/user_projects/domains', and use this as this location as the DOMAIN_HOME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ The fastest way to experience the operator is to follow the [Quick start guide](
 
 | Issue | Description |
 | --- | --- |
-| [#721](https://github.com/oracle/weblogic-kubernetes-operator/issues/721) | Incorrect default `domainHome` when `domainHomeInImage` is true. |
 | [#722](https://github.com/oracle/weblogic-kubernetes-operator/issues/722) | Server services not recreated when labels/annotations changed. |
 | [#726](https://github.com/oracle/weblogic-kubernetes-operator/issues/726) | Clusters only support default channel. |
 

--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -224,7 +224,7 @@
           "type": "string"
         },
         "domainHome": {
-          "description": "The folder for the Weblogic Domain. (Not required)Defaults to /shared/domains/domains/domainUID if domainHomeInImage is falseDefaults to /shared/domains/domain if domainHomeInImage is true",
+          "description": "The folder for the Weblogic Domain. (Not required)Defaults to /shared/domains/domains/domainUID if domainHomeInImage is falseDefaults to /u01/oracle/user_projects/domains/ if domainHomeInImage is true",
           "type": "string"
         },
         "logHomeEnabled": {

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1144,7 +1144,7 @@ window.onload = function() {
           "type": "string"
         },
         "domainHome": {
-          "description": "The folder for the Weblogic Domain. (Not required)Defaults to /shared/domains/domains/domainUID if domainHomeInImage is falseDefaults to /shared/domains/domain if domainHomeInImage is true",
+          "description": "The folder for the Weblogic Domain. (Not required)Defaults to /shared/domains/domains/domainUID if domainHomeInImage is falseDefaults to /u01/oracle/user_projects/domains/ if domainHomeInImage is true",
           "type": "string"
         },
         "logHomeEnabled": {

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -321,13 +321,13 @@ public class Domain {
   /**
    * Returns the domain home
    *
-   * <p>Defaults to either /shared/domain/ or /shared/domains/domainUID
+   * <p>Defaults to either /u01/oracle/user_projects/domains or /shared/domains/domainUID
    *
    * @return domain home
    */
   public String getDomainHome() {
     if (spec.getDomainHome() != null) return spec.getDomainHome();
-    if (spec.isDomainHomeInImage()) return "/shared/domain";
+    if (spec.isDomainHomeInImage()) return "/u01/oracle/user_projects/domains";
     return "/shared/domains/" + getDomainUID();
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -41,7 +41,7 @@ public class DomainSpec extends BaseConfiguration {
   @Description(
       "The folder for the Weblogic Domain. (Not required)"
           + "Defaults to /shared/domains/domains/domainUID if domainHomeInImage is false"
-          + "Defaults to /shared/domains/domain if domainHomeInImage is true")
+          + "Defaults to /u01/oracle/user_projects/domains/ if domainHomeInImage is true")
   private String domainHome;
 
   /**

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -1207,7 +1207,7 @@ public class DomainV2Test extends DomainTestBase {
   public void domainHomeTest_standardHome3() {
     configureDomain(domain).withDomainHomeInImage(true);
 
-    assertThat(domain.getDomainHome(), equalTo("/shared/domain"));
+    assertThat(domain.getDomainHome(), equalTo("/u01/oracle/user_projects/domains"));
   }
 
   @Test

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018, Oracle Corporation and/or its affiliates. All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 #
@@ -73,6 +73,10 @@ done
 for dir_var in DOMAIN_HOME JAVA_HOME WL_HOME MW_HOME; do
   [ ! -d "${!dir_var}" ] && trace "Error: missing ${dir_var} directory '${!dir_var}'." && exit 1
 done
+
+# check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed
+
+exportEffectiveDomainHome || exit 1
 
 # start node manager
 

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
@@ -8,24 +8,30 @@
 # the pod should be restarted. The script checks a WebLogic Server state file which
 # is updated by the node manager.
 
+# if the livenessProbeSuccessOverride file is available, treat failures as success:
+RETVAL=$(test -f /weblogic-operator/debug/livenessProbeSuccessOverride ; echo $?)
+
+SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
+source ${SCRIPTPATH}/traceUtils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit $RETVAL
+
+# check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
+exportEffectiveDomainHome || exit $RETVAL
+
 DN=${DOMAIN_NAME?}
 SN=${SERVER_NAME?}
 DH=${DOMAIN_HOME?}
 
 STATEFILE=${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
-# if the livenessProbeSuccessOverride file is available, treat failures as success
-#
-RETVAL=$(test -f /weblogic-operator/debug/livenessProbeSuccessOverride ; echo $?)
-
 if [ "${MOCK_WLS}" != 'true' ]; then
   if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
-    echo "Error: WebLogic NodeManager process not found."
+    trace "Error: WebLogic NodeManager process not found."
     exit $RETVAL
   fi
 fi
 if [ -f ${STATEFILE} ] && [ `grep -c "FAILED_NOT_RESTARTABLE" ${STATEFILE}` -eq 1 ]; then
-  echo "Error: WebLogic Server state is FAILED_NOT_RESTARTABLE."
+  trace "Error: WebLogic Server state is FAILED_NOT_RESTARTABLE."
   exit $RETVAL
 fi
 exit 0

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
-# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
 # Reads the current state of a server. The script checks a WebLogic Server state
 # file which is updated by the node manager.
+
+SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
+source ${SCRIPTPATH}/traceUtils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1
+
+# check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
+exportEffectiveDomainHome || exit 1
 
 DN=${DOMAIN_NAME?}
 SN=${SERVER_NAME?}
@@ -14,12 +21,12 @@ DH=${DOMAIN_HOME?}
 STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
 if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
-  echo "Error: WebLogic NodeManager process not found."
+  trace "Error: WebLogic NodeManager process not found."
   exit 1
 fi
 
 if [ ! -f ${STATEFILE} ]; then
-  echo "Error: WebLogic Server state file not found."
+  trace "Error: WebLogic Server state file not found."
   exit 2
 fi
 

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
@@ -173,6 +173,11 @@ trace "LOG_HOME=${LOG_HOME}"
 trace "SERVER_OUT_IN_POD_LOG=${SERVER_OUT_IN_POD_LOG}"
 trace "USER_MEM_ARGS=${USER_MEM_ARGS}"
 trace "JAVA_OPTIONS=${JAVA_OPTIONS}"
+
+#
+# check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
+#
+exportEffectiveDomainHome || exitOrLoop
 
 #
 # Check if introspector actually ran.  This should never fail since

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -309,7 +309,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     assertThat(
         getCreatedPodSpecContainer().getEnv(),
         allOf(
-            hasEnvVar("item1", "find uid1 at /shared/domain"),
+            hasEnvVar("item1", "find uid1 at /u01/oracle/user_projects/domains"),
             hasEnvVar("item2", "ADMIN_SERVER is ADMIN_SERVER:7001")));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -33,7 +33,7 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   private static final String VALUE1 = "value1";
   private static final String VALUE2 = "value2";
   private static final String RAW_VALUE_1 = "find uid1 at $(DOMAIN_HOME)";
-  private static final String END_VALUE_1 = "find uid1 at /shared/domain";
+  private static final String END_VALUE_1 = "find uid1 at /u01/oracle/user_projects/domains";
   private static final String RAW_VALUE_2 = "$(SERVER_NAME) is not $(ADMIN_NAME):$(ADMIN_PORT)";
   private static final String END_VALUE_2 = "ms1 is not ADMIN_SERVER:7001";
   private static final String CLUSTER_NAME = "test-cluster";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -317,7 +317,7 @@ public abstract class PodHelperTestBase {
         getCreatedPodSpecContainer().getEnv(),
         allOf(
             hasEnvVar("DOMAIN_NAME", DOMAIN_NAME),
-            hasEnvVar("DOMAIN_HOME", "/shared/domain"),
+            hasEnvVar("DOMAIN_HOME", "/u01/oracle/user_projects/domains"),
             hasEnvVar("ADMIN_NAME", ADMIN_SERVER),
             hasEnvVar("ADMIN_PORT", Integer.toString(ADMIN_PORT)),
             hasEnvVar("SERVER_NAME", getServerName()),
@@ -594,7 +594,7 @@ public abstract class PodHelperTestBase {
             .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DEFAULT_DOMAIN_VERSION)
             .putLabelsItem(LabelConstants.DOMAINUID_LABEL, UID)
             .putLabelsItem(LabelConstants.DOMAINNAME_LABEL, DOMAIN_NAME)
-            .putLabelsItem(LabelConstants.DOMAINHOME_LABEL, "/shared/domain")
+            .putLabelsItem(LabelConstants.DOMAINHOME_LABEL, "/u01/oracle/user_projects/domains")
             .putLabelsItem(LabelConstants.SERVERNAME_LABEL, getServerName())
             .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
     AnnotationHelper.annotateForPrometheus(meta, listenPort);
@@ -612,7 +612,7 @@ public abstract class PodHelperTestBase {
         .volumeMounts(PodDefaults.getStandardVolumeMounts(UID))
         .command(createStartCommand())
         .addEnvItem(envItem("DOMAIN_NAME", DOMAIN_NAME))
-        .addEnvItem(envItem("DOMAIN_HOME", "/shared/domain"))
+        .addEnvItem(envItem("DOMAIN_HOME", "/u01/oracle/user_projects/domains"))
         .addEnvItem(envItem("ADMIN_NAME", ADMIN_SERVER))
         .addEnvItem(envItem("ADMIN_PORT", Integer.toString(ADMIN_PORT)))
         .addEnvItem(envItem("SERVER_NAME", getServerName()))


### PR DESCRIPTION
__Change Summary__:

Fix for Issue #721.

When domain resource 'domainHome' is not set and 'domainHomeInImage' is 'true' look for a single WebLogic domain under '/u01/oracle/user_projects/domains', and use this as this location as the DOMAIN_HOME.   Fail and report an error if no 'config/config.xml' is found among these locations, or more than one is found.   

WIP:  This mandate has been broadened slightly beyond "when domain resource 'domainHome' is not set and 'domainHomeInImage' is 'true'" to always hunt for a single domain among the subdirectories of 'domainHome' if 'domainHome' equals ''/u01/oracle/user_projects/domains' regardless of whether this value came from a default or was specifically set by the administrator.

_Test status_:

Jenkins, QUICKTEST, and some ad hoc testing passed (including a domain-in-image test).
