### PR TITLE
get introspector job imagePullPolicy from domain resource (inste…

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -266,7 +266,11 @@ public abstract class JobStepContext implements StepContextConstants {
   }
 
   String getImagePullPolicy() {
-    return KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
+    String imagePullPolicy = getDomain().getSpec().getImagePullPolicy();
+    if (imagePullPolicy == null) {
+      imagePullPolicy = KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
+    }
+    return imagePullPolicy;
   }
 
   protected List<String> getContainerCommand() {


### PR DESCRIPTION
Get introspector job imagePullPolicy from domain resource instead of hard coding to IfNotPresent.

This fixes a problem @bobdonat and @TheFrogPad found.

Tracked internally via OWLS-71152

