### PR TITLE
allow different startup policies for domains, servers and clusters

### DIFF
--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -22,13 +22,12 @@
           "$ref": "#/definitions/ServerPod"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are ALWAYS, NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
-            "NEVER",
             "ALWAYS",
-            "IF_NEEDED",
-            "ADMIN_ONLY"
+            "NEVER",
+            "IF_NEEDED"
           ]
         },
         "restartVersion": {
@@ -110,13 +109,11 @@
           "$ref": "#/definitions/KubernetesResource"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
             "NEVER",
-            "ALWAYS",
-            "IF_NEEDED",
-            "ADMIN_ONLY"
+            "IF_NEEDED"
           ]
         },
         "restartVersion": {
@@ -218,11 +215,10 @@
           "type": "string"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
             "NEVER",
-            "ALWAYS",
             "IF_NEEDED",
             "ADMIN_ONLY"
           ]
@@ -350,13 +346,12 @@
           "type": "string"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are ALWAYS, NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
-            "NEVER",
             "ALWAYS",
-            "IF_NEEDED",
-            "ADMIN_ONLY"
+            "NEVER",
+            "IF_NEEDED"
           ]
         },
         "restartVersion": {

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -942,13 +942,12 @@ window.onload = function() {
           "$ref": "#/definitions/ServerPod"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are ALWAYS, NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
-            "NEVER",
             "ALWAYS",
-            "IF_NEEDED",
-            "ADMIN_ONLY"
+            "NEVER",
+            "IF_NEEDED"
           ]
         },
         "restartVersion": {
@@ -1030,13 +1029,11 @@ window.onload = function() {
           "$ref": "#/definitions/KubernetesResource"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
             "NEVER",
-            "ALWAYS",
-            "IF_NEEDED",
-            "ADMIN_ONLY"
+            "IF_NEEDED"
           ]
         },
         "restartVersion": {
@@ -1138,11 +1135,10 @@ window.onload = function() {
           "type": "string"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
             "NEVER",
-            "ALWAYS",
             "IF_NEEDED",
             "ADMIN_ONLY"
           ]
@@ -1270,13 +1266,12 @@ window.onload = function() {
           "type": "string"
         },
         "serverStartPolicy": {
-          "description": "The strategy for deciding whether to start a server. Legal values are ADMIN_ONLY, NEVER, ALWAYS, or IF_NEEDED.",
+          "description": "The strategy for deciding whether to start a server. Legal values are ALWAYS, NEVER, or IF_NEEDED.",
           "type": "string",
           "enum": [
-            "NEVER",
             "ALWAYS",
-            "IF_NEEDED",
-            "ADMIN_ONLY"
+            "NEVER",
+            "IF_NEEDED"
           ]
         },
         "restartVersion": {

--- a/json-schema/src/main/java/oracle/kubernetes/json/EnumClass.java
+++ b/json-schema/src/main/java/oracle/kubernetes/json/EnumClass.java
@@ -15,4 +15,6 @@ import java.lang.annotation.Target;
 @Target(FIELD)
 public @interface EnumClass {
   Class<? extends java.lang.Enum> value();
+
+  String qualifier() default "";
 }

--- a/json-schema/src/test/java/oracle/kubernetes/json/SchemaGeneratorTest.java
+++ b/json-schema/src/test/java/oracle/kubernetes/json/SchemaGeneratorTest.java
@@ -102,8 +102,17 @@ public class SchemaGeneratorTest {
   @SuppressWarnings("unused")
   private enum TrafficLightColors {
     RED,
-    YELLOW,
-    GREEN
+    YELLOW {
+      @Override
+      boolean forSmallLight() {
+        return false;
+      }
+    },
+    GREEN;
+
+    boolean forSmallLight() {
+      return true;
+    }
   }
 
   @SuppressWarnings("unused")
@@ -122,6 +131,19 @@ public class SchemaGeneratorTest {
   @SuppressWarnings("unused")
   @EnumClass(TrafficLightColors.class)
   private String colorString;
+
+  @Test
+  public void generateSchemaForEnumAnnotatedStringWithQualifier() throws NoSuchFieldException {
+    Object schema = generateForField(getClass().getDeclaredField("twoColorString"));
+
+    assertThat(schema, hasJsonPath("$.twoColorString.type", equalTo("string")));
+    assertThat(
+        schema, hasJsonPath("$.twoColorString.enum", arrayContainingInAnyOrder("RED", "GREEN")));
+  }
+
+  @SuppressWarnings("unused")
+  @EnumClass(value = TrafficLightColors.class, qualifier = "forSmallLight")
+  private String twoColorString;
 
   @Test
   public void whenIntegerAnnotatedWithMinimumOnly_addToSchema() throws NoSuchFieldException {

--- a/model/src/main/java/oracle/kubernetes/operator/ServerStartPolicy.java
+++ b/model/src/main/java/oracle/kubernetes/operator/ServerStartPolicy.java
@@ -5,10 +5,42 @@
 package oracle.kubernetes.operator;
 
 public enum ServerStartPolicy {
+  ALWAYS {
+    @Override
+    public boolean forDomain() {
+      return false;
+    }
+
+    @Override
+    public boolean forCluster() {
+      return false;
+    }
+  },
   NEVER,
-  ALWAYS,
   IF_NEEDED,
-  ADMIN_ONLY;
+  ADMIN_ONLY {
+    @Override
+    public boolean forCluster() {
+      return false;
+    }
+
+    @Override
+    public boolean forServer() {
+      return false;
+    }
+  };
+
+  public boolean forDomain() {
+    return true;
+  }
+
+  public boolean forCluster() {
+    return true;
+  }
+
+  public boolean forServer() {
+    return true;
+  }
 
   public static ServerStartPolicy getDefaultPolicy() {
     return IF_NEEDED;

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Cluster.java
@@ -5,8 +5,11 @@
 package oracle.kubernetes.weblogic.domain.v2;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import oracle.kubernetes.json.Description;
+import oracle.kubernetes.json.EnumClass;
 import oracle.kubernetes.json.Range;
+import oracle.kubernetes.operator.ServerStartPolicy;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -26,6 +29,19 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
   @Description("The number of managed servers to run in this cluster")
   @Range(minimum = 0)
   private Integer replicas;
+
+  /**
+   * Tells the operator whether the customer wants the server to be running. For clustered servers -
+   * the operator will start it if the policy is ALWAYS or the policy is IF_NEEDED and the server
+   * needs to be started to get to the cluster's replica count..
+   *
+   * @since 2.0
+   */
+  @EnumClass(value = ServerStartPolicy.class, qualifier = "forCluster")
+  @Description(
+      "The strategy for deciding whether to start a server. "
+          + "Legal values are NEVER, or IF_NEEDED.")
+  private String serverStartPolicy;
 
   @Description(
       "The maximum number of cluster membrers that can be temporarily unavailable. Defaults to 1.")
@@ -63,11 +79,22 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
     this.replicas = replicas;
   }
 
-  public Integer getMaxUnavailable() {
+  @Override
+  public void setServerStartPolicy(String serverStartPolicy) {
+    this.serverStartPolicy = serverStartPolicy;
+  }
+
+  @Nullable
+  @Override
+  public String getServerStartPolicy() {
+    return serverStartPolicy;
+  }
+
+  Integer getMaxUnavailable() {
     return maxUnavailable;
   }
 
-  public void setMaxUnavailable(Integer maxUnavailable) {
+  void setMaxUnavailable(Integer maxUnavailable) {
     this.maxUnavailable = maxUnavailable;
   }
 
@@ -77,6 +104,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
         .appendSuper(super.toString())
         .append("clusterName", clusterName)
         .append("replicas", replicas)
+        .append("serverStartPolicy", serverStartPolicy)
         .append("maxUnavailable", maxUnavailable)
         .toString();
   }
@@ -93,6 +121,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
         .appendSuper(super.equals(o))
         .append(clusterName, cluster.clusterName)
         .append(replicas, cluster.replicas)
+        .append(serverStartPolicy, cluster.serverStartPolicy)
         .append(maxUnavailable, cluster.maxUnavailable)
         .isEquals();
   }
@@ -103,12 +132,13 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
         .appendSuper(super.hashCode())
         .append(clusterName)
         .append(replicas)
+        .append(serverStartPolicy)
         .append(maxUnavailable)
         .toHashCode();
   }
 
   @Override
-  public int compareTo(Cluster o) {
+  public int compareTo(@Nonnull Cluster o) {
     return clusterName.compareTo(o.clusterName);
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Server.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Server.java
@@ -4,11 +4,27 @@
 
 package oracle.kubernetes.weblogic.domain.v2;
 
+import oracle.kubernetes.json.Description;
+import oracle.kubernetes.json.EnumClass;
+import oracle.kubernetes.operator.ServerStartPolicy;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class Server extends BaseConfiguration {
+
+  /**
+   * Tells the operator whether the customer wants the server to be running. For clustered servers -
+   * the operator will start it if the policy is ALWAYS or the policy is IF_NEEDED and the server
+   * needs to be started to get to the cluster's replica count..
+   *
+   * @since 2.0
+   */
+  @EnumClass(value = ServerStartPolicy.class, qualifier = "forServer")
+  @Description(
+      "The strategy for deciding whether to start a server. "
+          + "Legal values are ALWAYS, NEVER, or IF_NEEDED.")
+  private String serverStartPolicy;
 
   protected Server getConfiguration() {
     Server configuration = new Server();
@@ -19,7 +35,10 @@ public class Server extends BaseConfiguration {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this).appendSuper(super.toString()).toString();
+    return new ToStringBuilder(this)
+        .appendSuper(super.toString())
+        .append(serverStartPolicy)
+        .toString();
   }
 
   @Override
@@ -32,11 +51,27 @@ public class Server extends BaseConfiguration {
 
     Server that = (Server) o;
 
-    return new EqualsBuilder().appendSuper(super.equals(o)).isEquals();
+    return new EqualsBuilder()
+        .appendSuper(super.equals(o))
+        .append(serverStartPolicy, that.serverStartPolicy)
+        .isEquals();
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).appendSuper(super.hashCode()).toHashCode();
+    return new HashCodeBuilder(17, 37)
+        .appendSuper(super.hashCode())
+        .append(serverStartPolicy)
+        .toHashCode();
+  }
+
+  @Override
+  public void setServerStartPolicy(String serverStartPolicy) {
+    this.serverStartPolicy = serverStartPolicy;
+  }
+
+  @Override
+  public String getServerStartPolicy() {
+    return serverStartPolicy;
   }
 }


### PR DESCRIPTION
Moved serverStartPolicy field down one level in order to allow different options for domain, servers and clusters.
Used qualifier to select enum values