### PR TITLE
OWLS-71186 Update log home on PV sample

### DIFF
--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 #
@@ -463,7 +463,7 @@ function createDomain {
   validateDomainSecret
 
   # Validate the domain's persistent volume claim
-  if [ "$doValidation" == true ]; then
+  if [ "${doValidation}" == true ] && [ "${domainHomeInImage}" == false -o "${logHomeOnPV}" == true ]; then
     validateDomainPVC
   fi
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -114,8 +114,8 @@ The following parameters can be provided in the inputs file.
 | `includeServerOutInPodLog` | Boolean indicating whether to include `server.out` to the pod's stdout. | `true` |
 | `initialManagedServerReplicas` | Number of Managed Servers to initially start for the domain. | `2` |
 | `javaOptions` | Java options for starting the Administration and Managed Servers. A Java option can have references to one or more of the following pre-defined variables to obtain WebLogic domain information: `$(DOMAIN_NAME)`, `$(DOMAIN_HOME)`, `$(ADMIN_NAME)`, `$(ADMIN_PORT)`, and `$(SERVER_NAME)`. | `-Dweblogic.StdoutDebugEnabled=false` |
-| `logHomeOnPV` | Specifies whether the log home is stored on the persistent volume. If set to true, then the customer must specify the `logHome`, `persistentVolumeClaimName` and `domainPVMountPath` parameters.| `false` |
-| `logHome` | The in-pod name of the directory to store the domain, node manager, server logs, and server .out files in. If not specified, the value is derived from the `domainUID` as `/shared/logs/<domainUID>`. This parameter is required if `logHomeOnPV` is true. Otherwise, it is ignored. | `/shared/logs/domain1` |
+| `logHomeOnPV` | Specifies whether the log home is stored on the persistent volume. If set to true, then you must specify the `logHome`, `persistentVolumeClaimName` and `domainPVMountPath` parameters.| `false` |
+| `logHome` | The in-pod name of the directory in which to store the domain, Node Manager, server logs, and server .out files. If not specified, the value is derived from the `domainUID` as `/shared/logs/<domainUID>`. This parameter is required if `logHomeOnPV` is true. Otherwise, it is ignored. | `/shared/logs/domain1` |
 | `managedServerNameBase` | Base string used to generate Managed Server names. | `managed-server` |
 | `managedServerPort` | Port number for each Managed Server. | `8001` |
 | `namespace` | Kubernetes namespace in which to create the domain. | `default` |

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -104,7 +104,7 @@ The following parameters can be provided in the inputs file.
 | `configuredManagedServerCount` | Number of Managed Server instances to generate for the domain. | `5` |
 | `domainHomeImageBase` | Base WebLogic binary image used to build the WebLogic domain image. The operator requires WebLogic Server 12.2.1.3.0 with patch 28076014 applied. Refer to [Weblogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how to create one. If a different `domainHomeImageBase` is specified, the specified image needs to be built locally or pulled from a repository before the `create-domain.sh` script is executed. | |
 | `domainHomeImageBuildPath` | Location of the WebLogic "domain home in image" Docker image in `https://github.com/oracle/docker-images.git` project. If not specified, use "./docker-images/OracleWebLogic/samples/12213-domain-home-in-image". Another possible value is "./docker-images/OracleWebLogic/samples/12213-domain-home-in-image-wdt" which uses WDT, instead of WLST, to generate the domain configuration. | `./docker-images/OracleWebLogic/samples/12213-domain-home-in-image` |
-| `domainPVMountPath` | Mount path of the domain persistent volume. | `/shared` |
+| `domainPVMountPath` | Mount path of the domain persistent volume. This parameter is required if `logHomeOnPV` is true. Otherwise, it is ignored. | `/shared` |
 | `domainUID` | Unique ID that will be used to identify this particular domain. Used as the name of the generated WebLogic domain as well as the name of the Kubernetes domain resource. This ID must be unique across all domains in a Kubernetes cluster. This ID cannot contain any character that is not valid in a Kubernetes service name. | `domain1` |
 | `exposeAdminNodePort` | Boolean indicating if the Administration Server is exposed outside of the Kubernetes cluster. | `false` |
 | `exposeAdminT3Channel` | Boolean indicating if the T3 administrative channel is exposed outside the Kubernetes cluster. | `false` |
@@ -114,12 +114,12 @@ The following parameters can be provided in the inputs file.
 | `includeServerOutInPodLog` | Boolean indicating whether to include `server.out` to the pod's stdout. | `true` |
 | `initialManagedServerReplicas` | Number of Managed Servers to initially start for the domain. | `2` |
 | `javaOptions` | Java options for starting the Administration and Managed Servers. A Java option can have references to one or more of the following pre-defined variables to obtain WebLogic domain information: `$(DOMAIN_NAME)`, `$(DOMAIN_HOME)`, `$(ADMIN_NAME)`, `$(ADMIN_PORT)`, and `$(SERVER_NAME)`. | `-Dweblogic.StdoutDebugEnabled=false` |
-| `logHomeOnPV` | Specifies whether the log home is stored on the persistent volume. | `false` |
-| `logHome` | The in-pod name of the directory to store the domain, node manager, server logs, and server .out files in. If not specified, the value is derived from the `domainUID` as `/shared/logs/<domainUID>`. | `/shared/logs/domain1` |
+| `logHomeOnPV` | Specifies whether the log home is stored on the persistent volume. If set to true, then the customer must specify the `logHome`, `persistentVolumeClaimName` and `domainPVMountPath` parameters.| `false` |
+| `logHome` | The in-pod name of the directory to store the domain, node manager, server logs, and server .out files in. If not specified, the value is derived from the `domainUID` as `/shared/logs/<domainUID>`. This parameter is required if `logHomeOnPV` is true. Otherwise, it is ignored. | `/shared/logs/domain1` |
 | `managedServerNameBase` | Base string used to generate Managed Server names. | `managed-server` |
 | `managedServerPort` | Port number for each Managed Server. | `8001` |
 | `namespace` | Kubernetes namespace in which to create the domain. | `default` |
-| `persistentVolumeClaimName` | Name of the persistent volume claim. If not specified, the value is derived from the `domainUID` as `<domainUID>-weblogic-sample-pvc` | `domain1-weblogic-sample-pvc` |
+| `persistentVolumeClaimName` | Name of the persistent volume claim. If not specified, the value is derived from the `domainUID` as `<domainUID>-weblogic-sample-pvc`. This parameter is required if `logHomeOnPV` is true. Otherwise, it is ignored. | `domain1-weblogic-sample-pvc` |
 | `productionModeEnabled` | Boolean indicating if production mode is enabled for the domain. | `true` |
 | `serverStartPolicy` | Determines which WebLogic Servers will be started up. Legal values are `NEVER`, `IF_NEEDED`, `ADMIN_ONLY`. | `IF_NEEDED` |
 | `t3ChannelPort` | Port for the T3 channel of the NetworkAccessPoint. | `30012` |

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -69,12 +69,16 @@ weblogicCredentialsSecretName: domain1-weblogic-credentials
 includeServerOutInPodLog: true
 
 # Specifies whether the log home is stored on the persistent volume.
+# If set to true, then the customer must specify the 'logHome', 'persistentVolumeClaimName'
+# and 'domainPVMountPath' properties.
 # The default is false.
 logHomeOnPV: false
 
 # The in-pod name of the directory to store the domain, node manager, server logs, and server .out
 # files in.
 # If not specified, the value is derived from the domainUID as /shared/logs/<domainUID>
+# This parameter is required if 'logHomeOnPV' is true.
+# Otherwise, it is ignored.
 logHome: /shared/logs/domain1
 
 # Port for the T3Channel of the NetworkAccessPoint
@@ -103,9 +107,13 @@ javaOptions: -Dweblogic.StdoutDebugEnabled=false
 
 # Name of the persistent volume claim 
 # If not specified, the value is derived from the domainUID as <domainUID>-weblogic-sample-pvc
+# This parameter is required if 'logHomeOnPV' is true.
+# Otherwise, it is ignored.
 persistentVolumeClaimName: domain1-weblogic-sample-pvc
 
 # Mount path of the domain persistent volume. 
+# This parameter is required if 'logHomeOnPV' is true.
+# Otherwise, it is ignored.
 domainPVMountPath: /shared
 
 # Base WebLogic binary image used to build the WebLogic domain image

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -69,13 +69,13 @@ weblogicCredentialsSecretName: domain1-weblogic-credentials
 includeServerOutInPodLog: true
 
 # Specifies whether the log home is stored on the persistent volume.
-# If set to true, then the customer must specify the 'logHome', 'persistentVolumeClaimName'
+# If set to true, then you must specify the 'logHome', 'persistentVolumeClaimName'
 # and 'domainPVMountPath' properties.
 # The default is false.
 logHomeOnPV: false
 
-# The in-pod name of the directory to store the domain, node manager, server logs, and server .out
-# files in.
+# The in-pod name of the directory in which to store the domain, node manager, server logs,
+# and server .out files.
 # If not specified, the value is derived from the domainUID as /shared/logs/<domainUID>
 # This parameter is required if 'logHomeOnPV' is true.
 # Otherwise, it is ignored.


### PR DESCRIPTION
The pull request contains following change:
1. Call validateDomainPVC under conditionally
 domainHomeInImage is false (domain home on pv case) Or logHomeOnPV is true.
2. Update the documentation to clarify the logHomeOnPV parameters relationship

Jenkins passed. http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/830/