### PR TITLE
updates for rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Oracle is finding ways for organizations using WebLogic Server to run important 
 The fastest way to experience the operator is to follow the [Quick start guide](site/quickstart.md), or you can peruse our [documentation](site), read our [blogs](https://blogs.oracle.com/weblogicserver/how-to-weblogic-server-on-kubernetes), or try out the [samples](kubernetes/samples/README.md).
 
 ```diff
-+ The current release of the operator is 2.0-rc1, a release candidate for our 2.0 release.
-+ This release candidate was published on Dec 20, 2018.
-+ We expect to publish the final 2.0 release in January 2019.
++ The current release of the operator is 2.0-rc2, a release candidate for our 2.0 release.
++ This release candidate was published on Jan. 10, 2019.
++ We expect to publish the final 2.0 release later in January, 2019.
 + We expect that there will be some minor changes to documentation and samples in the final 2.0 release.
 + However, this release candidate is suitable for testing and early adopters.
 ```

--- a/site/helm-charts.md
+++ b/site/helm-charts.md
@@ -4,8 +4,7 @@
 
 The WebLogic Kubernetes Operator uses Helm to create and deploy any necessary resources and then run the operator in a Kubernetes cluster. Helm helps you manage Kubernetes applications. Helm charts help you define and install applications into the Kubernetes cluster. The operator's Helm chart is located in the `kubernetes/charts/weblogic-operator` directory.
 
-> If you have an older version of the operator installed on your cluster, then you must remove
-  it before installing this version.  You should remove the deployment (for example, `kubectl delete deploy weblogic-operator -n your-namespace`) and the custom
+> If you have an older version of the operator installed on your cluster, then you must remove it before installing this version. This includes the 2.0-rc1 version; it must be completely removed. You should remove the deployment (for example, `kubectl delete deploy weblogic-operator -n your-namespace`) and the custom
   resource definition (for example, `kubectl delete crd domain`).  If you do not remove
   the custom resource definition, then you might see errors like this:
 

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -5,7 +5,8 @@ These instructions assume that you are already familiar with Kubernetes.  If you
 refer to the [User guide](user-guide.md).
 
 > If you have an older version of the operator installed on your cluster, you must remove
-  it before installing this version.  You should remove the deployment (for example, `kubectl delete deploy weblogic-operator -n your-namespace`) and the custom
+  it before installing this version.  This includes the 2.0-rc1 version; it must be completely removed.
+  You should remove the deployment (for example, `kubectl delete deploy weblogic-operator -n your-namespace`) and the custom
   resource definition (for example, `kubectl delete crd domain`).  If you do not remove
   the custom resource definition you may see errors like this:
 
@@ -34,8 +35,8 @@ $ docker login
 ```
 c.	Pull the operator image and tag it with the default image value of the operator:
 ```
-$ docker pull oracle/weblogic-kubernetes-operator:2.0-rc1
-$ docker tag oracle/weblogic-kubernetes-operator:2.0-rc1 weblogic-kubernetes-operator:2.0
+$ docker pull oracle/weblogic-kubernetes-operator:2.0-rc2
+$ docker tag oracle/weblogic-kubernetes-operator:2.0-rc2 weblogic-kubernetes-operator:2.0
 ```
 d.	Pull the Traefik load balancer image:
 ```
@@ -162,7 +163,7 @@ domain namespace (`sample-domain1-ns`) and the `domainHomeImageBase` (`oracle/we
 
 * Setting `weblogicCredentialsSecretName` to the name of the secret containing the WebLogic credentials.
   By convention, the secret will be named`domainUID-weblogic-credentials` (where `domainUID` is replaced with the
-  actual `domainUID` value). 
+  actual `domainUID` value).
 
 * Leaving the `image` empty unless you need to tag the new image that the script builds to a different name.
 

--- a/site/recent-changes.md
+++ b/site/recent-changes.md
@@ -4,6 +4,7 @@ This document tracks recent changes to the operator, especially ones that introd
 
 | Date | Version | Introduces backward incompatibilities | Change |
 | --- | --- | --- | --- |
+| January 10, 2019 | v2.0-rc2 | yes | 
 | December 20, 2018 | v2.0-rc1 | yes | Operator is now installed via Helm charts, replacing the earlier scripts.  The operator now supports the domain home on persistent volume or in Docker image use cases, which required a redesign of the domain schema.  You can override the domain configuration using configuration override templates.  Now load balancers and Ingresses can be independently configured.  You can direct WebLogic logs to a persistent volume or to the pod's log.  Added lifecycle support for servers and significantly enhanced configurability for generated pods.  The final v2.0 release will be the initial release where the operator team intends to provide backward compatibility as part of future releases.
 | March 20, 2018 | v1.1 | yes | Several files and input parameters have been renamed.  This affects how operators and domains are created.  It also changes generated Kubernetes artifacts, therefore customers must recreate their operators and domains.
 | April 4, 2018 | v1.0 | yes | Many Kubernetes artifact names and labels have changed. Also, the names of generated YAML files for creating a domain's PV and PVC have changed.  Because of these changes, customers must recreate their operators and domains.

--- a/site/weblogic-docker-images.md
+++ b/site/weblogic-docker-images.md
@@ -9,7 +9,7 @@ There are two main options available:
   and the domain directory.
 
 If you want to use the first option, you will need to obtain the standard
-WebLogic Server image from the Docker Store [see here](#obtaining-standard-images-from-the-docker-store)
+WebLogic Server image from the Docker Store, [see here](#obtaining-standard-images-from-the-docker-store),
 and then create a new image with the mandatory patches applied as described in [this section](#creating-a-custom-images-with-patches-applied).
 If you want to use additional patches, you can customize that process to include additional patches.
 
@@ -19,7 +19,7 @@ as described in [this section](#creating-a-custom-image-with-your-domain-inside-
 
 ## Setting up secrets to access the Docker Store
 
-**Note** This version of the operator requires WebLogic Server 12.2.1.3.0 plus patch 28076014, so pulling an unpatched image directly to the Kubernetes cluster is not particularly useful.  However, we have left this information in the documentation for reference purposes. 
+**Note**: This version of the operator requires WebLogic Server 12.2.1.3.0 plus patch 28076014, so pulling an unpatched image directly to the Kubernetes cluster is not particularly useful.  However, we have left this information in the documentation for reference purposes.
 
 In order for Kubernetes to obtain the WebLogic Server Docker image from the Docker Store, which requires authentication, a Kubernetes secret containing the registry credentials must be created. To create a secret with Docker Store credentials, issue the following command:
 
@@ -34,7 +34,7 @@ $ kubectl create secret docker-registry SECRET_NAME
 
 In this command, replace the uppercase items with the appropriate values. The `SECRET_NAME` will be needed in later parameter files.  The `NAMESPACE` must match the namespace where the first domain will be deployed, otherwise Kubernetes will not be able to find it.  
 
-It may be preferable to manually pull the image in advance, on each Kubernetes worker node, as described in the next section. 
+It may be preferable to manually pull the image in advance, on each Kubernetes worker node, as described in the next section.
 If you choose this approach, you do not require the Kubernetes secret.
 
 ## Obtaining standard images from the Docker store
@@ -44,10 +44,10 @@ Oracle provides a [WebLogic Server 12.2.1.3.0 Docker image](https://store.docker
 must have a Docker Store account, log on to the Docker Store, navigate
 to that image and click on the "Proceed to Checkout" button which will
 prompt you to read and accept the license agreement for the image.
-Once you have accepted the license agreement, you will be able to
+After you have accepted the license agreement, you will be able to
 pull the image using your Docker store credentials.
 
-First, you will need to login to the Docker Store:
+First, you will need to log in to the Docker Store:
 
 ```
 $ docker login


### PR DESCRIPTION
This PR includes:
* Updating the current version, where specified, from 2.0-rc1 to 2.0-rc2.
* Updating the informal warning to remove earlier versions of the operator, to include removing 2.0-rc1 completely.
* Hmm, thought I had updated Recent Changes doc in this PR; might have to do another commit.