### PR TITLE
Fix a regression in domain home in image sample

### DIFF
--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -410,7 +410,7 @@ function createFiles {
     if [ -z $image ]; then
       sed -i -e "s|%WEBLOGIC_IMAGE%|${imageName}|g" ${dcrOutput}
     else
-      sed -i -e "s:%WEBLOGIC_IMAGE%:${image}:g" ${dcrOutput}
+      sed -i -e "s|%WEBLOGIC_IMAGE%|${image}|g" ${dcrOutput}
     fi
   else
     sed -i -e "s:%WEBLOGIC_IMAGE%:${image}:g" ${dcrOutput}


### PR DESCRIPTION
Restore the "image" substitution line that was mistakenly changed to the same as the domain-home-on-pv case as part of the script refactoring in PR#733.

The Jenkins job with this PR is in progress (http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/836).