### PR TITLE
Develop ingress per domain fixes

### DIFF
--- a/kubernetes/samples/charts/ingress-per-domain/README.md
+++ b/kubernetes/samples/charts/ingress-per-domain/README.md
@@ -13,7 +13,9 @@ To install the chart with the release name, `my-ingress`, with the given `values
 ```
 # Change directory to the cloned git weblogic-kubernetes-operator repo.
 $ cd kubernetes/samples/charts
-$ helm install ingress-per-domain --name my-ingress --values values.yaml
+
+# Use helm to install the chart.  Use `--namespace` to specify the name of the WebLogic domain's namespace.
+$ helm install ingress-per-domain --name my-ingress --namespace my-domain-namespace --values values.yaml
 ```
 The Ingress resource will be created in the same namespace as the WebLogic domain cluster.
 
@@ -23,10 +25,9 @@ type: TRAEFIK
 
 # WLS domain as backend to the load balancer
 wlsDomain:
-  namespace: default
   domainUID: domain1
   clusterName: cluster1
-  svcPort: 8001
+  managedServerPort: 8001
 
 # Traefik specific values
 traefik:
@@ -40,10 +41,9 @@ type: VOYAGER
 
 # WLS domain as backend to the load balancer
 wlsDomain:
-  namespace: default
   domainUID: domain1
   clusterName: cluster1  
-  svcPort: 8001
+  managedServerPort: 8001
 
 # Voyager specific values
 voyager:
@@ -60,15 +60,14 @@ $ helm delete --purge my-ingress
 ## Configuration
 The following table lists the configurable parameters of this chart and their default values.
 
-| Parameter                              | Description                                                                                                                  | Default                                           |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `type`                     | Type of Ingress controller. Legal values are `TRAEFIK` or `VOYAGER`.                                                                                            | `TRAEFIK` |
-| `wlsDomain.namespace`                     | Namespace of the WLS domain cluster.                                                                                            | `default` |
-| `wlsDomain.domainUID`                     | DomainUID of the WLS domain.                                                                                            | `domain1` |
-| `wlsDomain.clusterName`                     | Cluster name in the WLS domain.                                                                                            | `cluster-1` |
-| `wlsDomain.svcPort`                     | Service port of the WLS domain cluster.                                                                                            | `8001` |
-| `traefik.hostname`                     | Hostname to route to the WLS domain cluster.                                                                                            | `domain1.org` |
-| `voyager.webPort`                     | Web port to access the Voyager load balancer.                                                                                         | `30305` |
-| `voyager.statsPort`                     | Port to access the Voyager/HAProxy stats page.                                                                                            | `30315` |
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `type` | Type of Ingress controller. Legal values are `TRAEFIK` or `VOYAGER`. | `TRAEFIK` |
+| `wlsDomain.domainUID` | DomainUID of the WLS domain. | `domain1` |
+| `wlsDomain.clusterName` | Cluster name in the WLS domain. | `cluster-1` |
+| `wlsDomain.managedServerPort` | Port number of the managed servers in the WLS domain cluster. | `8001` |
+| `traefik.hostname` | Hostname to route to the WLS domain cluster. | `domain1.org` |
+| `voyager.webPort` | Web port to access the Voyager load balancer. | `30305` |
+| `voyager.statsPort` | Port to access the Voyager/HAProxy stats page. | `30315` |
 
 **Note:** The input values `domainUID` and `clusterName` will be used to generate the Kubernetes `serviceName` of the WLS cluster with the format `domainUID-cluster-clusterName`.

--- a/kubernetes/samples/charts/ingress-per-domain/templates/traefik-ingress.yaml
+++ b/kubernetes/samples/charts/ingress-per-domain/templates/traefik-ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018, Oracle Corporation and/or its affiliates. All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 {{- if eq .Values.type "TRAEFIK" }}
@@ -6,8 +6,10 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-traefik
-  namespace: {{ .Values.wlsDomain.namespace }}
+  name: {{ .Values.wlsDomain.domainUID }}-traefik
+  namespace: {{ .Release.Namespace }}
+  labels:
+    weblogic.resourceVersion: domain-v2
 spec:
   annotations:
     kubernetes.io/ingress.class: traefik
@@ -18,5 +20,5 @@ spec:
       - path:
         backend:
           serviceName: '{{ .Values.wlsDomain.domainUID }}-cluster-{{ .Values.wlsDomain.clusterName | lower | replace "_" "-" }}'
-          servicePort: {{ .Values.wlsDomain.svcPort }}
+          servicePort: {{ .Values.wlsDomain.managedServerPort }}
 {{- end }}

--- a/kubernetes/samples/charts/ingress-per-domain/templates/voyager-ingress.yaml
+++ b/kubernetes/samples/charts/ingress-per-domain/templates/voyager-ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018, Oracle Corporation and/or its affiliates. All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 {{- if eq .Values.type "VOYAGER" }}
@@ -6,8 +6,10 @@
 apiVersion: voyager.appscode.com/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-voyager
-  namespace: {{ .Values.wlsDomain.namespace }}
+  name: {{ .Values.wlsDomain.domainUID }}-voyager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    weblogic.resourceVersion: domain-v2
   annotations:
     ingress.appscode.com/type: 'NodePort'
     ingress.appscode.com/stats: 'true'
@@ -20,14 +22,16 @@ spec:
       paths:
       - backend:
           serviceName: '{{ .Values.wlsDomain.domainUID }}-cluster-{{ .Values.wlsDomain.clusterName | lower | replace "_" "-" }}'
-          servicePort: '{{ .Values.wlsDomain.svcPort }}'
+          servicePort: '{{ .Values.wlsDomain.managedServerPort }}'
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-voyager-stats
-  namespace: {{ .Values.wlsDomain.namespace }}
+  name: {{ .Values.wlsDomain.domainUID }}-voyager-stats
+  namespace: {{ .Release.Namespace }}
+  labels:
+    weblogic.resourceVersion: domain-v2
 spec:
   type: NodePort
   ports:

--- a/kubernetes/samples/charts/ingress-per-domain/values.yaml
+++ b/kubernetes/samples/charts/ingress-per-domain/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 # Default values for ingress-per-domain.
@@ -10,10 +10,9 @@ type: TRAEFIK
 
 # WLS domain as backend to the load balancer
 wlsDomain:
-  namespace: default
   domainUID: domain1
   clusterName: cluster-1
-  svcPort: 8001
+  managedServerPort: 8001
 
 # Traefik specific values
 traefik:

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -205,11 +205,10 @@ $ kubectl get services -n sample-domain1-ns
 ```
 
 d.	Create an Ingress for the domain, in the domain namespace, by using the [sample](../kubernetes/samples/charts/ingress-per-domain/README.md) Helm chart:
-* Use `helm install`, specifying the `domainUID` (`sample-domain1`) and domain namespace (`sample-domain1-ns`) in the `values.yaml` file.
 ```
 $ helm install kubernetes/samples/charts/ingress-per-domain \
   --name sample-domain1-ingress \
-  --set wlsDomain.namespace=sample-domain1-ns \
+  --namespace sample-domain1-ns \
   --set wlsDomain.domainUID=sample-domain1 \
   --set traefik.hostname=sample-domain1.org
 ```


### PR DESCRIPTION
I've updated the ingress-per-domain helm chart (including the site doc) and hand tested it against traefik.

Maggie's going to try this branch against a p4 test she already has for this chart.  She'll test it against traefik and voyager.

Lily, I made the following changes to the ingress-per-domain helm chart to make it consistent with our other helm charts and samples:

1) use the helm install --namespace arg to get the domain namespace (v.s. wlsDomain.namespace in values.yalm)

2) renamed svcPort in values.yaml to managedServerPort

3) added a version label to the generated ingresses and services

4) renamed the generated ingresses and services to start with the domain uid instead of the helm release name.

See http://aseng-wiki.us.oracle.com/asengwiki/display/ASDevWLS/2.0+Naming+Summary and
https://jira.oraclecorp.com/jira/browse/OWLS-71195

