### PR TITLE
remove reference to onessl

### DIFF
--- a/kubernetes/samples/charts/traefik/README.md
+++ b/kubernetes/samples/charts/traefik/README.md
@@ -3,10 +3,6 @@
 This sample demonstrates how to install the Traefik ingress controller to provide 
 load balancing for WebLogic clusters.
 
-## Prerequisites
-
-To use this sample you must download [onessl](https://github.com/kubepack/onessl) and place it in the `util` directory.
-
 ## Install the Traefik operator with a Helm chart
 The Traefik Helm chart is located in the official Helm project `charts` directory at https://github.com/helm/charts/tree/master/stable/traefik.
 The chart is in the default repository for Helm.

--- a/kubernetes/samples/charts/traefik/values.yaml
+++ b/kubernetes/samples/charts/traefik/values.yaml
@@ -1,3 +1,5 @@
+image: traefik
+imageTag: 1.7.4
 serviceType: NodePort
 service:
   nodePorts:

--- a/kubernetes/samples/charts/util/setup.sh
+++ b/kubernetes/samples/charts/util/setup.sh
@@ -25,7 +25,6 @@ function createVoyager() {
     helm install appscode/voyager --name voyager-operator --version 7.4.0 \
       --namespace voyager \
       --set cloudProvider=baremetal \
-      --set apiserver.ca="$(${MYDIR}/onessl get kube-ca)" \
       --set apiserver.enableValidatingWebhook=false
   else
     echo "Voyager operator is already installed."

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -5,30 +5,20 @@ AppsCode has provided a Helm chart to install Voyager. See the official installa
 
 As a demonstration, the following are the detailed steps to install the Voyager operator by using a Helm chart on a Linux OS.
 
-### 1. Install Onessl
-Onessl is a utility provided by AppsCode. We'll use it to get a CA certificate for the Kubernetes cluster.
-```
-# The assumption is that you have added ~/bin to your PATH env.
-$ curl -fsSL -o onessl https://github.com/kubepack/onessl/releases/download/0.3.0/onessl-linux-amd64 \
-  && chmod +x onessl \
-  && mv onessl ~/bin
-```
-
-### 2. Add the AppsCode chart repository
+### 1. Add the AppsCode chart repository
 ```
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
 $ helm search appscode/voyager
 ```
 
-### 3. Install the Voyager operator
+### 2. Install the Voyager operator
 ```
 # Kubernetes 1.9.x - 1.10.x
 $ kubectl create ns voyager
 $ helm install appscode/voyager --name voyager-operator --version 7.4.0 \
   --namespace voyager \
   --set cloudProvider=baremetal \
-  --set apiserver.ca="$(onessl get kube-ca)" \
   --set apiserver.enableValidatingWebhook=false
 ```
 ## Optionally, download the Voyager Helm chart

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -40,7 +40,7 @@ $ docker tag oracle/weblogic-kubernetes-operator:2.0-rc2 weblogic-kubernetes-ope
 ```
 d.	Pull the Traefik load balancer image:
 ```
-$ docker pull traefik:latest
+$ docker pull traefik:1.7.4
 ```
 e.	Pull the WebLogic 12.2.1.3 install image:
 ```


### PR DESCRIPTION
1. onessl is only needed by voyager, not traefik. And it's only needed if voyager's ValidatingWebhook is enabled. Since we disable the ValidatingWebhook in our sample, no need to download and use onessl. So remove all the reference to onessl.
2. stick Traefik image to v1.7.4 to get stable results.