### PR TITLE
Fix for #772

### DIFF
--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -20,7 +20,7 @@ domainNamespaces:
   - "default"
 
 # image specifies the docker image containing the operator code.
-image: "weblogic-kubernetes-operator:2.0"
+image: "oracle/weblogic-kubernetes-operator:2.0-rc1"
 
 # imagePullPolicy specifies the image pull policy for the operator docker image.
 imagePullPolicy: "IfNotPresent"

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -98,6 +98,7 @@ $ helm install kubernetes/charts/weblogic-operator \
   --namespace sample-weblogic-operator-ns \
   --set serviceAccount=sample-weblogic-operator-sa \
   --set "domainNamespaces={}" \
+  --set value="oracle/weblogic-kubernetes-operator:2.0-rc1" \
   --wait
 ```
 


### PR DESCRIPTION
Fix for #772 
This will fix the quick start to make users pull in the cirrect weblogic-kubernetes-operator image from Dockerhub