### PR TITLE
Use oracle/weblogic-kubernetes-operator:2.0 and update quickstart instructions

### DIFF
--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -20,7 +20,7 @@ domainNamespaces:
   - "default"
 
 # image specifies the docker image containing the operator code.
-image: "weblogic-kubernetes-operator:2.0"
+image: "oracle/weblogic-kubernetes-operator:2.0"
 
 # imagePullPolicy specifies the image pull policy for the operator docker image.
 imagePullPolicy: "IfNotPresent"

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
@@ -476,7 +476,7 @@ public class HelmOperatorValuesTest {
         .append("externalDebugHttpPort: 30999\n")
         .append("externalRestEnabled: false\n")
         .append("externalRestHttpsPort: 31001\n")
-        .append("image: weblogic-kubernetes-operator:2.0\n")
+        .append("image: oracle/weblogic-kubernetes-operator:2.0\n")
         .append("imagePullPolicy: IfNotPresent\n")
         .append("internalDebugHttpPort: 30999\n")
         .append("javaLoggingLevel: INFO\n")

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -33,10 +33,9 @@ b.  Log in to the Docker Store from your docker client:
 ```
 $ docker login
 ```
-c.	Pull the operator image and tag it with the default image value of the operator:
+c.	Pull the operator image:
 ```
 $ docker pull oracle/weblogic-kubernetes-operator:2.0-rc2
-$ docker tag oracle/weblogic-kubernetes-operator:2.0-rc2 weblogic-kubernetes-operator:2.0
 ```
 d.	Pull the Traefik load balancer image:
 ```


### PR DESCRIPTION
Set the default for image in our helm chart values to oracle/weblogic-kubernetes-operator:2.0, so that it will be right when we release 2.0.

Update the quick start instructions to *NOT* say to tag 2.0-rc2 as 2.0 -- this would lead to confusion later.

The helm install step had already been updated to include "--set image=oracle/weblogic-kubernetes-operator:2.0-rc2".

When we release 2.0, we'll update the quick start to remove these references to 2.0-rc2.