### PR TITLE
Fix domain home on pv sample readme about the size of the cluster.

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README.md
@@ -55,7 +55,7 @@ If you copy the sample scripts to a different location, make sure that you copy 
 The default domain created by the script has the following characteristics:
 
 * An Administration Server named `admin-server` listening on port `7001`.
-* A dynamic cluster named `cluster-1` of size 2.
+* A dynamic cluster named `cluster-1` of size 5.
 * Two Managed Servers, named `managed-server1` and `managed-server2`, listening on port `8001`.
 * Log files that are located in `/shared/logs/<domainUID>`.
 * No applications deployed.


### PR DESCRIPTION
The default of the "configuredManagedServerCount" in the inputs and README are "5", but the description of the default domain started by the script says the cluster size is "2".