### PR TITLE
incorporate edits from Bob D

### DIFF
--- a/site/helm-charts.md
+++ b/site/helm-charts.md
@@ -495,7 +495,7 @@ The `helm install` eventually times out and creates a failed release.
 $ helm install kubernetes/charts/weblogic-operator --name op2 --namespace myuser-op2-ns --values o24.yaml --wait --no-hooks
 Error: release op2 failed: timed out waiting for the condition
 
-kubectl log -n kube-system tiller-deploy-f9b8476d-mht6v
+kubectl logs -n kube-system tiller-deploy-f9b8476d-mht6v
 ...
 [kube] 2018/12/06 21:16:54 Deployment is not ready: myuser-op2-ns/weblogic-operator
 ...

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -166,9 +166,6 @@ domain namespace (`sample-domain1-ns`), and the `domainHomeImageBase` (`oracle/w
 
 * Setting `weblogicCredentialsSecretName` to the name of the secret containing the WebLogic credentials, in this case, `sample-domain1-weblogic-credentials`.
 
-  By convention, the secret will be named`domainUID-weblogic-credentials` (where `domainUID` is replaced with the
-  actual `domainUID` value).
-
 * Leaving the `image` empty unless you need to tag the new image that the script builds to a different name.
 
 For example, assuming you named your copy `my-inputs.yaml`:


### PR DESCRIPTION
Including:
* Noting that the guide assumes a single node cluster.
* Moved up the instruction to grant the Helm service account the cluster-admin role.
* Changed the “kubectl log” command to “kubectl logs” (in both files).
* Added the path for the kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml file.
