### PR TITLE
An override file sometimes needs a domain name

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -106,6 +106,7 @@ class OfflineWlstEnv(object):
 
     self.DOMAIN_UID               = self.getEnv('DOMAIN_UID')
     self.DOMAIN_HOME              = self.getEnv('DOMAIN_HOME')
+    self.DOMAIN_NAME              = self.getEnv('DOMAIN_NAME')
     self.LOG_HOME                 = self.getEnv('LOG_HOME')
     self.CREDENTIALS_SECRET_NAME  = self.getEnv('CREDENTIALS_SECRET_NAME')
 
@@ -786,7 +787,7 @@ class SitConfigGenerator(Generator):
     self.writeln("<?xml version='1.0' encoding='UTF-8'?>")
     self.writeln("<d:domain xmlns:d=\"http://xmlns.oracle.com/weblogic/domain\" xmlns:f=\"http://xmlns.oracle.com/weblogic/domain-fragment\" xmlns:s=\"http://xmlns.oracle.com/weblogic/situational-config\">")
     self.indent()
-    self.writeln("<s:expiration> 2020-07-16T19:20+01:00 </s:expiration>")
+    self.writeln("<d:name>" + self.env.DOMAIN_NAME + "</d:name>")
     self.customizeNodeManagerCreds()
     self.customizeDomainLogPath()
     self.customizeServers()
@@ -908,6 +909,7 @@ class CustomSitConfigIntrospector(SecretManager):
     self.macroMap['env:DOMAIN_UID']  = self.env.DOMAIN_UID
     self.macroMap['env:DOMAIN_HOME'] = self.env.DOMAIN_HOME
     self.macroMap['env:LOG_HOME']    = self.env.LOG_HOME
+    self.macroMap['env:DOMAIN_NAME'] = self.env.DOMAIN_NAME
 
     keys=self.macroMap.keys()
     keys.sort()

--- a/site/config-overrides.md
+++ b/site/config-overrides.md
@@ -203,7 +203,7 @@ The following `config.xml` override file demonstrates setting the `max-message-s
 </domain>
 ```
 
-**IMPORTANT: To ensure all situational config takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name as in the sample above.**
+**IMPORTANT: To ensure all situational configuration takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name as in the sample above.**
 
 ### Overriding a data source module
 
@@ -270,7 +270,7 @@ The following `jdbc-testDS.xml` override template demonstrates setting the URL, 
 
 **IMPORTANT: Incorrectly formatted override files are 'somewhat' silently ignored. WebLogic Servers log errors or warnings when they detect an incorrectly formatted configuration override template file, but will still boot, and will skip overriding. So it is important to make sure that the template files are correct in a QA environment by checking your WebLogic pod logs for situational configuration errors and warnings, before attempting to use them in production.**
 
-**IMPORTANT: To ensure all custom overrides takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name when overriding config.xml fields. Also, remember to use 'replace' verb to modify existing fields in the domain home configuration, and the 'add' verb to add a field that doesn't yet exist in the domain home configuration.  Otherwise, situational config may be partially ignored without generating any errors or warnings. See the sample in [Override template samples](#override-template-samples).**
+**IMPORTANT: To ensure all custom overrides takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name when overriding config.xml fields. Also, remember to use the 'replace' verb to modify existing fields in the domain home configuration, and the 'add' verb to add a field that doesn't yet exist in the domain home configuration.  Otherwise, situational configuration may be partially ignored without generating any errors or warnings. See the sample in [Override template samples](#override-template-samples).**
 
 
 Example domain resource yaml:
@@ -337,7 +337,7 @@ spec:
 
 **IMPORTANT: Incorrectly formatted override files are 'somewhat' silently ignored. WebLogic Servers log errors or warnings when they detect an incorrectly formatted configuration override template file, but will still boot, and will skip overriding. So it is important to make sure that the template files are correct in a QA environment by checking your WebLogic pod logs for situational configuration errors and warnings, before attempting to use them in production.**
 
-**IMPORTANT: To ensure all custom overrides takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name when overriding config.xml fields. Also, remember to use 'replace' verb to modify existing fields in the domain home configuration, and the 'add' verb to add a field that doesn't yet exist in the domain home configuration.  Otherwise, situational config may be partially ignored without generating any errors or warnings. See the sample in [Override template samples](#override-template-samples).**
+**IMPORTANT: To ensure all custom overrides takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name when overriding config.xml fields. Also, remember to use the 'replace' verb to modify existing fields in the domain home configuration, and the 'add' verb to add a field that doesn't yet exist in the domain home configuration.  Otherwise, situational configuration may be partially ignored without generating any errors or warnings. See the sample in [Override template samples](#override-template-samples).**
 
 ---
 # Internal design flow

--- a/site/config-overrides.md
+++ b/site/config-overrides.md
@@ -167,7 +167,7 @@ The operator supports embedding macros within override templates.  This helps ma
 
 Two types of macros are supported `environment variable macros` and `secret macros`:
 
-* Environment variable macros have the syntax `${env:ENV-VAR-NAME}`, where the supported environment variables include `DOMAIN_HOME`, `LOG_HOME`, and `DOMAIN_UID`.
+* Environment variable macros have the syntax `${env:ENV-VAR-NAME}`, where the supported environment variables include `DOMAIN_UID`, `DOMAIN_NAME`, `DOMAIN_HOME`,  and `LOG_HOME`.
 
 * Secret macros have the syntax `${secret:SECRETNAME.SECRETKEY}` and `${secret:SECRETNAME.SECRETKEY:encrypt}`.
 
@@ -190,6 +190,7 @@ The following `config.xml` override file demonstrates setting the `max-message-s
 <domain xmlns="http://xmlns.oracle.com/weblogic/domain"
         xmlns:f="http://xmlns.oracle.com/weblogic/domain-fragment"
         xmlns:s="http://xmlns.oracle.com/weblogic/situational-config">
+  <name>${env:DOMAIN_NAME}</name>
   <server>
     <name>admin-server</name>
     <max-message-size f:combine-mode="add">78787878</max-message-size>
@@ -201,6 +202,8 @@ The following `config.xml` override file demonstrates setting the `max-message-s
   </server>
 </domain>
 ```
+
+**IMPORTANT: To ensure all situational config takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name as in the sample above.**
 
 ### Overriding a data source module
 
@@ -267,6 +270,8 @@ The following `jdbc-testDS.xml` override template demonstrates setting the URL, 
 
 **IMPORTANT: Incorrectly formatted override files are 'somewhat' silently ignored. WebLogic Servers log errors or warnings when they detect an incorrectly formatted configuration override template file, but will still boot, and will skip overriding. So it is important to make sure that the template files are correct in a QA environment by checking your WebLogic pod logs for situational configuration errors and warnings, before attempting to use them in production.**
 
+**IMPORTANT: To ensure all custom overrides takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name when overriding config.xml fields. Also, remember to use 'replace' verb to modify existing fields in the domain home configuration, and the 'add' verb to add a field that doesn't yet exist in the domain home configuration.  Otherwise, situational config may be partially ignored without generating any errors or warnings. See the sample in [Override template samples](#override-template-samples).**
+
 
 Example domain resource yaml:
 ```
@@ -331,6 +336,8 @@ spec:
 **IMPORTANT: Custom override changes, such as updating an override configuration map, a secret, or a domain resource, will not take effect until all running WebLogic Server pods in your domain are shutdown (so no servers are left running), and the domain is subsequently restarted.**
 
 **IMPORTANT: Incorrectly formatted override files are 'somewhat' silently ignored. WebLogic Servers log errors or warnings when they detect an incorrectly formatted configuration override template file, but will still boot, and will skip overriding. So it is important to make sure that the template files are correct in a QA environment by checking your WebLogic pod logs for situational configuration errors and warnings, before attempting to use them in production.**
+
+**IMPORTANT: To ensure all custom overrides takes effect, remember to reference the name of each bean in the hierarchy that is overridden, including the domain name when overriding config.xml fields. Also, remember to use 'replace' verb to modify existing fields in the domain home configuration, and the 'add' verb to add a field that doesn't yet exist in the domain home configuration.  Otherwise, situational config may be partially ignored without generating any errors or warnings. See the sample in [Override template samples](#override-template-samples).**
 
 ---
 # Internal design flow

--- a/src/integration-tests/introspector/override--config.xmlt
+++ b/src/integration-tests/introspector/override--config.xmlt
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <domain xmlns="http://xmlns.oracle.com/weblogic/domain" xmlns:f="http://xmlns.oracle.com/weblogic/domain-fragment" xmlns:s="http://xmlns.oracle.com/weblogic/situational-config">
+  <name>${env:DOMAIN_NAME}</name>
   <server>
     <name>${ADMIN_NAME}</name>
     <max-message-size f:combine-mode="replace">78787878</max-message-size>


### PR DESCRIPTION
_Description:_

- QA testing recently discovered that when a sit-cfg override file of config.xml doesn't include the domain-name, then some of the overrides within may be silently ignored.   This now confirmed by two different testers using two different tests @davisn9 and Huiling Zhao.
- The problem occurred in (1) a custom override file that had become moderately complex (it introduced debug overrides in addition to some other overrides), and (2) in a custom override file that only has a single override.
- Note that pretty much all internal testing of the sit-cfg feature prior to the operator project happened to specify the domain-name. 

_This update includes:_

- Add a domain-name stanza to the internal sit-cfg the introspector generates for overriding listen-addresses and log directories.
- Add support for an `${env:DOMAIN_NAME}` macro in custom override templates.
- Update public custom override doc to state the need for a domain name stanza and to mention the DOMAIN_NAME macro support.

_Test Status:_

- This change passes override unit/mock testing, Jenkins, Wercker, and 'p4' QA testing. 

_Side Notes:_

- This change also removes the 'expiration' field from the introspector generated sit-cfg (since we know it isn't needed).    Note that removing this can cause sit-cfg errors for customers that forget to use a supported image (e.g. they need to use a patched image or a version newer than 12.2.1.3, as is already documented).

- This problem is internally tracked via OWLS-71350.