### PR TITLE
move to okio 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,11 @@
         <version>3.0.0</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>2.2.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.7.25</version>


### PR DESCRIPTION
From @russgold: We are seeing I/O errors in the okio library, but we are using a very old version, inherited from the k8s client. The simplest possible fix is to upgrade that library. If that doesn't solve it, we have at least ruled out one possible source of error.