### PR TITLE
Add a step to set imagePullSecretName

### DIFF
--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -192,10 +192,10 @@ script will just generate the YAML files, but will not take any action on your c
 
 If you run the sample from a machine that is remote to the Kubernetes cluster, and you need to push the new image to a registry that is local to the cluster, you need to do the following:
 * Set the `image` property in the inputs file to the target image name (including the registry hostname/port, and the tag if needed).
+* If you want the Kubernetes to pull the image from a private registry, create a Kubernetes secret to hold your credentials, and set the `imagePullSecretName` property in the inputs file to the name of the secret. Note that the secret needs to be in the same namespace as where you want to run the domain.
 * Run the `create-domain.sh` script without the `-e` option.
 * Push the `image` to the registry.
 * Run the following command to create the domain.
-
 ```
 $ kubectl apply -f /some/output/directory/weblogic-domains/sample-domain1/domain.yaml
 ```


### PR DESCRIPTION
Add a step in quick start doc to set the imagePullSecretName when the generated image is to be pulled from a private registry.  This comes from an internal customer's experience in wls-operator-support channel. 