### PR TITLE
update patched image info

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -11,7 +11,7 @@ adminPort: 7001
 adminServerName: admin-server
 
 # Unique ID identifying a domain.
-# This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains 
+# This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains
 # in a Kubernetes cluster.
 domainUID: domain1
 
@@ -52,7 +52,7 @@ productionModeEnabled: true
 # to be used in a registry local to that Kubernetes cluster. You also need to push the `image` to
 # that registry before starting the domain using the `kubectl create -f` or `kubectl apply -f` command.
 # See README.md for more help.
-#image: 
+#image:
 
 # Image pull policy
 # Legal values are "IfNotPresent", "Always", or "Never"
@@ -63,7 +63,7 @@ imagePullPolicy: IfNotPresent
 #imagePullSecretName:
 
 # Name of the Kubernetes secret for the Admin Server's username and password
-# The name must be lowercase. 
+# The name must be lowercase.
 # If not specified, the value is derived from the domainUID as <domainUID>-weblogic-credentials
 weblogicCredentialsSecretName: domain1-weblogic-credentials
 
@@ -107,25 +107,26 @@ namespace: default
 # Java Option for WebLogic Server
 javaOptions: -Dweblogic.StdoutDebugEnabled=false
 
-# Name of the persistent volume claim 
+# Name of the persistent volume claim
 # If not specified, the value is derived from the domainUID as <domainUID>-weblogic-sample-pvc
 # This parameter is required if 'logHomeOnPV' is true.
 # Otherwise, it is ignored.
 persistentVolumeClaimName: domain1-weblogic-sample-pvc
 
-# Mount path of the domain persistent volume. 
+# Mount path of the domain persistent volume.
 # This parameter is required if 'logHomeOnPV' is true.
 # Otherwise, it is ignored.
 domainPVMountPath: /shared
 
 # Base WebLogic binary image used to build the WebLogic domain image
 # The operator requires WebLogic Server 12.2.1.3.0 with patch 29135930 applied.
+# The WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, meets this requirement.
 # Refer to [WebLogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how
-# to create a custom Docker image with the required patch.
+# to obtain or create the image.
 # See README.md for more help.
-#domainHomeImageBase: 
+#domainHomeImageBase:
 
-# Location of the WebLogic "domain home in image" Docker image sample in the 
+# Location of the WebLogic "domain home in image" Docker image sample in the
 # `https://github.com/oracle/docker-images.git` project.
 # If not specified, use "./docker-images/OracleWebLogic/samples/12213-domain-home-in-image".
 # Another possible value is "./docker-images/OracleWebLogic/samples/12213-domain-home-in-image-wdt",

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -121,7 +121,7 @@ domainPVMountPath: /shared
 # Base WebLogic binary image used to build the WebLogic domain image
 # The operator requires WebLogic Server 12.2.1.3.0 with patch 29135930 applied.
 # The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019,
-# and has all the necessary patches applied; a `docker pull` is required if the you already have this image.
+# and has all the necessary patches applied; a `docker pull` is required if you already have this image.
 # Refer to [WebLogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how
 # to obtain or create the image.
 # See README.md for more help.

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -120,7 +120,8 @@ domainPVMountPath: /shared
 
 # Base WebLogic binary image used to build the WebLogic domain image
 # The operator requires WebLogic Server 12.2.1.3.0 with patch 29135930 applied.
-# The WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, meets this requirement.
+# The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019,
+# and has all the necessary patches applied; a `docker pull` is required if the you already have this image.
 # Refer to [WebLogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how
 # to obtain or create the image.
 # See README.md for more help.

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -39,7 +39,8 @@ managedServerPort: 8001
 
 # WebLogic Server Docker image.
 # The operator requires WebLogic Server 12.2.1.3.0 with patch 29135930 applied.
-# The WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, meets this requirement.
+# The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019,
+# and has all the necessary patches applied; a `docker pull` is required if the you already have this image.
 # Refer to [WebLogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how
 # to obtain or create the image.
 #image:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -40,7 +40,7 @@ managedServerPort: 8001
 # WebLogic Server Docker image.
 # The operator requires WebLogic Server 12.2.1.3.0 with patch 29135930 applied.
 # The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019,
-# and has all the necessary patches applied; a `docker pull` is required if the you already have this image.
+# and has all the necessary patches applied; a `docker pull` is required if you already have this image.
 # Refer to [WebLogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how
 # to obtain or create the image.
 #image:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -39,8 +39,9 @@ managedServerPort: 8001
 
 # WebLogic Server Docker image.
 # The operator requires WebLogic Server 12.2.1.3.0 with patch 29135930 applied.
+# The WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, meets this requirement.
 # Refer to [WebLogic Docker images](../../../../../site/weblogic-docker-images.md) for details on how
-# to create a custom Docker image with the required patch.
+# to obtain or create the image.
 #image:
 
 # Image pull policy
@@ -55,11 +56,11 @@ imagePullPolicy: IfNotPresent
 productionModeEnabled: true
 
 # Name of the Kubernetes secret for the Admin Server's username and password
-# The name must be lowercase. 
+# The name must be lowercase.
 # If not specified, the value is derived from the domainUID as <domainUID>-weblogic-credentials
 weblogicCredentialsSecretName: domain1-weblogic-credentials
 
-# Whether to include server .out to the pod's stdout. 
+# Whether to include server .out to the pod's stdout.
 # The default is true.
 includeServerOutInPodLog: true
 
@@ -91,11 +92,11 @@ namespace: default
 #Java Option for WebLogic Server
 javaOptions: -Dweblogic.StdoutDebugEnabled=false
 
-# Name of the persistent volume claim 
+# Name of the persistent volume claim
 # If not specified, the value is derived from the domainUID as <domainUID>-weblogic-sample-pvc
-persistentVolumeClaimName: domain1-weblogic-sample-pvc 
+persistentVolumeClaimName: domain1-weblogic-sample-pvc
 
-# Mount path of the domain persistent volume. 
+# Mount path of the domain persistent volume.
 domainPVMountPath: /shared
 
 # Mount path where the create domain scripts are located inside a pod
@@ -112,7 +113,7 @@ createDomainScriptsMountPath: /u01/weblogic
 # domain home. The script is located in the in-pod directory that is specified in the
 # `createDomainScriptsMountPath` property.
 #
-# If you need to provide your own scripts to create the domain home, instead of using the 
+# If you need to provide your own scripts to create the domain home, instead of using the
 # built-it scripts, you must use this property to set the name of the script that you want
 # the create domain job to run.
 createDomainScriptName: create-domain-job.sh
@@ -124,7 +125,7 @@ createDomainScriptName: create-domain-job.sh
 # use the built-in WLST offline scripts in the `wlst` directory to create the WebLogic domain.
 # It can also be set to the relative path `wdt`, and then the built-in WDT scripts will be
 # used instead.
-# 
+#
 # An absolute path is also supported to point to an arbitrary directory in the file system.
 #
 # The built-in scripts can be replaced by the user-provided scripts or model files as long

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -42,9 +42,11 @@ d.	Pull the Traefik load balancer image:
 $ docker pull traefik:1.7.4
 ```
 e.	Pull the WebLogic 12.2.1.3 install image:
+
 ```
 $ docker pull store/oracle/weblogic:12.2.1.3
 ```  
+**Note**: The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019, and has all the necessary patches applied; a `docker pull` is required if the you already have this image.
 
 f. Copy the image to all the nodes in your cluster, or put it in a Docker registry that your cluster can access.
 
@@ -158,13 +160,13 @@ Follow the directions in the [README](../kubernetes/samples/scripts/create-weblo
 including:
 
 * Copying the sample `kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml` file and updating your copy with the `domainUID` (`sample-domain1`),
-domain namespace (`sample-domain1-ns`), and the `domainHomeImageBase` (`oracle/weblogic:12213-patch-wls-for-k8s`).
+domain namespace (`sample-domain1-ns`), and the `domainHomeImageBase` (`store/oracle/weblogic:12.2.1.3`).
 
 * Setting `weblogicCredentialsSecretName` to the name of the secret containing the WebLogic credentials, in this case, `sample-domain1-weblogic-credentials`.
 
 * Leaving the `image` empty unless you need to tag the new image that the script builds to a different name.
 
-**NOTE**: Make sure that your `JAVA_HOME` is set to a Java JDK version 1.8 or later.
+**NOTE**: If you set the `domainHomeImageBuildPath` property to `./docker-images/OracleWebLogic/samples/12213-domain-home-in-image-wdt`, make sure that your `JAVA_HOME` is set to a Java JDK version 1.8 or later.
 
 For example, assuming you named your copy `my-inputs.yaml`:
 ```

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -44,13 +44,9 @@ $ docker pull traefik:1.7.4
 e.	Pull the WebLogic 12.2.1.3 install image:
 ```
 $ docker pull store/oracle/weblogic:12.2.1.3
-```
-f.	Then patch the WebLogic image according to the instructions [here](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-patch-wls-for-k8s), with these modifications:
+```  
 
-* Change the `FROM` clause to extend the `store/oracle/weblogic:12.2.1.3` image from `Dockerfile.patch-ontop-12213`.
-* Comment out commands that apply patch 27117282.   
-
-g. Copy the image to all the nodes in your cluster, or put it in a Docker registry that your cluster can access.
+f. Copy the image to all the nodes in your cluster, or put it in a Docker registry that your cluster can access.
 
 ## 2. Grant the Helm service account the `cluster-admin` role.
 
@@ -167,6 +163,8 @@ domain namespace (`sample-domain1-ns`), and the `domainHomeImageBase` (`oracle/w
 * Setting `weblogicCredentialsSecretName` to the name of the secret containing the WebLogic credentials, in this case, `sample-domain1-weblogic-credentials`.
 
 * Leaving the `image` empty unless you need to tag the new image that the script builds to a different name.
+
+**NOTE**: Make sure that your `JAVA_HOME` is set to a Java JDK version 1.8 or later.
 
 For example, assuming you named your copy `my-inputs.yaml`:
 ```

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -46,7 +46,7 @@ e.	Pull the WebLogic 12.2.1.3 install image:
 ```
 $ docker pull store/oracle/weblogic:12.2.1.3
 ```  
-**Note**: The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019, and has all the necessary patches applied; a `docker pull` is required if the you already have this image.
+**Note**: The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, was updated on January 17, 2019, and has all the necessary patches applied; a `docker pull` is required if you already have this image.
 
 f. Copy the image to all the nodes in your cluster, or put it in a Docker registry that your cluster can access.
 

--- a/site/user-guide.md
+++ b/site/user-guide.md
@@ -80,5 +80,5 @@ You can find the operator image in
 * Oracle WebLogic Server 12.2.1.3.0 with patch 29135930.
    * The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`,
 was updated on January 17, 2019, and has all the necessary patches applied.
-   * A `docker pull` is required if the you already have this image.
+   * A `docker pull` is required if you already have this image.
 * You must have the `cluster-admin` role to install the operator.

--- a/site/user-guide.md
+++ b/site/user-guide.md
@@ -77,5 +77,5 @@ You can find the operator image in
 * Flannel networking v0.9.1-amd64 (check with `docker images | grep flannel`).
 * Docker 18.03.1.ce (check with `docker version`).
 * Helm 2.8.2+ (check with `helm version`).
-* Oracle WebLogic Server 12.2.1.3.0 with patch 29135930.
+* Oracle WebLogic Server 12.2.1.3.0 with patch 29135930. The WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, meets this requirement.
 * You must have the `cluster-admin` role to install the operator.

--- a/site/user-guide.md
+++ b/site/user-guide.md
@@ -77,5 +77,8 @@ You can find the operator image in
 * Flannel networking v0.9.1-amd64 (check with `docker images | grep flannel`).
 * Docker 18.03.1.ce (check with `docker version`).
 * Helm 2.8.2+ (check with `helm version`).
-* Oracle WebLogic Server 12.2.1.3.0 with patch 29135930. The WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`, meets this requirement.
+* Oracle WebLogic Server 12.2.1.3.0 with patch 29135930.
+   * The existing WebLogic Docker image, `store/oracle/weblogic:12.2.1.3`,
+was updated on January 17, 2019, and has all the necessary patches applied.
+   * A `docker pull` is required if the you already have this image.
 * You must have the `cluster-admin` role to install the operator.


### PR DESCRIPTION
Updated info:
* Quick Start Guide (removed patching instructions)
* User Guide (added info regarding Docker store image)
* create-domain-inputs.yaml files (added info regarding Docker store image)

Unrelated, customer request: Added note to Quick Start about requiring `JAVA_HOME` to be set to a Java JDK version 1.8 or later.
