### PR TITLE
Fix problem with pull 797.

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -787,6 +787,7 @@ class SitConfigGenerator(Generator):
     self.writeln("<?xml version='1.0' encoding='UTF-8'?>")
     self.writeln("<d:domain xmlns:d=\"http://xmlns.oracle.com/weblogic/domain\" xmlns:f=\"http://xmlns.oracle.com/weblogic/domain-fragment\" xmlns:s=\"http://xmlns.oracle.com/weblogic/situational-config\">")
     self.indent()
+    self.writeln("<s:expiration> 2099-07-16T19:20+01:00 </s:expiration>")
     self.writeln("<d:name>" + self.env.DOMAIN_NAME + "</d:name>")
     self.customizeNodeManagerCreds()
     self.customizeDomainLogPath()


### PR DESCRIPTION
This pull fixes a problem introduced by pull #797:

Patched 12.2.1.3 images still need the expiration sit-cfg field (unlike 19.1), so put back the line that was removed in pull 797.   Plus set the expiry further into the future 2099 instead of 2020.

Test status:
-Testing by @doxiao passes.   
-Local tests pass.
-Passes Wercker test.