### PR TITLE
Get domain name from domain home instead of env var.  Try#2.

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -106,7 +106,6 @@ class OfflineWlstEnv(object):
 
     self.DOMAIN_UID               = self.getEnv('DOMAIN_UID')
     self.DOMAIN_HOME              = self.getEnv('DOMAIN_HOME')
-    self.DOMAIN_NAME              = self.getEnv('DOMAIN_NAME')
     self.LOG_HOME                 = self.getEnv('LOG_HOME')
     self.CREDENTIALS_SECRET_NAME  = self.getEnv('CREDENTIALS_SECRET_NAME')
 
@@ -155,6 +154,7 @@ class OfflineWlstEnv(object):
     trace("About to load domain from "+self.getDomainHome())
     readDomain(self.getDomainHome())
     self.domain = cmo
+    self.DOMAIN_NAME = self.getDomain().getName()
 
   def close(self):
     closeDomain()


### PR DESCRIPTION
Fix for pulls #797 and #820: the calculated DOMAIN_NAME value in introspectDomain.py should be discovered via wlst instead of from a domain env var. @alai8 discovered that the domain env var isn't necessarily in sync with the 'actual' value.