### PR TITLE
Elasticsearch env variables ES_JAVA_OPTS and bootstrap.memory_lock ha…

### DIFF
--- a/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
+++ b/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
@@ -47,6 +47,11 @@ spec:
         ports:
         - containerPort: 9200
         - containerPort: 9300
+        env:
+        - name: ES_JAVA_OPTS
+          value: -Xms512m -Xmx512m
+        - name: bootstrap.memory_lock
+          value: "false"
 
 ---
 kind: "Service"


### PR DESCRIPTION
…ve been added in order to control the memory (useful for running Elasticsearch container in low resources environments (ie: Minishift))