### PR TITLE
fix traefik version

### DIFF
--- a/kubernetes/samples/charts/traefik/values.yaml
+++ b/kubernetes/samples/charts/traefik/values.yaml
@@ -1,5 +1,3 @@
-image: traefik
-imageTag: 1.7.4
 serviceType: NodePort
 service:
   nodePorts:

--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -39,7 +39,7 @@ $ docker pull oracle/weblogic-kubernetes-operator:2.0-rc2
 ```
 d.	Pull the Traefik load balancer image:
 ```
-$ docker pull traefik:1.7.4
+$ docker pull traefik:1.7.6
 ```
 e.	Pull the WebLogic 12.2.1.3 install image:
 ```


### PR DESCRIPTION
The traefik helm chart we are using https://github.com/helm/charts/tree/master/stable/traefik was just updated few days again and the traefik image version has been changed from `1.7.4` to `1.7.6`.  So we need to change our sample/code accordingly. Otherwise the traefik pod will fail to startup.

In the long run, we may need to find a way to use a fixed version of traefik helm chart and fixed version of traefik image to get a stable result. But I couldn't find a way so far. The helm chart https://github.com/helm/charts/tree/master/stable/traefik only keep the latest version and it will be updated without notice.