### PR TITLE
OWLS-69366 Remove log and address setup from domain home on pv sample

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/create-domain-job.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/create-domain-job.sh
@@ -18,7 +18,7 @@ script=${CREATE_DOMAIN_SCRIPT_DIR}/create-domain-script.sh
 
 checkCreateDomainScript $script
 checkDomainSecret
-prepareDomainHomeDir
+checkDomainHomeDir
 
 # Execute the script to create the domain
 source $script

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 #
@@ -8,25 +8,6 @@
 function fail {
   echo ERROR: $1
   exit 1
-}
-
-#
-# Create a folder
-# $1 - path of folder to create
-function createFolder {
-  mkdir -m 777 -p $1
-  if [ ! -d $1 ]; then
-    fail "Unable to create folder $1"
-  fi
-}
-
-#
-# Check a file exists
-# $1 - path of file to check
-function checkFileExists {
-  if [ ! -f $1 ]; then
-    fail "The file $1 does not exist"
-  fi
 }
 
 function checkCreateDomainScript {
@@ -48,17 +29,11 @@ function checkDomainSecret {
   fi
 }
 
-function prepareDomainHomeDir { 
+function checkDomainHomeDir { 
   # Do not proceed if the domain already exists
   local domainFolder=${DOMAIN_HOME_DIR}
   if [ -d ${domainFolder} ]; then
     fail "The create domain job will not overwrite an existing domain. The domain folder ${domainFolder} already exists"
   fi
-
-  # Create the base folders
-  createFolder ${DOMAIN_ROOT_DIR}/domains
-  createFolder ${DOMAIN_LOGS_DIR}
-  createFolder ${DOMAIN_ROOT_DIR}/applications
-  createFolder ${DOMAIN_ROOT_DIR}/stores
 }
 


### PR DESCRIPTION
The PR includes the following:
1. The setup logic is already in the Operator runtime,  so we remove the logic from the domain-home-on-pv sample scripts.
2. Remove the unused code.