### PR TITLE
OWLS-69366 Remove log and address setup from domain home on pv sample

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
@@ -47,6 +47,8 @@ function prepareDomainHomeDir {
   fi
 
   # Create the base folders
+  createFolder ${DOMAIN_ROOT_DIR}/domains
+  createFolder ${DOMAIN_LOGS_DIR}
   createFolder ${DOMAIN_ROOT_DIR}/applications
   createFolder ${DOMAIN_ROOT_DIR}/stores
 }

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 #
@@ -17,15 +17,6 @@ function createFolder {
   mkdir -m 777 -p $1
   if [ ! -d $1 ]; then
     fail "Unable to create folder $1"
-  fi
-}
-
-#
-# Check a file exists
-# $1 - path of file to check
-function checkFileExists {
-  if [ ! -f $1 ]; then
-    fail "The file $1 does not exist"
   fi
 }
 
@@ -56,8 +47,6 @@ function prepareDomainHomeDir {
   fi
 
   # Create the base folders
-  createFolder ${DOMAIN_ROOT_DIR}/domains
-  createFolder ${DOMAIN_LOGS_DIR}
   createFolder ${DOMAIN_ROOT_DIR}/applications
   createFolder ${DOMAIN_ROOT_DIR}/stores
 }

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_configured.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_configured.yaml
@@ -10,48 +10,35 @@ topology:
         '@@PROP:clusterName@@':
     Server:
         '@@PROP:adminServerName@@':
-            ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
-            Log:
-                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:adminServerName@@.log'
             NetworkAccessPoint:
                 T3Channel:
-                    ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
                     ListenPort: '@@PROP:t3ChannelPort@@'
                     PublicAddress: '@@PROP:t3PublicAddress@@'
                     PublicPort: '@@PROP:t3ChannelPort@@'
         '@@PROP:managedServerNameBase@@1':
             Cluster: '@@PROP:clusterName@@'
-            ListenAddress: '@@PROP:domainUID@@-@@PROP:managedServerNameBase@@1'
             ListenPort: '@@PROP:managedServerPort@@'
             NumOfRetriesBeforeMsiMode: 0
             RetryIntervalBeforeMsiMode: 1
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'
                 UserPreferredServer: '@@PROP:managedServerNameBase@@1'
-            Log:
-                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:managedServerNameBase@@1.log'
         '@@PROP:managedServerNameBase@@2':
             Cluster: '@@PROP:clusterName@@'
-            ListenAddress: '@@PROP:domainUID@@-@@PROP:managedServerNameBase@@2'
             ListenPort: '@@PROP:managedServerPort@@'
             NumOfRetriesBeforeMsiMode: 0
             RetryIntervalBeforeMsiMode: 1
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'
                 UserPreferredServer: '@@PROP:managedServerNameBase@@2'
-            Log:
-                FileName: '/shared/logs/@@PROP:managedServerNameBase@@2.log'
         '@@PROP:managedServerNameBase@@3':
             Cluster: '@@PROP:clusterName@@'
-            ListenAddress: '@@PROP:domainUID@@-@@PROP:managedServerNameBase@@3'
             ListenPort: '@@PROP:managedServerPort@@'
             NumOfRetriesBeforeMsiMode: 0
             RetryIntervalBeforeMsiMode: 1
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'
                 UserPreferredServer: '@@PROP:managedServerNameBase@@3'
-            Log:
-                FileName: '/shared/logs/@@PROP:domainUID@@/@@PROP:managedServerNameBase@@3.log'
     MigratableTarget:
         '@@PROP:managedServerNameBase@@1 (migratable)':
             Cluster: '@@PROP:clusterName@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
@@ -16,17 +16,14 @@ topology:
                 ServerTemplate: '@@PROP:clusterName@@-template'
     Server:
         '@@PROP:adminServerName@@':
-            ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
             NetworkAccessPoint:
                 T3Channel:
-                    ListenAddress: '@@PROP:domainUID@@-@@PROP:adminServerName@@'
                     ListenPort: '@@PROP:t3ChannelPort@@'
                     PublicAddress: '@@PROP:t3PublicAddress@@'
                     PublicPort: '@@PROP:t3ChannelPort@@'
     ServerTemplate:
         '@@PROP:clusterName@@-template':
             Cluster: '@@PROP:clusterName@@'
-            ListenAddress: '@@PROP:domainUID@@-@@PROP:managedServerNameBase@@${id}'
             ListenPort: '@@PROP:managedServerPort@@'
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wlst/create-domain.py
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wlst/create-domain.py
@@ -1,4 +1,4 @@
-# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 def getEnvVar(var):
@@ -48,7 +48,6 @@ setOption('DomainName', domain_name)
 # Configure the Administration Server
 # ===================================
 cd('/Servers/AdminServer')
-set('ListenAddress', '%s-%s' % (domain_uid, admin_server_name_svc))
 set('ListenPort', admin_port)
 set('Name', admin_server_name)
 
@@ -56,7 +55,6 @@ create('T3Channel', 'NetworkAccessPoint')
 cd('/Servers/%s/NetworkAccessPoints/T3Channel' % admin_server_name)
 set('PublicPort', t3_channel_port)
 set('PublicAddress', t3_public_address)
-set('ListenAddress', '%s-%s' % (domain_uid, admin_server_name_svc))
 set('ListenPort', t3_channel_port)
 
 # Set the admin user's username and password
@@ -87,7 +85,6 @@ if cluster_type == "CONFIGURED":
     create(name, 'Server')
     cd('/Servers/%s/' % name )
     print('managed server name is %s' % name);
-    set('ListenAddress', '%s-%s' % (domain_uid, name_svc))
     set('ListenPort', server_port)
     set('NumOfRetriesBeforeMSIMode', 0)
     set('RetryIntervalBeforeMSIMode', 1)
@@ -102,7 +99,6 @@ else:
   print('Done creating Server Template: %s' % templateName)
   cd('/ServerTemplates/%s' % templateName)
   cmo.setListenPort(server_port)
-  cmo.setListenAddress('%s-%s${id}' % (domain_uid, managed_server_name_base_svc))
   cmo.setCluster(cl)
   print('Done setting attributes for Server Template: %s' % templateName);
 


### PR DESCRIPTION
The PR includes the following:
1. The setup logic is already in the Operator runtime, so we remove the logic from the domain-home-on-pv sample scripts.
2. Remove the unused code.
3. Address review comments - clean up the wlst script and wdt model to get rid of setting log location and server listen addresses.

Jenkins passed http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/957/