### PR TITLE
Owls 71453: Operator logs NPE after (correctly) logging introspector validation errors.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -616,7 +616,7 @@ public class ConfigMapHelper {
 
     public String toString() {
       if (domainValid) {
-        return "Ddomain: " + domain;
+        return "domain: " + domain;
       }
       return "domainValid: " + domainValid + ", validationErrors: " + validationErrors;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -269,11 +269,8 @@ public class ConfigMapHelper {
       if (topologyYaml != null) {
         LOGGER.fine("topology.yaml: " + topologyYaml);
         DomainTopology domainTopology = parseDomainTopologyYaml(topologyYaml);
-        if (!domainTopology.getValidationErrors().isEmpty()) {
-          for (String err : domainTopology.getValidationErrors()) {
-            LOGGER.severe(err);
-          }
-          doNext(null, packet);
+        if (domainTopology.hasValidationErrors()) {
+          return doNext(null, packet);
         }
         WlsDomainConfig wlsDomainConfig = domainTopology.getDomain();
         ScanCache.INSTANCE.registerScan(
@@ -604,6 +601,28 @@ public class ConfigMapHelper {
 
     public void setValidationErrors(List<String> validationErrors) {
       this.validationErrors = validationErrors;
+    }
+
+    public String toString() {
+      if (domainValid) {
+        return "Ddomain: " + domain;
+      }
+      return "domainValid: " + domainValid + ", validationErrors: " + validationErrors;
+    }
+
+    public boolean hasValidationErrors() {
+      List<String> validationErrors = getValidationErrors();
+      if (!domainValid || !validationErrors.isEmpty()) {
+        logValidationErrors(validationErrors);
+        return true;
+      }
+      return false;
+    }
+
+    private void logValidationErrors(List<String> validationErrors) {
+      for (String err : validationErrors) {
+        LOGGER.severe(err);
+      }
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -270,7 +270,7 @@ public class ConfigMapHelper {
       if (topologyYaml != null) {
         LOGGER.fine("topology.yaml: " + topologyYaml);
         DomainTopology domainTopology = parseDomainTopologyYaml(topologyYaml);
-        if (domainTopology.isDomainInvalid()) {
+        if (!domainTopology.getDomainValid()) {
           // If introspector determines Domain is invalid then log erros and terminate the fiber
           logValidationErrors(domainTopology.getValidationErrors());
           return doNext(null, packet);
@@ -590,7 +590,11 @@ public class ConfigMapHelper {
     private List<String> validationErrors;
 
     public boolean getDomainValid() {
-      return this.domainValid;
+      // domainValid = true AND no validation errors exist
+      if (domainValid && getValidationErrors().isEmpty()) {
+        return true;
+      }
+      return false;
     }
 
     public void setDomainValid(boolean domainValid) {
@@ -616,7 +620,7 @@ public class ConfigMapHelper {
         // errors from introspector.
         validationErrors = new ArrayList<>();
         validationErrors.add(
-            "Error, domain is marked invalid without error messages from introspector job.");
+            "Error, domain is invalid although there are no validation errors from introspector job.");
       }
 
       return validationErrors;
@@ -631,14 +635,6 @@ public class ConfigMapHelper {
         return "domain: " + domain;
       }
       return "domainValid: " + domainValid + ", validationErrors: " + validationErrors;
-    }
-
-    boolean isDomainInvalid() {
-      // domainValid = false OR validation errors exist
-      if (!domainValid || !getValidationErrors().isEmpty()) {
-        return true;
-      }
-      return false;
     }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -564,7 +564,6 @@ public class ConfigMapHelperTest {
 
     assertNotNull(domainTopology);
     assertTrue(domainTopology.getDomainValid());
-    assertFalse(domainTopology.hasValidationErrors());
 
     WlsDomainConfig wlsDomainConfig = domainTopology.getDomain();
     assertNotNull(wlsDomainConfig);
@@ -594,7 +593,6 @@ public class ConfigMapHelperTest {
 
     assertFalse(domainTopology.getValidationErrors().isEmpty());
     assertFalse(domainTopology.getDomainValid());
-    assertTrue(domainTopology.hasValidationErrors());
     assertEquals(
         "The dynamic cluster \"mycluster\"'s dynamic servers use calculated listen ports.",
         domainTopology.getValidationErrors().get(0));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -567,7 +567,6 @@ public class ConfigMapHelperTest {
 
     assertNotNull(domainTopology);
     assertTrue(domainTopology.getDomainValid());
-    assertFalse(domainTopology.isDomainInvalid());
 
     WlsDomainConfig wlsDomainConfig = domainTopology.getDomain();
     assertNotNull(wlsDomainConfig);
@@ -597,7 +596,6 @@ public class ConfigMapHelperTest {
 
     assertFalse(domainTopology.getValidationErrors().isEmpty());
     assertFalse(domainTopology.getDomainValid());
-    assertTrue(domainTopology.isDomainInvalid());
     assertEquals(
         "The dynamic cluster \"mycluster\"'s dynamic servers use calculated listen ports.",
         domainTopology.getValidationErrors().get(0));
@@ -610,6 +608,5 @@ public class ConfigMapHelperTest {
 
     assertFalse(domainTopology.getValidationErrors().isEmpty());
     assertFalse(domainTopology.getDomainValid());
-    assertTrue(domainTopology.isDomainInvalid());
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -564,6 +564,7 @@ public class ConfigMapHelperTest {
 
     assertNotNull(domainTopology);
     assertTrue(domainTopology.getDomainValid());
+    assertFalse(domainTopology.hasValidationErrors());
 
     WlsDomainConfig wlsDomainConfig = domainTopology.getDomain();
     assertNotNull(wlsDomainConfig);
@@ -593,6 +594,7 @@ public class ConfigMapHelperTest {
 
     assertFalse(domainTopology.getValidationErrors().isEmpty());
     assertFalse(domainTopology.getDomainValid());
+    assertTrue(domainTopology.hasValidationErrors());
     assertEquals(
         "The dynamic cluster \"mycluster\"'s dynamic servers use calculated listen ports.",
         domainTopology.getValidationErrors().get(0));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -466,6 +466,9 @@ public class ConfigMapHelperTest {
           + "validationErrors:\n"
           + "  - \"The dynamic cluster \\\"mycluster\\\"'s dynamic servers use calculated listen ports.\"";
 
+  private static final String DOMAIN_INVALID_NO_ERRORS =
+      "domainValid: false\n" + "validationErrors:\n";
+
   @Test
   public void parseDomainTopologyYaml() {
     ConfigMapHelper.DomainTopology domainTopology =
@@ -564,6 +567,7 @@ public class ConfigMapHelperTest {
 
     assertNotNull(domainTopology);
     assertTrue(domainTopology.getDomainValid());
+    assertFalse(domainTopology.isDomainInvalid());
 
     WlsDomainConfig wlsDomainConfig = domainTopology.getDomain();
     assertNotNull(wlsDomainConfig);
@@ -593,8 +597,19 @@ public class ConfigMapHelperTest {
 
     assertFalse(domainTopology.getValidationErrors().isEmpty());
     assertFalse(domainTopology.getDomainValid());
+    assertTrue(domainTopology.isDomainInvalid());
     assertEquals(
         "The dynamic cluster \"mycluster\"'s dynamic servers use calculated listen ports.",
         domainTopology.getValidationErrors().get(0));
+  }
+
+  @Test
+  public void parseInvalidTopologyYamlWithNoValidationErrors() {
+    ConfigMapHelper.DomainTopology domainTopology =
+        ConfigMapHelper.parseDomainTopologyYaml(DOMAIN_INVALID_NO_ERRORS);
+
+    assertFalse(domainTopology.getValidationErrors().isEmpty());
+    assertFalse(domainTopology.getDomainValid());
+    assertTrue(domainTopology.isDomainInvalid());
   }
 }


### PR DESCRIPTION
If the introspector determines the domain is invalid  (due to validation errors) then log the errors and terminate the fiber by returning next action with and 'null' step.   Correctly terminating the fiber resolves the NPE.

