### PR TITLE
Owls-71580 Pass custom env vars to introspect job

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -11,7 +11,6 @@ import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodList;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
-import java.util.ArrayList;
 import java.util.List;
 import oracle.kubernetes.operator.JobWatcher;
 import oracle.kubernetes.operator.LabelConstants;
@@ -93,7 +92,9 @@ public class JobHelper {
 
     @Override
     List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
-      List<V1EnvVar> envVarList = new ArrayList<V1EnvVar>();
+      // Start with environment variables specified for Admin Server
+      List<V1EnvVar> envVarList = getDomain().getAdminServerSpec().getEnvironmentVariables();
+
       addEnvVar(envVarList, "NAMESPACE", getNamespace());
       addEnvVar(envVarList, "DOMAIN_UID", getDomainUID());
       addEnvVar(envVarList, "DOMAIN_HOME", getDomainHome());

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -91,20 +91,20 @@ public class JobHelper {
     }
 
     @Override
-    List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
-      // Start with environment variables specified for Admin Server
-      List<V1EnvVar> envVarList = getDomain().getAdminServerSpec().getEnvironmentVariables();
+    List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
+      // Pod for introspector job would use same environment variables as for admin server
+      List<V1EnvVar> vars = getDomain().getAdminServerSpec().getEnvironmentVariables();
 
-      addEnvVar(envVarList, "NAMESPACE", getNamespace());
-      addEnvVar(envVarList, "DOMAIN_UID", getDomainUID());
-      addEnvVar(envVarList, "DOMAIN_HOME", getDomainHome());
-      addEnvVar(envVarList, "NODEMGR_HOME", getNodeManagerHome());
-      addEnvVar(envVarList, "LOG_HOME", getEffectiveLogHome());
-      addEnvVar(envVarList, "INTROSPECT_HOME", getIntrospectHome());
-      addEnvVar(envVarList, "SERVER_OUT_IN_POD_LOG", getIncludeServerOutInPodLog());
-      addEnvVar(envVarList, "CREDENTIALS_SECRET_NAME", getWebLogicCredentialsSecretName());
+      addEnvVar(vars, "NAMESPACE", getNamespace());
+      addEnvVar(vars, "DOMAIN_UID", getDomainUID());
+      addEnvVar(vars, "DOMAIN_HOME", getDomainHome());
+      addEnvVar(vars, "NODEMGR_HOME", getNodeManagerHome());
+      addEnvVar(vars, "LOG_HOME", getEffectiveLogHome());
+      addEnvVar(vars, "INTROSPECT_HOME", getIntrospectHome());
+      addEnvVar(vars, "SERVER_OUT_IN_POD_LOG", getIncludeServerOutInPodLog());
+      addEnvVar(vars, "CREDENTIALS_SECRET_NAME", getWebLogicCredentialsSecretName());
 
-      return envVarList;
+      return vars;
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -11,6 +11,7 @@ import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodList;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
+import java.util.ArrayList;
 import java.util.List;
 import oracle.kubernetes.operator.JobWatcher;
 import oracle.kubernetes.operator.LabelConstants;
@@ -93,7 +94,8 @@ public class JobHelper {
     @Override
     List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
       // Pod for introspector job would use same environment variables as for admin server
-      List<V1EnvVar> vars = getDomain().getAdminServerSpec().getEnvironmentVariables();
+      List<V1EnvVar> vars =
+          new ArrayList<>(getDomain().getAdminServerSpec().getEnvironmentVariables());
 
       addEnvVar(vars, "NAMESPACE", getNamespace());
       addEnvVar(vars, "DOMAIN_UID", getDomainUID());

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -1,10 +1,24 @@
 package oracle.kubernetes.operator.helpers;
 
-import io.kubernetes.client.models.*;
+import io.kubernetes.client.models.V1ConfigMapVolumeSource;
+import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1Job;
+import io.kubernetes.client.models.V1JobSpec;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1PersistentVolumeClaimVolumeSource;
+import io.kubernetes.client.models.V1PodSpec;
+import io.kubernetes.client.models.V1PodTemplateSpec;
+import io.kubernetes.client.models.V1SecretVolumeSource;
+import io.kubernetes.client.models.V1Volume;
+import io.kubernetes.client.models.V1VolumeMount;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import oracle.kubernetes.operator.*;
+import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.operator.LabelConstants;
+import oracle.kubernetes.operator.ProcessingConstants;
+import oracle.kubernetes.operator.TuningParameters;
+import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
@@ -13,7 +27,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.v2.Domain;
 
-public abstract class JobStepContext implements StepContextConstants {
+public abstract class JobStepContext extends StepContextBase {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private static final String WEBLOGIC_OPERATOR_SCRIPTS_INTROSPECT_DOMAIN_SH =
@@ -30,6 +44,11 @@ public abstract class JobStepContext implements StepContextConstants {
 
   void init() {
     jobModel = createJobModel();
+    createSubstitutionMap();
+  }
+
+  private void createSubstitutionMap() {
+    substitutionVariables.put("DOMAIN_HOME", getDomainHome());
   }
 
   private V1Job getJobModel() {
@@ -277,14 +296,8 @@ public abstract class JobStepContext implements StepContextConstants {
     return Arrays.asList(WEBLOGIC_OPERATOR_SCRIPTS_INTROSPECT_DOMAIN_SH);
   }
 
-  abstract List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters);
-
   protected String getDomainHome() {
     return getDomain().getDomainHome();
-  }
-
-  static void addEnvVar(List<V1EnvVar> vars, String name, String value) {
-    vars.add(new V1EnvVar().name(name).value(value));
   }
 
   private static V1VolumeMount readOnlyVolumeMount(String volumeName, String mountPath) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -77,11 +77,10 @@ public class PodHelper {
     }
 
     @Override
-    List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
+    List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
       List<V1EnvVar> vars = new ArrayList<>(getServerSpec().getEnvironmentVariables());
       addEnvVar(vars, INTERNAL_OPERATOR_CERT_ENV, getInternalOperatorCertFile(tuningParameters));
       overrideContainerWeblogicEnvVars(vars);
-      doSubstitution(vars);
       return vars;
     }
 
@@ -246,7 +245,7 @@ public class PodHelper {
 
     @Override
     @SuppressWarnings("unchecked")
-    List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
+    List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
       List<V1EnvVar> envVars = (List<V1EnvVar>) packet.get(ProcessingConstants.ENVVARS);
 
       List<V1EnvVar> vars = new ArrayList<>();
@@ -254,7 +253,6 @@ public class PodHelper {
         vars.addAll(envVars);
       }
       overrideContainerWeblogicEnvVars(vars);
-      doSubstitution(vars);
       return vars;
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
@@ -43,7 +43,7 @@ public abstract class StepContextBase implements StepContextConstants {
     return vars;
   }
 
-  void doSubstitution(List<V1EnvVar> vars) {
+  protected void doSubstitution(List<V1EnvVar> vars) {
     for (V1EnvVar var : vars) {
       var.setValue(translate(var.getValue()));
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
@@ -1,0 +1,77 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+package oracle.kubernetes.operator.helpers;
+
+import io.kubernetes.client.models.V1EnvVar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import oracle.kubernetes.operator.TuningParameters;
+
+public abstract class StepContextBase implements StepContextConstants {
+
+  // Map of <token, substitution string> to be used in the translate method
+  // Subclass should populate this map prior to calling translate().
+  protected Map<String, String> substitutionVariables = new HashMap<>();
+
+  /**
+   * Abstract method to be implemented by subclasses to return a list of configured and additional
+   * environment variables to be set up in the pod
+   *
+   * @param tuningParameters TuningParameters that can be used when obtaining
+   * @return A list of configured and additional environment variables
+   */
+  abstract List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters);
+
+  /**
+   * Return a list of environment variables to be set up in the pod. This method does some
+   * processing of the list of environment variables such as token substitution before returning the
+   * list.
+   *
+   * @param tuningParameters TuningParameters containing parameters that may be used in environment
+   *     variables
+   * @return A List of environment variables to be set up in the pod
+   */
+  final List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
+
+    List<V1EnvVar> vars = getConfiguredEnvVars(tuningParameters);
+
+    hideAdminUserCredentials(vars);
+    doSubstitution(vars);
+
+    return vars;
+  }
+
+  void doSubstitution(List<V1EnvVar> vars) {
+    for (V1EnvVar var : vars) {
+      var.setValue(translate(var.getValue()));
+    }
+  }
+
+  private String translate(String rawValue) {
+    String result = rawValue;
+    for (Map.Entry<String, String> entry : substitutionVariables.entrySet()) {
+      if (result != null && entry.getValue() != null) {
+        result = result.replace(String.format("$(%s)", entry.getKey()), entry.getValue());
+      }
+    }
+    return result;
+  }
+
+  protected void addEnvVar(List<V1EnvVar> vars, String name, String value) {
+    vars.add(new V1EnvVar().name(name).value(value));
+  }
+
+  // Hide the admin account's user name and password.
+  // Note: need to use null v.s. "" since if you upload a "" to kubectl then download it,
+  // it comes back as a null and V1EnvVar.equals returns false even though it's supposed to
+  // be the same value.
+  // Regardless, the pod ends up with an empty string as the value (v.s. thinking that
+  // the environment variable hasn't been set), so it honors the value (instead of using
+  // the default, e.g. 'weblogic' for the user name).
+  protected void hideAdminUserCredentials(List<V1EnvVar> vars) {
+    addEnvVar(vars, "ADMIN_USERNAME", null);
+    addEnvVar(vars, "ADMIN_PASSWORD", null);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextConstants.java
@@ -1,3 +1,6 @@
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
 package oracle.kubernetes.operator.helpers;
 
 public interface StepContextConstants {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -314,6 +314,15 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   }
 
   @Test
+  public void createAdminPodStartupWithNullAdminUsernamePasswordEnvVarsValues() {
+    configureAdminServer();
+
+    assertThat(
+        getCreatedPodSpecContainer().getEnv(),
+        allOf(hasEnvVar("ADMIN_USERNAME", null), hasEnvVar("ADMIN_PASSWORD", null)));
+  }
+
+  @Test
   public void whenDomainHasAdditionalVolumes_createAdminPodWithThem() {
     getConfigurator()
         .withAdditionalVolume("volume1", "/source-path1")

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -5,20 +5,36 @@
 package oracle.kubernetes.operator.helpers;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
+import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1JobSpec;
 import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1SecretReference;
+import java.util.List;
+import oracle.kubernetes.operator.ProcessingConstants;
+import oracle.kubernetes.operator.TuningParameters;
+import oracle.kubernetes.operator.helpers.JobHelper.DomainIntrospectorJobStepContext;
+import oracle.kubernetes.operator.work.Component;
+import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.weblogic.domain.ClusterConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.ServerConfigurator;
 import oracle.kubernetes.weblogic.domain.v2.ConfigurationConstants;
 import oracle.kubernetes.weblogic.domain.v2.Domain;
+import oracle.kubernetes.weblogic.domain.v2.DomainSpec;
+import org.hamcrest.Matcher;
+import org.hamcrest.junit.MatcherAssert;
 import org.junit.Test;
 
 public class JobHelperTest {
 
   private static final String NS = "ns1";
+  private static final String DOMAIN_UID = "JobHelperTestDomain";
 
   @Test
   public void creatingServers_true_whenClusterReplicas_gt_0() {
@@ -126,9 +142,66 @@ public class JobHelperTest {
     assertThat(JobHelper.creatingServers(domainPresenceInfo), equalTo(true));
   }
 
+  @Test
+  public void whenDomainHasEnvironmentItems_introspectorPodStartupWithThem() {
+    DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
+
+    configureDomain(domainPresenceInfo)
+        .withEnvironmentVariable("item1", "value1")
+        .withEnvironmentVariable("item2", "value2");
+
+    Packet packet = new Packet();
+    packet
+        .getComponents()
+        .put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(domainPresenceInfo));
+    DomainIntrospectorJobStepContext domainIntrospectorJobStepContext =
+        new DomainIntrospectorJobStepContext(domainPresenceInfo, packet);
+    V1JobSpec jobSpec =
+        domainIntrospectorJobStepContext.createJobSpec(TuningParameters.getInstance());
+
+    MatcherAssert.assertThat(
+        getContainerFromJobSpec(jobSpec, domainPresenceInfo.getDomainUID()).getEnv(),
+        allOf(hasEnvVar("item1", "value1"), hasEnvVar("item2", "value2")));
+  }
+
+  @Test
+  public void whenAdminServerHasEnvironmentItems_introspectorPodStartupWithThem() {
+    DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
+
+    configureDomain(domainPresenceInfo)
+        .withEnvironmentVariable("item1", "domain-value1")
+        .withEnvironmentVariable("item2", "domain-value2")
+        .configureAdminServer()
+        .withEnvironmentVariable("item2", "admin-value2")
+        .withEnvironmentVariable("item3", "admin-value3");
+
+    Packet packet = new Packet();
+    packet
+        .getComponents()
+        .put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(domainPresenceInfo));
+    DomainIntrospectorJobStepContext domainIntrospectorJobStepContext =
+        new DomainIntrospectorJobStepContext(domainPresenceInfo, packet);
+    V1JobSpec jobSpec =
+        domainIntrospectorJobStepContext.createJobSpec(TuningParameters.getInstance());
+
+    MatcherAssert.assertThat(
+        getContainerFromJobSpec(jobSpec, domainPresenceInfo.getDomainUID()).getEnv(),
+        allOf(
+            hasEnvVar("item1", "domain-value1"),
+            hasEnvVar("item2", "admin-value2"),
+            hasEnvVar("item3", "admin-value3")));
+  }
+
   private DomainPresenceInfo createDomainPresenceInfo() {
     DomainPresenceInfo domainPresenceInfo =
-        new DomainPresenceInfo(new Domain().withMetadata(new V1ObjectMeta().namespace(NS)));
+        new DomainPresenceInfo(
+            new Domain()
+                .withMetadata(new V1ObjectMeta().namespace(NS))
+                .withSpec(
+                    new DomainSpec()
+                        .withDomainUID(DOMAIN_UID)
+                        .withWebLogicCredentialsSecret(
+                            new V1SecretReference().name("webLogicCredentialsSecretName"))));
     configureDomain(domainPresenceInfo)
         .withDefaultServerStartPolicy(ConfigurationConstants.START_NEVER);
     return domainPresenceInfo;
@@ -146,5 +219,21 @@ public class JobHelperTest {
   private ServerConfigurator configureServer(
       DomainPresenceInfo domainPresenceInfo, String serverName) {
     return configureDomain(domainPresenceInfo).configureServer(serverName);
+  }
+
+  private V1Container getContainerFromJobSpec(V1JobSpec jobSpec, String domainUID) {
+    List<V1Container> containersList = jobSpec.getTemplate().getSpec().getContainers();
+    if (containersList != null) {
+      for (V1Container container : containersList) {
+        if (JobHelper.createJobName(domainUID).equals(container.getName())) {
+          return container;
+        }
+      }
+    }
+    return null;
+  }
+
+  static Matcher<Iterable<? super V1EnvVar>> hasEnvVar(String name, String value) {
+    return hasItem(new V1EnvVar().name(name).value(value));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -137,6 +137,15 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   }
 
   @Test
+  public void createManagedPodStartupWithNullAdminUsernamePasswordEnvVarsValues() {
+    testSupport.addToPacket(ProcessingConstants.ENVVARS, Arrays.asList());
+
+    assertThat(
+        getCreatedPodSpecContainer().getEnv(),
+        allOf(hasEnvVar("ADMIN_USERNAME", null), hasEnvVar("ADMIN_PASSWORD", null)));
+  }
+
+  @Test
   public void whenPacketHasClusterConfig_managedPodHasClusterLabel() {
     testSupport.addToPacket(ProcessingConstants.CLUSTER_NAME, CLUSTER_NAME);
 


### PR DESCRIPTION
Pass custom env vars configured under serverPod attribute, either configured at domain spec level or at domain.adminServer level, to the container for the introspector job.

Also did some refactoring and introduced a common parent abstract class StepContextBase to allow AdminPodStepContext, ManagedPodStepContext, and DomainIntrospectorJobStepContext classes to share common code.

Passes jenkins http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/968/