### PR TITLE
Add code coverage reporting

### DIFF
--- a/build-tools/src/main/resources/weblogic-kubernetes-operator/checkstyle/customized_google_checks.xml
+++ b/build-tools/src/main/resources/weblogic-kubernetes-operator/checkstyle/customized_google_checks.xml
@@ -53,7 +53,6 @@
             <property name="tokens"
              value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
-        <module name="NeedBraces"/>
         <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
@@ -192,10 +191,9 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.oracle"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="NoWhitespaceBefore">
@@ -255,4 +253,3 @@
         <module name="CommentsIndentation"/>
     </module>
 </module>
-

--- a/buildtime-reports/pom.xml
+++ b/buildtime-reports/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>operator-parent</artifactId>
+        <groupId>oracle.kubernetes</groupId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>buildtime-reports</artifactId>
+    <packaging>pom</packaging>
+    <name>Project Reports</name>
+
+    <profiles>
+        <profile>
+            <id>reports</id>
+            <activation>
+                <property>
+                  <name>!no-reports</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>operator-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>weblogic-kubernetes-operator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>operator-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>kubernetes</module>
     <module>json-schema-maven-plugin</module>
     <module>json-schema</module>
+    <module>buildtime-reports</module>
   </modules>
 
   <scm>
@@ -350,7 +351,32 @@
         </plugins>
       </build>
     </profile>
-
+    
+    <profile>
+        <id>jacoco</id>
+        <activation>
+            <property>
+              <name>!no-reports</name>
+            </property>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    
     <profile>
       <id>default</id>
       <activation>


### PR DESCRIPTION
1. Adds code coverage reports for model and runtime modules. Should also take into consideration coverage from functional tests when enable. Html reports is generated at `buildtime-reports/target/site/jacoco-aggregate/index.html `

2. Modifies code style checks to match what the maven format plugin currently enforces. We should probably have a discussion over any additional checks. 
