### PR TITLE
OWLS-71901-OPERATOR FAILS TO BRING UP WEBLOGIC DOMAIN WITH SITCONFIG OVERRIDE CONFIGURATION

### DIFF
--- a/kubernetes/samples/scripts/common/domain-template.yaml
+++ b/kubernetes/samples/scripts/common/domain-template.yaml
@@ -46,7 +46,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "%JAVA_OPTIONS%"
     - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
     %LOG_HOME_ON_PV_PREFIX%volumes:
     %LOG_HOME_ON_PV_PREFIX%- name: weblogic-domain-storage-volume
     %LOG_HOME_ON_PV_PREFIX%  persistentVolumeClaim:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/README.md
@@ -195,7 +195,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
     # volumes:
     # - name: weblogic-domain-storage-volume
     #   persistentVolumeClaim:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README.md
@@ -163,7 +163,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
     volumes:
     - name: weblogic-domain-storage-volume
       persistentVolumeClaim:

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -395,7 +395,11 @@ public abstract class DomainTestBase {
     assertThat(
         serverSpec.getEnvironmentVariables(),
         both(hasItem(envVar("JAVA_OPTIONS", "-server")))
-            .and(hasItem(envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "))));
+            .and(
+                hasItem(
+                    envVar(
+                        "USER_MEM_ARGS",
+                        "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "))));
     assertThat(serverSpec.getDesiredState(), equalTo("RUNNING"));
   }
 

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Test.java
@@ -697,7 +697,7 @@ public class DomainV2Test extends DomainTestBase {
         serverSpec.getEnvironmentVariables(),
         containsInAnyOrder(
             envVar("JAVA_OPTIONS", "-server"),
-            envVar("USER_MEM_ARGS", "-Xms64m -Xmx256m "),
+            envVar("USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "),
             envVar("var1", "value0")));
     assertThat(serverSpec.getConfigOverrides(), equalTo("overrides-config-map"));
     assertThat(

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -79,7 +79,7 @@ spec:
       - name: JAVA_OPTIONS
         value: "-server"
       - name: USER_MEM_ARGS
-        value: "-Xms64m -Xmx256m "
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
       nodeSelector:
         os_arch: arm64
       resources:

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -91,26 +91,11 @@ public class JobHelper {
       return getDomain().getSpec().getAdditionalVolumeMounts();
     }
 
-    private boolean excludeEnvVar(V1EnvVar envVar) {
-      // Do not allow the overriding of USER_MEM_ARGS environment variable
-      // in introspector pod which has the value of
-      // "-Djava.security.egd=file:/dev/./urandom" from the WebLogic docker image
-      if ("USER_MEM_ARGS".equals(envVar.getName())) {
-        return true;
-      }
-      return false;
-    }
-
     @Override
     List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
       // Pod for introspector job would use same environment variables as for admin server
-      List<V1EnvVar> vars = new ArrayList<>();
-      for (V1EnvVar adminServerEnvVar :
-          getDomain().getAdminServerSpec().getEnvironmentVariables()) {
-        if (!excludeEnvVar(adminServerEnvVar)) {
-          vars.add(adminServerEnvVar);
-        }
-      }
+      List<V1EnvVar> vars =
+          new ArrayList<>(getDomain().getAdminServerSpec().getEnvironmentVariables());
 
       addEnvVar(vars, "NAMESPACE", getNamespace());
       addEnvVar(vars, "DOMAIN_UID", getDomainUID());

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -35,8 +35,8 @@ public abstract class JobStepContext extends StepContextBase {
 
   private final DomainPresenceInfo info;
   private V1Job jobModel;
-  final long DEFAULT_ACTIVE_DEADLINE_SECONDS = 120L;
-  final long DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS = 60L;
+  static final long DEFAULT_ACTIVE_DEADLINE_SECONDS = 120L;
+  static final long DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS = 60L;
 
   JobStepContext(Packet packet) {
     info = packet.getSPI(DomainPresenceInfo.class);
@@ -217,7 +217,7 @@ public abstract class JobStepContext extends StepContextBase {
   private V1PodSpec createPodSpec(TuningParameters tuningParameters) {
     V1PodSpec podSpec =
         new V1PodSpec()
-            .activeDeadlineSeconds(60L)
+            .activeDeadlineSeconds(getActiveDeadlineSeconds())
             .restartPolicy("Never")
             .addContainersItem(createContainer(tuningParameters))
             .addVolumesItem(new V1Volume().name(SECRETS_VOLUME).secret(getSecretsVolume()))

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
@@ -37,6 +37,8 @@ public abstract class StepContextBase implements StepContextConstants {
 
     List<V1EnvVar> vars = getConfiguredEnvVars(tuningParameters);
 
+    addDefaultEnvVarIfMissing(vars, "USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom");
+
     hideAdminUserCredentials(vars);
     doSubstitution(vars);
 
@@ -61,6 +63,21 @@ public abstract class StepContextBase implements StepContextConstants {
 
   protected void addEnvVar(List<V1EnvVar> vars, String name, String value) {
     vars.add(new V1EnvVar().name(name).value(value));
+  }
+
+  protected boolean hasEnvVar(List<V1EnvVar> vars, String name) {
+    for (V1EnvVar var : vars) {
+      if (name.equals(var.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected void addDefaultEnvVarIfMissing(List<V1EnvVar> vars, String name, String value) {
+    if (!hasEnvVar(vars, name)) {
+      addEnvVar(vars, name, value);
+    }
   }
 
   // Hide the admin account's user name and password.

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -78,12 +78,6 @@ done
 
 exportEffectiveDomainHome || exit 1
 
-# append java.security.egd to speed up domain introspection
-
-export USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom ${USER_MEM_ARGS} "
-
-trace "USER_MEM_ARGS=${USER_MEM_ARGS}"
-
 # start node manager
 
 trace "Starting node manager"

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -78,6 +78,12 @@ done
 
 exportEffectiveDomainHome || exit 1
 
+# append java.security.egd to speed up domain introspection
+
+export USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom ${USER_MEM_ARGS} "
+
+trace "USER_MEM_ARGS=${USER_MEM_ARGS}"
+
 # start node manager
 
 trace "Starting node manager"
@@ -87,6 +93,7 @@ ${SCRIPTPATH}/startNodeManager.sh || exit 1
 # run instrospector wlst script
 
 trace "Running introspector WLST script ${SCRIPTPATH}/introspectDomain.py"
+
 
 ${SCRIPTPATH}/wlst.sh ${SCRIPTPATH}/introspectDomain.py || exit 1
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -174,6 +174,65 @@ public class JobHelperTest {
   }
 
   @Test
+  public void introspectorPodStartsWithDefaultUSER_MEM_ARGS_environmentVariable() {
+    DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
+
+    Packet packet = new Packet();
+    packet
+        .getComponents()
+        .put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(domainPresenceInfo));
+    DomainIntrospectorJobStepContext domainIntrospectorJobStepContext =
+        new DomainIntrospectorJobStepContext(domainPresenceInfo, packet);
+    V1JobSpec jobSpec =
+        domainIntrospectorJobStepContext.createJobSpec(TuningParameters.getInstance());
+
+    MatcherAssert.assertThat(
+        getContainerFromJobSpec(jobSpec, domainPresenceInfo.getDomainUID()).getEnv(),
+        allOf(hasEnvVar("USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom")));
+  }
+
+  @Test
+  public void whenDomainHasUSER_MEM_ARGS_EnvironmentItem_introspectorPodStartupWithIt() {
+    DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
+
+    configureDomain(domainPresenceInfo)
+        .withEnvironmentVariable("USER_MEM_ARGS", "-Xms64m -Xmx256m");
+
+    Packet packet = new Packet();
+    packet
+        .getComponents()
+        .put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(domainPresenceInfo));
+    DomainIntrospectorJobStepContext domainIntrospectorJobStepContext =
+        new DomainIntrospectorJobStepContext(domainPresenceInfo, packet);
+    V1JobSpec jobSpec =
+        domainIntrospectorJobStepContext.createJobSpec(TuningParameters.getInstance());
+
+    MatcherAssert.assertThat(
+        getContainerFromJobSpec(jobSpec, domainPresenceInfo.getDomainUID()).getEnv(),
+        allOf(hasEnvVar("USER_MEM_ARGS", "-Xms64m -Xmx256m")));
+  }
+
+  @Test
+  public void whenDomainHasEmptyStringUSER_MEM_ARGS_EnvironmentItem_introspectorPodStartupWithIt() {
+    DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
+
+    configureDomain(domainPresenceInfo).withEnvironmentVariable("USER_MEM_ARGS", "");
+
+    Packet packet = new Packet();
+    packet
+        .getComponents()
+        .put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(domainPresenceInfo));
+    DomainIntrospectorJobStepContext domainIntrospectorJobStepContext =
+        new DomainIntrospectorJobStepContext(domainPresenceInfo, packet);
+    V1JobSpec jobSpec =
+        domainIntrospectorJobStepContext.createJobSpec(TuningParameters.getInstance());
+
+    MatcherAssert.assertThat(
+        getContainerFromJobSpec(jobSpec, domainPresenceInfo.getDomainUID()).getEnv(),
+        allOf(hasEnvVar("USER_MEM_ARGS", "")));
+  }
+
+  @Test
   public void whenDomainHasEnvironmentItemsWithVariables_introspectorPodStartupWithThem() {
     DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import io.kubernetes.client.models.V1Container;
@@ -172,32 +171,6 @@ public class JobHelperTest {
             hasEnvVar("item2", "value2"),
             hasEnvVar("WL_HOME", "/u01/custom_wl_home/"),
             hasEnvVar("MW_HOME", "/u01/custom_mw_home/")));
-  }
-
-  @Test
-  public void introspectorPodDoesNotStartsWithUSER_MEM_ARGS_envVar() {
-    DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo();
-
-    configureDomain(domainPresenceInfo)
-        .withEnvironmentVariable("item1", "value1")
-        .withEnvironmentVariable("item2", "value2")
-        .withEnvironmentVariable("USER_MEM_ARGS", "-Xms64m -Xmx256m");
-
-    Packet packet = new Packet();
-    packet
-        .getComponents()
-        .put(ProcessingConstants.DOMAIN_COMPONENT_NAME, Component.createFor(domainPresenceInfo));
-    DomainIntrospectorJobStepContext domainIntrospectorJobStepContext =
-        new DomainIntrospectorJobStepContext(domainPresenceInfo, packet);
-    V1JobSpec jobSpec =
-        domainIntrospectorJobStepContext.createJobSpec(TuningParameters.getInstance());
-
-    MatcherAssert.assertThat(
-        getContainerFromJobSpec(jobSpec, domainPresenceInfo.getDomainUID()).getEnv(),
-        allOf(
-            hasEnvVar("item1", "value1"),
-            hasEnvVar("item2", "value2"),
-            not(hasEnvVar("USER_MEM_ARGS", "-Xms64m -Xmx256m"))));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -332,7 +332,8 @@ public abstract class PodHelperTestBase {
             hasEnvVar("SERVER_OUT_IN_POD_LOG", Boolean.toString(INCLUDE_SERVER_OUT_IN_POD_LOG)),
             hasEnvVar("LOG_HOME", null),
             hasEnvVar("SERVICE_NAME", LegalNames.toServerServiceName(UID, getServerName())),
-            hasEnvVar("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER))));
+            hasEnvVar("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER)),
+            hasEnvVar("USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom")));
   }
 
   @Test
@@ -630,6 +631,7 @@ public abstract class PodHelperTestBase {
         .addEnvItem(envItem("LOG_HOME", null))
         .addEnvItem(envItem("SERVICE_NAME", LegalNames.toServerServiceName(UID, getServerName())))
         .addEnvItem(envItem("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER)))
+        .addEnvItem(envItem("USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom"))
         .livenessProbe(createLivenessProbe())
         .readinessProbe(createReadinessProbe());
   }

--- a/site/domains.md
+++ b/site/domains.md
@@ -85,7 +85,7 @@ running in Kubernetes.
 * _Host Path Persistent Volumes:_ If using a `hostPath` persistent volume, then it must be available on all worker nodes in the cluster and have read/write/many permissions for all container/pods in the WebLogic Server deployment.  Be aware
   that many cloud provider's volume providers may not support volumes across availability zones.  You may want to use NFS or a clustered file system to work around this limitation.
 
-* _Security Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource yaml using the `env` attribute under the `serverPod` configuration.
+* _Security Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
 
 The following features are not certified or supported in this release:
 

--- a/site/domains.md
+++ b/site/domains.md
@@ -87,6 +87,8 @@ running in Kubernetes.
 * _Host Path Persistent Volumes:_ If using a `hostPath` persistent volume, then it must be available on all worker nodes in the cluster and have read/write/many permissions for all container/pods in the WebLogic Server deployment.  Be aware
   that many cloud provider's volume providers may not support volumes across availability zones.  You may want to use NFS or a clustered file system to work around this limitation.
 
+* _Security Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource yaml using the `env` attribute under the `serverPod` configuration.
+
 The following features are not certified or supported in this release:
 
 * Whole Server Migration

--- a/src/integration-tests/introspector/wl-pod.yamlt
+++ b/src/integration-tests/introspector/wl-pod.yamlt
@@ -20,7 +20,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false "
     - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
     - name: DOMAIN_NAME
       value: "${DOMAIN_NAME}"
     - name: DOMAIN_HOME


### PR DESCRIPTION
This is a regression caused by owls-71580 when we start passing en vars to introspector job. The WLS container is preconfigured with USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom". When this env var is overridden, the introspector script would take a longer time to run. In Pani's environment, it took longer than the timeout of 60s specified in job.template.spec.activeDeadlineSeconds. This results in the introspector job failing with DeadlineExceeded

Changes made in this PR:

- The operator should always explicitly set USER_MEM_ARGS to `-Djava.security.egd=file:/dev/./urandom` if the domain.yaml does not specify this env var.  (This will override any value that the docker image itself might be setting.)

- If the domain.yaml specifies USER_MEM_ARGS of “” or any value, then honor the custom value instead.

- Use the same approach for both the introspector job and for wl pods- Append USER_MEM_ARGS with "-Djava.security.egd=file:/dev/./urandom" in introspector.sh instead of in operator code so we are not relying on it being set in the weblogic docker image

- there are 2 activeDeadlineSeconds, one in job.spec and another in job.template.spec. The former is for the job and the second is for the pod started by the job. We have been setting the former to 120s, with an increment of 60s in subsequent retries. Now we are also setting the latter with the same values.

- tested by Pani
- passed jenkins http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/1008/