### PR TITLE
fix typo

### DIFF
--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -230,9 +230,9 @@ e.	To confirm that the load balancer noticed the new Ingress and is successfully
 
   Substitute the Node IP address of the worker node for `your.server.com`. You can find it by running:
 
-    ```
+```
     $ kubectl get po -n sample-domain1-ns -o wide
-    ```
+```
 
 **NOTE**: Be sure to include the trailing forward slash on the URL, otherwise the command won't work.
 

--- a/site/user-guide.md
+++ b/site/user-guide.md
@@ -16,8 +16,8 @@ presented in the correct order.
 
 * [Important terms](#important-terms)
 * [Getting started](#getting-started)
+  * [Operator Docker image](#operator-docker-image)
   * [Exposing applications outside the Kubernetes cluster](#exposing-applications-outside-the-kubernetes-cluster)
-  * [Operator Docker image](#0perator-docker-image)
 * [Prerequisites](#prerequisites)
 * [Preparing your Kubernetes environment to run the operator](prepare-k8s.md)
   * [Set up your Kubernetes cluster](k8s_setup.md)
@@ -68,6 +68,11 @@ You can have one or more operators in your Kubernetes cluster that manage one or
 We provide a Helm chart to manage the installation and configuration of the operator.
 Detailed instructions are available [here](install.md).
 
+### Operator Docker image
+
+You can find the operator image in
+[Docker Hub](https://hub.docker.com/r/oracle/weblogic-kubernetes-operator/).
+
 ### Exposing applications outside the Kubernetes cluster
 The operator can configure services to expose WebLogic applications and features outside of the Kubernetes cluster.  Care should be taken when exposing anything externally to ensure that the appropriate security considerations are taken into account. In this regard, there is no significant difference between a WebLogic domain running in a Kubernetes cluster and a domain running in a traditional data center.  The same kinds of considerations should be taken into account, for example:
 
@@ -86,10 +91,6 @@ While it is natural to expose web applications outside the cluster, exposing adm
 
 Oracle recommends careful consideration before deciding to expose any administrative or non-HTTP(S) interfaces or protocols externally.
 
-### Operator Docker image
-
-You can find the operator image in
-[Docker Hub](https://hub.docker.com/r/oracle/weblogic-kubernetes-operator/).
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixed typo in Quick Start and rearranged two minor sections in User Guide.