### PR TITLE
Fix ES_JAVA_OPTS to prevent Initial heap size failure

### DIFF
--- a/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
+++ b/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
@@ -49,7 +49,7 @@ spec:
         - containerPort: 9300
         env:
         - name: ES_JAVA_OPTS
-          value: -Xms2014m -Xmx1024m
+          value: -Xms1024m -Xmx1024m
         - name: bootstrap.memory_lock
           value: "true"
 


### PR DESCRIPTION
The following change in elasticsearch_and_kibana.yaml from the samples has broken the deployment of elasticsearch.

      - name: ES_JAVA_OPTS
        value: -Xms2014m -Xmx1024m

This results in "Error occurred during initialization of VM Initial heap size set to a larger value than the maximum heap size".

The fix is to make the values the same which is the recommendation from elasticsearch.