### PR TITLE
Issue #876 fix

### DIFF
--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -87,7 +87,7 @@ elkIntegrationEnabled: false
 
 # logStashImage specifies the docker image containing logstash.
 # This parameter is ignored if 'elkIntegrationEnabled' is false.
-logStashImage: "logstash:5"
+logStashImage: "logstash:6.6.0"
 
 # elasticSearchHost specifies the hostname of where elasticsearch is running.
 # This parameter is ignored if 'elkIntegrationEnabled' is false.


### PR DESCRIPTION
logStashImage parameter in file weblogic-kubernetes-operator/kubernetes/charts/weblogic-operator/values.yaml now contains "logstash:6.6.0" value.
Container based on image logstash:6.6.0 solved the "/var/lib/logstash is not writable" error

Signed-off-by: Denis Maggiorotto <denis.maggiorotto@sunnyvale.it>