### PR TITLE
Fix readiness probe.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -69,7 +69,7 @@ public abstract class PodStepContext extends StepContextBase {
   private static final String START_SERVER = "/weblogic-operator/scripts/startServer.sh";
   private static final String LIVENESS_PROBE = "/weblogic-operator/scripts/livenessProbe.sh";
 
-  private static final String READINESS_PATH = "/weblogic";
+  private static final String READINESS_PATH = "/weblogic/";
 
   private final DomainPresenceInfo info;
   private final WlsDomainConfig domainTopology;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -278,7 +278,7 @@ public abstract class PodHelperTestBase {
   @Test
   public void whenPodCreated_readinessProbeHasReadinessCommand() {
     V1HTTPGetAction getAction = getCreatedPodSpecContainer().getReadinessProbe().getHttpGet();
-    assertThat(getAction.getPath(), equalTo("/weblogic"));
+    assertThat(getAction.getPath(), equalTo("/weblogic/"));
     assertThat(getAction.getPort().getIntValue(), equalTo(listenPort));
   }
 


### PR DESCRIPTION
This PR fixes a problem in the readiness probe.  The previous code set the probe to "/weblogic" which will result in the server returning a 302 redirect.  In cases where the cluster is behind a load balancer and WebLogic has been configured with a frontend host/port so that external clients can use applications deployed in the cluster, the 302 will redirect to the load balancer address, and kubelet will not be able to hit this address successfully.  The readiness probe will show as failed (503), because the endpoints have not been added to the cluster service (and therefore the ingress) yet, because the pod is not yet considered ready.  So you get a chicken and egg problem.

This change fixes the readiness probe to use "/weblogic/" (with the trailing slash).  This will not result in a 302, it will return the 200, and then kubelet will consider the pod as ready and add it into the cluster service, ingress, etc., and everything will work as expected. 

Credit to BRIAN DUECK for initial identification of this problem.
