### PR TITLE
OWLS-71184 REDUNDANT WORD VOYAGER,APACHE OR IN LBER SERVICE NAME

### DIFF
--- a/kubernetes/samples/charts/util/setup.sh
+++ b/kubernetes/samples/charts/util/setup.sh
@@ -5,6 +5,8 @@
 #  This script is to create or delete Ingress controllers. We support two ingress controllers: traefik and voyager.
 
 MYDIR="$(dirname "$(readlink -f "$0")")"
+VNAME=operator-v  # release name of Voyager
+TNAME=traefik-operator  # release name of Traefik
 
 function createVoyager() {
   echo "Creating Voyager operator on namespace 'voyager'."
@@ -19,10 +21,10 @@ function createVoyager() {
   fi
   echo
 
-  if [ "$(helm list | grep voyager-operator |  wc -l)" = 0 ]; then
+  if [ "$(helm list | grep $VNAME |  wc -l)" = 0 ]; then
     echo "Ihstall voyager operator."
     
-    helm install appscode/voyager --name voyager-operator --version 7.4.0 \
+    helm install appscode/voyager --name $VNAME --version 7.4.0 \
       --namespace voyager \
       --set cloudProvider=baremetal \
       --set apiserver.enableValidatingWebhook=false
@@ -52,9 +54,9 @@ function createTraefik() {
   echo "Creating Traefik operator on namespace 'traefik'." 
   echo
 
-  if [ "$(helm list | grep traefik-operator |  wc -l)" = 0 ]; then
+  if [ "$(helm list | grep $TNAME |  wc -l)" = 0 ]; then
     echo "Install Traefik Operator."
-    helm install --name traefik-operator --namespace traefik --values ${MYDIR}/../traefik/values.yaml stable/traefik
+    helm install --name $TNAME --namespace traefik --values ${MYDIR}/../traefik/values.yaml stable/traefik
   else
     echo "Traefik Operator is already installed."
   fi
@@ -108,9 +110,9 @@ function purgeCRDs() {
 }
 
 function deleteVoyager() {
-  if [ "$(helm list | grep voyager-operator |  wc -l)" = 1 ]; then
+  if [ "$(helm list | grep $VNAME |  wc -l)" = 1 ]; then
     echo "Delete Voyager Operator. "
-    helm delete --purge voyager-operator
+    helm delete --purge $VNAME 
     kubectl delete ns voyager
     purgeCRDs
   else
@@ -127,9 +129,9 @@ function deleteVoyager() {
 }
 
 function deleteTraefik() {
-  if [ "$(helm list | grep traefik-operator |  wc -l)" = 1 ]; then
+  if [ "$(helm list | grep $TNAME |  wc -l)" = 1 ]; then
     echo "Delete Traefik operator." 
-    helm delete --purge traefik-operator
+    helm delete --purge $TNAME
     kubectl delete ns traefik
   else
     echo "Traefik operator has already been deleted." 

--- a/kubernetes/samples/charts/util/setup.sh
+++ b/kubernetes/samples/charts/util/setup.sh
@@ -5,7 +5,7 @@
 #  This script is to create or delete Ingress controllers. We support two ingress controllers: traefik and voyager.
 
 MYDIR="$(dirname "$(readlink -f "$0")")"
-VNAME=operator-v  # release name of Voyager
+VNAME=voyager-operator  # release name of Voyager
 TNAME=traefik-operator  # release name of Traefik
 
 function createVoyager() {

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -9,7 +9,12 @@ As a demonstration, the following are the detailed steps to install the Voyager 
 ```
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
+```
+Verify the chart repository has been added.
+```
 $ helm search appscode/voyager
+NAME            	CHART VERSION	APP VERSION	DESCRIPTION                                       
+appscode/voyager	8.0.1        	8.0.1      	Voyager by AppsCode - Secure HAProxy Ingress Co...
 ```
 
 ### 2. Install the Voyager operator
@@ -21,6 +26,23 @@ $ helm install appscode/voyager --name voyager-operator --version 7.4.0 \
   --set cloudProvider=baremetal \
   --set apiserver.enableValidatingWebhook=false
 ```
+Wait until Voyager Operator is running.
+```
+$ kubectl -n voyager get all
+NAME                                            READY     STATUS    RESTARTS   AGE
+pod/voyager-voyager-operator-77cbfdcb86-gqwgt   1/1       Running   0          46m
+
+NAME                               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+service/voyager-voyager-operator   ClusterIP   10.105.254.144   <none>        443/TCP,56791/TCP   46m
+
+NAME                                       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/voyager-voyager-operator   1         1         1            1           46m
+
+NAME                                                  DESIRED   CURRENT   READY     AGE
+replicaset.apps/voyager-voyager-operator-77cbfdcb86   1         1         1         46m
+```
+> NOTE: All the generated Kubernetes resources of Voyager operator have names with pattern 'voyager-<releaseName>XXX'. This is the logic controlled by Voyager Helm chart. In our case we use releaseName 'voyager-operator', so all the generated resources have name like 'voyager-voyager-operatorXXX'.
+
 ## Optionally, download the Voyager Helm chart
 If you want, you can download the Voyager Helm chart and untar it into a local folder:
 ```

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -10,7 +10,7 @@ As a demonstration, the following are the detailed steps to install the Voyager 
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
 ```
-Verify the chart repository has been added.
+Verify that the chart repository has been added.
 ```
 $ helm search appscode/voyager
 NAME            	CHART VERSION	APP VERSION	DESCRIPTION                                       
@@ -26,7 +26,7 @@ $ helm install appscode/voyager --name voyager-operator --version 7.4.0 \
   --set cloudProvider=baremetal \
   --set apiserver.enableValidatingWebhook=false
 ```
-Wait until Voyager Operator is running.
+Wait until the Voyager Operator is running.
 ```
 $ kubectl -n voyager get all
 NAME                                            READY     STATUS    RESTARTS   AGE
@@ -41,7 +41,7 @@ deployment.apps/voyager-voyager-operator   1         1         1            1   
 NAME                                                  DESIRED   CURRENT   READY     AGE
 replicaset.apps/voyager-voyager-operator-77cbfdcb86   1         1         1         46m
 ```
-> NOTE: All the generated Kubernetes resources of Voyager operator have names with pattern 'voyager-<releaseName>XXX'. This is the logic controlled by Voyager Helm chart. In our case we use releaseName 'voyager-operator', so all the generated resources have name like 'voyager-voyager-operatorXXX'.
+> **NOTE**: All the generated Kubernetes resources of the Voyager operator have names with the pattern `voyager-<releaseName>XXX`. This logic is controlled by the Voyager Helm chart. In our case, we use `releaseName` `voyager-operator`, so all the generated resources have names like `voyager-voyager-operatorXXX`.
 
 ## Optionally, download the Voyager Helm chart
 If you want, you can download the Voyager Helm chart and untar it into a local folder:


### PR DESCRIPTION
Update setup.sh:
1. Parameterize release name for Voyager and Traefik operator.
2. Change the release name of Voyager to avoid redundant words in the generated k8s resources.

For more information see https://jira.oraclecorp.com/jira/browse/OWLS-71184.