### PR TITLE
READY TO MERGE: fix create-domain.py 

### DIFF
--- a/integration-tests/src/test/resources/domain-home-on-pv/create-domain.py
+++ b/integration-tests/src/test/resources/domain-home-on-pv/create-domain.py
@@ -1,4 +1,4 @@
-# Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 def getEnvVar(var):
@@ -48,26 +48,14 @@ setOption('DomainName', domain_name)
 # Configure the Administration Server
 # ===================================
 cd('/Servers/AdminServer')
-# Dont set listenaddress, introspector overrides automatically with sit-config
-#set('ListenAddress', '%s-%s' % (domain_uid, admin_server_name_svc))
 set('ListenPort', admin_port)
 set('Name', admin_server_name)
 
 create('T3Channel', 'NetworkAccessPoint')
 cd('/Servers/%s/NetworkAccessPoints/T3Channel' % admin_server_name)
 set('PublicPort', t3_channel_port)
-set('PublicAddress', 'junkvalue')
-# Dont set listenaddress, introspector overrides automatically with sit-config
-#set('ListenAddress', '%s-%s' % (domain_uid, admin_server_name_svc))
+set('PublicAddress', t3_public_address)
 set('ListenPort', t3_channel_port)
-
-cd('/Servers/%s' % admin_server_name)
-create(admin_server_name,'Log')
-cd('/Servers/%s/Log/%s' % (admin_server_name, admin_server_name))
-# Give incorrect filelog, introspector overrides with sit-config
-set('FileName', 'dirdoesnotexist')
-
-
 
 # Set the admin user's username and password
 # ==========================================
@@ -97,7 +85,6 @@ if cluster_type == "CONFIGURED":
     create(name, 'Server')
     cd('/Servers/%s/' % name )
     print('managed server name is %s' % name);
-    set('ListenAddress', '%s-%s' % (domain_uid, name_svc))
     set('ListenPort', server_port)
     set('NumOfRetriesBeforeMSIMode', 0)
     set('RetryIntervalBeforeMSIMode', 1)
@@ -112,7 +99,6 @@ else:
   print('Done creating Server Template: %s' % templateName)
   cd('/ServerTemplates/%s' % templateName)
   cmo.setListenPort(server_port)
-  cmo.setListenAddress('%s-%s${id}' % (domain_uid, managed_server_name_base_svc))
   cmo.setCluster(cl)
   print('Done setting attributes for Server Template: %s' % templateName);
 
@@ -125,7 +111,7 @@ else:
   set('DynamicClusterSize', number_of_ms)
   set('MaxDynamicClusterSize', number_of_ms)
   set('CalculatedListenPorts', false)
-  set('Id', 1)
+  # set('Id', 1)
 
   print('Done setting attributes for Dynamic Cluster: %s' % cluster_name);
 


### PR DESCRIPTION
Somehow integration-tests/src/test/resources/domain-home-on-pv/create-domain.py got incorrect configuration. Fixing it by copying the file from samples.

Jenkins passed with this change - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/1071/consoleFull