### PR TITLE
OWLS-71954 remove synchronize block from Fiber.getName() to avoid deadlock

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/work/Fiber.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Fiber.java
@@ -64,7 +64,7 @@ public final class Fiber implements Runnable, Future<Void>, ComponentRegistry {
   private CompletionCallback completionCallback;
 
   /** The thread on which this Fiber is currently executing, if applicable. */
-  private Thread currentThread;
+  private volatile Thread currentThread;
 
   private ExitCallback exitCallback;
 
@@ -658,11 +658,10 @@ public final class Fiber implements Runnable, Future<Void>, ComponentRegistry {
       sb.append(parent.getName());
       sb.append("-child-");
     } else {
-      synchronized (this) {
-        if (currentThread != null) {
-          sb.append(currentThread.getName());
-          sb.append("-");
-        }
+      Thread thread = currentThread;
+      if (thread != null) {
+        sb.append(thread.getName());
+        sb.append("-");
       }
       sb.append("fiber-");
     }


### PR DESCRIPTION
Fixes a deadlock when the javaLoggingLevel includes FINER log level by removing the
synchronized block from the Fiber.getName() method. The currentThread field in Fiber class is made volatile so getName() can still obtain the most up-to-date value.

Example of deadlock:
`"engine-operator-thread-1":
        at oracle.kubernetes.operator.work.Fiber.getName(Fiber.java:661)
        - waiting to lock <0x000000042b116548> (a oracle.kubernetes.operator.work.Fiber)
        at oracle.kubernetes.operator.work.Fiber.toString(Fiber.java:675)
        at oracle.kubernetes.operator.logging.LoggingFormatter.format(LoggingFormatter.java:111)
        at java.util.logging.StreamHandler.publish(StreamHandler.java:211)
        - locked <0x000000055cdd49a8> (a java.util.logging.FileHandler)
        at java.util.logging.FileHandler.publish(FileHandler.java:701)
        - locked <0x000000055cdd49a8> (a java.util.logging.FileHandler)
        at java.util.logging.Logger.log(Logger.java:738)
        at java.util.logging.Logger.doLog(Logger.java:765)
        at java.util.logging.Logger.logp(Logger.java:1011)
        at oracle.kubernetes.operator.logging.LoggingFacade.finer(LoggingFacade.java:187)
        at oracle.kubernetes.operator.work.Fiber.doRun(Fiber.java:550)
        at oracle.kubernetes.operator.work.Fiber.run(Fiber.java:467)
        at oracle.kubernetes.operator.work.ThreadLocalContainerResolver.lambda$null$0(ThreadLocalContainerResolver.java:87)
        ...

"engine-operator-thread-6":
        at java.util.logging.FileHandler.publish(FileHandler.java:698)
        - waiting to lock <0x000000055cdd49a8> (a java.util.logging.FileHandler)
        at java.util.logging.Logger.log(Logger.java:738)
        at java.util.logging.Logger.doLog(Logger.java:765)
        at java.util.logging.Logger.logp(Logger.java:1011)
        at oracle.kubernetes.operator.logging.LoggingFacade.finer(LoggingFacade.java:187)
        at oracle.kubernetes.operator.work.Fiber.doRun(Fiber.java:523)
        - locked <0x000000042b116548> (a oracle.kubernetes.operator.work.Fiber)
        at oracle.kubernetes.operator.work.Fiber.run(Fiber.java:467)
        at oracle.kubernetes.operator.work.ThreadLocalContainerResolver.lambda$null$0(ThreadLocalContainerResolver.java:87)
        ...
`

