### PR TITLE
Changes to domain-home-on-pv scripts for istio environment

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -13,6 +13,8 @@ spec:
         weblogic.domainUID: %DOMAIN_UID%
         weblogic.domainName: %DOMAIN_NAME%
         app: %DOMAIN_UID%-create-weblogic-sample-domain-job
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
       containers:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -180,7 +180,8 @@ function createDomainHome {
   createDomainConfigmap
 
   # There is no way to re-run a kubernetes job, so first delete any prior job
-  JOB_NAME="${domainUID}-create-weblogic-sample-domain-job"
+  CONTAINER_NAME="create-weblogic-sample-domain-job"
+  JOB_NAME="${domainUID}-${CONTAINER_NAME}"
   deleteK8sObj job $JOB_NAME ${createJobOutput}
 
   echo Creating the domain by creating the job ${createJobOutput}
@@ -193,8 +194,8 @@ function createDomainHome {
   while [ "$JOB_STATUS" != "Completed" -a $count -lt $max ] ; do
     sleep 30
     count=`expr $count + 1`
-    JOBS=`kubectl get pods --show-all -n ${namespace} | grep ${JOB_NAME}`
-    JOB_ERRORS=`kubectl logs jobs/$JOB_NAME -n ${namespace} | grep "ERROR:" `
+    JOBS=`kubectl get pods -n ${namespace} | grep ${JOB_NAME}`
+    JOB_ERRORS=`kubectl logs jobs/$JOB_NAME $CONTAINER_NAME -n ${namespace} | grep "ERROR:" `
     JOB_STATUS=`echo $JOBS | awk ' { print $3; } '`
     JOB_INFO=`echo $JOBS | awk ' { print "pod", $1, "status is", $3; } '`
     echo "status on iteration $count of $max"
@@ -216,17 +217,17 @@ function createDomainHome {
   if [ "$JOB_STATUS" != "Completed" ]; then
     echo "The create domain job is not showing status completed after waiting 300 seconds."
     echo "Check the log output for errors."
-    kubectl logs jobs/$JOB_NAME -n ${namespace}
+    kubectl logs jobs/$JOB_NAME $CONTAINER_NAME -n ${namespace}
     fail "Exiting due to failure - the job status is not Completed!"
   fi
 
   # Check for successful completion in log file
-  JOB_POD=`kubectl get pods --show-all -n ${namespace} | grep ${JOB_NAME} | awk ' { print $1; } '`
-  JOB_STS=`kubectl logs $JOB_POD -n ${namespace} | grep "Successfully Completed" | awk ' { print $1; } '`
+  JOB_POD=`kubectl get pods -n ${namespace} | grep ${JOB_NAME} | awk ' { print $1; } '`
+  JOB_STS=`kubectl logs $JOB_POD $CONTAINER_NAME -n ${namespace} | grep "Successfully Completed" | awk ' { print $1; } '`
   if [ "${JOB_STS}" != "Successfully" ]; then
     echo The log file for the create domain job does not contain a successful completion status
     echo Check the log output for errors
-    kubectl logs $JOB_POD -n ${namespace}
+    kubectl logs $JOB_POD $CONTAINER_NAME -n ${namespace}
     fail "Exiting due to failure - the job log file does not contain a successful completion status!"
   fi
 }

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/delete-domain-job-template.yaml
@@ -31,6 +31,8 @@ spec:
         weblogic.domainUID: %DOMAIN_UID%
         weblogic.domainName: %DOMAIN_NAME%
         app: %DOMAIN_UID%-delete-weblogic-sample-domain-job
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
This pull request includes changes to the domain-home-on-pv scripts for the istio environment.

The changes are:
- included the container name in the **kubectl logs** command so the command works when there are multiple containers in the pod (for example, istio-proxy container included in pod)
- included annotation **sidecar.istio.io/inject: "false"** in the create and delete jobs to prevent istio injection for these jobs
- removed the deprecated **--show-all** option for **kubectl get pods** command

Jira: https://jira.oraclecorp.com/jira/browse/OWLS-72018