### PR TITLE
Handle watch status that is missing or for 410 doesn't include good resource version

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
@@ -193,19 +193,25 @@ abstract class Watcher<T> {
       // not available to our layer, so respond defensively by resetting resource version.
       resourceVersion = 0l;
     } else if (status.getCode() == HTTP_GONE) {
-      resourceVersion = 0l;
-      String message = status.getMessage();
+      resourceVersion = computeNextResourceVersionFromMessage(status);
+    }
+  }
+
+  private long computeNextResourceVersionFromMessage(V1Status status) {
+    String message = status.getMessage();
+    if (message != null) {
       int index1 = message.indexOf('(');
       if (index1 > 0) {
         int index2 = message.indexOf(')', index1 + 1);
         if (index2 > 0) {
           String val = message.substring(index1 + 1, index2);
           if (!isNullOrEmptyString(val)) {
-            resourceVersion = Long.parseLong(val);
+            return Long.parseLong(val);
           }
         }
       }
     }
+    return 0l;
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
@@ -107,6 +107,14 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
     return WatchEvent.createErrorEvent(HTTP_GONE, nextResourceVersion).toWatchResponse();
   }
 
+  private Watch.Response createHttpGoneErrorWithoutResourceVersionResponse() {
+    return WatchEvent.createErrorEvent(HTTP_GONE).toWatchResponse();
+  }
+
+  private Watch.Response createErrorWithoutStatusResponse() {
+    return WatchEvent.createErrorEventWithoutStatus().toWatchResponse();
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void receivedEvents_areSentToListeners() {
@@ -147,6 +155,36 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
       assertThat(
           StubWatchFactory.getRequestParameters().get(1),
           hasEntry("resourceVersion", Integer.toString(NEXT_RESOURCE_VERSION)));
+    } catch (Throwable t) {
+      t.printStackTrace();
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Test
+  public void afterHttpGoneErrorWithoutResourceVersion_nextRequestSendsResourceVersionZero() {
+    try {
+      StubWatchFactory.addCallResponses(createHttpGoneErrorWithoutResourceVersionResponse());
+      scheduleDeleteResponse(createObjectWithMetaData());
+
+      createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
+
+      assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
+    } catch (Throwable t) {
+      t.printStackTrace();
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Test
+  public void afterErrorWithoutStatus_nextRequestSendsResourceVersionZero() {
+    try {
+      StubWatchFactory.addCallResponses(createErrorWithoutStatusResponse());
+      scheduleDeleteResponse(createObjectWithMetaData());
+
+      createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
+
+      assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
     } catch (Throwable t) {
       t.printStackTrace();
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
@@ -146,48 +146,36 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void afterHttpGoneError_nextRequestSendsIncludedResourceVersion() {
-    try {
-      StubWatchFactory.addCallResponses(createHttpGoneErrorResponse(NEXT_RESOURCE_VERSION));
-      scheduleDeleteResponse(createObjectWithMetaData());
+    StubWatchFactory.addCallResponses(createHttpGoneErrorResponse(NEXT_RESOURCE_VERSION));
+    scheduleDeleteResponse(createObjectWithMetaData());
 
-      createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
+    createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
 
-      assertThat(
-          StubWatchFactory.getRequestParameters().get(1),
-          hasEntry("resourceVersion", Integer.toString(NEXT_RESOURCE_VERSION)));
-    } catch (Throwable t) {
-      t.printStackTrace();
-    }
+    assertThat(
+        StubWatchFactory.getRequestParameters().get(1),
+        hasEntry("resourceVersion", Integer.toString(NEXT_RESOURCE_VERSION)));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void afterHttpGoneErrorWithoutResourceVersion_nextRequestSendsResourceVersionZero() {
-    try {
-      StubWatchFactory.addCallResponses(createHttpGoneErrorWithoutResourceVersionResponse());
-      scheduleDeleteResponse(createObjectWithMetaData());
+    StubWatchFactory.addCallResponses(createHttpGoneErrorWithoutResourceVersionResponse());
+    scheduleDeleteResponse(createObjectWithMetaData());
 
-      createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
+    createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
 
-      assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
-    } catch (Throwable t) {
-      t.printStackTrace();
-    }
+    assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void afterErrorWithoutStatus_nextRequestSendsResourceVersionZero() {
-    try {
-      StubWatchFactory.addCallResponses(createErrorWithoutStatusResponse());
-      scheduleDeleteResponse(createObjectWithMetaData());
+    StubWatchFactory.addCallResponses(createErrorWithoutStatusResponse());
+    scheduleDeleteResponse(createObjectWithMetaData());
 
-      createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
+    createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
 
-      assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
-    } catch (Throwable t) {
-      t.printStackTrace();
-    }
+    assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/operator/src/test/java/oracle/kubernetes/operator/builders/WatchEvent.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/builders/WatchEvent.java
@@ -48,6 +48,10 @@ public class WatchEvent<T> {
     return new WatchEvent<>("DELETED", object);
   }
 
+  public static <S> WatchEvent<S> createErrorEventWithoutStatus() {
+    return new WatchEvent<>(null);
+  }
+
   public static <S> WatchEvent<S> createErrorEvent(int statusCode) {
     return new WatchEvent<>(new V1Status().code(statusCode).message("Oops"));
   }


### PR DESCRIPTION
We found two issues with watches while certifying on OpenShift.  Both issues involved use cases where the API server needs to return an HTTP 401 "Gone" status because the resource version used when the watch was started has aged out.

The expected behavior is that the V1Status contains a message that encodes a "good" resource version as part of the error message.  The error message from OpenShift does not include this good resource.

Additionally, we found that the Kubernetes Java client can incorrectly parse the status if the "target" type of the watch contains similar enough fields, e.g. V1ConfigMap.  In these cases, the watch response is of type ERROR; however, the status is not available.

In each case, the correct behavior is to use a resource version of "0".