### PR TITLE
Add more debugging output to integration tests.

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -992,6 +992,7 @@ public class Domain {
         .append(clusterName)
         .append("'");
     logger.info("Command to call kubectl sh file " + cmdKubectlSh);
+    ExecResult result = ExecCommand.exec(cmdKubectlSh.toString());
     String resultStr =
         "Command= '"
             + cmdKubectlSh

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -992,15 +992,20 @@ public class Domain {
         .append(clusterName)
         .append("'");
     logger.info("Command to call kubectl sh file " + cmdKubectlSh);
-    ExecResult result = ExecCommand.exec(cmdKubectlSh.toString());
-    if (result.exitValue() != 0) {
-      throw new RuntimeException(
-          "FAILURE: command " + cmdKubectlSh + " failed, returned " + result.stderr());
-    }
-    String output = result.stdout().trim();
-    if (!output.contains("Deployment State : completed")) {
-      throw new RuntimeException("Failure: webapp deployment failed." + output);
-    }
+    String resultStr =
+        "Command= '"
+            + cmdKubectlSh
+            + "'"
+            + ", exitValue="
+            + result.exitValue()
+            + ", stdout='"
+            + result.stdout()
+            + "'"
+            + ", stderr='"
+            + result.stderr()
+            + "'";
+    if (result.exitValue() != 0 || !resultStr.contains("Deployment State : completed"))
+      throw new RuntimeException("FAILURE: webapp deploy failed - " + resultStr);
   }
 
   private void callWebAppAndWaitTillReady(String curlCmd) throws Exception {

--- a/wercker.yml
+++ b/wercker.yml
@@ -170,6 +170,9 @@ integration-test-java:
       echo "Integration test suite running for test image: $IMAGE_NAME_OPERATOR:$IMAGE_TAG_OPERATOR"
       echo "WebLogic version is: $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC"
 
+      # Echo the image's WL version - we don't care if this fails...
+      $WERCKER_SOURCE_DIR/src/integration-tests/introspector/util_krun.sh -t 120 -i $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC -s $IMAGE_PULL_SECRET_WEBLOGIC -c 'source /u01/oracle/wlserver/server/bin/setWLSEnv.sh && java weblogic.version'
+
   - script:
     name: Install pre-reqs
     code: |


### PR DESCRIPTION
This branch cherry-picks instrumentation changes from `investigation` branch owls-72310:

- kubectl describe various k8s resources across all namespaces during integration test 'archive' step.
- show WL version during wercker lease/clean step.
- show additional information when integration test webapp deploy fails

Test status:  Passes locally and on Wercker.