### PR TITLE
Add Kubernetes stub-style testing

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -887,7 +887,13 @@ public class DomainProcessorImpl implements DomainProcessor {
     Step strategy =
         Step.chain(
             domainIntrospectionSteps(
-                info, new DomainStatusStep(info, bringAdminServerUp(info, managedServerStrategy))));
+                info,
+                new DomainStatusStep(
+                    info,
+                    bringAdminServerUp(
+                        info,
+                        getPodAwaiterStepFactory(info.getNamespace()),
+                        managedServerStrategy))));
 
     strategy =
         DomainStatusUpdater.createProgressingStep(
@@ -899,6 +905,10 @@ public class DomainProcessorImpl implements DomainProcessor {
         new UpHeadStep(info),
         ConfigMapHelper.readExistingSituConfigMap(info.getNamespace(), info.getDomainUID()),
         strategy);
+  }
+
+  private static PodAwaiterStepFactory getPodAwaiterStepFactory(String namespace) {
+    return Main.podWatchers.get(namespace);
   }
 
   static Step createDomainDownPlan(DomainPresenceInfo info) {
@@ -924,7 +934,7 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     @Override
     public NextAction apply(Packet packet) {
-      PodWatcher pw = Main.podWatchers.get(info.getNamespace());
+      PodWatcher pw = (PodWatcher) Main.podWatchers.get(info.getNamespace());
       info.setDeleting(false);
       packet
           .getComponents()
@@ -969,7 +979,7 @@ public class DomainProcessorImpl implements DomainProcessor {
     public NextAction apply(Packet packet) {
       info.setDeleting(true);
       unregisterStatusUpdater(ns, info.getDomainUID());
-      PodWatcher pw = Main.podWatchers.get(ns);
+      PodWatcher pw = (PodWatcher) Main.podWatchers.get(ns);
       packet
           .getComponents()
           .put(
@@ -991,8 +1001,9 @@ public class DomainProcessorImpl implements DomainProcessor {
 
   // pre-conditions: DomainPresenceInfo SPI
   // "principal"
-  private static Step bringAdminServerUp(DomainPresenceInfo info, Step next) {
-    return Step.chain(bringAdminServerUpSteps(info, next));
+  static Step bringAdminServerUp(
+      DomainPresenceInfo info, PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
+    return Step.chain(bringAdminServerUpSteps(info, podAwaiterStepFactory, next));
   }
 
   private static Step[] domainIntrospectionSteps(DomainPresenceInfo info, Step next) {
@@ -1007,10 +1018,11 @@ public class DomainProcessorImpl implements DomainProcessor {
             next,
             jws,
             Main.isNamespaceStopping(dom.getMetadata().getNamespace())));
-    return resources.toArray(new Step[resources.size()]);
+    return resources.toArray(new Step[0]);
   }
 
-  private static Step[] bringAdminServerUpSteps(DomainPresenceInfo info, Step next) {
+  private static Step[] bringAdminServerUpSteps(
+      DomainPresenceInfo info, PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
     List<Step> resources = new ArrayList<>();
     resources.add(new BeforeAdminServiceStep(null));
     resources.add(PodHelper.createAdminPodStep(null));
@@ -1024,8 +1036,8 @@ public class DomainProcessorImpl implements DomainProcessor {
     }
 
     resources.add(ServiceHelper.createForServerStep(null));
-    resources.add(new WatchPodReadyAdminStep(Main.podWatchers, next));
-    return resources.toArray(new Step[resources.size()]);
+    resources.add(new WatchPodReadyAdminStep(podAwaiterStepFactory, next));
+    return resources.toArray(new Step[0]);
   }
 
   private static Step bringManagedServersUp(Step next) {

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -19,13 +19,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.builders.WatchI;
-import oracle.kubernetes.operator.helpers.CallBuilderFactory;
+import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.watcher.WatchListener;
-import oracle.kubernetes.operator.work.ContainerResolver;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
@@ -184,13 +183,10 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
             completeCallbackRegistrations.put(metadata.getName(), complete);
 
             // Timing window -- job may have come ready before registration for callback
-            CallBuilderFactory factory =
-                ContainerResolver.getInstance().getContainer().getSPI(CallBuilderFactory.class);
             fiber
                 .createChildFiber()
                 .start(
-                    factory
-                        .create()
+                    new CallBuilder()
                         .readJobAsync(
                             metadata.getName(),
                             metadata.getNamespace(),

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/WatchPodReadyAdminStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/WatchPodReadyAdminStep.java
@@ -5,9 +5,7 @@
 package oracle.kubernetes.operator.steps;
 
 import io.kubernetes.client.models.V1Pod;
-import java.util.Map;
 import oracle.kubernetes.operator.PodAwaiterStepFactory;
-import oracle.kubernetes.operator.PodWatcher;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
@@ -17,11 +15,12 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
 public class WatchPodReadyAdminStep extends Step {
-  private final Map<String, PodWatcher> podWatchers;
 
-  public WatchPodReadyAdminStep(Map<String, PodWatcher> podWatchers, Step next) {
+  private final PodAwaiterStepFactory podAwaiterStepFactory;
+
+  public WatchPodReadyAdminStep(PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
     super(next);
-    this.podWatchers = podWatchers;
+    this.podAwaiterStepFactory = podAwaiterStepFactory;
   }
 
   @Override
@@ -31,7 +30,7 @@ public class WatchPodReadyAdminStep extends Step {
         (WlsDomainConfig) packet.get(ProcessingConstants.DOMAIN_TOPOLOGY);
     V1Pod adminPod = info.getServers().get(domainTopology.getAdminServerName()).getPod().get();
 
-    PodWatcher pw = podWatchers.get(adminPod.getMetadata().getNamespace());
+    PodAwaiterStepFactory pw = podAwaiterStepFactory;
     packet
         .getComponents()
         .put(

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
@@ -4,21 +4,32 @@
 
 package oracle.kubernetes.operator;
 
+import static oracle.kubernetes.operator.DomainUpPlanTest.ContainerPortMatcher.hasContainerPort;
 import static oracle.kubernetes.operator.DomainUpPlanTest.StepChainMatcher.hasChainWithStep;
 import static oracle.kubernetes.operator.DomainUpPlanTest.StepChainMatcher.hasChainWithStepsInOrder;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.POD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import com.meterware.simplestub.Memento;
+import io.kubernetes.client.models.V1ContainerPort;
 import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.models.V1SecretReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.TuningParametersStub;
+import oracle.kubernetes.operator.helpers.UnitTestHash;
 import oracle.kubernetes.operator.steps.DomainPresenceStep;
-import oracle.kubernetes.operator.work.FiberTestSupport;
+import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
@@ -32,12 +43,16 @@ import org.junit.Test;
 
 public class DomainUpPlanTest {
   private static final String NS = "namespace";
-  private FiberTestSupport testSupport = new FiberTestSupport();
+  private static final String UID = "test-uid";
+  private static final V1SecretReference SECRET = new V1SecretReference().name("secret");
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private List<Memento> mementos = new ArrayList<>();
   private final TerminalStep adminStep = new TerminalStep();
   private final TerminalStep managedServersStep = new TerminalStep();
   private Domain domain =
-      new Domain().withMetadata(new V1ObjectMeta().namespace(NS)).withSpec(new DomainSpec());
+      new Domain()
+          .withMetadata(new V1ObjectMeta().namespace(NS))
+          .withSpec(new DomainSpec().withDomainUID(UID).withWebLogicCredentialsSecret(SECRET));
   private DomainConfigurator configurator = DomainConfiguratorFactory.forDomain(domain);
   private DomainPresenceInfo domainPresenceInfo = new DomainPresenceInfo(domain);
 
@@ -48,6 +63,7 @@ public class DomainUpPlanTest {
   @Before
   public void setUp() {
     mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(testSupport.install());
 
     testSupport.addDomainPresenceInfo(domainPresenceInfo);
   }
@@ -131,6 +147,65 @@ public class DomainUpPlanTest {
             "EndProgressingStep"));
   }
 
+  @Test
+  public void whenAdminPodCreated_hasListenPort() throws NoSuchFieldException {
+    mementos.add(TuningParametersStub.install());
+    mementos.add(UnitTestHash.install());
+
+    WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("domain");
+    configSupport.addWlsServer("admin", 8045);
+    configSupport.setAdminServerName("admin");
+    Step plan =
+        DomainProcessorImpl.bringAdminServerUp(
+            new DomainPresenceInfo(domain), new NullPodWaiter(), null);
+    testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
+    testSupport.runSteps(plan);
+
+    List<V1Pod> resources = testSupport.getResources(POD);
+    assertThat(resources.get(0), hasContainerPort(8045));
+  }
+
+  static class NullPodWaiter implements PodAwaiterStepFactory {
+    @Override
+    public Step waitForReady(V1Pod pod, Step next) {
+      return null;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  static class ContainerPortMatcher
+      extends org.hamcrest.TypeSafeDiagnosingMatcher<io.kubernetes.client.models.V1Pod> {
+    private int expectedPort;
+
+    private ContainerPortMatcher(int expectedPort) {
+      this.expectedPort = expectedPort;
+    }
+
+    static ContainerPortMatcher hasContainerPort(int expectedPort) {
+      return new ContainerPortMatcher(expectedPort);
+    }
+
+    @Override
+    protected boolean matchesSafely(V1Pod item, Description mismatchDescription) {
+      if (getContainerPorts(item).stream().anyMatch(p -> p.getContainerPort() == expectedPort))
+        return true;
+
+      mismatchDescription.appendText("No matching port found in pod ").appendText(item.toString());
+      return false;
+    }
+
+    private List<V1ContainerPort> getContainerPorts(V1Pod item) {
+      return Optional.ofNullable(item.getSpec().getContainers().get(0).getPorts())
+          .orElse(Collections.emptyList());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("Pod with container port ").appendValue(expectedPort);
+    }
+  }
+
+  @SuppressWarnings("unused")
   static class StepChainMatcher
       extends org.hamcrest.TypeSafeDiagnosingMatcher<oracle.kubernetes.operator.work.Step> {
     private String[] expectedSteps;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -1,0 +1,434 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static java.util.Collections.emptyMap;
+import static oracle.kubernetes.operator.calls.AsyncRequestStep.RESPONSE_COMPONENT_NAME;
+
+import com.meterware.simplestub.Memento;
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.models.V1ConfigMap;
+import io.kubernetes.client.models.V1ConfigMapList;
+import io.kubernetes.client.models.V1Job;
+import io.kubernetes.client.models.V1JobList;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1PersistentVolume;
+import io.kubernetes.client.models.V1PersistentVolumeClaim;
+import io.kubernetes.client.models.V1PersistentVolumeClaimList;
+import io.kubernetes.client.models.V1PersistentVolumeList;
+import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.models.V1PodList;
+import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1ServiceList;
+import io.kubernetes.client.models.V1Status;
+import io.kubernetes.client.models.V1beta1CustomResourceDefinition;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import oracle.kubernetes.operator.calls.CallFactory;
+import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.calls.RequestParams;
+import oracle.kubernetes.operator.work.Component;
+import oracle.kubernetes.operator.work.FiberTestSupport;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.v2.Domain;
+import oracle.kubernetes.weblogic.domain.v2.DomainList;
+
+@SuppressWarnings("WeakerAccess")
+public class KubernetesTestSupport extends FiberTestSupport {
+  private Map<String, DataRepository<?>> repositories = new HashMap<>();
+  private Map<Class<?>, String> dataTypes = new HashMap<>();
+
+  public static final String CONFIG_MAP = "ConfigMap";
+  public static final String CUSTOM_RESOURCE_DEFINITION = "CRD";
+  public static final String DOMAIN = "Domain";
+  public static final String JOB = "Job";
+  public static final String PV = "PersistentVolume";
+  public static final String PVC = "PersistentVolumeClaim";
+  public static final String POD = "Pod";
+  public static final String SERVICE = "Service";
+
+  /**
+   * Installs a factory into CallBuilder to use canned responses.
+   *
+   * @return a memento which can be used to restore the production factory
+   */
+  public Memento install() {
+    support(CUSTOM_RESOURCE_DEFINITION, V1beta1CustomResourceDefinition.class);
+    supportNamespaced(CONFIG_MAP, V1ConfigMap.class, this::createConfigMapList);
+    supportNamespaced(DOMAIN, Domain.class, this::createDomainList);
+    supportNamespaced(JOB, V1Job.class, this::createJobList);
+    supportNamespaced(POD, V1Pod.class, this::createPodList);
+    supportNamespaced(PV, V1PersistentVolume.class, this::createPVList);
+    supportNamespaced(PVC, V1PersistentVolumeClaim.class, this::createPVCList);
+    supportNamespaced(SERVICE, V1Service.class, this::createServiceList);
+
+    return new KubernetesTestSupport.StepFactoryMemento(
+        new KubernetesTestSupport.RequestStepFactory());
+  }
+
+  private V1ConfigMapList createConfigMapList(List<V1ConfigMap> items) {
+    return new V1ConfigMapList().items(items);
+  }
+
+  private DomainList createDomainList(List<Domain> items) {
+    return new DomainList().withItems(items);
+  }
+
+  private V1PersistentVolumeList createPVList(List<V1PersistentVolume> items) {
+    return new V1PersistentVolumeList().items(items);
+  }
+
+  private V1PersistentVolumeClaimList createPVCList(List<V1PersistentVolumeClaim> items) {
+    return new V1PersistentVolumeClaimList().items(items);
+  }
+
+  private V1PodList createPodList(List<V1Pod> items) {
+    return new V1PodList().items(items);
+  }
+
+  private V1JobList createJobList(List<V1Job> items) {
+    return new V1JobList().items(items);
+  }
+
+  private V1ServiceList createServiceList(List<V1Service> items) {
+    return new V1ServiceList().items(items);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private void support(String resourceName, Class<?> resourceClass) {
+    dataTypes.put(resourceClass, resourceName);
+    repositories.put(resourceName, new DataRepository());
+  }
+
+  private <T> void supportNamespaced(
+      String resourceName, Class<T> resourceClass, Function<List<T>, Object> toList) {
+    dataTypes.put(resourceClass, resourceName);
+    repositories.put(resourceName, new NamespacedDataRepository<>(toList));
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> List<T> getResources(String resourceType) {
+    return ((DataRepository<T>) repositories.get(resourceType)).getResources();
+  }
+
+  @SafeVarargs
+  public final <T> void defineResources(T... resources) {
+    for (T resource : resources) getDataRepository(resource).createResourceInNamespace(resource);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> DataRepository<T> getDataRepository(T resource) {
+    return (DataRepository<T>) repositories.get(dataTypes.get(resource.getClass()));
+  }
+
+  private static class StepFactoryMemento implements Memento {
+    private AsyncRequestStepFactory oldFactory;
+
+    StepFactoryMemento(AsyncRequestStepFactory newFactory) {
+      oldFactory = CallBuilder.setStepFactory(newFactory);
+    }
+
+    @Override
+    public void revert() {
+      CallBuilder.resetStepFactory();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOriginalValue() {
+      return (T) oldFactory;
+    }
+  }
+
+  private class RequestStepFactory implements AsyncRequestStepFactory {
+
+    @Override
+    public <T> Step createRequestAsync(
+        ResponseStep<T> next,
+        RequestParams requestParams,
+        CallFactory<T> factory,
+        ClientPool helper,
+        int timeoutSeconds,
+        int maxRetryCount,
+        String fieldSelector,
+        String labelSelector,
+        String resourceVersion) {
+      return new KubernetesTestSupport.SimulatedResponseStep(
+          next, requestParams, fieldSelector, labelSelector);
+    }
+  }
+
+  private class DataRepository<T> {
+    private Map<String, T> data = new HashMap<>();
+    private Method getMetadataMethod;
+
+    void createResourceInNamespace(T resource) {
+      createResource(getMetadata(resource).getNamespace(), resource);
+    }
+
+    T createResource(String namespace, T resource) {
+      if (hasElementWithName(getName(resource))) throw new RuntimeException("element exists");
+
+      data.put(getName(resource), resource);
+      return resource;
+    }
+
+    Object listResources(String namespace, String fieldSelector, String... labelSelectors) {
+      throw new UnsupportedOperationException("list operation not supported");
+    }
+
+    List<T> getResources(String fieldSelector, String... labelSelectors) {
+      assert fieldSelector == null : "field selector not implemented";
+      return data.values().stream().filter(withLabels(labelSelectors)).collect(Collectors.toList());
+    }
+
+    private Predicate<Object> withLabels(String[] labelSelectors) {
+      return o -> labelSelectors == null || hasLabels(getMetadata(o), labelSelectors);
+    }
+
+    private boolean hasLabels(V1ObjectMeta metadata, String[] selectors) {
+      return Arrays.stream(selectors).allMatch(s -> hasLabel(metadata, s));
+    }
+
+    private boolean hasLabel(V1ObjectMeta metadata, String selector) {
+      String[] split = selector.split("=");
+      return includesLabel(metadata.getLabels(), split[0], split.length == 1 ? null : split[1]);
+    }
+
+    private boolean includesLabel(Map<String, String> labels, String key, String value) {
+      if (!labels.containsKey(key)) return false;
+      return value == null || value.equals(labels.get(key));
+    }
+
+    T replaceResource(String name, T resource) {
+      setName(resource, name);
+
+      data.put(name, resource);
+      return resource;
+    }
+
+    V1Status deleteResource(String namespace, String name) {
+      if (!hasElementWithName(name)) throw new NotFoundException();
+      data.remove(name);
+
+      return new V1Status().code(200);
+    }
+
+    public T readResource(String namespace, String name) {
+      if (!data.containsKey(name)) throw new NotFoundException();
+      return data.get(name);
+    }
+
+    boolean hasElementWithName(String name) {
+      return data.containsKey(name);
+    }
+
+    private String getName(@Nonnull Object resource) {
+      return getMetadata(resource).getName();
+    }
+
+    private V1ObjectMeta getMetadata(@Nonnull Object resource) {
+      try {
+        return (V1ObjectMeta) getMetadataMethod(resource).invoke(resource);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        throw new RuntimeException("unable to get name");
+      }
+    }
+
+    private Method getMetadataMethod(Object resource) {
+      if (getMetadataMethod == null) {
+        try {
+          getMetadataMethod = resource.getClass().getDeclaredMethod("getMetadata");
+        } catch (NoSuchMethodException e) {
+          throw new RuntimeException("unable to get metadata");
+        }
+      }
+      return getMetadataMethod;
+    }
+
+    private void setName(@Nonnull Object resource, String name) {
+      getMetadata(resource).setName(name);
+    }
+
+    List<T> getResources() {
+      return new ArrayList<>(data.values());
+    }
+  }
+
+  private class NamespacedDataRepository<T> extends DataRepository<T> {
+    private Map<String, DataRepository<T>> repositories = new HashMap<>();
+    private Function<List<T>, Object> listFactory;
+
+    NamespacedDataRepository(Function<List<T>, Object> listFactory) {
+      this.listFactory = listFactory;
+    }
+
+    @Override
+    T createResource(String namespace, T resource) {
+      return inNamespace(namespace).createResource(null, resource);
+    }
+
+    private DataRepository<T> inNamespace(String namespace) {
+      return repositories.computeIfAbsent(namespace, n -> new DataRepository<>());
+    }
+
+    @Override
+    V1Status deleteResource(String namespace, String name) {
+      return inNamespace(namespace).deleteResource(null, name);
+    }
+
+    @Override
+    public T readResource(String namespace, String name) {
+      return inNamespace(namespace).readResource(null, name);
+    }
+
+    @Override
+    Object listResources(String namespace, String fieldSelector, String... labelSelectors) {
+      return listFactory.apply(inNamespace(namespace).getResources(fieldSelector, labelSelectors));
+    }
+
+    @Override
+    List<T> getResources() {
+      List<T> result = new ArrayList<>();
+      for (DataRepository<T> repository : repositories.values())
+        result.addAll(repository.getResources());
+      return result;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private enum Operation {
+    create {
+      @Override
+      Object execute(SimulatedResponseStep simulatedResponseStep, DataRepository dataRepository) {
+        return simulatedResponseStep.createResource(dataRepository);
+      }
+    },
+    delete {
+      @Override
+      Object execute(SimulatedResponseStep simulatedResponseStep, DataRepository dataRepository) {
+        return simulatedResponseStep.deleteResource(dataRepository);
+      }
+    },
+    read {
+      @Override
+      Object execute(SimulatedResponseStep simulatedResponseStep, DataRepository dataRepository) {
+        return simulatedResponseStep.readResource(dataRepository);
+      }
+    },
+    replace {
+      @Override
+      Object execute(SimulatedResponseStep simulatedResponseStep, DataRepository dataRepository) {
+        return simulatedResponseStep.replaceResource(dataRepository);
+      }
+    },
+    list {
+      @Override
+      Object execute(SimulatedResponseStep simulatedResponseStep, DataRepository dataRepository) {
+        return simulatedResponseStep.listResources(dataRepository);
+      }
+    };
+
+    abstract Object execute(
+        SimulatedResponseStep simulatedResponseStep, DataRepository dataRepository);
+  }
+
+  private class SimulatedResponseStep extends Step {
+
+    private final RequestParams requestParams;
+    private final String fieldSelector;
+    private final String[] labelSelector;
+    private String resourceType;
+    private Operation operation;
+
+    SimulatedResponseStep(
+        Step next, RequestParams requestParams, String fieldSelector, String labelSelector) {
+      super(next);
+      this.requestParams = requestParams;
+      this.fieldSelector = fieldSelector;
+      this.labelSelector = labelSelector == null ? null : labelSelector.split(",");
+
+      parseCallName(requestParams.call);
+    }
+
+    private void parseCallName(String callName) {
+      int i = indexOfFirstCapital(callName);
+      this.resourceType = callName.substring(i);
+      this.operation = Operation.valueOf(callName.substring(0, i));
+    }
+
+    private int indexOfFirstCapital(String callName) {
+      for (int i = 0; i < callName.length(); i++)
+        if (Character.isUpperCase(callName.charAt(i))) return i;
+
+      throw new RuntimeException(callName + " is not a valid call name");
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> T createResource(DataRepository<T> dataRepository) {
+      return dataRepository.createResource(requestParams.namespace, (T) requestParams.body);
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> T replaceResource(DataRepository<T> dataRepository) {
+      return dataRepository.replaceResource(requestParams.name, (T) requestParams.body);
+    }
+
+    Object deleteResource(DataRepository dataRepository) {
+      return dataRepository.deleteResource(requestParams.namespace, requestParams.name);
+    }
+
+    Object listResources(DataRepository dataRepository) {
+      return dataRepository.listResources(requestParams.namespace, fieldSelector, labelSelector);
+    }
+
+    <T> T readResource(DataRepository<T> dataRepository) {
+      return dataRepository.readResource(requestParams.namespace, requestParams.name);
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      try {
+        Object callResult = operation.execute(this, repositories.get(resourceType));
+        CallResponse callResponse = createResponse(callResult);
+        packet.getComponents().put(RESPONSE_COMPONENT_NAME, Component.createFor(callResponse));
+      } catch (NotFoundException e) {
+        packet.getComponents().put(RESPONSE_COMPONENT_NAME, Component.createFor(createResponse(e)));
+      } catch (Exception e) {
+        packet.getComponents().put(RESPONSE_COMPONENT_NAME, Component.createFor(createResponse(e)));
+      }
+
+      return doNext(packet);
+    }
+
+    private CallResponse createResponse(Object callResult) {
+      return new CallResponse<>(callResult, null, HTTP_OK, emptyMap());
+    }
+
+    private CallResponse createResponse(NotFoundException e) {
+      return new CallResponse<>(null, new ApiException(e), HTTP_NOT_FOUND, emptyMap());
+    }
+
+    private CallResponse createResponse(Throwable t) {
+      return new CallResponse<>(null, new ApiException(t), HTTP_UNAVAILABLE, emptyMap());
+    }
+  }
+
+  static class NotFoundException extends RuntimeException {}
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
@@ -1,0 +1,225 @@
+package oracle.kubernetes.operator.helpers;
+
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.CUSTOM_RESOURCE_DEFINITION;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.POD;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.meterware.simplestub.Memento;
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.models.V1ConfigMap;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.models.V1PodList;
+import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1ServiceList;
+import io.kubernetes.client.models.V1Status;
+import io.kubernetes.client.models.V1beta1CustomResourceDefinition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import oracle.kubernetes.TestUtils;
+import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.steps.DefaultResponseStep;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.v2.Domain;
+import oracle.kubernetes.weblogic.domain.v2.DomainList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KubernetesTestSupportTest {
+  private static final String NS = "namespace1";
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  List<Memento> mementos = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(testSupport.install());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    for (Memento memento : mementos) memento.revert();
+
+    testSupport.throwOnCompletionFailure();
+  }
+
+  // tests for non-namespaced resources
+
+  @Test
+  public void afterCreateCRD_crdExists() {
+    V1beta1CustomResourceDefinition crd = createCrd("mycrd");
+
+    TestResponseStep<V1beta1CustomResourceDefinition> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().createCustomResourceDefinitionAsync(crd, responseStep));
+
+    assertThat(testSupport.getResources(CUSTOM_RESOURCE_DEFINITION), contains(crd));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1beta1CustomResourceDefinition createCrd(String name) {
+    return new V1beta1CustomResourceDefinition().metadata(new V1ObjectMeta().name(name));
+  }
+
+  @Test
+  public void afterCreateCRD_crdReturnedInCallResponse() {
+    V1beta1CustomResourceDefinition crd = createCrd("mycrd");
+
+    TestResponseStep<V1beta1CustomResourceDefinition> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().createCustomResourceDefinitionAsync(crd, responseStep));
+
+    assertThat(responseStep.callResponse.getResult(), equalTo(crd));
+  }
+
+  @Test
+  public void whenCRDWithSameNameExists_createFails() {
+    testSupport.defineResources(createCrd("mycrd"));
+
+    TestResponseStep<V1beta1CustomResourceDefinition> responseStep = new TestResponseStep<>();
+    Step steps =
+        new CallBuilder().createCustomResourceDefinitionAsync(createCrd("mycrd"), responseStep);
+    testSupport.runSteps(steps);
+
+    testSupport.verifyCompletionThrowable(ApiException.class);
+  }
+
+  @Test
+  public void afterReplaceExistingCRD_crdExists() {
+    V1beta1CustomResourceDefinition oldCrd = createCrd("mycrd");
+    testSupport.defineResources(oldCrd);
+
+    V1beta1CustomResourceDefinition crd = createCrd("");
+    crd.getMetadata().putLabelsItem("be", "different");
+
+    TestResponseStep<V1beta1CustomResourceDefinition> responseStep = new TestResponseStep<>();
+    Step steps = new CallBuilder().replaceCustomResourceDefinitionAsync("mycrd", crd, responseStep);
+    testSupport.runSteps(steps);
+
+    assertThat(testSupport.getResources(CUSTOM_RESOURCE_DEFINITION), contains(crd));
+  }
+
+  // tests for namespaced resources
+
+  @Test
+  public void afterCreatePod_podExists() {
+    V1Pod pod = createPod(NS, "mycrd");
+
+    TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().createPodAsync(NS, pod, responseStep));
+
+    assertThat(testSupport.getResources(POD), contains(pod));
+  }
+
+  private V1Pod createPod(String namespace, String name) {
+    return new V1Pod().metadata(new V1ObjectMeta().namespace(namespace).name(name));
+  }
+
+  @Test
+  public void afterCreatePodsWithSameNameAndDifferentNamespaces_bothExist() {
+    V1Pod pod1 = createPod("ns1", "mycrd");
+    V1Pod pod2 = createPod("ns2", "mycrd");
+
+    TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().createPodAsync("ns1", pod1, responseStep));
+    testSupport.runSteps(new CallBuilder().createPodAsync("ns2", pod2, responseStep));
+
+    assertThat(testSupport.getResources(POD), containsInAnyOrder(pod1, pod2));
+  }
+
+  @Test
+  public void afterDeletePod_podsInDifferentNamespacesStillExist() {
+    V1Pod pod1 = createPod("ns1", "mycrd");
+    V1Pod pod2 = createPod("ns2", "mycrd");
+    V1Pod pod3 = createPod("ns3", "another");
+    testSupport.defineResources(pod1, pod2, pod3);
+
+    TestResponseStep<V1Status> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().deletePodAsync("mycrd", "ns2", null, responseStep));
+
+    assertThat(testSupport.getResources(POD), containsInAnyOrder(pod1, pod3));
+  }
+
+  @Test
+  public void listPodSelectsByLabel() {
+    V1Pod pod1 = createLabeledPod("ns1", "pod1", ImmutableMap.of("k1", "v1", "k2", "v2"));
+    V1Pod pod2 = createLabeledPod("ns1", "pod2", ImmutableMap.of("k1", "v2"));
+    V1Pod pod3 = createLabeledPod("ns1", "pod3", ImmutableMap.of("k1", "v1", "k2", "v3"));
+    V1Pod pod4 = createLabeledPod("ns2", "pod4", ImmutableMap.of("k1", "v1", "k2", "v3"));
+    testSupport.defineResources(pod1, pod2, pod3, pod4);
+
+    TestResponseStep<V1PodList> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(
+        new CallBuilder().withLabelSelectors("k1=v1").listPodAsync("ns1", responseStep));
+
+    assertThat(responseStep.callResponse.getResult().getItems(), containsInAnyOrder(pod1, pod3));
+  }
+
+  private V1Pod createLabeledPod(String namespace, String name, Map<String, String> labels) {
+    return new V1Pod().metadata(new V1ObjectMeta().namespace(namespace).name(name).labels(labels));
+  }
+
+  @Test
+  public void listDomain_returnsAllInNamespace() {
+    Domain dom1 = createDomain("ns1", "domain1");
+    Domain dom2 = createDomain("ns1", "domain2");
+    Domain dom3 = createDomain("ns2", "domain3");
+    testSupport.defineResources(dom1, dom2, dom3);
+
+    TestResponseStep<DomainList> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().listDomainAsync("ns1", responseStep));
+
+    assertThat(responseStep.callResponse.getResult().getItems(), containsInAnyOrder(dom1, dom2));
+  }
+
+  private Domain createDomain(String namespace, String name) {
+    return new Domain().withMetadata(new V1ObjectMeta().name(name).namespace(namespace));
+  }
+
+  @Test
+  public void listService_returnsAllInNamespace() {
+    V1Service s1 = createService("ns1", "service1");
+    V1Service s2 = createService("ns1", "service2");
+    V1Service s3 = createService("ns2", "service3");
+    testSupport.defineResources(s1, s2, s3);
+
+    TestResponseStep<V1ServiceList> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().listServiceAsync("ns1", responseStep));
+
+    assertThat(responseStep.callResponse.getResult().getItems(), containsInAnyOrder(s1, s2));
+  }
+
+  private V1Service createService(String namespace, String name) {
+    return new V1Service().metadata(new V1ObjectMeta().name(name).namespace(namespace));
+  }
+
+  @Test
+  public void whenConfigMapNotFound_readStatusIsNotFound() {
+    TestResponseStep<V1ConfigMap> endStep = new TestResponseStep<>();
+    Packet packet = testSupport.runSteps(new CallBuilder().readConfigMapAsync("", "", endStep));
+
+    assertThat(packet.getSPI(CallResponse.class).getStatusCode(), equalTo(CallBuilder.NOT_FOUND));
+    assertThat(packet.getSPI(CallResponse.class).getE(), notNullValue());
+  }
+
+  static class TestResponseStep<T> extends DefaultResponseStep<T> {
+    private CallResponse<T> callResponse;
+
+    TestResponseStep() {
+      super(null);
+    }
+
+    @Override
+    public NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
+      this.callResponse = callResponse;
+      return super.onSuccess(packet, callResponse);
+    }
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -19,6 +19,12 @@ import static oracle.kubernetes.operator.helpers.PodHelperTestBase.ProbeMatcher.
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.VolumeMountMatcher.readOnlyVolumeMount;
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.VolumeMountMatcher.writableVolumeMount;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.SIT_CONFIG_MAP_VOLUME_SUFFIX;
+import static oracle.kubernetes.operator.helpers.TuningParametersStub.LIVENESS_INITIAL_DELAY;
+import static oracle.kubernetes.operator.helpers.TuningParametersStub.LIVENESS_PERIOD;
+import static oracle.kubernetes.operator.helpers.TuningParametersStub.LIVENESS_TIMEOUT;
+import static oracle.kubernetes.operator.helpers.TuningParametersStub.READINESS_INITIAL_DELAY;
+import static oracle.kubernetes.operator.helpers.TuningParametersStub.READINESS_PERIOD;
+import static oracle.kubernetes.operator.helpers.TuningParametersStub.READINESS_TIMEOUT;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -34,7 +40,6 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.meterware.simplestub.Memento;
-import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1Container;
 import io.kubernetes.client.models.V1ContainerPort;
@@ -59,21 +64,16 @@ import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.PodAwaiterStepFactory;
 import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.TuningParameters;
-import oracle.kubernetes.operator.TuningParametersImpl;
 import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
@@ -108,12 +108,6 @@ public abstract class PodHelperTestBase {
   private static final String STORAGE_VOLUME_NAME = "weblogic-domain-storage-volume";
   private static final String LATEST_IMAGE = "image:latest";
   private static final String VERSIONED_IMAGE = "image:1.2.3";
-  private static final int READINESS_INITIAL_DELAY = 1;
-  private static final int READINESS_TIMEOUT = 2;
-  private static final int READINESS_PERIOD = 3;
-  private static final int LIVENESS_INITIAL_DELAY = 4;
-  private static final int LIVENESS_PERIOD = 6;
-  private static final int LIVENESS_TIMEOUT = 5;
   private static final int CONFIGURED_DELAY = 21;
   private static final int CONFIGURED_TIMEOUT = 27;
   private static final int CONFIGURED_PERIOD = 35;
@@ -161,8 +155,7 @@ public abstract class PodHelperTestBase {
             .withLogLevel(Level.FINE));
     mementos.add(testSupport.installRequestStepFactory());
     mementos.add(TuningParametersStub.install());
-    mementos.add(
-        StaticStubSupport.install(AnnotationHelper.class, "HASH_FUNCTION", new UnitTestHash()));
+    mementos.add(UnitTestHash.install());
 
     WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport(DOMAIN_NAME);
     configSupport.addWlsServer(ADMIN_SERVER, ADMIN_PORT);
@@ -928,37 +921,6 @@ public abstract class PodHelperTestBase {
     void mutate(V1Pod pod);
   }
 
-  abstract static class TuningParametersStub implements TuningParameters {
-    static Map<String, String> namedParameters;
-
-    static Memento install() throws NoSuchFieldException {
-      namedParameters = new HashMap<>();
-      return StaticStubSupport.install(
-          TuningParametersImpl.class, "INSTANCE", createStrictStub(TuningParametersStub.class));
-    }
-
-    @Override
-    public PodTuning getPodTuning() {
-      return new PodTuning(
-          READINESS_INITIAL_DELAY,
-          READINESS_TIMEOUT,
-          READINESS_PERIOD,
-          LIVENESS_INITIAL_DELAY,
-          LIVENESS_TIMEOUT,
-          LIVENESS_PERIOD);
-    }
-
-    @Override
-    public CallBuilderTuning getCallBuilderTuning() {
-      return null;
-    }
-
-    @Override
-    public String get(Object key) {
-      return namedParameters.get(key);
-    }
-  }
-
   static class PodFetcher implements BodyMatcher {
     private String podName;
     V1Pod createdPod;
@@ -1112,13 +1074,6 @@ public abstract class PodHelperTestBase {
         actualInstructions.add(new Gson().toJson((JsonElement) instruction));
 
       return actualInstructions.equals(expectedInstructions);
-    }
-  }
-
-  static class UnitTestHash implements Function<V1Pod, String> {
-    @Override
-    public String apply(V1Pod v1Pod) {
-      return Integer.toString(v1Pod.hashCode());
     }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
@@ -1,0 +1,51 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import static com.meterware.simplestub.Stub.createStrictStub;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import java.util.HashMap;
+import java.util.Map;
+import oracle.kubernetes.operator.TuningParameters;
+import oracle.kubernetes.operator.TuningParametersImpl;
+
+public abstract class TuningParametersStub implements TuningParameters {
+  static final int READINESS_INITIAL_DELAY = 1;
+  static final int READINESS_TIMEOUT = 2;
+  static final int READINESS_PERIOD = 3;
+  static final int LIVENESS_INITIAL_DELAY = 4;
+  static final int LIVENESS_PERIOD = 6;
+  static final int LIVENESS_TIMEOUT = 5;
+  static Map<String, String> namedParameters;
+
+  public static Memento install() throws NoSuchFieldException {
+    namedParameters = new HashMap<>();
+    return StaticStubSupport.install(
+        TuningParametersImpl.class, "INSTANCE", createStrictStub(TuningParametersStub.class));
+  }
+
+  @Override
+  public PodTuning getPodTuning() {
+    return new PodTuning(
+        READINESS_INITIAL_DELAY,
+        READINESS_TIMEOUT,
+        READINESS_PERIOD,
+        LIVENESS_INITIAL_DELAY,
+        LIVENESS_TIMEOUT,
+        LIVENESS_PERIOD);
+  }
+
+  @Override
+  public CallBuilderTuning getCallBuilderTuning() {
+    return null;
+  }
+
+  @Override
+  public String get(Object key) {
+    return namedParameters.get(key);
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/UnitTestHash.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/UnitTestHash.java
@@ -1,0 +1,21 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import io.kubernetes.client.models.V1Pod;
+import java.util.function.Function;
+
+public class UnitTestHash implements Function<V1Pod, String> {
+  public static Memento install() throws NoSuchFieldException {
+    return StaticStubSupport.install(AnnotationHelper.class, "HASH_FUNCTION", new UnitTestHash());
+  }
+
+  @Override
+  public String apply(V1Pod v1Pod) {
+    return Integer.toString(v1Pod.hashCode());
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
@@ -133,6 +133,7 @@ public class FiberTestSupport {
    * @param step the first step to run
    */
   public Packet runSteps(Step step) {
+    fiber = engine.createFiber();
     fiber.start(step, packet, completionCallback);
 
     return packet;
@@ -144,6 +145,7 @@ public class FiberTestSupport {
    * @param step the first step to run
    */
   public Packet runStepsToCompletion(Step step) {
+    fiber = engine.createFiber();
     fiber.start(step, packet, completionCallback);
 
     // Wait for fiber to finish
@@ -161,6 +163,7 @@ public class FiberTestSupport {
    * @param nextStep the first step to run
    */
   public Packet runSteps(StepFactory factory, Step nextStep) {
+    fiber = engine.createFiber();
     fiber.start(factory.createStepList(nextStep), packet, completionCallback);
     return packet;
   }


### PR DESCRIPTION
The initial approach for testing kubernetes calls implemented in AsyncCallTestSupport / CallTestSupport turns out to be rather cumbersome for complex cases. The developer needs to define exactly the calls to be made.

This change adds an alternative, KubernetesTestSupport, which takes advantage of the pattern used for call names and translates them into changes to in-memory resources. Tests can then simply look at the results to see if the correct resource changes have been made.

This strategy is demonstrated in DomainUpPlanTest.whenAdminPodCreated_hasListenPort, which verifies the functionality added to fix OWLS-72015, which was not so easy to test, previously.