### PR TITLE
fix format

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ $ helm repo add weblogic-operator https://oracle.github.io/weblogic-kubernetes-o
 
 Verify repository was added correctly:
 
-````
+```
 $ helm repo list
 NAME           URL
 weblogic-operator    https://oracle.github.io/weblogic-kubernetes-operator/charts

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Only pull requests from committers that can be verified as having signed the OCA
 
 Please be aware that pull requests that seek to introduce a new dependency will be subject to additional review.  In general, contributors should avoid dependencies with incompatible licenses, and should try to use recent versions of dependencies.  Standard security vulnerability checklists will be consulted before accepting a new dependency.  Dependencies on closed-source code, including WebLogic Server, will most likely be rejected.
 
-## Use Helm Chart from Github chart repository
+## Use Helm Chart from GitHub chart repository
 
 Add this repo to Helm installation:
 


### PR DESCRIPTION
Because of an error in the number of code marks (tics), the format was incorrect in the"Use Helm Chart from Github chart repository" section code examples.