### PR TITLE
docker pull is needed in setup.env to get the wlthinclient jar

### DIFF
--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -87,8 +87,9 @@ function pull_tag_images {
 	    echo "secret $IMAGE_PULL_SECRET_WEBLOGIC was not created successfully"
 	    exit 1
 	  fi
-	  # docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-   	  # docker pull $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC
+	  # below docker pull is needed to get wlthint3client.jar from image to put in the classpath
+	  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+   	  docker pull $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC
   fi
   set -x
   echo "Pull and tag the images we need"


### PR DESCRIPTION
docker login and docker pull was commented in my previous PR which makes the tests to fail if the image doesn't image locally. reverting the change.

