### PR TITLE
simplify testing of ServiceHelper

### DIFF
--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -51,6 +51,14 @@
           "items": {
             "$ref": "#/definitions/Channel"
           }
+        },
+        "annotations": {
+          "description": "Annotations to associate with the external channel service",
+          "$ref": "#/definitions/Map"
+        },
+        "labels": {
+          "description": "Labels to associate with the external channel service",
+          "$ref": "#/definitions/Map"
         }
       }
     },

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -143,7 +143,9 @@ ServerPod describes the configuration for a Kubernetes pod for a server.
 
 | Name | Type | Description |
 | --- | --- | --- |
+| annotations | Map | Annotations to associate with the external channel service |
 | channels | array of [Channel](#channel) | Specifies which of the admin server's WebLogic channels should be exposed outside the Kubernetes cluster via a node port service, along with the node port for each channel. If not specified, the admin server's node port service will not be created. |
+| labels | Map | Labels to associate with the external channel service |
 
 ### Probe Tuning
 

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -971,6 +971,14 @@ window.onload = function() {
           "items": {
             "$ref": "#/definitions/Channel"
           }
+        },
+        "annotations": {
+          "description": "Annotations to associate with the external channel service",
+          "$ref": "#/definitions/Map"
+        },
+        "labels": {
+          "description": "Labels to associate with the external channel service",
+          "$ref": "#/definitions/Map"
         }
       }
     },

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018,2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -9,7 +9,7 @@ import io.kubernetes.client.models.V1SecurityContext;
 
 /** An interface for an object to configure a cluster in a test. */
 @SuppressWarnings("UnusedReturnValue")
-public interface ClusterConfigurator {
+public interface ClusterConfigurator extends ServiceConfigurator {
   ClusterConfigurator withReplicas(int replicas);
 
   ClusterConfigurator withMaxUnavailable(int maxUnavailable);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
@@ -5,7 +5,7 @@
 package oracle.kubernetes.weblogic.domain;
 
 import java.util.List;
-import oracle.kubernetes.weblogic.domain.v2.Channel;
+import oracle.kubernetes.weblogic.domain.v2.AdminServerSpec;
 import oracle.kubernetes.weblogic.domain.v2.ClusterSpec;
 import oracle.kubernetes.weblogic.domain.v2.ServerSpec;
 
@@ -15,7 +15,7 @@ import oracle.kubernetes.weblogic.domain.v2.ServerSpec;
  */
 public interface EffectiveConfigurationFactory {
 
-  ServerSpec getAdminServerSpec();
+  AdminServerSpec getAdminServerSpec();
 
   ServerSpec getServerSpec(String serverName, String clusterName);
 
@@ -30,8 +30,4 @@ public interface EffectiveConfigurationFactory {
   boolean isShuttingDown();
 
   List<String> getAdminServerChannelNames();
-
-  List<Channel> getAdminServerChannels();
-
-  Integer getDefaultReplicaLimit();
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -9,7 +9,7 @@ import io.kubernetes.client.models.V1SecurityContext;
 
 /** An interface for an object to configure a server in a test. */
 @SuppressWarnings("UnusedReturnValue")
-public interface ServerConfigurator {
+public interface ServerConfigurator extends ServiceConfigurator {
   ServerConfigurator withDesiredState(String desiredState);
 
   ServerConfigurator withEnvironmentVariable(String name, String value);

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/ServiceConfigurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/ServiceConfigurator.java
@@ -1,0 +1,12 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain;
+
+@SuppressWarnings("UnusedReturnValue")
+public interface ServiceConfigurator {
+  ServiceConfigurator withServiceLabel(String name, String value);
+
+  ServiceConfigurator withServiceAnnotation(String name, String value);
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServer.java
@@ -63,23 +63,6 @@ public class AdminServer extends Server {
     return adminService.getChannels();
   }
 
-  /**
-   * Gets channel.
-   *
-   * @param channelName Channel name
-   * @return Channel
-   */
-  public Channel getChannel(String channelName) {
-    if (adminService != null) {
-      for (Channel c : adminService.getChannels()) {
-        if (channelName.equals(c.getChannelName())) {
-          return c;
-        }
-      }
-    }
-    return null;
-  }
-
   @Override
   public String toString() {
     return new ToStringBuilder(this)
@@ -115,10 +98,7 @@ public class AdminServer extends Server {
   }
 
   public AdminService getAdminService() {
+    if (adminService == null) adminService = new AdminService();
     return adminService;
-  }
-
-  public void setAdminService(AdminService adminService) {
-    this.adminService = adminService;
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServerSpec.java
@@ -1,0 +1,17 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+/** Represents the effective configuration for an admin server, as seen by the operator runtime. */
+public interface AdminServerSpec extends ServerSpec {
+
+  /**
+   * Returns the admin service configuration for the admin server, which controls the external
+   * channel service.
+   *
+   * @return the admin service configuration
+   */
+  public abstract AdminService getAdminService();
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminServerSpecV2Impl.java
@@ -1,11 +1,19 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018,2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.weblogic.domain.v2;
 
-public class AdminServerSpecV2Impl extends ServerSpecV2Impl {
-  public AdminServerSpecV2Impl(DomainSpec spec, AdminServer server) {
+public class AdminServerSpecV2Impl extends ServerSpecV2Impl implements AdminServerSpec {
+  private final AdminServer adminServer;
+
+  AdminServerSpecV2Impl(DomainSpec spec, AdminServer server) {
     super(spec, server, null, null);
+    adminServer = server;
+  }
+
+  @Override
+  public AdminService getAdminService() {
+    return adminServer.getAdminService();
   }
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
@@ -44,8 +44,8 @@ public class AdminService implements ServiceConfigurator {
   }
 
   /**
-   * Adds a channel to expose an admin server port outside the cluster. Will use the matching
-   * NAP port number.
+   * Adds a channel to expose an admin server port outside the cluster. Will use the matching NAP
+   * port number.
    *
    * @param channelName name of the channel to expose
    * @return this object

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/AdminService.java
@@ -32,7 +32,7 @@ public class AdminService implements ServiceConfigurator {
   private Map<String, String> annotations = new HashMap<>();
 
   /**
-   * Adds a channel to expose an admin server port outside the cluster
+   * Adds a channel to expose an admin server port outside the cluster via a specified port.
    *
    * @param channelName name of the channel to expose
    * @param nodePort the external port on which the channel will be exposed
@@ -40,6 +40,18 @@ public class AdminService implements ServiceConfigurator {
    */
   public AdminService withChannel(String channelName, int nodePort) {
     channels.add(new Channel().withChannelName(channelName).withNodePort(nodePort));
+    return this;
+  }
+
+  /**
+   * Adds a channel to expose an admin server port outside the cluster. Will use the matching
+   * NAP port number.
+   *
+   * @param channelName name of the channel to expose
+   * @return this object
+   */
+  public AdminService withChannel(String channelName) {
+    channels.add(new Channel().withChannelName(channelName));
     return this;
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/Domain.java
@@ -179,7 +179,7 @@ public class Domain {
     return this;
   }
 
-  public ServerSpec getAdminServerSpec() {
+  public AdminServerSpec getAdminServerSpec() {
     return getEffectiveConfigurationFactory().getAdminServerSpec();
   }
 
@@ -443,7 +443,7 @@ public class Domain {
   @SuppressWarnings({"rawtypes", "unchecked"})
   static List sortOrNull(List list, Comparator c) {
     if (list != null) {
-      Object[] a = list.toArray(new Object[list.size()]);
+      Object[] a = list.toArray(new Object[0]);
       Arrays.sort(a, c);
       return Arrays.asList(a);
     }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainSpec.java
@@ -642,7 +642,7 @@ public class DomainSpec extends BaseConfiguration {
 
   class V2EffectiveConfigurationFactory implements EffectiveConfigurationFactory {
     @Override
-    public ServerSpec getAdminServerSpec() {
+    public AdminServerSpec getAdminServerSpec() {
       return new AdminServerSpecV2Impl(DomainSpec.this, adminServer);
     }
 
@@ -687,16 +687,6 @@ public class DomainSpec extends BaseConfiguration {
     @Override
     public List<String> getAdminServerChannelNames() {
       return adminServer != null ? adminServer.getChannelNames() : Collections.emptyList();
-    }
-
-    @Override
-    public List<Channel> getAdminServerChannels() {
-      return adminServer != null ? adminServer.getChannels() : Collections.emptyList();
-    }
-
-    @Override
-    public Integer getDefaultReplicaLimit() {
-      return 0;
     }
 
     private Cluster getOrCreateCluster(String clusterName) {

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/DomainV2Configurator.java
@@ -121,9 +121,6 @@ public class DomainV2Configurator extends DomainConfigurator {
 
     @Override
     public AdminService configureAdminService() {
-      if (adminServer.getAdminService() == null) {
-        adminServer.setAdminService(new AdminService());
-      }
       return adminServer.getAdminService();
     }
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
@@ -191,16 +191,6 @@ public abstract class ServerSpec {
   public abstract Map<String, String> getServiceAnnotations();
 
   @Nonnull
-  public Map<String, String> getListenAddressServiceLabels() {
-    return Collections.emptyMap();
-  }
-
-  @Nonnull
-  public Map<String, String> getListenAddressServiceAnnotations() {
-    return Collections.emptyMap();
-  }
-
-  @Nonnull
   public Map<String, String> getNodeSelectors() {
     return Collections.emptyMap();
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpec.java
@@ -1,12 +1,8 @@
-// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.weblogic.domain.v2;
-
-import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
-import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
-import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
 
 import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1LocalObjectReference;
@@ -15,116 +11,49 @@ import io.kubernetes.client.models.V1ResourceRequirements;
 import io.kubernetes.client.models.V1SecurityContext;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nonnull;
-import oracle.kubernetes.operator.KubernetesConstants;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
-/** Represents the effective configuration for a server, as seen by the operator runtime. */
-@SuppressWarnings("WeakerAccess")
-public abstract class ServerSpec {
+public interface ServerSpec {
+  String getImage();
 
-  private static final String ADMIN_MODE_FLAG = "-Dweblogic.management.startupMode=ADMIN";
-  protected DomainSpec domainSpec;
-
-  public ServerSpec(DomainSpec domainSpec) {
-    this.domainSpec = domainSpec;
-  }
-
-  public String getImage() {
-    return Optional.ofNullable(domainSpec.getImage()).orElse(DEFAULT_IMAGE);
-  }
-
-  public String getImagePullPolicy() {
-    return Optional.ofNullable(getConfiguredImagePullPolicy()).orElse(getInferredPullPolicy());
-  }
-
-  protected String getConfiguredImagePullPolicy() {
-    return domainSpec.getImagePullPolicy();
-  }
-
-  private String getInferredPullPolicy() {
-    return useLatestImage() ? ALWAYS_IMAGEPULLPOLICY : IFNOTPRESENT_IMAGEPULLPOLICY;
-  }
-
-  private boolean useLatestImage() {
-    return getImage().endsWith(KubernetesConstants.LATEST_IMAGE_SUFFIX);
-  }
+  String getImagePullPolicy();
 
   /**
    * The secrets used to authenticate to a docker repository when pulling an image.
    *
    * @return a list of objects containing the name of secrets. May be empty.
    */
-  public List<V1LocalObjectReference> getImagePullSecrets() {
-    return domainSpec.getImagePullSecrets();
-  }
+  List<V1LocalObjectReference> getImagePullSecrets();
 
   /**
    * Returns the environment variables to be defined for this server.
    *
    * @return a list of environment variables
    */
-  public abstract List<V1EnvVar> getEnvironmentVariables();
-
-  protected List<V1EnvVar> withStateAdjustments(List<V1EnvVar> env) {
-    if (!getDesiredState().equals("ADMIN")) {
-      return env;
-    } else {
-      List<V1EnvVar> adjustedEnv = new ArrayList<>(env);
-      V1EnvVar var = getOrCreateVar(adjustedEnv, "JAVA_OPTIONS");
-      var.setValue(prepend(var.getValue(), ADMIN_MODE_FLAG));
-      return adjustedEnv;
-    }
-  }
+  List<V1EnvVar> getEnvironmentVariables();
 
   /**
    * The Kubernetes config map name used in WebLogic configuration overrides.
    *
    * @return configMapName. May be empty.
    */
-  public String getConfigOverrides() {
-    return domainSpec.getConfigOverrides();
-  }
+  String getConfigOverrides();
 
   /**
    * The secret names used in WebLogic configuration overrides.
    *
    * @return a list of secret names. May be empty.
    */
-  public List<String> getConfigOverrideSecrets() {
-    return domainSpec.getConfigOverrideSecrets();
-  }
-
-  @SuppressWarnings("SameParameterValue")
-  private V1EnvVar getOrCreateVar(List<V1EnvVar> env, String name) {
-    for (V1EnvVar var : env) {
-      if (var.getName().equals(name)) {
-        return var;
-      }
-    }
-    V1EnvVar var = new V1EnvVar().name(name);
-    env.add(var);
-    return var;
-  }
-
-  @SuppressWarnings("SameParameterValue")
-  private String prepend(String value, String prefix) {
-    return value == null ? prefix : value.contains(prefix) ? value : prefix + ' ' + value;
-  }
+  List<String> getConfigOverrideSecrets();
 
   /**
    * Desired startup state. Legal values are RUNNING or ADMIN.
    *
    * @return desired state
    */
-  public abstract String getDesiredState();
+  String getDesiredState();
 
   /**
    * Returns true if the specified server should be started, based on the current domain spec.
@@ -132,31 +61,27 @@ public abstract class ServerSpec {
    * @param currentReplicas the number of replicas already selected for the cluster.
    * @return whether to start the server
    */
-  public abstract boolean shouldStart(int currentReplicas);
+  boolean shouldStart(int currentReplicas);
 
   /**
    * Returns the volume mounts to be defined for this server.
    *
    * @return a list of environment volume mounts
    */
-  public abstract List<V1VolumeMount> getAdditionalVolumeMounts();
+  List<V1VolumeMount> getAdditionalVolumeMounts();
 
   /**
    * Returns the volumes to be defined for this server.
    *
    * @return a list of volumes
    */
-  public abstract List<V1Volume> getAdditionalVolumes();
+  List<V1Volume> getAdditionalVolumes();
 
   @Nonnull
-  public ProbeTuning getLivenessProbe() {
-    return new ProbeTuning();
-  }
+  ProbeTuning getLivenessProbe();
 
   @Nonnull
-  public ProbeTuning getReadinessProbe() {
-    return new ProbeTuning();
-  }
+  ProbeTuning getReadinessProbe();
 
   /**
    * Returns the labels applied to the pod.
@@ -164,7 +89,7 @@ public abstract class ServerSpec {
    * @return a map of labels
    */
   @Nonnull
-  public abstract Map<String, String> getPodLabels();
+  Map<String, String> getPodLabels();
 
   /**
    * Returns the annotations applied to the pod.
@@ -172,7 +97,7 @@ public abstract class ServerSpec {
    * @return a map of annotations
    */
   @Nonnull
-  public abstract Map<String, String> getPodAnnotations();
+  Map<String, String> getPodAnnotations();
 
   /**
    * Returns the labels applied to the service.
@@ -180,7 +105,7 @@ public abstract class ServerSpec {
    * @return a map of labels
    */
   @Nonnull
-  public abstract Map<String, String> getServiceLabels();
+  Map<String, String> getServiceLabels();
 
   /**
    * Returns the annotations applied to the service.
@@ -188,57 +113,20 @@ public abstract class ServerSpec {
    * @return a map of annotations
    */
   @Nonnull
-  public abstract Map<String, String> getServiceAnnotations();
+  Map<String, String> getServiceAnnotations();
 
   @Nonnull
-  public Map<String, String> getNodeSelectors() {
-    return Collections.emptyMap();
-  }
+  Map<String, String> getNodeSelectors();
 
-  public V1ResourceRequirements getResources() {
-    return null;
-  }
+  V1ResourceRequirements getResources();
 
-  public V1PodSecurityContext getPodSecurityContext() {
-    return null;
-  }
+  V1PodSecurityContext getPodSecurityContext();
 
-  public V1SecurityContext getContainerSecurityContext() {
-    return null;
-  }
+  V1SecurityContext getContainerSecurityContext();
 
-  public abstract String getDomainRestartVersion();
+  String getDomainRestartVersion();
 
-  public abstract String getClusterRestartVersion();
+  String getClusterRestartVersion();
 
-  public abstract String getServerRestartVersion();
-
-  @Override
-  public String toString() {
-    return new ToStringBuilder(this).append("domainSpec", domainSpec).toString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    if (!(o instanceof ServerSpec)) {
-      return false;
-    }
-
-    ServerSpec that = (ServerSpec) o;
-
-    return new EqualsBuilder().append(domainSpec, that.domainSpec).isEquals();
-  }
-
-  @Override
-  public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(domainSpec).toHashCode();
-  }
+  String getServerRestartVersion();
 }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecBase.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecBase.java
@@ -1,0 +1,164 @@
+// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.v2;
+
+import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
+import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
+
+import io.kubernetes.client.models.V1EnvVar;
+import io.kubernetes.client.models.V1LocalObjectReference;
+import io.kubernetes.client.models.V1PodSecurityContext;
+import io.kubernetes.client.models.V1ResourceRequirements;
+import io.kubernetes.client.models.V1SecurityContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import oracle.kubernetes.operator.KubernetesConstants;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/** Represents the effective configuration for a server, as seen by the operator runtime. */
+@SuppressWarnings("WeakerAccess")
+public abstract class ServerSpecBase implements ServerSpec {
+
+  private static final String ADMIN_MODE_FLAG = "-Dweblogic.management.startupMode=ADMIN";
+  protected DomainSpec domainSpec;
+
+  public ServerSpecBase(DomainSpec domainSpec) {
+    this.domainSpec = domainSpec;
+  }
+
+  @Override
+  public String getImage() {
+    return Optional.ofNullable(domainSpec.getImage()).orElse(DEFAULT_IMAGE);
+  }
+
+  @Override
+  public String getImagePullPolicy() {
+    return Optional.ofNullable(getConfiguredImagePullPolicy()).orElse(getInferredPullPolicy());
+  }
+
+  protected String getConfiguredImagePullPolicy() {
+    return domainSpec.getImagePullPolicy();
+  }
+
+  private String getInferredPullPolicy() {
+    return useLatestImage() ? ALWAYS_IMAGEPULLPOLICY : IFNOTPRESENT_IMAGEPULLPOLICY;
+  }
+
+  private boolean useLatestImage() {
+    return getImage().endsWith(KubernetesConstants.LATEST_IMAGE_SUFFIX);
+  }
+
+  @Override
+  public List<V1LocalObjectReference> getImagePullSecrets() {
+    return domainSpec.getImagePullSecrets();
+  }
+
+  protected List<V1EnvVar> withStateAdjustments(List<V1EnvVar> env) {
+    if (!getDesiredState().equals("ADMIN")) {
+      return env;
+    } else {
+      List<V1EnvVar> adjustedEnv = new ArrayList<>(env);
+      V1EnvVar var = getOrCreateVar(adjustedEnv, "JAVA_OPTIONS");
+      var.setValue(prepend(var.getValue(), ADMIN_MODE_FLAG));
+      return adjustedEnv;
+    }
+  }
+
+  @Override
+  public String getConfigOverrides() {
+    return domainSpec.getConfigOverrides();
+  }
+
+  @Override
+  public List<String> getConfigOverrideSecrets() {
+    return domainSpec.getConfigOverrideSecrets();
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1EnvVar getOrCreateVar(List<V1EnvVar> env, String name) {
+    for (V1EnvVar var : env) {
+      if (var.getName().equals(name)) {
+        return var;
+      }
+    }
+    V1EnvVar var = new V1EnvVar().name(name);
+    env.add(var);
+    return var;
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private String prepend(String value, String prefix) {
+    return value == null ? prefix : value.contains(prefix) ? value : prefix + ' ' + value;
+  }
+
+  @Override
+  @Nonnull
+  public ProbeTuning getLivenessProbe() {
+    return new ProbeTuning();
+  }
+
+  @Override
+  @Nonnull
+  public ProbeTuning getReadinessProbe() {
+    return new ProbeTuning();
+  }
+
+  @Override
+  @Nonnull
+  public Map<String, String> getNodeSelectors() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public V1ResourceRequirements getResources() {
+    return null;
+  }
+
+  @Override
+  public V1PodSecurityContext getPodSecurityContext() {
+    return null;
+  }
+
+  @Override
+  public V1SecurityContext getContainerSecurityContext() {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this).append("domainSpec", domainSpec).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    if (!(o instanceof ServerSpecBase)) {
+      return false;
+    }
+
+    ServerSpecBase that = (ServerSpecBase) o;
+
+    return new EqualsBuilder().append(domainSpec, that.domainSpec).isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37).append(domainSpec).toHashCode();
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
@@ -75,11 +75,13 @@ public abstract class ServerSpecV2Impl extends ServerSpec {
   }
 
   @Override
+  @Nonnull
   public Map<String, String> getServiceLabels() {
     return server.getServiceLabels();
   }
 
   @Override
+  @Nonnull
   public Map<String, String> getServiceAnnotations() {
     return server.getServiceAnnotations();
   }

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/v2/ServerSpecV2Impl.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /** The effective configuration for a server configured by the version 2 domain model. */
-public abstract class ServerSpecV2Impl extends ServerSpec {
+public abstract class ServerSpecV2Impl extends ServerSpecBase {
   private final Server server;
   private final Cluster cluster;
   private Integer clusterLimit;

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/ChannelMatcher.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/ChannelMatcher.java
@@ -1,0 +1,47 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain;
+
+import javax.annotation.Nonnull;
+import oracle.kubernetes.weblogic.domain.v2.Channel;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class ChannelMatcher extends TypeSafeDiagnosingMatcher<Channel> {
+  private String expectedName;
+  private Integer expectedNodePort;
+
+  private ChannelMatcher(String expectedName, Integer expectedNodePort) {
+    this.expectedName = expectedName;
+    this.expectedNodePort = expectedNodePort;
+  }
+
+  public static ChannelMatcher channelWith(
+      @Nonnull String expectedName, @Nonnull Integer expectedNodePort) {
+    return new ChannelMatcher(expectedName, expectedNodePort);
+  }
+
+  @Override
+  protected boolean matchesSafely(Channel item, Description mismatchDescription) {
+    if (item.getChannelName().equals(expectedName) && item.getNodePort().equals(expectedNodePort))
+      return true;
+
+    describe(mismatchDescription, item.getChannelName(), item.getNodePort());
+    return false;
+  }
+
+  private void describe(Description description, String channelName, Integer nodePort) {
+    description
+        .appendText("channel with name ")
+        .appendValue(channelName)
+        .appendText(" and port ")
+        .appendValue(nodePort);
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    describe(description, expectedName, expectedNodePort);
+  }
+}

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/AdminServerTest.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/v2/AdminServerTest.java
@@ -4,15 +4,30 @@
 
 package oracle.kubernetes.weblogic.domain.v2;
 
+import static oracle.kubernetes.weblogic.domain.ChannelMatcher.channelWith;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
+import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
+import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import org.junit.Test;
 
 public class AdminServerTest extends BaseConfigurationTestBase {
+  private static final String CHANNEL1 = "default";
+  private static final int PORT1 = 12345;
+  private static final String CHANNEL2 = "nap1";
+  private static final int PORT2 = 56780;
+  private static final String NAME1 = "name1";
+  private static final String VALUE1 = "value1";
+  private static final String NAME2 = "name2";
+  private static final String VALUE2 = "value2";
   private AdminServer server1;
   private AdminServer server2;
+  private Domain domain = new Domain();
 
   public AdminServerTest() {
     super(new AdminServer(), new AdminServer());
@@ -20,16 +35,20 @@ public class AdminServerTest extends BaseConfigurationTestBase {
     server2 = getInstance2();
   }
 
+  private AdminServerConfigurator configureAdminServer() {
+    return DomainConfiguratorFactory.forDomain(domain).configureAdminServer();
+  }
+
   @Test
   public void whenChannelsLabelsAnnotationsAreTheSame_objectsAreEqual() {
     server1.withChannel("nap1", 0);
-    server1.addPodLabel("label1", "value1");
-    server1.addPodAnnotation("annotation1", "value2");
+    server1.addPodLabel("label1", VALUE1);
+    server1.addPodAnnotation("annotation1", VALUE2);
     server1.withChannel("nap2", 1);
     server2.withChannel("nap2", 1);
     server2.withChannel("nap1", 0);
-    server2.addPodAnnotation("annotation1", "value2");
-    server2.addPodLabel("label1", "value1");
+    server2.addPodAnnotation("annotation1", VALUE2);
+    server2.addPodLabel("label1", VALUE1);
 
     assertThat(server1, equalTo(server2));
   }
@@ -70,6 +89,102 @@ public class AdminServerTest extends BaseConfigurationTestBase {
   public void whenDifferByServiceAnnotation_objectsAreNotEqual() {
     server1.addServiceAnnotation("a", "b");
     server2.addServiceAnnotation("a", "c");
+
+    assertThat(server1, not(equalTo(server2)));
+  }
+
+  @Test
+  public void whenConstructedWithAdminService_mayCreateChannels() {
+    configureAdminServer()
+        .configureAdminService()
+        .withChannel(CHANNEL1, PORT1)
+        .withChannel(CHANNEL2, PORT2);
+
+    assertThat(
+        domain.getAdminServerSpec().getAdminService().getChannels(),
+        containsInAnyOrder(channelWith(CHANNEL1, PORT1), channelWith(CHANNEL2, PORT2)));
+  }
+
+  @Test
+  public void whenHaveSameAdminServiceChannels_objectsAreEqual() {
+    server1.getAdminService().withChannel(CHANNEL1, PORT1).withChannel(CHANNEL2, PORT2);
+    server2.getAdminService().withChannel(CHANNEL2, PORT2).withChannel(CHANNEL1, PORT1);
+
+    assertThat(server1, equalTo(server2));
+  }
+
+  @Test
+  public void whenHaveDifferentAdminServiceChannels_objectsAreNotEqual() {
+    server1.getAdminService().withChannel(CHANNEL1, PORT1).withChannel(CHANNEL2, PORT2);
+    server2.getAdminService().withChannel(CHANNEL1, PORT2).withChannel(CHANNEL2, PORT1);
+
+    assertThat(server1, not(equalTo(server2)));
+  }
+
+  @Test
+  public void whenConstructedWithAdminService_mayAddLabels() {
+    configureAdminServer()
+        .configureAdminService()
+        .withServiceLabel(NAME1, VALUE1)
+        .withServiceLabel(NAME2, VALUE2);
+
+    assertThat(
+        domain.getAdminServerSpec().getAdminService().getLabels(),
+        both(hasEntry(NAME1, VALUE1)).and(hasEntry(NAME2, VALUE2)));
+  }
+
+  @Test
+  public void whenHaveSameAdminServiceLabels_objectsAreEqual() {
+    server1.getAdminService().withServiceLabel(NAME1, VALUE1).withServiceLabel(NAME2, VALUE2);
+    server2.getAdminService().withServiceLabel(NAME2, VALUE2).withServiceLabel(NAME1, VALUE1);
+
+    assertThat(server1, equalTo(server2));
+  }
+
+  @Test
+  public void whenHaveDifferentAdminServiceLabels_objectsAreNotEqual() {
+    server1.getAdminService().withServiceLabel(NAME1, VALUE1).withServiceLabel(NAME2, VALUE2);
+    server2.getAdminService().withServiceLabel(NAME1, VALUE2).withServiceLabel(NAME2, VALUE1);
+
+    assertThat(server1, not(equalTo(server2)));
+  }
+
+  @Test
+  public void whenConstructedWithAdminService_mayAddAnnotations() {
+    configureAdminServer()
+        .configureAdminService()
+        .withServiceAnnotation(NAME1, VALUE1)
+        .withServiceAnnotation(NAME2, VALUE2);
+
+    assertThat(
+        domain.getAdminServerSpec().getAdminService().getAnnotations(),
+        both(hasEntry(NAME1, VALUE1)).and(hasEntry(NAME2, VALUE2)));
+  }
+
+  @Test
+  public void whenHaveSameAdminServiceAnnotations_objectsAreEqual() {
+    server1
+        .getAdminService()
+        .withServiceAnnotation(NAME1, VALUE1)
+        .withServiceAnnotation(NAME2, VALUE2);
+    server2
+        .getAdminService()
+        .withServiceAnnotation(NAME2, VALUE2)
+        .withServiceAnnotation(NAME1, VALUE1);
+
+    assertThat(server1, equalTo(server2));
+  }
+
+  @Test
+  public void whenHaveDifferentAdminServiceAnnotations_objectsAreNotEqual() {
+    server1
+        .getAdminService()
+        .withServiceAnnotation(NAME1, VALUE1)
+        .withServiceAnnotation(NAME2, VALUE2);
+    server2
+        .getAdminService()
+        .withServiceAnnotation(NAME1, VALUE2)
+        .withServiceAnnotation(NAME2, VALUE1);
 
     assertThat(server1, not(equalTo(server2)));
   }

--- a/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
+++ b/model/src/test/resources/oracle/kubernetes/weblogic/domain/v2/domain-sample.yaml
@@ -58,6 +58,14 @@ spec:
       channels:
       - channelName: default
         nodePort: 7001
+      - channelName: extra
+        nodePort: 7011
+      labels:
+        red: maroon
+        blue: azure
+      annotations:
+        sunday: dimanche
+        monday: lundi
     serverPod:
       env:
       - name: var1

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -330,9 +330,7 @@ public class DomainProcessorImpl implements DomainProcessor {
                     removeIfPresentAnd(
                         existing.getClusters(),
                         clusterName,
-                        (current) -> {
-                          return isOutdated(current.getMetadata(), metadata);
-                        });
+                        (current) -> isOutdated(current.getMetadata(), metadata));
                 if (removed && !existing.isDeleting()) {
                   // Service was deleted, but clusters still contained a non-null entry
                   LOGGER.info(
@@ -350,9 +348,7 @@ public class DomainProcessorImpl implements DomainProcessor {
                         removeIfPresentAnd(
                             sko.getChannels(),
                             channelName,
-                            (current) -> {
-                              return isOutdated(current.getMetadata(), metadata);
-                            });
+                            (current) -> isOutdated(current.getMetadata(), metadata));
                     if (removed && !existing.isDeleting()) {
                       // Service was deleted, but sko still contained a non-null entry
                       LOGGER.info(
@@ -789,7 +785,7 @@ public class DomainProcessorImpl implements DomainProcessor {
           String channelName = ServiceWatcher.getServiceChannelName(service);
           String clusterName = ServiceWatcher.getServiceClusterName(service);
           if (clusterName != null) {
-            info.getClusters().put(clusterName, service);
+            info.setClusterService(clusterName, service);
           } else if (serverName != null) {
             ServerKubernetesObjects sko =
                 info.getServers().computeIfAbsent(serverName, k -> new ServerKubernetesObjects());

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -639,7 +639,7 @@ public class Main {
             DomainPresenceInfo info =
                 dpis.computeIfAbsent(domainUID, k -> new DomainPresenceInfo(ns, domainUID));
             if (clusterName != null) {
-              info.getClusters().put(clusterName, service);
+              info.setClusterService(clusterName, service);
             } else if (serverName != null) {
               ServerKubernetesObjects sko =
                   info.getServers().computeIfAbsent(serverName, k -> new ServerKubernetesObjects());

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -35,7 +35,6 @@ public class DomainPresenceInfo {
 
   private final ConcurrentMap<String, ServerKubernetesObjects> servers = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
-  private final AtomicReference<V1Service> externalService = new AtomicReference<>();
 
   private DateTime lastCompletionTime;
 
@@ -69,7 +68,7 @@ public class DomainPresenceInfo {
   }
 
   private ServerKubernetesObjects getSko(String serverName) {
-    return getServers().putIfAbsent(serverName, new ServerKubernetesObjects());
+    return getServers().computeIfAbsent(serverName, (n -> new ServerKubernetesObjects()));
   }
 
   V1Service getServerService(String serverName) {
@@ -88,12 +87,12 @@ public class DomainPresenceInfo {
     getClusters().put(clusterName, service);
   }
 
-  V1Service getExternalService() {
-    return externalService.get();
+  V1Service getExternalService(String serverName) {
+    return getSko(serverName).getExternalService();
   }
 
-  void setExternalService(V1Service service) {
-    externalService.set(service);
+  void setExternalService(String serverName, V1Service service) {
+    getSko(serverName).setExternalService(service);
   }
 
   public boolean isDeleting() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -35,6 +35,7 @@ public class DomainPresenceInfo {
 
   private final ConcurrentMap<String, ServerKubernetesObjects> servers = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
+  private final AtomicReference<V1Service> externalService = new AtomicReference<>();
 
   private DateTime lastCompletionTime;
 
@@ -61,6 +62,38 @@ public class DomainPresenceInfo {
     this.namespace = namespace;
     this.domainUID = domainUID;
     this.serverStartupInfo = new AtomicReference<>(null);
+  }
+
+  void setServerService(String serverName, V1Service service) {
+    getSko(serverName).getService().set(service);
+  }
+
+  private ServerKubernetesObjects getSko(String serverName) {
+    return getServers().putIfAbsent(serverName, new ServerKubernetesObjects());
+  }
+
+  V1Service getServerService(String serverName) {
+    return getSko(serverName).getService().get();
+  }
+
+  void removeClusterService(String clusterName) {
+    getClusters().remove(clusterName);
+  }
+
+  V1Service getClusterService(String clusterName) {
+    return getClusters().get(clusterName);
+  }
+
+  public void setClusterService(String clusterName, V1Service service) {
+    getClusters().put(clusterName, service);
+  }
+
+  V1Service getExternalService() {
+    return externalService.get();
+  }
+
+  void setExternalService(V1Service service) {
+    externalService.set(service);
   }
 
   public boolean isDeleting() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -10,7 +10,7 @@ public class LegalNames {
   private static final String SERVER_PATTERN = "%s-%s";
   private static final String CLUSTER_SERVICE_PATTERN = "%s-cluster-%s";
   private static final String DOMAIN_INTROSPECTOR_JOB_PATTERN = "%s-introspect-domain-job";
-  private static final String EXTERNAL_SERVICE_PATTERN = "%s-external";
+  private static final String EXTERNAL_SERVICE_PATTERN = "%s-%s-external";
 
   public static String toServerServiceName(String domainUID, String serverName) {
     return toServerName(domainUID, serverName);
@@ -32,8 +32,8 @@ public class LegalNames {
     return toDNS1123LegalName(String.format(DOMAIN_INTROSPECTOR_JOB_PATTERN, domainUID));
   }
 
-  static String toExternalServiceName(String domainUID) {
-    return toDNS1123LegalName(String.format(EXTERNAL_SERVICE_PATTERN, domainUID));
+  static String toExternalServiceName(String domainUID, String serverName) {
+    return toDNS1123LegalName(String.format(EXTERNAL_SERVICE_PATTERN, domainUID, serverName));
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -10,7 +10,7 @@ public class LegalNames {
   private static final String SERVER_PATTERN = "%s-%s";
   private static final String CLUSTER_SERVICE_PATTERN = "%s-cluster-%s";
   private static final String DOMAIN_INTROSPECTOR_JOB_PATTERN = "%s-introspect-domain-job";
-  private static final String EXTERNAL_SERVICE_PATTERN = "%s-%s-external";
+  private static final String EXTERNAL_SERVICE_PATTERN = "%s-external";
 
   public static String toServerServiceName(String domainUID, String serverName) {
     return toServerName(domainUID, serverName);
@@ -32,8 +32,8 @@ public class LegalNames {
     return toDNS1123LegalName(String.format(DOMAIN_INTROSPECTOR_JOB_PATTERN, domainUID));
   }
 
-  static String toExternalServiceName(String domainUID, String serverName) {
-    return toDNS1123LegalName(String.format(EXTERNAL_SERVICE_PATTERN, domainUID, serverName));
+  static String toExternalServiceName(String domainUID) {
+    return toDNS1123LegalName(String.format(EXTERNAL_SERVICE_PATTERN, domainUID));
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjects.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServerKubernetesObjects.java
@@ -15,6 +15,7 @@ public class ServerKubernetesObjects {
   private final AtomicReference<V1Pod> pod = new AtomicReference<>(null);
   private final AtomicReference<String> lastKnownStatus = new AtomicReference<>(null);
   private final AtomicReference<V1Service> service = new AtomicReference<>(null);
+  private final AtomicReference<V1Service> externalService = new AtomicReference<>();
   private final ConcurrentMap<String, V1Service> channels = new ConcurrentHashMap<>();
 
   public ServerKubernetesObjects() {}
@@ -53,5 +54,13 @@ public class ServerKubernetesObjects {
    */
   public ConcurrentMap<String, V1Service> getChannels() {
     return channels;
+  }
+
+  public V1Service getExternalService() {
+    return externalService.get();
+  }
+
+  public void setExternalService(V1Service service) {
+    externalService.set(service);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -123,6 +123,7 @@ public class ServiceHelper {
     protected List<V1ServicePort> createServicePorts() {
       if (scan == null) return null;
 
+      ports = null;
       addServicePorts(scan);
       return ports;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -800,13 +800,16 @@ public class ServiceHelper {
 
   private static class ForExternalServiceStepContext extends ServiceStepContext {
 
+    private final String adminServerName;
+
     ForExternalServiceStepContext(Step conflictStep, Packet packet) {
       super(conflictStep, packet);
+      adminServerName = (String) packet.get(ProcessingConstants.SERVER_NAME);
     }
 
     @Override
     protected String createServiceName() {
-      return LegalNames.toExternalServiceName(getDomainUID());
+      return LegalNames.toExternalServiceName(getDomainUID(), adminServerName);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -50,7 +50,6 @@ import oracle.kubernetes.weblogic.domain.v2.Domain;
 import oracle.kubernetes.weblogic.domain.v2.ServerSpec;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
-@SuppressWarnings("deprecation")
 public class ServiceHelper {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
@@ -64,6 +63,10 @@ public class ServiceHelper {
    */
   public static Step createForServerStep(Step next) {
     return new ForServerStep(next);
+  }
+
+  static V1Service createServerServiceModel(Packet packet) {
+    return new ForServerStepContext(null, packet).createModel();
   }
 
   private static class ForServerStep extends ServiceHelperStep {
@@ -591,6 +594,10 @@ public class ServiceHelper {
     return new ForClusterStep(next);
   }
 
+  static V1Service createClusterServiceModel(Packet packet) {
+    return new ClusterStepContext(null, packet).createModel();
+  }
+
   private static class ForClusterStep extends ServiceHelperStep {
     ForClusterStep(Step next) {
       super(next);
@@ -790,6 +797,10 @@ public class ServiceHelper {
    */
   public static Step createForExternalServiceStep(Step next) {
     return new ForExternalServiceStep(next);
+  }
+
+  static V1Service createExternalServiceModel(Packet packet) {
+    return new ForExternalServiceStepContext(null, packet).createModel();
   }
 
   private static class ForExternalServiceStep extends ServiceHelperStep {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -132,11 +132,7 @@ public class ServiceHelper {
     void addServicePortIfNeeded(String portName, Integer port) {
       if (port == null) return;
 
-      addPort(
-          new V1ServicePort()
-              .name(LegalNames.toDNS1123LegalName(portName))
-              .protocol("TCP")
-              .port(port));
+      addPort(createServicePort(portName, port));
     }
 
     @Override
@@ -333,6 +329,13 @@ public class ServiceHelper {
     }
 
     abstract void addServicePortIfNeeded(String portName, Integer port);
+
+    V1ServicePort createServicePort(String portName, Integer port) {
+      return new V1ServicePort()
+          .name(LegalNames.toDNS1123LegalName(portName))
+          .port(port)
+          .protocol("TCP");
+    }
 
     protected V1ObjectMeta createMetadata() {
       V1ObjectMeta metadata =
@@ -653,11 +656,9 @@ public class ServiceHelper {
           .orElse(Collections.emptyList());
     }
 
-    void addServicePortIfNeeded(String channelName, Integer port) {
+    void addServicePortIfNeeded(String portName, Integer port) {
       if (port != null) {
-        ports.putIfAbsent(
-            LegalNames.toDNS1123LegalName(channelName),
-            new V1ServicePort().name(channelName).port(port).protocol("TCP"));
+        ports.putIfAbsent(portName, createServicePort(portName, port));
       }
     }
 
@@ -885,10 +886,7 @@ public class ServiceHelper {
       if (channel == null || internalPort == null) return;
 
       addPort(
-          new V1ServicePort()
-              .name(LegalNames.toDNS1123LegalName(channelName))
-              .protocol("TCP")
-              .port(internalPort)
+          createServicePort(channelName, internalPort)
               .nodePort(Optional.ofNullable(channel.getNodePort()).orElse(internalPort)));
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -157,31 +157,29 @@ public class ServiceHelper {
 
     @Override
     protected V1Service getServiceFromRecord() {
-      return sko.getService().get();
+      return info.getServerService(serverName);
     }
 
     @Override
     protected void addServiceToRecord(@Nonnull V1Service service) {
-      sko.getService().set(service);
+      info.setServerService(serverName, service);
     }
 
     @Override
     protected void removeServiceFromRecord() {
-      sko.getService().set(null);
+      info.setServerService(serverName, null);
     }
   }
 
   private abstract static class ServerServiceStepContext extends ServiceStepContext {
     protected final String serverName;
     protected final String clusterName;
-    protected final ServerKubernetesObjects sko;
     protected final WlsServerConfig scan;
 
     ServerServiceStepContext(Step conflictStep, Packet packet) {
       super(conflictStep, packet);
       serverName = (String) packet.get(ProcessingConstants.SERVER_NAME);
       clusterName = (String) packet.get(ProcessingConstants.CLUSTER_NAME);
-      sko = info.getServers().computeIfAbsent(getServerName(), k -> new ServerKubernetesObjects());
       scan = (WlsServerConfig) packet.get(ProcessingConstants.SERVER_SCAN);
     }
 
@@ -836,17 +834,17 @@ public class ServiceHelper {
 
     @Override
     protected V1Service getServiceFromRecord() {
-      return info.getExternalService();
+      return info.getExternalService(adminServerName);
     }
 
     @Override
     protected void addServiceToRecord(V1Service service) {
-      info.setExternalService(service);
+      info.setExternalService(adminServerName, service);
     }
 
     @Override
     protected void removeServiceFromRecord() {
-      info.setExternalService(null);
+      info.setExternalService(adminServerName, null);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -814,6 +814,12 @@ public class ServiceHelper {
     }
 
     @Override
+    protected V1ServiceSpec createServiceSpec() {
+      return super.createServiceSpec()
+          .putSelectorItem(LabelConstants.SERVERNAME_LABEL, adminServerName);
+    }
+
+    @Override
     protected String createServiceName() {
       return LegalNames.toExternalServiceName(getDomainUID(), adminServerName);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -132,7 +132,11 @@ public class ServiceHelper {
     void addServicePortIfNeeded(String portName, Integer port) {
       if (port == null) return;
 
-      addPort(new V1ServicePort().name(portName).protocol("TCP").port(port));
+      addPort(
+          new V1ServicePort()
+              .name(LegalNames.toDNS1123LegalName(portName))
+              .protocol("TCP")
+              .port(port));
     }
 
     @Override
@@ -325,7 +329,7 @@ public class ServiceHelper {
     }
 
     void addNapServicePort(NetworkAccessPoint nap) {
-      addServicePortIfNeeded(LegalNames.toDNS1123LegalName(nap.getName()), nap.getListenPort());
+      addServicePortIfNeeded(nap.getName(), nap.getListenPort());
     }
 
     abstract void addServicePortIfNeeded(String portName, Integer port);
@@ -652,7 +656,8 @@ public class ServiceHelper {
     void addServicePortIfNeeded(String channelName, Integer port) {
       if (port != null) {
         ports.putIfAbsent(
-            channelName, new V1ServicePort().name(channelName).port(port).protocol("TCP"));
+            LegalNames.toDNS1123LegalName(channelName),
+            new V1ServicePort().name(channelName).port(port).protocol("TCP"));
       }
     }
 
@@ -881,7 +886,7 @@ public class ServiceHelper {
 
       addPort(
           new V1ServicePort()
-              .name(channel.getChannelName())
+              .name(LegalNames.toDNS1123LegalName(channelName))
               .protocol("TCP")
               .port(internalPort)
               .nodePort(Optional.ofNullable(channel.getNodePort()).orElse(internalPort)));

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -151,4 +151,7 @@ public class MessageKeys {
   public static final String REPLICAS_EXCEEDS_TOTAL_CLUSTER_SERVER_COUNT = "WLSKO-0146";
   public static final String SYNC_RETRY = "WLSKO-0147";
   public static final String POD_DUMP = "WLSKO-0148";
+  public static final String EXTERNAL_CHANNEL_SERVICE_CREATED = "WLSKO-0150";
+  public static final String EXTERNAL_CHANNEL_SERVICE_REPLACED = "WLSKO-0151";
+  public static final String EXTERNAL_CHANNEL_SERVICE_EXISTS = "WLSKO-0152";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/utils/WlsDomainConfigSupport.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/utils/WlsDomainConfigSupport.java
@@ -47,8 +47,10 @@ public class WlsDomainConfigSupport {
    * @param serverName the name of the server.
    * @param listenPort the listen port
    */
-  public void addWlsServer(String serverName, Integer listenPort) {
-    wlsServers.put(serverName, createServerConfig(serverName, listenPort));
+  public WlsServerConfig addWlsServer(String serverName, Integer listenPort) {
+    WlsServerConfig serverConfig = createServerConfig(serverName, listenPort);
+    wlsServers.put(serverName, serverConfig);
+    return serverConfig;
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/utils/WlsDomainConfigSupport.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/utils/WlsDomainConfigSupport.java
@@ -51,6 +51,20 @@ public class WlsDomainConfigSupport {
     wlsServers.put(serverName, createServerConfig(serverName, listenPort));
   }
 
+  /**
+   * Adds a WLS server to the configuration. Any non-clustered server must be added explicitly.
+   * Clustered servers may be added, or may be added simply as part of their cluster.
+   *
+   * @param serverName the name of the server.
+   * @param listenPort the listen port
+   * @param adminPort the admin port
+   */
+  public void addWlsServer(String serverName, Integer listenPort, Integer adminPort) {
+    wlsServers.put(
+        serverName,
+        new ServerConfigBuilder(serverName, listenPort).withAdminPort(adminPort).build());
+  }
+
   private static WlsServerConfig createServerConfig(String serverName, Integer listenPort) {
     return new ServerConfigBuilder(serverName, listenPort).build();
   }
@@ -134,14 +148,20 @@ public class WlsDomainConfigSupport {
   static class ServerConfigBuilder {
     private String name;
     private Integer listenPort;
+    private Integer adminPort;
 
     ServerConfigBuilder(String name, Integer listenPort) {
       this.name = name;
       this.listenPort = listenPort;
     }
 
+    ServerConfigBuilder withAdminPort(Integer adminPort) {
+      this.adminPort = adminPort;
+      return this;
+    }
+
     WlsServerConfig build() {
-      return new WlsServerConfig(name, listenPort, null, null, false, null, null, null, false);
+      return new WlsServerConfig(name, null, null, listenPort, null, adminPort, null);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/utils/WlsDomainConfigSupport.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/utils/WlsDomainConfigSupport.java
@@ -53,20 +53,6 @@ public class WlsDomainConfigSupport {
     return serverConfig;
   }
 
-  /**
-   * Adds a WLS server to the configuration. Any non-clustered server must be added explicitly.
-   * Clustered servers may be added, or may be added simply as part of their cluster.
-   *
-   * @param serverName the name of the server.
-   * @param listenPort the listen port
-   * @param adminPort the admin port
-   */
-  public void addWlsServer(String serverName, Integer listenPort, Integer adminPort) {
-    wlsServers.put(
-        serverName,
-        new ServerConfigBuilder(serverName, listenPort).withAdminPort(adminPort).build());
-  }
-
   private static WlsServerConfig createServerConfig(String serverName, Integer listenPort) {
     return new ServerConfigBuilder(serverName, listenPort).build();
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServerConfig.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018,2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -72,7 +72,6 @@ public class WlsDynamicServerConfig extends WlsServerConfig {
         listenPort,
         macroSubstitutor.substituteMacro(serverTemplate.getListenAddress()),
         sslListenPort,
-        serverTemplate.isSslPortEnabled(),
         macroSubstitutor.substituteMacro(serverTemplate.getMachineName()),
         networkAccessPoints);
   }
@@ -85,7 +84,6 @@ public class WlsDynamicServerConfig extends WlsServerConfig {
    * @param listenPort list port of the dynamic server
    * @param listenAddress listen address of the dynamic server
    * @param sslListenPort SSL listen port of the dynamic server
-   * @param sslPortEnabled boolean indicating whether SSL listen port is enabled
    * @param machineName machine name of the dynamic server
    * @param networkAccessPoints network access points or channels configured for this dynamic server
    */
@@ -94,19 +92,9 @@ public class WlsDynamicServerConfig extends WlsServerConfig {
       Integer listenPort,
       String listenAddress,
       Integer sslListenPort,
-      boolean sslPortEnabled,
       String machineName,
       List<NetworkAccessPoint> networkAccessPoints) {
-    super(
-        name,
-        listenPort,
-        listenAddress,
-        sslListenPort,
-        sslPortEnabled,
-        machineName,
-        networkAccessPoints,
-        null,
-        false);
+    super(name, listenAddress, machineName, listenPort, sslListenPort, null, networkAccessPoints);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
@@ -94,6 +94,11 @@ public class WlsServerConfig {
     networkAccessPoints.add(networkAccessPoint);
   }
 
+  public WlsServerConfig addNetworkAccessPoint(String name, int listenPort) {
+    addNetworkAccessPoint(new NetworkAccessPoint(name, "TCP", listenPort, null));
+    return this;
+  }
+
   public String getClusterName() {
     return this.clusterName;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
@@ -99,6 +99,11 @@ public class WlsServerConfig {
     return this;
   }
 
+  public WlsServerConfig setAdminPort(int adminPort) {
+    this.adminPort = adminPort;
+    return this;
+  }
+
   public String getClusterName() {
     return this.clusterName;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
@@ -18,10 +18,8 @@ public class WlsServerConfig {
   String listenAddress;
   String clusterName;
   Integer sslListenPort;
-  boolean sslPortEnabled;
   String machineName;
   Integer adminPort;
-  boolean adminPortEnabled;
   List<NetworkAccessPoint> networkAccessPoints;
 
   public WlsServerConfig() {}
@@ -116,6 +114,10 @@ public class WlsServerConfig {
     this.listenPort = listenPort;
   }
 
+  public void setSslListenPort(Integer listenPort) {
+    this.sslListenPort = listenPort;
+  }
+
   public boolean isAdminPortEnabled() {
     return adminPort != null;
   }
@@ -148,56 +150,46 @@ public class WlsServerConfig {
     // parse the SSL configuration
     Map<String, Object> sslMap = (Map<String, Object>) serverConfigMap.get("SSL");
     Integer sslListenPort = (sslMap == null) ? null : (Integer) sslMap.get("listenPort");
-    boolean sslPortEnabled = (sslMap != null && sslMap.get("listenPort") != null) ? true : false;
+    boolean sslPortEnabled = sslMap != null && sslMap.get("listenPort") != null;
 
     // parse the administration port
-    Integer adminPort = (Integer) serverConfigMap.get("adminPort");
-    boolean adminPortEnabled = (adminPort != null);
 
     return new WlsServerConfig(
         (String) serverConfigMap.get("name"),
-        (Integer) serverConfigMap.get("listenPort"),
         (String) serverConfigMap.get("listenAddress"),
-        sslListenPort,
-        sslPortEnabled,
         getMachineNameFromJsonMap(serverConfigMap),
-        networkAccessPoints,
-        adminPort,
-        adminPortEnabled);
+        (Integer) serverConfigMap.get("listenPort"),
+        sslListenPort,
+        (Integer) serverConfigMap.get("adminPort"),
+        networkAccessPoints);
   }
 
   /**
    * Construct a WlsServerConfig object using values provided.
    *
    * @param name Name of the WLS server
-   * @param listenPort Configured listen port for this WLS server
    * @param listenAddress Configured listen address for this WLS server
-   * @param sslListenPort Configured SSL listen port for this WLS server
-   * @param sslPortEnabled boolean indicating whether the SSL listen port should be enabled
    * @param machineName Configured machine name for this WLS server
-   * @param networkAccessPoints List of NetworkAccessPoint containing channels configured for this
+   * @param listenPort Configured listen port for this WLS server
+   * @param sslListenPort Configured SSL listen port for this WLS server
    * @param adminPort Configured domain wide administration port
-   * @param adminPortEnabled boolean indicating whether administration port should be enabled
+   * @param networkAccessPoints List of NetworkAccessPoint containing channels configured for this
    */
   public WlsServerConfig(
       String name,
-      Integer listenPort,
       String listenAddress,
-      Integer sslListenPort,
-      boolean sslPortEnabled,
       String machineName,
-      List<NetworkAccessPoint> networkAccessPoints,
+      Integer listenPort,
+      Integer sslListenPort,
       Integer adminPort,
-      boolean adminPortEnabled) {
+      List<NetworkAccessPoint> networkAccessPoints) {
     this.name = name;
-    this.listenPort = listenPort;
     this.listenAddress = listenAddress;
-    this.networkAccessPoints = networkAccessPoints;
-    this.sslListenPort = sslListenPort;
-    this.sslPortEnabled = sslPortEnabled;
-    this.adminPort = adminPort;
-    this.adminPortEnabled = adminPortEnabled;
     this.machineName = machineName;
+    this.listenPort = listenPort;
+    this.sslListenPort = sslListenPort;
+    this.adminPort = adminPort;
+    this.networkAccessPoints = networkAccessPoints;
   }
 
   /**
@@ -318,13 +310,11 @@ public class WlsServerConfig {
     WlsServerConfig that = (WlsServerConfig) o;
 
     return new EqualsBuilder()
-        .append(sslPortEnabled, that.sslPortEnabled)
         .append(name, that.name)
         .append(listenPort, that.listenPort)
         .append(listenAddress, that.listenAddress)
         .append(sslListenPort, that.sslListenPort)
         .append(adminPort, that.adminPort)
-        .append(adminPortEnabled, that.adminPortEnabled)
         .append(machineName, that.machineName)
         .append(networkAccessPoints, that.networkAccessPoints)
         .isEquals();
@@ -337,9 +327,7 @@ public class WlsServerConfig {
         .append(listenPort)
         .append(listenAddress)
         .append(sslListenPort)
-        .append(sslPortEnabled)
         .append(adminPort)
-        .append(adminPortEnabled)
         .append(machineName)
         .append(networkAccessPoints)
         .toHashCode();
@@ -352,9 +340,7 @@ public class WlsServerConfig {
         .append("listenPort", listenPort)
         .append("listenAddress", listenAddress)
         .append("sslListenPort", sslListenPort)
-        .append("sslPortEnabled", sslPortEnabled)
         .append("adminPort", adminPort)
-        .append("adminPortEnabled", adminPortEnabled)
         .append("machineName", machineName)
         .append("networkAccessPoints", networkAccessPoints)
         .toString();

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -147,3 +147,6 @@ WLSKO-0145=Replacing pod {0} because: {1}
 WLSKO-0146=Replica request of {0} exceeds the maximum dynamic server count + server count of {1} configured for cluster {2}
 WLSKO-0147=Call {0} has failed with code {1}: message {2}. It has failed {3} times and will be retried up to {4} times.
 WLSKO-0148=Current Pod dump [{0}] vs expected pod [{1}].
+WLSKO-0150=Creating external channel service for WebLogic domain with UID: {0}.
+WLSKO-0151=Replacing external channel service for WebLogic domain with UID: {0}.
+WLSKO-0152=Existing external channel service is correct for WebLogic domain with UID: {0}.

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoTest.java
@@ -1,0 +1,55 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import io.kubernetes.client.models.V1Service;
+import org.junit.Test;
+
+public class DomainPresenceInfoTest {
+  private DomainPresenceInfo info = new DomainPresenceInfo("ns", "domain");
+
+  @Test
+  public void whenNoneDefined_getClusterServiceReturnsNull() {
+    assertThat(info.getClusterService("cluster"), nullValue());
+  }
+
+  @Test
+  public void afterClusterServiceDefined_nextCallReturnsIt() {
+    V1Service service = new V1Service();
+    info.setClusterService("cluster", service);
+
+    assertThat(info.getClusterService("cluster"), sameInstance(service));
+  }
+
+  @Test
+  public void whenNoneDefined_getServerServiceReturnsNull() {
+    assertThat(info.getServerService("admin"), nullValue());
+  }
+
+  @Test
+  public void afterServerServiceDefined_nextCallReturnsIt() {
+    V1Service service = new V1Service();
+    info.setServerService("admin", service);
+
+    assertThat(info.getServerService("admin"), sameInstance(service));
+  }
+
+  @Test
+  public void whenNoneDefined_getExternalServiceReturnsNull() {
+    assertThat(info.getExternalService("admin"), nullValue());
+  }
+
+  @Test
+  public void afterExternalServiceDefined_nextCallReturnsIt() {
+    V1Service service = new V1Service();
+    info.setExternalService("admin", service);
+
+    assertThat(info.getExternalService("admin"), sameInstance(service));
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.VersionConstants;
-import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step.StepAndPacket;
@@ -54,11 +53,6 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
 
   public ManagedPodHelperTest() {
     super(SERVER_NAME, LISTEN_PORT);
-  }
-
-  private WlsServerConfig createServerConfig() {
-    return new WlsServerConfig(
-        SERVER_NAME, LISTEN_PORT, null, null, false, null, null, null, false);
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperDeletionTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperDeletionTest.java
@@ -1,0 +1,91 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Service;
+import oracle.kubernetes.TestUtils;
+import oracle.kubernetes.operator.work.TerminalStep;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServiceHelperDeletionTest extends ServiceHelperTestBase {
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private V1Service service = createMinimalService();
+  private ServerKubernetesObjects sko;
+
+  private V1Service createMinimalService() {
+    return new V1Service().metadata(new V1ObjectMeta().name(SERVICE_NAME).namespace(NS));
+  }
+
+  @Before
+  public void setUpDeletionTest() {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(testSupport.install());
+
+    sko = createSko(service);
+    testSupport.addDomainPresenceInfo(domainPresenceInfo);
+  }
+
+  @Test
+  public void afterDeleteServiceStepRun_serviceRemovedFromKubernetes() {
+    testSupport.defineResources(service);
+
+    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, null));
+
+    assertThat(testSupport.getResources(KubernetesTestSupport.SERVICE), empty());
+  }
+
+  @Test
+  public void afterDeleteServiceStepRun_removeServiceFromSko() {
+    testSupport.defineResources(service);
+
+    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, null));
+
+    assertThat(sko.getService().get(), nullValue());
+  }
+
+  @Test
+  public void whenServiceNotFound_removeServiceFromSko() {
+    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, null));
+
+    assertThat(sko.getService().get(), nullValue());
+  }
+
+  @Test
+  public void whenDeleteFails_reportCompletionFailure() {
+    testSupport.failOnResource(SERVICE_NAME, NS, HTTP_BAD_REQUEST);
+
+    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, null));
+
+    testSupport.verifyCompletionThrowable(ApiException.class);
+  }
+
+  @Test
+  public void whenDeleteServiceStepRunWithNoService_doNotSendDeleteCall() {
+    ServerKubernetesObjects sko = createSko(null);
+
+    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, null));
+
+    assertThat(sko.getService().get(), nullValue());
+  }
+
+  @Test
+  public void afterDeleteServiceStepRun_runSpecifiedNextStep() {
+    TerminalStep terminalStep = new TerminalStep();
+    ServerKubernetesObjects sko = createSko(null);
+
+    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, terminalStep));
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -644,12 +644,12 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
 
     @Override
     public V1Service getRecordedService(DomainPresenceInfo info) {
-      return info.getExternalService();
+      return info.getExternalService(ADMIN_SERVER);
     }
 
     @Override
     public void recordService(DomainPresenceInfo info, V1Service service) {
-      info.setExternalService(service);
+      info.setExternalService(ADMIN_SERVER, service);
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -75,7 +75,7 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
   private static final String TEST_CLUSTER = "cluster-1";
   private static final int TEST_NODE_PORT = 30001;
   private static final int TEST_NODE_SSL_PORT = 30002;
-  private static final int TEST_NODE_NAP_PORT = 30012;
+  private static final int NAP1_NODE_PORT = 30012;
   private static final int TEST_PORT = 7000;
   private static final int ADMIN_PORT = 8000;
   private static final String DOMAIN_NAME = "domain1";
@@ -105,7 +105,9 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
   private static final ExternalServiceTestFacade EXTERNAL_SERVICE_TEST_FACADE =
       new ExternalServiceTestFacade();
   private static final String NAP_1 = "nap1";
+  private static final String NAP_2 = "Nap2";
   private static final int NAP_PORT_1 = 7100;
+  private static final int NAP_PORT_2 = 37100;
 
   private KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final TerminalStep terminalStep = new TerminalStep();
@@ -120,7 +122,8 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
         .configureAdminService()
         .withChannel("default", TEST_NODE_PORT)
         .withChannel("default-secure", TEST_NODE_SSL_PORT)
-        .withChannel(NAP_1, TEST_NODE_NAP_PORT);
+        .withChannel(NAP_1, NAP1_NODE_PORT)
+        .withChannel(NAP_2);
     mementos.add(
         consoleHandlerMemento =
             TestUtils.silenceOperatorLogger()
@@ -129,7 +132,10 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
     mementos.add(testSupport.install());
 
     WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport(DOMAIN_NAME);
-    configSupport.addWlsServer(ADMIN_SERVER, ADMIN_PORT).addNetworkAccessPoint(NAP_1, NAP_PORT_1);
+    configSupport
+        .addWlsServer(ADMIN_SERVER, ADMIN_PORT)
+        .addNetworkAccessPoint(NAP_1, NAP_PORT_1)
+        .addNetworkAccessPoint(NAP_2, NAP_PORT_2);
     configSupport.addWlsServer(TEST_SERVER, TEST_PORT, ADMIN_PORT);
     configSupport.addWlsCluster(TEST_CLUSTER, TEST_SERVER);
     configSupport.setAdminServerName(ADMIN_SERVER);
@@ -539,7 +545,8 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
   static class ExternalServiceTestFacade extends TestFacade {
     ExternalServiceTestFacade() {
       getExpectedNodePorts().put("default", TEST_NODE_PORT);
-      getExpectedNodePorts().put(NAP_1, TEST_NODE_NAP_PORT);
+      getExpectedNodePorts().put(LegalNames.toDNS1123LegalName(NAP_1), NAP1_NODE_PORT);
+      getExpectedNodePorts().put(LegalNames.toDNS1123LegalName(NAP_2), NAP_PORT_2);
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -564,7 +564,7 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
 
     @Override
     public String getServiceName() {
-      return LegalNames.toExternalServiceName(UID);
+      return LegalNames.toExternalServiceName(UID, ADMIN_SERVER);
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -1,24 +1,18 @@
-// Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static oracle.kubernetes.LogMatcher.containsFine;
 import static oracle.kubernetes.LogMatcher.containsInfo;
-import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.CLUSTER_NAME;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_SCAN;
-import static oracle.kubernetes.operator.VersionConstants.DEFAULT_DOMAIN_VERSION;
+import static oracle.kubernetes.operator.helpers.ServiceHelperTest.PortMatcher.containsPort;
+import static oracle.kubernetes.operator.helpers.ServiceHelperTest.ServiceNameMatcher.serviceWithName;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_CREATED;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_EXISTS;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_REPLACED;
@@ -28,59 +22,52 @@ import static oracle.kubernetes.operator.logging.MessageKeys.CLUSTER_SERVICE_REP
 import static oracle.kubernetes.operator.logging.MessageKeys.MANAGED_SERVICE_CREATED;
 import static oracle.kubernetes.operator.logging.MessageKeys.MANAGED_SERVICE_EXISTS;
 import static oracle.kubernetes.operator.logging.MessageKeys.MANAGED_SERVICE_REPLACED;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
-import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.Stub;
 import io.kubernetes.client.ApiException;
-import io.kubernetes.client.models.V1DeleteOptions;
-import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServicePort;
-import io.kubernetes.client.models.V1ServiceSpec;
-import io.kubernetes.client.models.V1Status;
-import java.net.HttpURLConnection;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
 import oracle.kubernetes.TestUtils;
-import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
+import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
+import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
-import oracle.kubernetes.weblogic.domain.v2.Domain;
-import oracle.kubernetes.weblogic.domain.v2.DomainSpec;
+import oracle.kubernetes.weblogic.domain.ServiceConfigurator;
+import org.hamcrest.Description;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-@SuppressWarnings({"SameParameterValue"})
-public class ServiceHelperTest {
+@RunWith(Parameterized.class)
+public class ServiceHelperTest extends ServiceHelperTestBase {
 
-  private static final String NS = "namespace";
   private static final String TEST_CLUSTER = "cluster-1";
   private static final int TEST_NODE_PORT = 7002;
-  private static final int BAD_NODE_PORT = 9900;
   private static final int TEST_PORT = 7000;
-  private static final int BAD_PORT = 9999;
+  private static final int ADMIN_PORT = 8000;
   private static final String DOMAIN_NAME = "domain1";
-  private static final String TEST_SERVER_NAME = "server1";
-  private static final String SERVICE_NAME = "service1";
-  private static final String UID = "uid1";
-  private static final String BAD_VERSION = "bad-version";
-  private static final String UNREADY_ENDPOINTS_ANNOTATION =
-      "service.alpha.kubernetes.io/tolerate-unready-endpoints";
+  private static final String TEST_SERVER = "server1";
   private static final String ADMIN_SERVER = "ADMIN_SERVER";
   private static final String[] MESSAGE_KEYS = {
     CLUSTER_SERVICE_CREATED,
@@ -93,16 +80,22 @@ public class ServiceHelperTest {
     ADMIN_SERVICE_REPLACED,
     MANAGED_SERVICE_REPLACED
   };
+  private static final String OLD_LABEL = "oldLabel";
+  private static final String OLD_ANNOTATION = "annotation";
+  private static final ClusterServiceTestFacade CLUSTER_SERVICE_TEST_FACADE =
+      new ClusterServiceTestFacade();
+  private static final ManagedServerTestFacade MANAGED_SERVER_TEST_FACADE =
+      new ManagedServerTestFacade();
+  private static final AdminServerTestFacade ADMIN_SERVER_TEST_FACADE = new AdminServerTestFacade();
+  private static final ExternalServiceTestFacade EXTERNAL_SERVICE_TEST_FACADE =
+      new ExternalServiceTestFacade();
 
-  private DomainPresenceInfo domainPresenceInfo = createPresenceInfo();
-  private AsyncCallTestSupport testSupport = new AsyncCallTestSupport();
-  private List<Memento> mementos = new ArrayList<>();
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final TerminalStep terminalStep = new TerminalStep();
   private RetryStrategyStub retryStrategy = createStrictStub(RetryStrategyStub.class);
   private List<LogRecord> logRecords = new ArrayList<>();
   private WlsDomainConfig domainConfig;
-
-  public ServiceHelperTest() {}
+  private WlsServerConfig serverConfig;
 
   @Before
   public void setUp() throws Exception {
@@ -111,38 +104,29 @@ public class ServiceHelperTest {
         TestUtils.silenceOperatorLogger()
             .collectLogMessages(logRecords, MESSAGE_KEYS)
             .withLogLevel(Level.FINE));
-    mementos.add(testSupport.installRequestStepFactory());
+    mementos.add(testSupport.install());
 
     WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport(DOMAIN_NAME);
-    configSupport.addWlsServer(ADMIN_SERVER, TEST_PORT);
-    configSupport.addWlsServer(TEST_SERVER_NAME, TEST_PORT);
-    configSupport.addWlsCluster(TEST_CLUSTER, TEST_SERVER_NAME);
+    configSupport.addWlsServer(ADMIN_SERVER, ADMIN_PORT);
+    configSupport.addWlsServer(TEST_SERVER, TEST_PORT, ADMIN_PORT);
+    configSupport.addWlsCluster(TEST_CLUSTER, TEST_SERVER);
     configSupport.setAdminServerName(ADMIN_SERVER);
 
     domainConfig = configSupport.createDomainConfig();
+    serverConfig = domainConfig.getServerConfig(testFacade.getServerName());
     testSupport
         .addToPacket(CLUSTER_NAME, TEST_CLUSTER)
-        .addToPacket(SERVER_NAME, TEST_SERVER_NAME)
-        .addToPacket(ProcessingConstants.DOMAIN_TOPOLOGY, domainConfig)
-        .addToPacket(SERVER_SCAN, domainConfig.getServerConfig(TEST_SERVER_NAME))
+        .addToPacket(SERVER_NAME, testFacade.getServerName())
+        .addToPacket(DOMAIN_TOPOLOGY, domainConfig)
+        .addToPacket(SERVER_SCAN, serverConfig)
         .addDomainPresenceInfo(domainPresenceInfo);
+    testFacade.configureService(configureDomain()).withServiceLabel(OLD_LABEL, "value");
+    testFacade.configureService(configureDomain()).withServiceAnnotation(OLD_ANNOTATION, "value");
   }
 
   @After
-  public void tearDown() throws Exception {
-    for (Memento memento : mementos) memento.revert();
-
+  public void tearDownServiceHelperTest() throws Exception {
     testSupport.throwOnCompletionFailure();
-    testSupport.verifyAllDefinedResponsesInvoked();
-  }
-
-  private DomainPresenceInfo createPresenceInfo() {
-    return new DomainPresenceInfo(
-        new Domain().withMetadata(new V1ObjectMeta().namespace(NS)).withSpec(createDomainSpec()));
-  }
-
-  private DomainSpec createDomainSpec() {
-    return new DomainSpec().withDomainUID(UID);
   }
 
   private AdminServerConfigurator configureAdminServer() {
@@ -153,661 +137,471 @@ public class ServiceHelperTest {
     return DomainConfiguratorFactory.forDomain(domainPresenceInfo.getDomain());
   }
 
-  // ------ service deletion --------
+  @Parameters(name = "{index} : {0} service test")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {"cluster", CLUSTER_SERVICE_TEST_FACADE},
+          {"managed server", MANAGED_SERVER_TEST_FACADE},
+          {"admin server", ADMIN_SERVER_TEST_FACADE},
+          {"external", EXTERNAL_SERVICE_TEST_FACADE}
+        });
+  }
+
+  @Parameter public String testType;
+
+  @Parameter(1)
+  public TestFacade testFacade;
 
   @Test
-  public void afterDeleteServiceStepRun_removeServiceFromSko() {
-    expectDeleteServiceCall().returning(new V1Status());
-    ServerKubernetesObjects sko = createSko(createMinimalService());
+  public void whenCreated_modelIncludesListenPorts() {
+    Assume.assumeFalse(testType.equals("external"));
 
-    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, terminalStep));
+    V1Service model = testFacade.createServiceModel(testSupport.getPacket());
 
-    assertThat(sko.getService().get(), nullValue());
-  }
-
-  private CallTestSupport.CannedResponse expectDeleteServiceCall() {
-    return testSupport
-        .createCannedResponse("deleteService")
-        .withName(SERVICE_NAME)
-        .withNamespace(NS)
-        .withBody(new V1DeleteOptions());
-  }
-
-  private V1Service createMinimalService() {
-    return new V1Service().metadata(new V1ObjectMeta().name(SERVICE_NAME));
-  }
-
-  private ServerKubernetesObjects createSko(V1Service service) {
-    ServerKubernetesObjects sko = new ServerKubernetesObjects();
-    sko.getService().set(service);
-    return sko;
+    assertThat(model, containsPort("default", testFacade.getExpectedListenPort()));
+    assertThat(model, containsPort("default-secure", testFacade.getExpectedSslListenPort()));
+    assertThat(model, containsPort("default-admin", testFacade.getExpectedAdminPort()));
   }
 
   @Test
-  public void whenServiceNotFound_removeServiceFromSko() {
-    expectDeleteServiceCall().failingWithStatus(HttpURLConnection.HTTP_NOT_FOUND);
-    ServerKubernetesObjects sko = createSko(createMinimalService());
+  public void onRunWithNoService_createIt() {
+    runServiceHelper();
 
-    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, terminalStep));
+    assertThat(getCreatedResources(), contains(serviceWithName(testFacade.getServiceName())));
+    assertThat(testFacade.getRecordedService(domainPresenceInfo), notNullValue());
+    assertThat(logRecords, containsInfo(testFacade.getServiceCreateLogMessage()));
+  }
 
-    assertThat(sko.getService().get(), nullValue());
+  private void runServiceHelper() {
+    testSupport.runSteps(testFacade.createSteps(terminalStep));
   }
 
   @Test
-  public void whenDeleteFails_reportCompletionFailure() {
-    expectDeleteServiceCall().failingWithStatus(HTTP_BAD_REQUEST);
-    ServerKubernetesObjects sko = createSko(createMinimalService());
-
-    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, terminalStep));
-
-    testSupport.verifyCompletionThrowable(ApiException.class);
-  }
-
-  @Test
-  public void whenDeleteServiceStepRunWithNoService_doNotSendDeleteCall() {
-    ServerKubernetesObjects sko = createSko(null);
-
-    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, terminalStep));
-
-    assertThat(sko.getService().get(), nullValue());
-  }
-
-  @Test
-  public void afterDeleteServiceStepRun_runSpecifiedNextStep() {
-    ServerKubernetesObjects sko = createSko(null);
-
-    testSupport.runSteps(ServiceHelper.deleteServicesStep(sko, terminalStep));
-
-    assertThat(terminalStep.wasRun(), is(true));
-  }
-
-  // ------ cluster service creation --------
-
-  @Test
-  public void onClusterStepRunWithNoService_createIt() {
-    initializeClusterServiceFromRecord(null);
-    expectSuccessfulCreateClusterService();
-
-    testSupport.runSteps(ServiceHelper.createForClusterStep(terminalStep));
-
-    assertThat(domainPresenceInfo.getClusters(), hasEntry(TEST_CLUSTER, createClusterService()));
-    assertThat(logRecords, containsInfo(CLUSTER_SERVICE_CREATED));
-  }
-
-  @Test
-  public void onClusterStepRunWithNoService_retryOnFailure() {
+  public void onFailedRun_reportFailure() {
     testSupport.addRetryStrategy(retryStrategy);
-    initializeClusterServiceFromRecord(null);
-    expectCreateClusterService().failingWithStatus(401);
+    testSupport.failOnResource(null, NS, 401);
 
-    Step forClusterStep = ServiceHelper.createForClusterStep(terminalStep);
-    testSupport.runSteps(forClusterStep);
+    runServiceHelper();
 
     testSupport.verifyCompletionThrowable(ApiException.class);
   }
 
   @Test
-  public void onClusterStepRunWithMatchingService_addToDomainPresenceInfo() {
-    V1Service service =
-        new V1Service()
-            .spec(createClusterServiceSpec())
-            .metadata(
-                new V1ObjectMeta().putLabelsItem(RESOURCE_VERSION_LABEL, DEFAULT_DOMAIN_VERSION));
-    initializeClusterServiceFromRecord(service);
+  public void whenMatchingServiceRecordedInDomainPresence_logServiceExists() {
+    V1Service originalService = testFacade.createServiceModel(testSupport.getPacket());
+    testFacade.recordService(domainPresenceInfo, originalService);
 
-    testSupport.runSteps(ServiceHelper.createForClusterStep(terminalStep));
+    runServiceHelper();
 
-    assertThat(domainPresenceInfo.getClusters(), hasEntry(TEST_CLUSTER, service));
-    assertThat(logRecords, containsFine(CLUSTER_SERVICE_EXISTS));
+    assertThat(logRecords, containsFine(testFacade.getServiceExistsLogMessage()));
   }
 
   @Test
-  public void onClusterStepRunWithMatchingServiceWithoutSpecType_addToDomainPresenceInfo() {
-    V1Service service =
-        new V1Service()
-            .spec(createUntypedClusterServiceSpec())
-            .metadata(
-                new V1ObjectMeta().putLabelsItem(RESOURCE_VERSION_LABEL, DEFAULT_DOMAIN_VERSION));
-    initializeClusterServiceFromRecord(service);
-
-    testSupport.runSteps(ServiceHelper.createForClusterStep(terminalStep));
-
-    assertThat(domainPresenceInfo.getClusters(), hasEntry(TEST_CLUSTER, service));
-    assertThat(logRecords, containsFine(CLUSTER_SERVICE_EXISTS));
+  public void whenLabelAdded_replaceService() {
+    verifyServiceReplaced(this::addNewLabel);
   }
 
   @Test
-  public void onClusterStepRunWithServiceWithBadVersion_replaceIt() {
-    verifyClusterServiceReplaced(this::withBadVersion);
+  public void whenLabelChanged_replaceService() {
+    verifyServiceReplaced(this::changeLabel);
   }
 
   @Test
-  public void onClusterStepRunWithServiceWithBadSpecType_replaceIt() {
-    verifyClusterServiceReplaced(this::withBadSpecType);
+  public void whenAnnotationAdded_replaceService() {
+    verifyServiceReplaced(this::addNewAnnotation);
   }
 
   @Test
-  public void onClusterStepRunWithServiceWithBadPort_replaceIt() {
-    verifyClusterServiceReplaced(this::withBadPort);
+  public void whenAnnotationChanged_replaceService() {
+    verifyServiceReplaced(this::changeAnnotation);
   }
 
   @Test
-  public void onClusterStepRunWithServiceWithLabelAdded_replaceIt() {
-    configureClusterWithLabel("anyLabel", "anyValue");
-    verifyClusterServiceReplaced(createClusterService(), withLabel(createClusterService()));
+  public void whenListenPortChanged_replaceService() {
+    verifyServiceReplaced(this::changeListenPort);
   }
 
   @Test
-  public void onClusterStepRunWithServiceWithLabelValueChanged_replaceIt() {
-    final String newLabelValue = "newValue";
-    configureClusterWithLabel("anyLabel", newLabelValue);
-    verifyClusterServiceReplaced(
-        withLabel(createClusterService()), withLabel(createClusterService(), newLabelValue));
+  public void whenSslListenPortChanged_replaceService() {
+    verifyServiceReplaced(this::changeSslListenPort);
   }
 
-  @Test
-  public void onClusterStepRunWithServiceWithLabelRemoved_replaceIt() {
-    verifyClusterServiceReplaced(this::withLabel);
+  private void verifyServiceReplaced(Runnable serviceMutator) {
+    Assume.assumeFalse(testType.equals("external"));
+
+    recordInitialService();
+    serviceMutator.run();
+
+    runServiceHelper();
+
+    assertThat(logRecords, containsInfo(testFacade.getServiceReplacedLogMessage()));
   }
 
-  @Test
-  public void onClusterStepRunWithServiceWithAnnotationAdded_replaceIt() {
-    configureClusterWithAnnotation("anyAnnotation", "anyValue");
-    verifyClusterServiceReplaced(createClusterService(), withAnnotation(createClusterService()));
+  private void addNewLabel() {
+    testFacade.configureService(configureDomain()).withServiceLabel("newLabel", "value");
   }
 
-  @Test
-  public void onClusterStepRunWithServiceWithAnnotationValueChanged_replaceIt() {
-    final String newAnnotationValue = "newValue";
-    configureClusterWithAnnotation("anyAnnotation", newAnnotationValue);
-    verifyClusterServiceReplaced(
-        withAnnotation(createClusterService()),
-        withAnnotation(createClusterService(), newAnnotationValue));
+  private void changeLabel() {
+    testFacade.configureService(configureDomain()).withServiceLabel(OLD_LABEL, "newValue");
   }
 
-  @Test
-  public void onClusterStepRunWithServiceWithAnnotationRemoved_replaceIt() {
-    verifyClusterServiceReplaced(this::withAnnotation);
+  private void addNewAnnotation() {
+    testFacade.configureService(configureDomain()).withServiceAnnotation("newAnnotation", "value");
   }
 
-  @Test
-  public void whenAttemptToReplaceBadClusterServiceFailsOnDelete_reportCompletionFailure() {
-    V1Service existingService = createClusterServiceWithBadPort();
-    initializeClusterServiceFromRecord(existingService);
-    expectDeleteService(getClusterServiceName()).failingWithStatus(HTTP_BAD_REQUEST);
-
-    testSupport.runSteps(ServiceHelper.createForClusterStep(terminalStep));
-
-    testSupport.verifyCompletionThrowable(ApiException.class);
+  private void changeAnnotation() {
+    testFacade.configureService(configureDomain()).withServiceLabel(OLD_ANNOTATION, "newValue");
   }
 
-  @Test
-  public void whenAttemptToReplaceBadClusterServiceFindsServiceMissing_replaceItAnyway() {
-    initializeClusterServiceFromRecord(createClusterServiceWithBadPort());
-    expectDeleteService(getClusterServiceName()).failingWithStatus(HTTP_NOT_FOUND);
-    expectSuccessfulCreateClusterService();
-    V1Service expectedService = createClusterService();
-
-    testSupport.runSteps(ServiceHelper.createForClusterStep(terminalStep));
-
-    assertThat(domainPresenceInfo.getClusters(), hasEntry(TEST_CLUSTER, expectedService));
-    assertThat(logRecords, containsInfo(CLUSTER_SERVICE_REPLACED));
+  private void changeListenPort() {
+    serverConfig.setListenPort(9900);
   }
 
-  private CallTestSupport.CannedResponse expectReadClusterService() {
-    return expectReadService(getClusterServiceName());
+  private void changeSslListenPort() {
+    serverConfig.setSslListenPort(9901);
   }
 
-  private void initializeClusterServiceFromRecord(V1Service service) {
-    if (service == null) {
-      domainPresenceInfo.getClusters().remove(TEST_CLUSTER);
-    } else {
-      domainPresenceInfo.getClusters().put(TEST_CLUSTER, service);
+  private void recordInitialService() {
+    V1Service originalService = testFacade.createServiceModel(testSupport.getPacket());
+    testSupport.defineResources(originalService);
+    testFacade.recordService(domainPresenceInfo, originalService);
+  }
+
+  private List<V1Service> getCreatedResources() {
+    return testSupport.getResources(KubernetesTestSupport.SERVICE);
+  }
+
+  interface TestFacade {
+    String getServiceCreateLogMessage();
+
+    String getServiceExistsLogMessage();
+
+    String getServiceReplacedLogMessage();
+
+    String getServerName();
+
+    String getServiceName();
+
+    Step createSteps(Step next);
+
+    V1Service createServiceModel(Packet packet);
+
+    V1Service getRecordedService(DomainPresenceInfo info);
+
+    void recordService(DomainPresenceInfo info, V1Service service);
+
+    Integer getExpectedListenPort();
+
+    default Integer getExpectedSslListenPort() {
+      return null;
+    }
+
+    default Integer getExpectedAdminPort() {
+      return null;
+    }
+
+    default ServiceConfigurator configureService(DomainConfigurator configurator) {
+      return Stub.createNiceStub(ServiceConfigurator.class);
     }
   }
 
-  private String getClusterServiceName() {
-    return LegalNames.toClusterServiceName(UID, TEST_CLUSTER);
-  }
-
-  private V1ServiceSpec createClusterServiceSpec() {
-    return createUntypedClusterServiceSpec().type("ClusterIP");
-  }
-
-  private V1ServiceSpec createUntypedClusterServiceSpec() {
-    return new V1ServiceSpec()
-        .putSelectorItem(DOMAINUID_LABEL, UID)
-        .putSelectorItem(CLUSTERNAME_LABEL, TEST_CLUSTER)
-        .putSelectorItem(CREATEDBYOPERATOR_LABEL, "true")
-        .ports(
-            Collections.singletonList(
-                new V1ServicePort().port(TEST_PORT).name("default").protocol("TCP")));
-  }
-
-  private void expectSuccessfulCreateClusterService() {
-    expectCreateClusterService().returning(createClusterService());
-  }
-
-  private CallTestSupport.CannedResponse expectCreateClusterService() {
-    return expectCreateService(createClusterService());
-  }
-
-  private V1Service createClusterService() {
-    return new V1Service()
-        .spec(createClusterServiceSpec())
-        .metadata(
-            new V1ObjectMeta()
-                .name(getClusterServiceName())
-                .namespace(NS)
-                .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DEFAULT_DOMAIN_VERSION)
-                .putLabelsItem(DOMAINUID_LABEL, UID)
-                .putLabelsItem(DOMAINNAME_LABEL, DOMAIN_NAME)
-                .putLabelsItem(CLUSTERNAME_LABEL, TEST_CLUSTER)
-                .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"));
-  }
-
-  private void expectDeleteServiceSuccessful(String serviceName) {
-    expectDeleteService(serviceName).returning(new V1Status());
-  }
-
-  private CallTestSupport.CannedResponse expectDeleteService(String serviceName) {
-    return testSupport
-        .createCannedResponse("deleteService")
-        .withNamespace(NS)
-        .withName(serviceName)
-        .withBody(new V1DeleteOptions());
-  }
-
-  private V1Service createClusterServiceWithBadVersion() {
-    return new V1Service()
-        .spec(createClusterServiceSpec())
-        .metadata(new V1ObjectMeta().putLabelsItem(RESOURCE_VERSION_LABEL, BAD_VERSION));
-  }
-
-  private V1Service createClusterServiceWithBadPort() {
-    return new V1Service()
-        .spec(createSpecWithBadPort())
-        .metadata(new V1ObjectMeta().putLabelsItem(RESOURCE_VERSION_LABEL, DEFAULT_DOMAIN_VERSION));
-  }
-
-  private V1ServiceSpec createSpecWithBadPort() {
-    return new V1ServiceSpec()
-        .type("ClusterIP")
-        .ports(Collections.singletonList(new V1ServicePort().port(BAD_PORT)));
-  }
-
-  // ------ per-server service creation --------
-
-  @Test
-  public void onServerStepRunWithNoService_createIt() {
-    verifyMissingServerServiceCreated(createServerService());
-  }
-
-  private void verifyMissingServerServiceCreated(V1Service newService) {
-    initializeServiceFromRecord(null);
-    expectCreateService(newService).returning(newService);
-
-    testSupport.runSteps(ServiceHelper.createForServerStep(terminalStep));
-
-    assertThat(logRecords, containsInfo(MANAGED_SERVICE_CREATED));
-  }
-
-  @Test
-  public void whenSupported_createServerServiceWithPublishNotReadyAddresses() {
-    testSupport.addVersion(new KubernetesVersion(1, 8));
-
-    verifyMissingServerServiceCreated(withPublishNotReadyAddresses(createServerService()));
-  }
-
-  private V1Service withPublishNotReadyAddresses(V1Service service) {
-    service.getSpec().setPublishNotReadyAddresses(true);
-    return service;
-  }
-
-  private V1Service withNodePort(V1Service service, int nodePort) {
-    service.getSpec().type("NodePort").clusterIP(null);
-    service.getSpec().getPorts().stream()
-        .findFirst()
-        .ifPresent(servicePort -> servicePort.setNodePort(nodePort));
-    return service;
-  }
-
-  @Test
-  public void onServerStepRunWithNoService_retryOnFailure() {
-    testSupport.addRetryStrategy(retryStrategy);
-    initializeServiceFromRecord(null);
-    expectCreateServerService().failingWithStatus(HTTP_BAD_REQUEST);
-
-    Step forServerStep = ServiceHelper.createForServerStep(terminalStep);
-    testSupport.runSteps(forServerStep);
-
-    testSupport.verifyCompletionThrowable(ApiException.class);
-  }
-
-  @Test
-  public void onServerStepRunWithMatchingService_addToSko() {
-    initializeServiceFromRecord(createServerService());
-
-    testSupport.runSteps(ServiceHelper.createForServerStep(terminalStep));
-
-    assertThat(logRecords, containsFine(MANAGED_SERVICE_EXISTS));
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithBadVersion_replaceIt() {
-    verifyServerServiceReplaced(this::withBadVersion);
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithLabelAdded_replaceIt() {
-    configureManagedServerWithLabel("anyLabel", "anyValue");
-    verifyServerServiceReplaced(createServerService(), withLabel(createServerService()));
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithLabelValueChanged_replaceIt() {
-    final String newLabelValue = "newValue";
-    configureManagedServerWithLabel("anyLabel", newLabelValue);
-    verifyServerServiceReplaced(
-        withLabel(createServerService()), withLabel(createServerService(), newLabelValue));
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithLabelRemoved_replaceIt() {
-    verifyServerServiceReplaced(this::withLabel);
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithAnnotationAdded_replaceIt() {
-    configureManagedServerWithAnnotation("anyAnnotation", "anyValue");
-    verifyServerServiceReplaced(createServerService(), withAnnotation(createServerService()));
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithAnnotationValueChanged_replaceIt() {
-    final String newAnnotationValue = "newValue";
-    configureManagedServerWithAnnotation("anyAnnotation", newAnnotationValue);
-    verifyServerServiceReplaced(
-        withAnnotation(createServerService()),
-        withAnnotation(createServerService(), newAnnotationValue));
-  }
-
-  @Test
-  public void onServerStepRunWithServiceWithAnnotationRemoved_replaceIt() {
-    verifyServerServiceReplaced(this::withAnnotation);
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithBadVersion_replaceIt() {
-    verifyExternalServiceReplaced(this::withBadVersion);
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithBadPort_replaceIt() {
-    verifyExternalServiceReplaced(this::withBadPort);
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithBadNodePort_replaceIt() {
-    verifyExternalServiceReplaced(this::withBadNodePort);
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithLabelAdded_replaceIt() {
-    configureAdminServerWithLabel("anyLabel", "anyValue");
-    verifyExternalServiceReplaced(createAdminService(), withLabel(createAdminService()));
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithLabelValueChanged_replaceIt() {
-    final String newLabelValue = "newValue";
-    configureAdminServerWithLabel("anyLabel", newLabelValue);
-    verifyExternalServiceReplaced(
-        withLabel(createAdminService()), withLabel(createAdminService(), newLabelValue));
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithLabelRemoved_replaceIt() {
-    verifyExternalServiceReplaced(this::withLabel);
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithAnnotationAdded_replaceIt() {
-    configureAdminServerWithAnnotation("anyAnnotation", "anyValue");
-    verifyExternalServiceReplaced(createAdminService(), withAnnotation(createAdminService()));
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithAnnotationValueChanged_replaceIt() {
-    final String newAnnotationValue = "newValue";
-    configureAdminServerWithAnnotation("anyAnnotation", newAnnotationValue);
-    verifyExternalServiceReplaced(
-        withAnnotation(createAdminService()),
-        withAnnotation(createAdminService(), newAnnotationValue));
-  }
-
-  @Test
-  public void onExternalServiceStepRunWithServiceWithAnnotationRemoved_replaceIt() {
-    verifyExternalServiceReplaced(this::withAnnotation);
-  }
-
-  private void verifyServerServiceReplaced(V1Service oldService, V1Service newService) {
-    initializeServiceFromRecord(oldService);
-    expectDeleteServiceSuccessful(getServerServiceName());
-    expectSuccessfulCreateService(newService);
-
-    testSupport.runSteps(ServiceHelper.createForServerStep(terminalStep));
-
-    assertThat(logRecords, containsInfo(MANAGED_SERVICE_REPLACED));
-  }
-
-  private void verifyExternalServiceReplaced(ServiceMutator mutator) {
-    verifyExternalServiceReplaced(mutator.change(createAdminService()), createAdminService());
-  }
-
-  private void verifyExternalServiceReplaced(V1Service oldService, V1Service newService) {
-    initializeAdminServiceFromRecord(oldService);
-    expectDeleteServiceSuccessful(getAdminServiceName());
-    expectSuccessfulCreateService(newService);
-
-    testSupport.addToPacket(SERVER_SCAN, domainConfig.getServerConfig(ADMIN_SERVER));
-    testSupport.addToPacket(SERVER_NAME, ADMIN_SERVER);
-    testSupport.runSteps(ServiceHelper.createForExternalServiceStep(terminalStep));
-
-    assertThat(logRecords, containsInfo(ADMIN_SERVICE_REPLACED));
-  }
-
-  private void verifyServerServiceReplaced(ServiceMutator mutator) {
-    verifyServerServiceReplaced(mutator.change(createServerService()), createServerService());
-  }
-
-  private void verifyClusterServiceReplaced(ServiceMutator mutator) {
-    verifyClusterServiceReplaced(mutator.change(createClusterService()), createClusterService());
-  }
-
-  private void verifyClusterServiceReplaced(V1Service oldService, V1Service newService) {
-    initializeClusterServiceFromRecord(oldService);
-    expectDeleteServiceSuccessful(getClusterServiceName());
-    expectCreateService(newService).returning(newService);
-
-    testSupport.runSteps(ServiceHelper.createForClusterStep(terminalStep));
-
-    assertThat(domainPresenceInfo.getClusters(), hasEntry(TEST_CLUSTER, newService));
-    assertThat(logRecords, containsInfo(CLUSTER_SERVICE_REPLACED));
-  }
-
-  private V1ServiceSpec createServerServiceSpec() {
-    return createUntypedServerServiceSpec(TEST_SERVER_NAME).type("ClusterIP").clusterIP("None");
-  }
-
-  private V1ServiceSpec createUntypedServerServiceSpec(String serverName) {
-    return new V1ServiceSpec()
-        .putSelectorItem(DOMAINUID_LABEL, UID)
-        .putSelectorItem(SERVERNAME_LABEL, serverName)
-        .putSelectorItem(CREATEDBYOPERATOR_LABEL, "true")
-        .ports(
-            Collections.singletonList(
-                new V1ServicePort().port(TEST_PORT).name("default").protocol("TCP")));
-  }
-
-  private void initializeServiceFromRecord(V1Service service) {
-    domainPresenceInfo.getServers().put(TEST_SERVER_NAME, createSko(service));
-  }
-
-  private void initializeAdminServiceFromRecord(V1Service service) {
-    domainPresenceInfo.getServers().put(ADMIN_SERVER, createSko(service));
-  }
-
-  private String getServerServiceName() {
-    return LegalNames.toServerServiceName(UID, TEST_SERVER_NAME);
-  }
-
-  private String getAdminServiceName() {
-    return LegalNames.toExternalServiceName(UID, ADMIN_SERVER);
-  }
-
-  private void expectSuccessfulCreateService(V1Service service) {
-    expectCreateService(service).returning(service);
-  }
-
-  private CallTestSupport.CannedResponse expectCreateServerService() {
-    return expectCreateService(createServerService());
-  }
-
-  private CallTestSupport.CannedResponse expectCreateService(V1Service service) {
-    return testSupport.createCannedResponse("createService").withNamespace(NS).withBody(service);
-  }
-
-  private V1Service createServerService() {
-    return createServerService(createServerServiceSpec());
-  }
-
-  private V1Service createServerService(V1ServiceSpec serviceSpec) {
-    return new V1Service()
-        .spec(serviceSpec)
-        .metadata(
-            new V1ObjectMeta()
-                .name(getServerServiceName())
-                .namespace(NS)
-                .putAnnotationsItem(UNREADY_ENDPOINTS_ANNOTATION, "true")
-                .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V2)
-                .putLabelsItem(DOMAINUID_LABEL, UID)
-                .putLabelsItem(DOMAINNAME_LABEL, DOMAIN_NAME)
-                .putLabelsItem(CLUSTERNAME_LABEL, TEST_CLUSTER)
-                .putLabelsItem(SERVERNAME_LABEL, TEST_SERVER_NAME)
-                .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"));
-  }
-
-  private V1Service createAdminService() {
-    return createAdminService(createAdminServiceSpec());
-  }
-
-  private V1Service createAdminService(V1ServiceSpec serviceSpec) {
-    return new V1Service()
-        .spec(serviceSpec)
-        .metadata(
-            new V1ObjectMeta()
-                .name(getAdminServiceName())
-                .namespace(NS)
-                .putLabelsItem(RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V2)
-                .putLabelsItem(DOMAINUID_LABEL, UID)
-                .putLabelsItem(DOMAINNAME_LABEL, DOMAIN_NAME)
-                .putLabelsItem(SERVERNAME_LABEL, ADMIN_SERVER)
-                .putLabelsItem(CLUSTERNAME_LABEL, TEST_CLUSTER)
-                .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"));
-  }
-
-  private V1ServiceSpec createAdminServiceSpec() {
-    final V1ServiceSpec serviceSpec = createUntypedServerServiceSpec(ADMIN_SERVER).type("NodePort");
-
-    serviceSpec.getPorts().stream().findAny().ifPresent(port -> port.setNodePort(TEST_NODE_PORT));
-
-    return serviceSpec;
-  }
-
-  interface ServiceMutator {
-    V1Service change(V1Service original);
-  }
-
-  private V1Service withBadVersion(V1Service service) {
-    service.getMetadata().putLabelsItem(RESOURCE_VERSION_LABEL, BAD_VERSION);
-    return service;
-  }
-
-  private V1Service withBadSpecType(V1Service service) {
-    service.getSpec().type("BadType");
-    return service;
-  }
-
-  private V1Service withBadPort(V1Service service) {
-    List<V1ServicePort> ports = service.getSpec().getPorts();
-    assertThat(ports.size(), is(1));
-
-    ports.stream().findAny().get().setPort(BAD_PORT);
-    return service;
-  }
-
-  private V1Service withBadNodePort(V1Service service) {
-    List<V1ServicePort> ports = service.getSpec().getPorts();
-    assertThat(ports.size(), is(1));
-
-    ports.stream().findAny().get().setNodePort(BAD_NODE_PORT);
-    return service;
-  }
-
-  private V1Service withLabel(V1Service service) {
-    return withLabel(service, "anyValue");
-  }
-
-  private V1Service withLabel(V1Service service, String labelValue) {
-    final String labelName = "anyLabel";
-
-    assertThat(service.getMetadata().getLabels(), not(hasKey(labelName)));
-    service.getMetadata().putLabelsItem(labelName, labelValue);
-    assertThat(service.getMetadata().getLabels(), hasKey(labelName));
-
-    return service;
-  }
-
-  private V1Service withAnnotation(V1Service service) {
-    return withAnnotation(service, "anyValue");
-  }
-
-  private V1Service withAnnotation(V1Service service, String value) {
-    final String annotationName = "anyAnnotation";
-
-    assertThat(service.getMetadata().getAnnotations(), not(hasKey(annotationName)));
-    service.getMetadata().putAnnotationsItem(annotationName, value);
-    assertThat(service.getMetadata().getAnnotations(), hasKey(annotationName));
-
-    return service;
-  }
-
-  private void configureClusterWithLabel(String label, String value) {
-    configureDomain().configureCluster(TEST_CLUSTER).withServiceLabel(label, value);
-  }
-
-  private void configureClusterWithAnnotation(String annotation, String value) {
-    configureDomain().configureCluster(TEST_CLUSTER).withServiceAnnotation(annotation, value);
-  }
-
-  private void configureManagedServerWithLabel(String label, String value) {
-    configureDomain().configureServer(TEST_SERVER_NAME).withServiceLabel(label, value);
-  }
-
-  private void configureManagedServerWithAnnotation(String annotation, String value) {
-    configureDomain().configureServer(TEST_SERVER_NAME).withServiceAnnotation(annotation, value);
-  }
-
-  private void configureAdminServerWithLabel(String label, String value) {
-    configureDomain().configureAdminServer().withServiceLabel(label, value);
-  }
-
-  private void configureAdminServerWithAnnotation(String annotation, String value) {
-    configureDomain().configureAdminServer().withServiceAnnotation(annotation, value);
-  }
-
-  private CallTestSupport.CannedResponse expectReadService(String serviceName) {
-    return testSupport.createCannedResponse("readService").withNamespace(NS).withName(serviceName);
+  static class ClusterServiceTestFacade implements TestFacade {
+    @Override
+    public String getServiceCreateLogMessage() {
+      return CLUSTER_SERVICE_CREATED;
+    }
+
+    @Override
+    public String getServiceExistsLogMessage() {
+      return CLUSTER_SERVICE_EXISTS;
+    }
+
+    @Override
+    public String getServiceReplacedLogMessage() {
+      return CLUSTER_SERVICE_REPLACED;
+    }
+
+    @Override
+    public String getServerName() {
+      return TEST_SERVER;
+    }
+
+    @Override
+    public String getServiceName() {
+      return LegalNames.toClusterServiceName(UID, TEST_CLUSTER);
+    }
+
+    @Override
+    public Step createSteps(Step next) {
+      return ServiceHelper.createForClusterStep(next);
+    }
+
+    @Override
+    public V1Service createServiceModel(Packet packet) {
+      return ServiceHelper.createClusterServiceModel(packet);
+    }
+
+    @Override
+    public V1Service getRecordedService(DomainPresenceInfo info) {
+      return info.getClusters().get(TEST_CLUSTER);
+    }
+
+    @Override
+    public void recordService(DomainPresenceInfo info, V1Service service) {
+      info.getClusters().put(TEST_CLUSTER, service);
+    }
+
+    @Override
+    public Integer getExpectedListenPort() {
+      return TEST_PORT;
+    }
+
+    @Override
+    public Integer getExpectedAdminPort() {
+      return ADMIN_PORT;
+    }
+
+    @Override
+    public ServiceConfigurator configureService(DomainConfigurator configurator) {
+      return configurator.configureCluster(TEST_CLUSTER);
+    }
+  }
+
+  abstract static class ServerTestFacade implements TestFacade {
+
+    @Override
+    public String getServiceName() {
+      return LegalNames.toServerServiceName(UID, getServerName());
+    }
+
+    @Override
+    public Step createSteps(Step next) {
+      return ServiceHelper.createForServerStep(next);
+    }
+
+    @Override
+    public V1Service createServiceModel(Packet packet) {
+      return ServiceHelper.createServerServiceModel(packet);
+    }
+
+    @Override
+    public V1Service getRecordedService(DomainPresenceInfo info) {
+      return info.getServers().get(getServerName()).getService().get();
+    }
+
+    @Override
+    public void recordService(DomainPresenceInfo info, V1Service service) {
+      info.getServers().put(getServerName(), createSko(service));
+    }
+
+    @Override
+    public ServiceConfigurator configureService(DomainConfigurator configurator) {
+      return configurator.configureServer(getServerName());
+    }
+  }
+
+  static class ManagedServerTestFacade extends ServerTestFacade {
+    @Override
+    public String getServiceCreateLogMessage() {
+      return MANAGED_SERVICE_CREATED;
+    }
+
+    @Override
+    public String getServiceExistsLogMessage() {
+      return MANAGED_SERVICE_EXISTS;
+    }
+
+    @Override
+    public String getServiceReplacedLogMessage() {
+      return MANAGED_SERVICE_REPLACED;
+    }
+
+    @Override
+    public Integer getExpectedListenPort() {
+      return TEST_PORT;
+    }
+
+    @Override
+    public Integer getExpectedAdminPort() {
+      return ADMIN_PORT;
+    }
+
+    @Override
+    public String getServerName() {
+      return TEST_SERVER;
+    }
+  }
+
+  static class AdminServerTestFacade extends ServerTestFacade {
+    @Override
+    public String getServiceCreateLogMessage() {
+      return ADMIN_SERVICE_CREATED;
+    }
+
+    @Override
+    public String getServiceExistsLogMessage() {
+      return ADMIN_SERVICE_EXISTS;
+    }
+
+    @Override
+    public String getServiceReplacedLogMessage() {
+      return ADMIN_SERVICE_REPLACED;
+    }
+
+    @Override
+    public Integer getExpectedListenPort() {
+      return ADMIN_PORT;
+    }
+
+    @Override
+    public String getServerName() {
+      return ADMIN_SERVER;
+    }
+  }
+
+  static class ExternalServiceTestFacade implements TestFacade {
+    @Override
+    public String getServiceCreateLogMessage() {
+      return ADMIN_SERVICE_CREATED;
+    }
+
+    @Override
+    public String getServiceExistsLogMessage() {
+      return ADMIN_SERVICE_EXISTS;
+    }
+
+    @Override
+    public String getServiceReplacedLogMessage() {
+      return ADMIN_SERVICE_REPLACED;
+    }
+
+    @Override
+    public String getServerName() {
+      return ADMIN_SERVER;
+    }
+
+    @Override
+    public String getServiceName() {
+      return LegalNames.toExternalServiceName(UID, ADMIN_SERVER);
+    }
+
+    @Override
+    public Step createSteps(Step next) {
+      return ServiceHelper.createForExternalServiceStep(next);
+    }
+
+    @Override
+    public V1Service createServiceModel(Packet packet) {
+      return ServiceHelper.createExternalServiceModel(packet);
+    }
+
+    @Override
+    public V1Service getRecordedService(DomainPresenceInfo info) {
+      return info.getServers().get(ADMIN_SERVER).getService().get();
+    }
+
+    @Override
+    public void recordService(DomainPresenceInfo info, V1Service service) {
+      info.getServers().put(ADMIN_SERVER, createSko(service));
+    }
+
+    @Override
+    public Integer getExpectedListenPort() {
+      return null;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  static class ServiceNameMatcher
+      extends org.hamcrest.TypeSafeDiagnosingMatcher<io.kubernetes.client.models.V1Service> {
+    private String expectedName;
+
+    private ServiceNameMatcher(String expectedName) {
+      this.expectedName = expectedName;
+    }
+
+    static ServiceNameMatcher serviceWithName(String expectedName) {
+      return new ServiceNameMatcher(expectedName);
+    }
+
+    @Override
+    protected boolean matchesSafely(V1Service item, Description mismatchDescription) {
+      if (expectedName.equals(getName(item))) return true;
+
+      mismatchDescription.appendText("service with name ").appendValue(getName(item));
+      return false;
+    }
+
+    private String getName(V1Service item) {
+      return item.getMetadata().getName();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("service with name ").appendValue(expectedName);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  static class PortMatcher
+      extends org.hamcrest.TypeSafeDiagnosingMatcher<io.kubernetes.client.models.V1Service> {
+    @Nonnull private final String expectedName;
+    private final Integer expectedValue;
+    private final Integer expectedNodePort;
+
+    private PortMatcher(@Nonnull String expectedName, Integer expectedValue, Integer nodePort) {
+      this.expectedName = expectedName;
+      this.expectedValue = expectedValue;
+      this.expectedNodePort = nodePort;
+    }
+
+    static PortMatcher containsPort(@Nonnull String expectedName, Integer expectedValue) {
+      return new PortMatcher(expectedName, expectedValue, null);
+    }
+
+    @Override
+    protected boolean matchesSafely(V1Service item, Description mismatchDescription) {
+      V1ServicePort matchingPort = getPortWithName(item);
+
+      if (matchingPort == null) {
+        if (expectedValue == null) return true;
+        mismatchDescription.appendText("contains no port with name ").appendValue(expectedName);
+        return false;
+      } else {
+        if (matchSelectedPort(matchingPort)) return true;
+        mismatchDescription.appendText("contains port ").appendValue(matchingPort);
+        return false;
+      }
+    }
+
+    private boolean matchSelectedPort(V1ServicePort matchingPort) {
+      return "TCP".equals(matchingPort.getProtocol())
+          && Objects.equals(expectedValue, matchingPort.getPort())
+          && Objects.equals(expectedNodePort, matchingPort.getNodePort());
+    }
+
+    private V1ServicePort getPortWithName(V1Service item) {
+      return item.getSpec().getPorts().stream().filter(this::hasName).findFirst().orElse(null);
+    }
+
+    private boolean hasName(V1ServicePort p) {
+      return expectedName.equals(p.getName());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      if (expectedValue == null)
+        description.appendText("service with no port named ").appendValue(expectedName);
+      else {
+        description
+            .appendText("service with TCP port with name ")
+            .appendValue(expectedName)
+            .appendText(", number ")
+            .appendValue(expectedValue);
+        if (expectedNodePort != null)
+          description.appendText(" and node port ").appendValue(expectedNodePort);
+      }
+    }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTestBase.java
@@ -1,0 +1,42 @@
+// Copyright 2019 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import com.meterware.simplestub.Memento;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Service;
+import java.util.ArrayList;
+import java.util.List;
+import oracle.kubernetes.weblogic.domain.v2.Domain;
+import oracle.kubernetes.weblogic.domain.v2.DomainSpec;
+import org.junit.After;
+
+public class ServiceHelperTestBase {
+  protected static final String SERVICE_NAME = "service1";
+  protected static final String NS = "namespace";
+  protected static final String UID = "uid1";
+  protected List<Memento> mementos = new ArrayList<>();
+  protected DomainPresenceInfo domainPresenceInfo = createPresenceInfo();
+
+  static ServerKubernetesObjects createSko(V1Service service) {
+    ServerKubernetesObjects sko = new ServerKubernetesObjects();
+    sko.getService().set(service);
+    return sko;
+  }
+
+  @After
+  public void tearDown() {
+    for (Memento memento : mementos) memento.revert();
+  }
+
+  private DomainPresenceInfo createPresenceInfo() {
+    return new DomainPresenceInfo(
+        new Domain().withMetadata(new V1ObjectMeta().namespace(NS)).withSpec(createDomainSpec()));
+  }
+
+  private DomainSpec createDomainSpec() {
+    return new DomainSpec().withDomainUID(UID);
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfigTest.java
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -665,7 +665,7 @@ public class WlsClusterConfigTest {
   static WlsDynamicServersConfig createDynamicServersConfig(
       int clusterSize, int maxClusterSize, String serverNamePrefix, String clusterName) {
     WlsServerConfig serverTemplate =
-        new WlsServerConfig("serverTemplate1", 7001, "host1", 7002, false, null, null, null, false);
+        new WlsServerConfig("serverTemplate1", "host1", null, 7001, 7002, null, null);
     List<String> serverNames = new ArrayList<>();
     final int startingServerNameIndex = 1;
     for (int i = 0; i < clusterSize; i++) {

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServerConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServerConfigTest.java
@@ -1,4 +1,4 @@
-// Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2018,2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -19,8 +19,7 @@ public class WlsDynamicServerConfigTest {
     List<NetworkAccessPoint> networkAccessPointList = new ArrayList<>();
     networkAccessPointList.add(networkAccessPoint);
     WlsServerConfig template =
-        new WlsServerConfig(
-            "template1", 1000, null, 2000, true, null, networkAccessPointList, null, false);
+        new WlsServerConfig("template1", null, null, 1000, 2000, null, networkAccessPointList);
 
     WlsServerConfig wlsServerConfig =
         WlsDynamicServerConfig.create("server1", 2, "cluster1", "domain1", false, template);
@@ -38,8 +37,7 @@ public class WlsDynamicServerConfigTest {
     List<NetworkAccessPoint> networkAccessPointList = new ArrayList<>();
     networkAccessPointList.add(networkAccessPoint);
     WlsServerConfig template =
-        new WlsServerConfig(
-            "template1", null, null, null, true, null, networkAccessPointList, null, false);
+        new WlsServerConfig("template1", null, null, null, null, null, networkAccessPointList);
 
     WlsServerConfig wlsServerConfig =
         WlsDynamicServerConfig.create("server1", 2, "cluster1", "domain1", false, template);
@@ -57,8 +55,7 @@ public class WlsDynamicServerConfigTest {
     List<NetworkAccessPoint> networkAccessPointList = new ArrayList<>();
     networkAccessPointList.add(networkAccessPoint);
     WlsServerConfig template =
-        new WlsServerConfig(
-            "template1", 1000, null, 2000, true, null, networkAccessPointList, null, false);
+        new WlsServerConfig("template1", null, null, 1000, 2000, null, networkAccessPointList);
 
     WlsServerConfig wlsServerConfig =
         WlsDynamicServerConfig.create("server1", 2, "cluster1", "domain1", true, template);
@@ -76,8 +73,7 @@ public class WlsDynamicServerConfigTest {
     List<NetworkAccessPoint> networkAccessPointList = new ArrayList<>();
     networkAccessPointList.add(networkAccessPoint);
     WlsServerConfig template =
-        new WlsServerConfig(
-            "template1", null, null, null, true, null, networkAccessPointList, null, false);
+        new WlsServerConfig("template1", null, null, null, null, null, networkAccessPointList);
 
     WlsServerConfig wlsServerConfig =
         WlsDynamicServerConfig.create("server1", 2, "cluster1", "domain1", true, template);


### PR DESCRIPTION
This is a step towards addressing OWLS-72379 and OWLS-72614.

The previous tests not only used the old mock-style (specifying the exact k8s calls to be made), they looked for services to be replaced after the life ones were modified. Given our experience with OpenShift, that it not a viable approach, so the new tests accomplish much the same by changing the domain to generate revised services. I have also simplified the testing and handled common cases via parameterization.

In doing this work, it became clear that there are some problems with the implementation of the External Service:

1. The "labels" and "annotations" fields of adminService were never implemented
2. The service is being added to the domain presence as a server service for the admin server

In addition, it is not clear to me that the correct node ports are being created, and I would like an explanation of the intent. I have marked a number of tests disabled for the external service, pending some clarification and corrections.

