### PR TITLE
OWLS-71987 - Re-enable load balancing test and add logging of service and pods info if it fails

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -332,7 +332,7 @@ public class BaseTest {
               + replicas);
     }
     // commenting the load balance check, bug 29325139
-    // domain.verifyWebAppLoadBalancing(TESTWEBAPP);
+    domain.verifyWebAppLoadBalancing(TESTWEBAPP);
     logger.info("Done - testClusterScaling");
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -315,11 +315,6 @@ public class BaseTest {
               + replicas);
     }
 
-    // print service (TODO- only if failed)
-    TestUtils.describeService(domainNS, domainUid + "-cluster-" + clusterName);
-    TestUtils.getPods(domainNS);
-
-    // commenting the load balance check, bug 29325139
     domain.verifyWebAppLoadBalancing(TESTWEBAPP);
 
     replicas = 2;
@@ -338,10 +333,7 @@ public class BaseTest {
               + "/"
               + replicas);
     }
-    // print services (TODO- only if failed)
-    TestUtils.describeService(domainNS, domainUid + "-cluster-" + clusterName);
 
-    // commenting the load balance check, bug 29325139
     domain.verifyWebAppLoadBalancing(TESTWEBAPP);
 
     logger.info("Done - testClusterScaling");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -315,6 +315,9 @@ public class BaseTest {
               + replicas);
     }
 
+    // print services (TODO- only if failed)
+    TestUtils.getServices(domainNS);
+
     // commenting the load balance check, bug 29325139
     domain.verifyWebAppLoadBalancing(TESTWEBAPP);
 
@@ -334,8 +337,12 @@ public class BaseTest {
               + "/"
               + replicas);
     }
+    // print services (TODO- only if failed)
+    TestUtils.getServices(domainNS);
+
     // commenting the load balance check, bug 29325139
-    // domain.verifyWebAppLoadBalancing(TESTWEBAPP);
+    domain.verifyWebAppLoadBalancing(TESTWEBAPP);
+
     logger.info("Done - testClusterScaling");
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -315,8 +315,9 @@ public class BaseTest {
               + replicas);
     }
 
-    // print services (TODO- only if failed)
-    TestUtils.getServices(domainNS);
+    // print service (TODO- only if failed)
+    TestUtils.describeService(domainNS, domainUid + "-cluster-" + clusterName);
+    TestUtils.getPods(domainNS);
 
     // commenting the load balance check, bug 29325139
     domain.verifyWebAppLoadBalancing(TESTWEBAPP);
@@ -338,7 +339,7 @@ public class BaseTest {
               + replicas);
     }
     // print services (TODO- only if failed)
-    TestUtils.getServices(domainNS);
+    TestUtils.describeService(domainNS, domainUid + "-cluster-" + clusterName);
 
     // commenting the load balance check, bug 29325139
     domain.verifyWebAppLoadBalancing(TESTWEBAPP);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -315,6 +315,9 @@ public class BaseTest {
               + replicas);
     }
 
+    // commenting the load balance check, bug 29325139
+    domain.verifyWebAppLoadBalancing(TESTWEBAPP);
+
     replicas = 2;
     podName = domainUid + "-" + managedServerNameBase + (replicas + 1);
     logger.info("Scale down to " + replicas + " managed servers");
@@ -332,7 +335,7 @@ public class BaseTest {
               + replicas);
     }
     // commenting the load balance check, bug 29325139
-    domain.verifyWebAppLoadBalancing(TESTWEBAPP);
+    // domain.verifyWebAppLoadBalancing(TESTWEBAPP);
     logger.info("Done - testClusterScaling");
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1068,10 +1068,14 @@ public class Domain {
       }
     }
     logger.info("ManagedServers " + managedServers);
+
     // error if any managedserver value is false
     if (verifyLoadBalancing) {
       for (Map.Entry<String, Boolean> entry : managedServers.entrySet()) {
         if (!entry.getValue().booleanValue()) {
+          // print service and pods info for debugging
+          TestUtils.describeService(domainNS, domainUid + "-cluster-" + clusterName);
+          TestUtils.getPods(domainNS);
           throw new RuntimeException(
               "FAILURE: Load balancer can not reach server " + entry.getKey());
         }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -239,9 +239,7 @@ public class TestUtils {
     logger.info(" Find services in namespage " + namespace + " with command: '" + cmd + "'");
 
     ExecResult result = ExecCommand.exec(cmd.toString());
-    String stdout = result.stdout();
-    logger.info(" Services found: ");
-    logger.info(stdout);
+    String stdout = getServices(namespace);
     String stdoutlines[] = stdout.split("\\r?\\n");
     if (result.exitValue() == 0 && stdoutlines.length > 0) {
       for (String stdoutline : stdoutlines) {
@@ -251,6 +249,18 @@ public class TestUtils {
       }
     }
     return false;
+  }
+
+  public static String getServices(String namespace) throws Exception {
+    StringBuffer cmd = new StringBuffer("kubectl get services ");
+    cmd.append(" -n ").append(namespace);
+    logger.info(" Find services in namespage " + namespace + " with command: '" + cmd + "'");
+
+    ExecResult result = ExecCommand.exec(cmd.toString());
+    String stdout = result.stdout();
+    logger.info(" Services found: ");
+    logger.info(stdout);
+    return stdout;
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -239,7 +239,9 @@ public class TestUtils {
     logger.info(" Find services in namespage " + namespace + " with command: '" + cmd + "'");
 
     ExecResult result = ExecCommand.exec(cmd.toString());
-    String stdout = getServices(namespace);
+    String stdout = result.stdout();
+    logger.info(" Services found: ");
+    logger.info(stdout);
     String stdoutlines[] = stdout.split("\\r?\\n");
     if (result.exitValue() == 0 && stdoutlines.length > 0) {
       for (String stdoutline : stdoutlines) {
@@ -251,18 +253,52 @@ public class TestUtils {
     return false;
   }
 
-  public static String getServices(String namespace) throws Exception {
-    StringBuffer cmd = new StringBuffer("kubectl get services ");
+  /**
+   * kubectl describe service serviceName -n namespace
+   *
+   * @param namespace namespace where the service is located
+   * @param serviceName name of the service to be described
+   * @return String containing output of the kubectl describe service command
+   * @throws Exception
+   */
+  public static String describeService(String namespace, String serviceName) throws Exception {
+    StringBuffer cmd = new StringBuffer("kubectl describe service ");
+    cmd.append(serviceName);
     cmd.append(" -n ").append(namespace);
-    logger.info(" Find services in namespage " + namespace + " with command: '" + cmd + "'");
+    logger.info(
+        " Describe service "
+            + serviceName
+            + " in namespage "
+            + namespace
+            + " with command: '"
+            + cmd
+            + "'");
 
     ExecResult result = ExecCommand.exec(cmd.toString());
     String stdout = result.stdout();
-    logger.info(" Services found: ");
+    logger.info(" Service " + serviceName + " found: ");
     logger.info(stdout);
     return stdout;
   }
 
+  /**
+   * kubectl get pods -o wide -n namespace
+   *
+   * @param namespace namespace in which the pods are to be listed
+   * @return String containing output of the kubectl get pods command
+   * @throws Exception
+   */
+  public static String getPods(String namespace) throws Exception {
+    StringBuffer cmd = new StringBuffer("kubectl get pods -o wide ");
+    cmd.append(" -n ").append(namespace);
+    logger.info(" Get pods in namespage " + namespace + " with command: '" + cmd + "'");
+
+    ExecResult result = ExecCommand.exec(cmd.toString());
+    String stdout = result.stdout();
+    logger.info(" Pods found: ");
+    logger.info(stdout);
+    return stdout;
+  }
   /**
    * First, kill the mgd server process in the container three times to cause the node manager to
    * mark the server 'failed not restartable'. This in turn is detected by the liveness probe, which


### PR DESCRIPTION
The issue reported in OWLS-71987, HTTP requests not load balanced to the newly scaled up server, cannot be reproduced. This change re-enables the tests as well as adding logging of service and pods info for debugging purposes in case the test fails again.