### PR TITLE
READY TO MERGE: Fix wercker lease failures and some code refactoring

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -27,6 +27,25 @@ public class BaseTest {
   public static final Logger logger = Logger.getLogger("OperatorIT", "OperatorIT");
   public static final String TESTWEBAPP = "testwebapp";
 
+  // property file used to customize operator properties for operator inputs yaml
+
+  public static final String OPERATOR1_YAML = "operator1.yaml";
+  public static final String OPERATOR2_YAML = "operator2.yaml";
+  public static final String OPERATORBC_YAML = "operator_bc.yaml";
+  public static final String OPERATOR_CHAIN_YAML = "operator_chain.yaml";
+
+  // file used to customize domain properties for domain, PV and LB inputs yaml
+  public static final String DOMAINONPV_WLST_YAML = "domainonpvwlst.yaml";
+  public static final String DOMAINONPV_WDT_YAML = "domainonpvwdt.yaml";
+  public static final String DOMAIN_ADMINONLY_YAML = "domainadminonly.yaml";
+  public static final String DOMAIN_RECYCLEPOLICY_YAML = "domainrecyclepolicy.yaml";
+  public static final String DOMAIN_SAMPLE_DEFAULTS_YAML = "domainsampledefaults.yaml";
+  public static final String DOMAININIMAGE_WLST_YAML = "domaininimagewlst.yaml";
+  public static final String DOMAININIMAGE_WDT_YAML = "domaininimagewdt.yaml";
+
+  // property file used to configure constants for integration tests
+  public static final String APP_PROPS_FILE = "OperatorIT.properties";
+
   private static String resultRoot = "";
   private static String pvRoot = "";
   private static String resultDir = "";
@@ -40,6 +59,28 @@ public class BaseTest {
   private static String branchName = "";
   private static String appLocationInPod = "/u01/oracle/apps";
   private static Properties appProps;
+
+  public static boolean QUICKTEST;
+  public static boolean SMOKETEST;
+  public static boolean JENKINS;
+  public static boolean INGRESSPERDOMAIN = true;
+
+  // Set QUICKTEST env var to true to run a small subset of tests.
+  // Set SMOKETEST env var to true to run an even smaller subset of tests
+  // set INGRESSPERDOMAIN to false to create LB's ingress by kubectl yaml file
+  static {
+    QUICKTEST =
+        System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true");
+    SMOKETEST =
+        System.getenv("SMOKETEST") != null && System.getenv("SMOKETEST").equalsIgnoreCase("true");
+    if (SMOKETEST) QUICKTEST = true;
+    if (System.getenv("JENKINS") != null) {
+      JENKINS = new Boolean(System.getenv("JENKINS")).booleanValue();
+    }
+    if (System.getenv("INGRESSPERDOMAIN") != null) {
+      INGRESSPERDOMAIN = new Boolean(System.getenv("INGRESSPERDOMAIN")).booleanValue();
+    }
+  }
 
   public static void initialize(String appPropsFile) throws Exception {
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -609,6 +609,8 @@ public class BaseTest {
       logger.info("Execution of statedump.sh failed, " + result.stderr() + "\n" + result.stdout());
     }
 
+    TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
+
     if (JENKINS) {
       result = cleanup();
       if (result.exitValue() != 0) {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -87,6 +87,7 @@ public class ITOperator extends BaseTest {
       domain = TestUtils.createDomain(DOMAINONPV_WLST_YAML);
       domain.verifyDomainCreated();
       testBasicUseCases(domain);
+      TestUtils.renewK8sClusterLease(getProjectRoot(), getLeaseId());
       testAdvancedUseCasesForADomain(operator1, domain);
 
       if (!SMOKETEST) domain.testWlsLivenessProbe();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -27,47 +27,10 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ITOperator extends BaseTest {
 
-  // property file used to customize operator properties for operator inputs yaml
-
-  private static String operator1File = "operator1.yaml";
-  private static String operator2File = "operator2.yaml";
-  private static final String operator_bcFile = "operator_bc.yaml";
-  private static final String operator_chainFile = "operator_chain.yaml";
-
-  // file used to customize domain properties for domain, PV and LB inputs yaml
-  private static String domainonpvwlstFile = "domainonpvwlst.yaml";
-  private static String domainonpvwdtFile = "domainonpvwdt.yaml";
-  private static String domainadminonlyFile = "domainadminonly.yaml";
-  private static String domainrecyclepolicyFile = "domainrecyclepolicy.yaml";
-  private static String domainsampledefaultsFile = "domainsampledefaults.yaml";
-  private static String domaininimagewlstFile = "domaininimagewlst.yaml";
-  private static String domaininimagewdtFile = "domaininimagewdt.yaml";
-
-  // property file used to configure constants for integration tests
-  private static String appPropsFile = "OperatorIT.properties";
-
   private static Operator operator1, operator2;
 
   private static Operator operatorForBackwardCompatibility;
   private static Operator operatorForRESTCertChain;
-
-  private static boolean QUICKTEST;
-  private static boolean SMOKETEST;
-  private static boolean JENKINS;
-
-  // Set QUICKTEST env var to true to run a small subset of tests.
-  // Set SMOKETEST env var to true to run an even smaller subset
-  // of tests, plus leave domain1 up and running when the test completes.
-  static {
-    QUICKTEST =
-        System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true");
-    SMOKETEST =
-        System.getenv("SMOKETEST") != null && System.getenv("SMOKETEST").equalsIgnoreCase("true");
-    if (SMOKETEST) QUICKTEST = true;
-    if (System.getenv("JENKINS") != null) {
-      JENKINS = new Boolean(System.getenv("JENKINS")).booleanValue();
-    }
-  }
 
   /**
    * This method gets called only once before any of the test methods are executed. It does the
@@ -79,7 +42,7 @@ public class ITOperator extends BaseTest {
   @BeforeClass
   public static void staticPrepare() throws Exception {
     // initialize test properties and create the directories
-    initialize(appPropsFile);
+    initialize(APP_PROPS_FILE);
   }
 
   /**
@@ -136,12 +99,12 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Operator & waiting for the script to complete execution");
     // create operator1
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
     Domain domain = null;
     boolean testCompletedSuccessfully = false;
     try {
-      domain = TestUtils.createDomain(domainonpvwlstFile);
+      domain = TestUtils.createDomain(DOMAINONPV_WLST_YAML);
       domain.verifyDomainCreated();
       testBasicUseCases(domain);
       testAdvancedUseCasesForADomain(operator1, domain);
@@ -175,13 +138,13 @@ public class ITOperator extends BaseTest {
     logger.info("Creating Domain using DomainOnPVUsingWDT & verifing the domain creation");
 
     if (operator2 == null) {
-      operator2 = TestUtils.createOperator(operator2File);
+      operator2 = TestUtils.createOperator(OPERATOR2_YAML);
     }
     Domain domain = null;
     boolean testCompletedSuccessfully = false;
     try {
       // create domain
-      domain = TestUtils.createDomain(domainonpvwdtFile);
+      domain = TestUtils.createDomain(DOMAINONPV_WDT_YAML);
       domain.verifyDomainCreated();
       testBasicUseCases(domain);
       testWLDFScaling(operator2, domain);
@@ -220,14 +183,14 @@ public class ITOperator extends BaseTest {
 
     logger.info("Checking if operator1 and domain1 are running, if not creating");
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
 
     Domain domain1 = null, domain2 = null;
     boolean testCompletedSuccessfully = false;
     try {
       // load input yaml to map and add configOverrides
-      Map<String, Object> wlstDomainMap = TestUtils.loadYaml(domainonpvwlstFile);
+      Map<String, Object> wlstDomainMap = TestUtils.loadYaml(DOMAINONPV_WLST_YAML);
       wlstDomainMap.put("domainUID", "domain1onpvwlst");
       wlstDomainMap.put("adminNodePort", new Integer("30702"));
       wlstDomainMap.put("t3ChannelPort", new Integer("30031"));
@@ -237,12 +200,12 @@ public class ITOperator extends BaseTest {
       testBasicUseCases(domain1);
       logger.info("Checking if operator2 is running, if not creating");
       if (operator2 == null) {
-        operator2 = TestUtils.createOperator(operator2File);
+        operator2 = TestUtils.createOperator(OPERATOR2_YAML);
       }
       // create domain2 with configured cluster
       // ToDo: configured cluster support is removed from samples, modify the test to create
       // configured cluster
-      Map<String, Object> wdtDomainMap = TestUtils.loadYaml(domainonpvwdtFile);
+      Map<String, Object> wdtDomainMap = TestUtils.loadYaml(DOMAINONPV_WDT_YAML);
       wdtDomainMap.put("domainUID", "domain2onpvwdt");
       wdtDomainMap.put("adminNodePort", new Integer("30703"));
       wdtDomainMap.put("t3ChannelPort", new Integer("30041"));
@@ -299,14 +262,14 @@ public class ITOperator extends BaseTest {
     logTestBegin(testMethodName);
     logger.info("Checking if operator1 is running, if not creating");
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
     logger.info("Creating Domain domain6 & verifing the domain creation");
     // create domain
     Domain domain = null;
     boolean testCompletedSuccessfully = false;
     try {
-      domain = TestUtils.createDomain(domainadminonlyFile);
+      domain = TestUtils.createDomain(DOMAIN_ADMINONLY_YAML);
       domain.verifyDomainCreated();
     } finally {
       if (domain != null) {
@@ -332,14 +295,14 @@ public class ITOperator extends BaseTest {
     logTestBegin(testMethodName);
     logger.info("Checking if operator1 is running, if not creating");
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
     logger.info("Creating Domain domain & verifing the domain creation");
     // create domain
     Domain domain = null;
 
     try {
-      domain = TestUtils.createDomain(domainrecyclepolicyFile);
+      domain = TestUtils.createDomain(DOMAIN_RECYCLEPOLICY_YAML);
       domain.verifyDomainCreated();
     } finally {
       if (domain != null) domain.shutdown();
@@ -365,14 +328,14 @@ public class ITOperator extends BaseTest {
     logTestBegin(testMethodName);
     logger.info("Creating Domain domain10 & verifing the domain creation");
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
 
     // create domain10
     Domain domain = null;
     boolean testCompletedSuccessfully = false;
     try {
-      domain = TestUtils.createDomain(domainsampledefaultsFile);
+      domain = TestUtils.createDomain(DOMAIN_SAMPLE_DEFAULTS_YAML);
       domain.verifyDomainCreated();
       testBasicUseCases(domain);
       // testAdvancedUseCasesForADomain(operator1, domain10);
@@ -404,13 +367,13 @@ public class ITOperator extends BaseTest {
     logTestBegin(testMethod);
 
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
     Domain domain11 = null;
     boolean testCompletedSuccessfully = false;
     try {
       // load input yaml to map and add configOverrides
-      Map<String, Object> domainMap = TestUtils.loadYaml(domainonpvwlstFile);
+      Map<String, Object> domainMap = TestUtils.loadYaml(DOMAINONPV_WLST_YAML);
       domainMap.put("configOverrides", "sitconfigcm");
       domainMap.put(
           "configOverridesFile",
@@ -457,7 +420,7 @@ public class ITOperator extends BaseTest {
     logger.info("Checking if operatorForBackwardCompatibility is running, if not creating");
     if (operatorForBackwardCompatibility == null) {
       operatorForBackwardCompatibility =
-          TestUtils.createOperator(operator_bcFile, RESTCertType.LEGACY);
+          TestUtils.createOperator(OPERATORBC_YAML, RESTCertType.LEGACY);
     }
     operatorForBackwardCompatibility.verifyOperatorExternalRESTEndpoint();
     logger.info("Operator using legacy REST identity created successfully");
@@ -478,7 +441,7 @@ public class ITOperator extends BaseTest {
     logTestBegin("testOperatorRESTUsingCertificateChain");
     logger.info("Checking if operatorForBackwardCompatibility is running, if not creating");
     if (operatorForRESTCertChain == null) {
-      operatorForRESTCertChain = TestUtils.createOperator(operator_chainFile, RESTCertType.CHAIN);
+      operatorForRESTCertChain = TestUtils.createOperator(OPERATOR_CHAIN_YAML, RESTCertType.CHAIN);
     }
     operatorForRESTCertChain.verifyOperatorExternalRESTEndpoint();
     logger.info("Operator using legacy REST identity created successfully");
@@ -499,14 +462,14 @@ public class ITOperator extends BaseTest {
 
     logger.info("Checking if operator1 is running, if not creating");
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
     logger.info("Creating Domain & verifing the domain creation");
     // create domain
     Domain domain = null;
     boolean testCompletedSuccessfully = false;
     try {
-      domain = TestUtils.createDomain(domaininimagewlstFile);
+      domain = TestUtils.createDomain(DOMAININIMAGE_WLST_YAML);
       domain.verifyDomainCreated();
 
       testBasicUseCases(domain);
@@ -531,14 +494,14 @@ public class ITOperator extends BaseTest {
 
     logger.info("Checking if operator1 is running, if not creating");
     if (operator1 == null) {
-      operator1 = TestUtils.createOperator(operator1File);
+      operator1 = TestUtils.createOperator(OPERATOR1_YAML);
     }
     logger.info("Creating Domain & verifing the domain creation");
     // create domain
     Domain domain = null;
     boolean testCompletedSuccessfully = false;
     try {
-      domain = TestUtils.createDomain(domaininimagewdtFile);
+      domain = TestUtils.createDomain(DOMAININIMAGE_WDT_YAML);
       domain.verifyDomainCreated();
 
       testBasicUseCases(domain);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITOperator.java
@@ -6,8 +6,6 @@ package oracle.kubernetes.operator;
 
 import java.util.Map;
 import oracle.kubernetes.operator.utils.Domain;
-import oracle.kubernetes.operator.utils.ExecCommand;
-import oracle.kubernetes.operator.utils.ExecResult;
 import oracle.kubernetes.operator.utils.Operator;
 import oracle.kubernetes.operator.utils.Operator.RESTCertType;
 import oracle.kubernetes.operator.utils.TestUtils;
@@ -56,25 +54,7 @@ public class ITOperator extends BaseTest {
     logger.info("BEGIN");
     logger.info("Run once, release cluster lease");
 
-    StringBuffer cmd =
-        new StringBuffer("export RESULT_ROOT=$RESULT_ROOT && export PV_ROOT=$PV_ROOT && ");
-    cmd.append(BaseTest.getProjectRoot())
-        .append("/integration-tests/src/test/resources/statedump.sh");
-    logger.info("Running " + cmd);
-
-    ExecResult result = ExecCommand.exec(cmd.toString());
-    if (result.exitValue() == 0) logger.info("Executed statedump.sh " + result.stdout());
-    else
-      logger.info("Execution of statedump.sh failed, " + result.stderr() + "\n" + result.stdout());
-
-    if (JENKINS) {
-      cleanup();
-    }
-
-    if (getLeaseId() != "") {
-      logger.info("Release the k8s cluster lease");
-      TestUtils.releaseLease(getProjectRoot(), getLeaseId());
-    }
+    tearDown();
 
     logger.info("SUCCESS");
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITServerDiscovery.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITServerDiscovery.java
@@ -81,40 +81,41 @@ public class ITServerDiscovery extends BaseTest {
    */
   @BeforeClass
   public static void staticPrepare() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
-    // initialize test properties and create the directories
-    initialize(appPropsFile);
+    if (!QUICKTEST) {
+      // initialize test properties and create the directories
+      initialize(appPropsFile);
 
-    // create operator1
-    if (operator == null) {
-      logger.info("Creating Operator & waiting for the script to complete execution");
-      operator = TestUtils.createOperator(operatorYmlFile);
+      // create operator1
+      if (operator == null) {
+        logger.info("Creating Operator & waiting for the script to complete execution");
+        operator = TestUtils.createOperator(operatorYmlFile);
+      }
+
+      // create domain
+      if (domain == null) {
+        logger.info("Creating WLS Domain & waiting for the script to complete execution");
+        domain = TestUtils.createDomain(domainonpvwlstFile);
+        domain.verifyDomainCreated();
+      }
+
+      domainYaml =
+          BaseTest.getUserProjectsDir()
+              + "/weblogic-domains/"
+              + domain.getDomainUid()
+              + "/domain.yaml";
+
+      // create test domain yaml file
+      testDomainYamlFile = BaseTest.getResultDir() + "/" + testYamlFileName;
+
+      Path sourceFile = Paths.get(domainYaml);
+      Path targetFile = Paths.get(testDomainYamlFile);
+
+      Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+
+      String content = new String(Files.readAllBytes(targetFile), StandardCharsets.UTF_8);
+      content = content.replaceAll("replicas: 2", "replicas: 3");
+      Files.write(targetFile, content.getBytes(StandardCharsets.UTF_8));
     }
-
-    // create domain
-    if (domain == null) {
-      logger.info("Creating WLS Domain & waiting for the script to complete execution");
-      domain = TestUtils.createDomain(domainonpvwlstFile);
-      domain.verifyDomainCreated();
-    }
-
-    domainYaml =
-        BaseTest.getUserProjectsDir()
-            + "/weblogic-domains/"
-            + domain.getDomainUid()
-            + "/domain.yaml";
-
-    // create test domain yaml file
-    testDomainYamlFile = BaseTest.getResultDir() + "/" + testYamlFileName;
-
-    Path sourceFile = Paths.get(domainYaml);
-    Path targetFile = Paths.get(testDomainYamlFile);
-
-    Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
-
-    String content = new String(Files.readAllBytes(targetFile), StandardCharsets.UTF_8);
-    content = content.replaceAll("replicas: 2", "replicas: 3");
-    Files.write(targetFile, content.getBytes(StandardCharsets.UTF_8));
   }
 
   /**
@@ -124,14 +125,15 @@ public class ITServerDiscovery extends BaseTest {
    */
   @AfterClass
   public static void staticUnPrepare() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
-    logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
-    logger.info("BEGIN");
-    logger.info("Run once, release cluster lease");
+    if (!QUICKTEST) {
+      logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
+      logger.info("BEGIN");
+      logger.info("Run once, release cluster lease");
 
-    tearDown();
+      tearDown();
 
-    logger.info("SUCCESS");
+      logger.info("SUCCESS");
+    }
   }
 
   /**
@@ -141,6 +143,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPConnToNewMS() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -166,6 +169,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPReconnToNewMS() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -198,6 +202,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPReconnToRunningMSAndScaleDown() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -227,6 +232,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPReconnToRunningMSAndScaleUp() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -252,6 +258,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPReconnToRunningMSWApp() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -291,6 +298,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPAdminReconnToDomain() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -333,6 +341,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPMSReconnToDomain() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 
@@ -375,6 +384,7 @@ public class ITServerDiscovery extends BaseTest {
    */
   @Test
   public void testOPRestartDeadMS() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITServerDiscovery.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITServerDiscovery.java
@@ -124,31 +124,12 @@ public class ITServerDiscovery extends BaseTest {
    */
   @AfterClass
   public static void staticUnPrepare() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
     logger.info("BEGIN");
     logger.info("Run once, release cluster lease");
 
-    StringBuffer cmd =
-        new StringBuffer("export RESULT_ROOT=$RESULT_ROOT && export PV_ROOT=$PV_ROOT && ");
-    cmd.append(BaseTest.getProjectRoot())
-        .append("/integration-tests/src/test/resources/statedump.sh");
-    logger.info("Running " + cmd);
-
-    ExecResult result = ExecCommand.exec(cmd.toString());
-    if (result.exitValue() == 0) logger.info("Executed statedump.sh " + result.stdout());
-    else
-      logger.info("Execution of statedump.sh failed, " + result.stderr() + "\n" + result.stdout());
-
-    if (domain != null && !SMOKETEST) domain.shutdownUsingServerStartPolicy();
-
-    if (JENKINS) {
-      cleanup();
-    }
-
-    if (getLeaseId() != "") {
-      logger.info("Release the k8s cluster lease");
-      TestUtils.releaseLease(getProjectRoot(), getLeaseId());
-    }
+    tearDown();
 
     logger.info("SUCCESS");
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
@@ -38,10 +38,9 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @BeforeClass
   public static void staticPrepare() throws Exception {
-    if (!QUICKTEST) {
-      // initialize test properties and create the directories
-      initialize(APP_PROPS_FILE);
-    }
+    Assume.assumeFalse(QUICKTEST);
+    // initialize test properties and create the directories
+    initialize(APP_PROPS_FILE);
   }
 
   /**
@@ -51,15 +50,14 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @AfterClass
   public static void staticUnPrepare() throws Exception {
-    if (!QUICKTEST) {
-      logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
-      logger.info("BEGIN");
-      logger.info("Run once, release cluster lease");
+    Assume.assumeFalse(QUICKTEST);
+    logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
+    logger.info("BEGIN");
+    logger.info("Run once, release cluster lease");
 
-      tearDown();
+    tearDown();
 
-      logger.info("SUCCESS");
-    }
+    logger.info("SUCCESS");
   }
 
   /**
@@ -69,7 +67,6 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testOperatorCreateDeleteCreate() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator firstoperator = null;
@@ -122,7 +119,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateSecondOperatorUsingSameOperatorNSNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator firstoperator = null;
@@ -179,7 +176,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testNotPreCreatedOpNSCreateOperatorNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -215,7 +212,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testNotPreexistedOpServiceAccountCreateOperatorNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -272,7 +269,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testSecondOpSharingSameTargetDomainsNSNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator secondoperator = null;
@@ -332,7 +329,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testTargetNSIsNotPreexistedNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -382,7 +379,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testSecondOpSharingSameExternalRestPortNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator1 = null;
@@ -442,7 +439,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateWithUpperCaseTargetDomainNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -488,7 +485,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateChartWithInvalidAttributesNegativeInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -539,7 +536,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateWithEmptyTargetDomainInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -561,7 +558,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
   }
 
   private void upgradeOperator(Operator operator, String upgradeSet) throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     operator.callHelmUpgrade(upgradeSet);
@@ -575,7 +572,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateWithDefaultTargetDomainInstall() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
+
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
@@ -38,9 +38,10 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @BeforeClass
   public static void staticPrepare() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
-    // initialize test properties and create the directories
-    initialize(APP_PROPS_FILE);
+    if (!QUICKTEST) {
+      // initialize test properties and create the directories
+      initialize(APP_PROPS_FILE);
+    }
   }
 
   /**
@@ -50,14 +51,15 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @AfterClass
   public static void staticUnPrepare() throws Exception {
-    Assume.assumeFalse(QUICKTEST);
-    logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
-    logger.info("BEGIN");
-    logger.info("Run once, release cluster lease");
+    if (!QUICKTEST) {
+      logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
+      logger.info("BEGIN");
+      logger.info("Run once, release cluster lease");
 
-    tearDown();
+      tearDown();
 
-    logger.info("SUCCESS");
+      logger.info("SUCCESS");
+    }
   }
 
   /**
@@ -67,6 +69,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testOperatorCreateDeleteCreate() throws Exception {
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator firstoperator = null;
@@ -119,7 +122,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateSecondOperatorUsingSameOperatorNSNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator firstoperator = null;
@@ -176,7 +179,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testNotPreCreatedOpNSCreateOperatorNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -212,7 +215,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testNotPreexistedOpServiceAccountCreateOperatorNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -269,7 +272,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testSecondOpSharingSameTargetDomainsNSNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator secondoperator = null;
@@ -329,7 +332,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testTargetNSIsNotPreexistedNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -379,7 +382,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testSecondOpSharingSameExternalRestPortNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator1 = null;
@@ -439,7 +442,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateWithUpperCaseTargetDomainNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -485,7 +488,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateChartWithInvalidAttributesNegativeInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -536,7 +539,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateWithEmptyTargetDomainInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;
@@ -558,7 +561,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
   }
 
   private void upgradeOperator(Operator operator, String upgradeSet) throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     operator.callHelmUpgrade(upgradeSet);
@@ -572,7 +575,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @Test
   public void testCreateWithDefaultTargetDomainInstall() throws Exception {
-
+    Assume.assumeFalse(QUICKTEST);
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     Operator operator = null;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
@@ -61,8 +61,10 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @BeforeClass
   public static void staticPrepare() throws Exception {
-    // initialize test properties and create the directories
-    initialize(appPropsFile);
+    if (!QUICKTEST) {
+      // initialize test properties and create the directories
+      initialize(appPropsFile);
+    }
   }
 
   /**
@@ -72,31 +74,34 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
    */
   @AfterClass
   public static void staticUnPrepare() throws Exception {
-    logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
-    logger.info("BEGIN");
-    logger.info("Run once, release cluster lease");
+    if (!QUICKTEST) {
+      logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
+      logger.info("BEGIN");
+      logger.info("Run once, release cluster lease");
 
-    StringBuffer cmd =
-        new StringBuffer("export RESULT_ROOT=$RESULT_ROOT && export PV_ROOT=$PV_ROOT && ");
-    cmd.append(BaseTest.getProjectRoot())
-        .append("/integration-tests/src/test/resources/statedump.sh");
-    logger.info("Running " + cmd);
+      StringBuffer cmd =
+          new StringBuffer("export RESULT_ROOT=$RESULT_ROOT && export PV_ROOT=$PV_ROOT && ");
+      cmd.append(BaseTest.getProjectRoot())
+          .append("/integration-tests/src/test/resources/statedump.sh");
+      logger.info("Running " + cmd);
 
-    ExecResult result = ExecCommand.exec(cmd.toString());
-    if (result.exitValue() == 0) logger.info("Executed statedump.sh " + result.stdout());
-    else
-      logger.info("Execution of statedump.sh failed, " + result.stderr() + "\n" + result.stdout());
+      ExecResult result = ExecCommand.exec(cmd.toString());
+      if (result.exitValue() == 0) logger.info("Executed statedump.sh " + result.stdout());
+      else
+        logger.info(
+            "Execution of statedump.sh failed, " + result.stderr() + "\n" + result.stdout());
 
-    if (JENKINS) {
-      cleanup();
+      if (JENKINS) {
+        cleanup();
+      }
+
+      if (getLeaseId() != "") {
+        logger.info("Release the k8s cluster lease");
+        TestUtils.releaseLease(getProjectRoot(), getLeaseId());
+      }
+
+      logger.info("SUCCESS");
     }
-
-    if (getLeaseId() != "") {
-      logger.info("Release the k8s cluster lease");
-      TestUtils.releaseLease(getProjectRoot(), getLeaseId());
-    }
-
-    logger.info("SUCCESS");
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
@@ -56,26 +56,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
       logger.info("BEGIN");
       logger.info("Run once, release cluster lease");
 
-      StringBuffer cmd =
-          new StringBuffer("export RESULT_ROOT=$RESULT_ROOT && export PV_ROOT=$PV_ROOT && ");
-      cmd.append(BaseTest.getProjectRoot())
-          .append("/integration-tests/src/test/resources/statedump.sh");
-      logger.info("Running " + cmd);
-
-      ExecResult result = ExecCommand.exec(cmd.toString());
-      if (result.exitValue() == 0) logger.info("Executed statedump.sh " + result.stdout());
-      else
-        logger.info(
-            "Execution of statedump.sh failed, " + result.stderr() + "\n" + result.stdout());
-
-      if (JENKINS) {
-        cleanup();
-      }
-
-      if (getLeaseId() != "") {
-        logger.info("Release the k8s cluster lease");
-        TestUtils.releaseLease(getProjectRoot(), getLeaseId());
-      }
+      tearDown();
 
       logger.info("SUCCESS");
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITUsabilityOperatorHelmChart.java
@@ -26,31 +26,8 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ITUsabilityOperatorHelmChart extends BaseTest {
 
-  // property file used to configure constants for integration tests
-  private static String appPropsFile = "OperatorIT.properties";
-  private static boolean QUICKTEST;
-  private static boolean SMOKETEST;
-  private static boolean JENKINS;
-  private static boolean INGRESSPERDOMAIN = true;
   private static int number = 3;
   String oprelease = "op" + number;
-
-  // Set QUICKTEST env var to true to run a small subset of tests.
-  // Set SMOKETEST env var to true to run an even smaller subset of tests
-  // set INGRESSPERDOMAIN to false to create LB's ingress by kubectl yaml file
-  static {
-    QUICKTEST =
-        System.getenv("QUICKTEST") != null && System.getenv("QUICKTEST").equalsIgnoreCase("true");
-    SMOKETEST =
-        System.getenv("SMOKETEST") != null && System.getenv("SMOKETEST").equalsIgnoreCase("true");
-    if (SMOKETEST) QUICKTEST = true;
-    if (System.getenv("JENKINS") != null) {
-      JENKINS = new Boolean(System.getenv("JENKINS")).booleanValue();
-    }
-    if (System.getenv("INGRESSPERDOMAIN") != null) {
-      INGRESSPERDOMAIN = new Boolean(System.getenv("INGRESSPERDOMAIN")).booleanValue();
-    }
-  }
 
   /**
    * This method gets called only once before any of the test methods are executed. It does the
@@ -63,7 +40,7 @@ public class ITUsabilityOperatorHelmChart extends BaseTest {
   public static void staticPrepare() throws Exception {
     if (!QUICKTEST) {
       // initialize test properties and create the directories
-      initialize(appPropsFile);
+      initialize(APP_PROPS_FILE);
     }
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -896,7 +896,12 @@ public class Domain {
           StandardCopyOption.REPLACE_EXISTING);
     }
 
-    StringBuffer createDomainScriptCmd = new StringBuffer(BaseTest.getResultDir());
+    StringBuffer createDomainScriptCmd = new StringBuffer("export JAVA_HOME=");
+
+    createDomainScriptCmd
+        .append(System.getenv("JAVA_HOME"))
+        .append(" && export PATH=$JAVA_HOME/bin:$PATH && ")
+        .append(BaseTest.getResultDir());
 
     // call different create-domain.sh based on the domain type
     if (domainMap.containsKey("domainHomeImageBase")) {

--- a/integration-tests/src/test/resources/statedump.sh
+++ b/integration-tests/src/test/resources/statedump.sh
@@ -128,16 +128,16 @@ function state_dump {
   
 
   
-  if [ ! "$LEASE_ID" = "" ]; then
+ # if [ ! "$LEASE_ID" = "" ]; then
     # release the lease if we own it
-    ${SCRIPTPATH}/lease.sh -d "$LEASE_ID" 2>&1 | tee ${RESULT_DIR}/release_lease.out
-    if [ "$?" = "0" ]; then
-      echo Lease released.
-    else
-      echo Lease could not be released:
-      cat /${RESULT_DIR}/release_lease.out 
-    fi
-  fi
+  #  ${SCRIPTPATH}/lease.sh -d "$LEASE_ID" 2>&1 | tee ${RESULT_DIR}/release_lease.out
+   # if [ "$?" = "0" ]; then
+   #   echo Lease released.
+   # else
+   #   echo Lease could not be released:
+   #   cat /${RESULT_DIR}/release_lease.out 
+   # fi
+ # fi
 
   # remove docker-images project before archiving
   rm -rf ${RESULT_DIR}/docker-images


### PR DESCRIPTION
Changed new test ITUsabilityOperatorHelmChart not to be called on wercker, this will fix the lease failures.
archive and cleanup is done after every IT class, so made changes to create PV_ROOT and RESULT_ROOT dirs in initialize() method in BaseTest and also moved some common code to BaseTest.java
