### PR TITLE
configure Voyager to only watch Voyager ingress class

### DIFF
--- a/kubernetes/samples/charts/ingress-per-domain/templates/traefik-ingress.yaml
+++ b/kubernetes/samples/charts/ingress-per-domain/templates/traefik-ingress.yaml
@@ -10,9 +10,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     weblogic.resourceVersion: domain-v2
-spec:
   annotations:
     kubernetes.io/ingress.class: traefik
+spec:
   rules:
   - host: '{{ .Values.traefik.hostname }}'
     http:

--- a/kubernetes/samples/charts/util/setup.sh
+++ b/kubernetes/samples/charts/util/setup.sh
@@ -25,7 +25,8 @@ function createVoyager() {
     helm install appscode/voyager --name voyager-operator --version 7.4.0 \
       --namespace voyager \
       --set cloudProvider=baremetal \
-      --set apiserver.enableValidatingWebhook=false
+      --set apiserver.enableValidatingWebhook=false \
+      --set ingressClass=voyager
   else
     echo "Voyager operator is already installed."
   fi 


### PR DESCRIPTION
By default, Voyager controller monitors both k8s standard Ingress class and Voyager Ingress class. With this change Voyager controller will only monitor Voyager Ingress class.  This can help to run the two supported Ingress Controllers: Voyager and Traefik, on the same k8s cluster at the same time without interfering with each other. Voyager is monitoring its own Voyager Ingress class and Traefik is monitoring k8s-provided Ingress class.

Another change is to fix annotation problem in chart ingress-per-domain.