### PR TITLE
Add README file for new documentation sources

### DIFF
--- a/docs-source/README.md
+++ b/docs-source/README.md
@@ -2,6 +2,6 @@
 
 ***
 For information on updating and contributing to the operator
-documentation please see the _Documentation_ section of the
+documentation, see the _Documentation_ section of the
 [Developer Guide](https://oracle.github.io/weblogic-kubernetes-operator/developerguide/documentation)
 ***

--- a/docs-source/README.md
+++ b/docs-source/README.md
@@ -1,0 +1,7 @@
+# Oracle WebLogic Server Kubernetes Operator Documentation
+
+***
+For information on updating and contributing to the operator
+documentation please see the _Documentation_ section of the
+[Developer Guide](https://oracle.github.io/weblogic-kubernetes-operator/developerguide/documentation)
+***

--- a/docs-source/content/developerguide/documentation.md
+++ b/docs-source/content/developerguide/documentation.md
@@ -24,6 +24,10 @@ update to the documentation, follow this process:
 
 3. Make your documentation updates by editing the source files in 
 `docs-source/content`.
+{{% notice note %}}
+Make sure you only check in the changes from the `docs-source/content` area;
+do not build the site and check in the static files.
+{{% /notice %}}
 
 4. If you wish to view your changes you can run the site locally using 
 these commands; the site will be available on the URL shown here:
@@ -38,7 +42,3 @@ and submit a pull request. Remember to follow the guidelines in the
 [CONTRIBUTING](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/CONTRIBUTING.md)
 document.
 
-{{% notice note %}}
-Make sure you only check in your source code changes in `docs-source`; do 
-not build the site and check in the static files.
-{{% /notice %}}


### PR DESCRIPTION
Create a README for `docs-source` that directs the reader to proper section of the [documentation site](https://oracle.github.io/weblogic-kubernetes-operator/) and make it clear that only the `content` folder should be updated when submitting an update.