### PR TITLE
update operator version number

### DIFF
--- a/site/quickstart.md
+++ b/site/quickstart.md
@@ -37,7 +37,7 @@ $ docker login
 ```
 c.	Pull the operator image:
 ```
-$ docker pull oracle/weblogic-kubernetes-operator:2.0
+$ docker pull oracle/weblogic-kubernetes-operator:2.0.1
 ```
 d.	Pull the Traefik load balancer image:
 ```


### PR DESCRIPTION
In the docker pull command, in the Quick Start guide, from 2.0 to 2.0.1.