### PR TITLE
fix version number, jenkins-ignore

### DIFF
--- a/docs-source/content/quickstart/install.md
+++ b/docs-source/content/quickstart/install.md
@@ -57,7 +57,7 @@ $ helm install stable/traefik \
     $ helm install kubernetes/charts/weblogic-operator \
       --name sample-weblogic-operator \
       --namespace sample-weblogic-operator-ns \
-      --set image=oracle/weblogic-kubernetes-operator:2.0-rc2 \
+      --set image=oracle/weblogic-kubernetes-operator:2.0.1 \
       --set serviceAccount=sample-weblogic-operator-sa \
       --set "domainNamespaces={}" \
       --wait


### PR DESCRIPTION
In the Quick Start guide, install command, updated the version number from 2.0-rc2 to 2.0.1.