### PR TITLE
Rise max_wait_secs in startNodeManager.sh

### DIFF
--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -290,7 +290,7 @@ ${stm_script} > ${nodemgr_out_file} 2>&1 &
 
 wait_count=0
 start_secs=$SECONDS
-max_wait_secs=15
+max_wait_secs=60
 while [ 1 -eq 1 ]; do
   sleep 1
   if [ -e ${nodemgr_log_file} ] && [ `grep -c "Plain socket listener started" ${nodemgr_log_file}` -gt 0 ]; then


### PR DESCRIPTION
15 seconds may be ta  too tight timeout. In some cases we saw the pod restarting several times until it can starts the nodemanager in the expected interval. We propose an arbitrary value of 60 seconds.