### PR TITLE
updated operator version number, jenkins-ignore

### DIFF
--- a/docs-source/content/userguide/managing-domains/domain-lifecycle/restarting.md
+++ b/docs-source/content/userguide/managing-domains/domain-lifecycle/restarting.md
@@ -161,7 +161,7 @@ d. Update the `image` property of the domain resource specifying the new image n
      ```
         domain:
               spec:
-                   image: oracle/weblogic-updated:2.0
+                   image: oracle/weblogic-updated:2.0.1
      ```
 e. The operator will now initiate a rolling restart, which will apply the updated image, for all the server pods in the domain.
 

--- a/docs-source/content/userguide/managing-operators/using-the-operator/using-helm.md
+++ b/docs-source/content/userguide/managing-operators/using-the-operator/using-helm.md
@@ -99,7 +99,7 @@ javaLoggingLevel:  "FINE"
 
 Specifies the Docker image containing the operator code.
 
-Defaults to `weblogic-kubernetes-operator:2.0`.
+Defaults to `weblogic-kubernetes-operator:2.0.1`.
 
 Example:
 ```


### PR DESCRIPTION
In two docs, "Using Helm" and "Restarting," from version 2.0 to 2.0.1.