### PR TITLE
Require JDK 11, Maven plugin and dependency versions

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,55 +1,7 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>oracle.kubernetes</groupId>
-    <artifactId>operator-parent</artifactId>
-    <version>2.2</version>
-  </parent>
-
-
   <groupId>oracle.kubernetes</groupId>
   <artifactId>build-tools</artifactId>
+  <version>1.0</version>
   <name>Build Tools</name>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${maven-enforcer-plugin-version}</version>
-        <executions>
-          <execution>
-            <id>enforce-maven</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>${maven.version.range}</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>${java.version.range}</version>
-                </requireJavaVersion>
-                <requirePluginVersions></requirePluginVersions>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin-version}</version>
-        <configuration>
-          <release>11</release>
-          <compilerArgs>
-            <arg>-Xpkginfo:always</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -29,6 +29,10 @@
                 <requireMavenVersion>
                   <version>${maven.version.range}</version>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>${java.version.range}</version>
+                </requireJavaVersion>
+                <requirePluginVersions></requirePluginVersions>
               </rules>
             </configuration>
           </execution>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,7 +1,51 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>oracle.kubernetes</groupId>
+    <artifactId>operator-parent</artifactId>
+    <version>2.2</version>
+  </parent>
+
+
   <groupId>oracle.kubernetes</groupId>
   <artifactId>build-tools</artifactId>
-  <version>1.0</version>
   <name>Build Tools</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin-version}</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>${maven.version.range}</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <release>11</release>
+          <compilerArgs>
+            <arg>-Xpkginfo:always</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/buildtime-reports/pom.xml
+++ b/buildtime-reports/pom.xml
@@ -2,16 +2,42 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>operator-parent</artifactId>
         <groupId>oracle.kubernetes</groupId>
         <version>2.2</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>buildtime-reports</artifactId>
     <packaging>pom</packaging>
     <name>Project Reports</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.version.range}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/buildtime-reports/pom.xml
+++ b/buildtime-reports/pom.xml
@@ -31,6 +31,10 @@
                                 <requireMavenVersion>
                                     <version>${maven.version.range}</version>
                                 </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version.range}</version>
+                                </requireJavaVersion>
+                                <requirePluginVersions></requirePluginVersions>
                             </rules>
                         </configuration>
                     </execution>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -96,6 +96,25 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>enforce-maven</id>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<requireMavenVersion>
+											<version>${maven.version.range}</version>
+										</requireMavenVersion>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.6.0</version>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -133,6 +133,26 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>${maven-release-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>${maven-resources-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>${maven-jar-plugin-version}</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -120,6 +120,19 @@
 					</compilerArgs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.coveo</groupId>
+				<artifactId>fmt-maven-plugin</artifactId>
+				<version>2.8</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -237,30 +250,5 @@
 				</plugins>
 			</build>
 		</profile>
-
-		<profile>
-			<id>default</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.coveo</groupId>
-						<artifactId>fmt-maven-plugin</artifactId>
-						<version>2.8</version>
-						<executions>
-							<execution>
-								<phase>test</phase>
-								<goals>
-									<goal>check</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
-
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -153,6 +153,51 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>${maven-jar-plugin-version}</version>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${maven-pmd-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>${maven-site-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>${maven-javadoc-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>${maven-clean-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven-checkstyle-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-install-plugin</artifactId>
+				<version>${maven-install-plugin-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>${maven-deploy-plugin-version}</version>
+			</plugin>
+			<plugin>
+			  <groupId>com.github.spotbugs</groupId>
+			  <artifactId>spotbugs-maven-plugin</artifactId>
+			  <version>${spotbugs-maven-plugin-version}</version>
+			</plugin>
+			<plugin>
+			  <groupId>org.jacoco</groupId>
+			  <artifactId>jacoco-maven-plugin</artifactId>
+			  <version>${jacoco.version}</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -100,6 +100,10 @@
 								<requireMavenVersion>
 									<version>${maven.version.range}</version>
 								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>${java.version.range}</version>
+								</requireJavaVersion>
+								<requirePluginVersions></requirePluginVersions>
 							</rules>
 						</configuration>
 					</execution>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -83,6 +83,41 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>${maven-enforcer-plugin-version}</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>${maven.version.range}</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin-version}</version>
+				<configuration>
+					<release>11</release>
+					<compilerArgs>
+						<arg>-Xpkginfo:always</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 
@@ -96,28 +131,9 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-enforcer-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>enforce-maven</id>
-								<goals>
-									<goal>enforce</goal>
-								</goals>
-								<configuration>
-									<rules>
-										<requireMavenVersion>
-											<version>${maven.version.range}</version>
-										</requireMavenVersion>
-									</rules>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<version>1.6.0</version>
+						<version>${exec-maven-plugin-version}</version>
 						<executions>
 							<execution>
 								<goals>
@@ -173,10 +189,15 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-failsafe-plugin</artifactId>
-						<version>2.22.1</version>
+						<version>${maven-failsafe-plugin-version}</version>
 						<configuration> <!-- run tests in parallel -->
+							<argLine>
+								--illegal-access=permit
+							</argLine>
 							<encoding>UTF-8</encoding>
-							<argLine>${failsafeArgLine}</argLine>
+							<argLine>
+								--illegal-access=permit
+							</argLine>
 							<failIfNoTests>false</failIfNoTests>
 							<systemPropertyVariables>
 								<!-- Add any system properties here -->
@@ -218,10 +239,6 @@
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
-			<properties>
-				<surefireArgLine></surefireArgLine>
-				<failsafeArgLine></failsafeArgLine>
-			</properties>
 			<build>
 				<plugins>
 					<plugin>

--- a/json-schema-maven-plugin/pom.xml
+++ b/json-schema-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId> <!-- was asm-all -->
+      <artifactId>asm</artifactId>
       <version>7.1</version>
       <scope>test</scope>
     </dependency>

--- a/json-schema-maven-plugin/pom.xml
+++ b/json-schema-maven-plugin/pom.xml
@@ -40,14 +40,25 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-all</artifactId>
-      <version>5.2</version>
+      <artifactId>asm</artifactId> <!-- was asm-all -->
+      <version>7.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <release>11</release>
+          <compilerArgs>
+            <arg>-Xpkginfo:always</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>

--- a/json-schema-maven-plugin/src/test/java/oracle/kubernetes/json/mojo/JsonSchemaMojoTest.java
+++ b/json-schema-maven-plugin/src/test/java/oracle/kubernetes/json/mojo/JsonSchemaMojoTest.java
@@ -9,7 +9,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_CLASSES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.objectweb.asm.Opcodes.ASM5;
+import static org.objectweb.asm.Opcodes.ASM7;
 
 import com.google.common.collect.ImmutableMap;
 import com.meterware.simplestub.Memento;
@@ -393,7 +393,7 @@ public class JsonSchemaMojoTest {
     private Class<?> theClass;
 
     Visitor(Class<?> theClass) {
-      super(ASM5);
+      super(ASM7);
       this.theClass = theClass;
     }
 
@@ -438,7 +438,7 @@ public class JsonSchemaMojoTest {
     private Map<String, AnnotationInfo> annotations;
 
     MojoAnnotationVisitor(Map<String, AnnotationInfo> annotations, String desc) {
-      super(ASM5);
+      super(ASM7);
       this.annotations = annotations;
       annotationClassDesc = desc;
       annotations.put(desc, new AnnotationInfo());
@@ -490,7 +490,7 @@ public class JsonSchemaMojoTest {
     private final Map<String, AnnotationInfo> annotationMap;
 
     MojoFieldVisitor(Field field) {
-      super(ASM5);
+      super(ASM7);
       this.annotationMap = getOrCreateAnnotationMap(field);
     }
 

--- a/json-schema/pom.xml
+++ b/json-schema/pom.xml
@@ -11,6 +11,21 @@
 
   <artifactId>json-schema</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <release>11</release>
+          <compilerArgs>
+            <arg>-Xpkginfo:always</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>io.kubernetes</groupId>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -31,6 +31,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin-version}</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -48,6 +49,17 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin-version}</version>
+        <configuration>
+          <release>11</release>
+          <compilerArgs>
+            <arg>-Xpkginfo:always</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.8</version>
@@ -63,7 +75,7 @@
       <plugin>
 	<groupId>org.codehaus.mojo</groupId>
 	<artifactId>exec-maven-plugin</artifactId>
-	<version>1.6.0</version>
+	<version>${exec-maven-plugin-version}</version>
 	<executions>
 	    <execution><!-- helm chart package-->
 		<id>package-helm-charts</id>
@@ -132,8 +144,12 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.1</version>
-            <executions>
+            <version>${maven-failsafe-plugin-version}</version>
+            <configuration>
+              <argLine>
+                --illegal-access=permit
+              </argLine>
+            </configuration>            <executions>
               <execution>
                 <goals>
                   <goal>integration-test</goal>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -43,6 +43,10 @@
                 <requireMavenVersion>
                   <version>${maven.version.range}</version>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>${java.version.range}</version>
+                </requireJavaVersion>
+                <requirePluginVersions></requirePluginVersions>
               </rules>
             </configuration>
           </execution>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -29,6 +29,25 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>${maven.version.range}</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.8</version>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -153,7 +153,8 @@
               <argLine>
                 --illegal-access=permit
               </argLine>
-            </configuration>            <executions>
+            </configuration>
+            <executions>
               <execution>
                 <goals>
                   <goal>integration-test</goal>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -30,6 +30,25 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>${maven.version.range}</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>3.0.0</version>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -32,6 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin-version}</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -73,8 +74,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>${maven-compiler-plugin-version}</version>
         <configuration>
+          <release>11</release>
           <compilerArgs>
             <arg>-Xpkginfo:always</arg>
           </compilerArgs>
@@ -116,7 +118,7 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-resources-plugin-version}</version>
         <executions>
           <execution>
             <phase>install</phase>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -44,6 +44,10 @@
                 <requireMavenVersion>
                   <version>${maven.version.range}</version>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>${java.version.range}</version>
+                </requireJavaVersion>
+                <requirePluginVersions></requirePluginVersions>
               </rules>
             </configuration>
           </execution>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -31,6 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -51,7 +52,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.4</version>
+                <version>2.2.6</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -84,15 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <version>${maven-jar-plugin-version}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -114,7 +107,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin-version}</version>
                 <configuration>
+                    <argLine>
+                        --illegal-access=permit
+                    </argLine>
                     <skipTests>${skip.unit.tests}</skipTests>
                     <includes>
                         <exclude>**/*Test.java</exclude>
@@ -141,7 +138,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin-version}</version>
                 <configuration>
+                    <release>11</release>
                     <compilerArgs>
                         <arg>-Xpkginfo:always</arg>
                     </compilerArgs>
@@ -150,7 +149,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>${maven-failsafe-plugin-version}</version>
+                <configuration>
+                    <argLine>
+                        --illegal-access=permit
+                    </argLine>
+                </configuration>
                 <executions>
                   <execution>
                     <goals>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -43,6 +43,10 @@
                                 <requireMavenVersion>
                                     <version>${maven.version.range}</version>
                                 </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version.range}</version>
+                                </requireJavaVersion>
+                                <requirePluginVersions></requirePluginVersions>
                             </rules>
                         </configuration>
                     </execution>
@@ -121,6 +125,7 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin-version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -28,6 +28,25 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.version.range}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>pl.project13.maven</groupId>
@@ -95,7 +114,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
                 <configuration>
                     <skipTests>${skip.unit.tests}</skipTests>
                     <includes>
@@ -123,7 +141,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-Xpkginfo:always</arg>
@@ -133,7 +150,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M3</version>
                 <executions>
                   <execution>
                     <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
         </executions>
         <dependencies>
           <dependency>
+            <groupId>oracle.kubernetes</groupId>
+            <artifactId>build-tools</artifactId>
+            <version>1.0</version>
+          </dependency>
+          <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-java</artifactId>
             <version>6.8.0</version>
@@ -197,6 +202,11 @@
           </execution>
         </executions>
         <dependencies>
+          <dependency>
+            <groupId>oracle.kubernetes</groupId>
+            <artifactId>build-tools</artifactId>
+            <version>1.0</version>
+          </dependency>
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin-version}</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -77,11 +78,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
+        <version>${maven-release-plugin-version}</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin-version}</version>
         <configuration>
           <aggregate>true</aggregate>
           <show>public</show>
@@ -95,6 +98,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin-version}</version>
         <executions>
           <execution>
             <id>checkstyle</id>
@@ -119,13 +123,14 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
+            <version>8.19</version>
           </dependency>
         </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
+        <version>${maven-pmd-plugin-version}</version>
         <configuration>
           <sourceEncoding>utf-8</sourceEncoding>
           <rulesets>
@@ -253,8 +258,11 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.1</version>
+            <version>${maven-failsafe-plugin-version}</version>
             <configuration> <!-- run tests in parallel -->
+              <argLine>
+                --illegal-access=permit
+              </argLine>
               <encoding>UTF-8</encoding>
               <argLine>${failsafeArgLine}</argLine>
               <failIfNoTests>false</failIfNoTests>
@@ -400,67 +408,91 @@
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>${maven-enforcer-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-clean-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>${maven-compiler-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven-deploy-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven-install-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>${maven-jar-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-resources-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>${maven-site-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>${maven-surefire-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>${maven-checkstyle-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>${maven-pmd-plugin-version}</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>${maven-release-plugin-version}</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin-version}</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin-version}</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin-version}</version>
         <type>maven-plugin</type>
       </dependency>
       <dependency>
@@ -502,9 +534,21 @@
 
   <properties>
     <maven.version.range>[3.5.2,)</maven.version.range>
-    <java.version>1.8</java.version>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven-enforcer-plugin-version>3.0.0-M2</maven-enforcer-plugin-version>
+    <maven-clean-plugin-version>3.1.0</maven-clean-plugin-version>
+    <maven-compiler-plugin-version>3.8.0</maven-compiler-plugin-version>
+    <maven-deploy-plugin-version>3.0.0-M1</maven-deploy-plugin-version>
+    <maven-install-plugin-version>3.0.0-M1</maven-install-plugin-version>
+    <maven-jar-plugin-version>3.1.1</maven-jar-plugin-version>
+    <maven-resources-plugin-version>3.1.0</maven-resources-plugin-version>
+    <maven-site-plugin-version>3.7.1</maven-site-plugin-version>
+    <maven-surefire-plugin-version>3.0.0-M3</maven-surefire-plugin-version>
+    <maven-checkstyle-plugin-version>3.0.0</maven-checkstyle-plugin-version>
+    <maven-pmd-plugin-version>3.11.0</maven-pmd-plugin-version>
+    <maven-release-plugin-version>2.5.3</maven-release-plugin-version>
+    <maven-javadoc-plugin-version>3.1.0</maven-javadoc-plugin-version>
+    <maven-failsafe-plugin-version>3.0.0-M3</maven-failsafe-plugin-version>
+    <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
     <swagger-core-version>1.5.22</swagger-core-version>
     <jodatime-version>2.10.1</jodatime-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,11 +173,6 @@
         </executions>
         <dependencies>
           <dependency>
-            <groupId>oracle.kubernetes</groupId>
-            <artifactId>build-tools</artifactId>
-            <version>1.0</version>
-          </dependency>
-          <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-java</artifactId>
             <version>6.8.0</version>
@@ -202,11 +197,6 @@
           </execution>
         </executions>
         <dependencies>
-          <dependency>
-            <groupId>oracle.kubernetes</groupId>
-            <artifactId>build-tools</artifactId>
-            <version>1.0</version>
-          </dependency>
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,31 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>${maven.version.range}</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.0</version>
         <configuration>
           <aggregate>true</aggregate>
           <show>public</show>
@@ -78,7 +95,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
         <executions>
           <execution>
             <id>checkstyle</id>
@@ -110,7 +126,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.11.0</version>
         <configuration>
           <sourceEncoding>utf-8</sourceEncoding>
           <rulesets>
@@ -383,6 +398,72 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.0.0</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.11.0</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java</artifactId>
         <version>4.0.0</version>
@@ -420,6 +501,7 @@
   </dependencies>
 
   <properties>
+    <maven.version.range>[3.5.2,)</maven.version.range>
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
                 <requireMavenVersion>
                   <version>${maven.version.range}</version>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>${java.version.range}</version>
+                </requireJavaVersion>
+                <requirePluginVersions></requirePluginVersions>
               </rules>
             </configuration>
           </execution>
@@ -79,6 +83,26 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>${maven-release-plugin-version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>${maven-clean-plugin-version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin-version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>${maven-site-plugin-version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin-version}</version>
       </plugin>
 
       <plugin>
@@ -490,6 +514,12 @@
         <type>maven-plugin</type>
       </dependency>
       <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin-version}</version>
+        <type>maven-plugin</type>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>${exec-maven-plugin-version}</version>
@@ -533,6 +563,7 @@
   </dependencies>
 
   <properties>
+    <java.version.range>11</java.version.range>
     <maven.version.range>[3.5.2,)</maven.version.range>
     <maven-enforcer-plugin-version>3.0.0-M2</maven-enforcer-plugin-version>
     <maven-clean-plugin-version>3.1.0</maven-clean-plugin-version>
@@ -548,6 +579,7 @@
     <maven-release-plugin-version>2.5.3</maven-release-plugin-version>
     <maven-javadoc-plugin-version>3.1.0</maven-javadoc-plugin-version>
     <maven-failsafe-plugin-version>3.0.0-M3</maven-failsafe-plugin-version>
+    <maven-dependency-plugin-version>3.1.1</maven-dependency-plugin-version>
     <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
     <swagger-core-version>1.5.22</swagger-core-version>
     <jodatime-version>2.10.1</jodatime-version>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.11</version>
+        <version>${spotbugs-maven-plugin-version}</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <failOnError>false</failOnError>
@@ -210,7 +210,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>3.1.11</version>
+            <version>${spotbugs-maven-plugin-version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -581,6 +581,7 @@
     <maven-failsafe-plugin-version>3.0.0-M3</maven-failsafe-plugin-version>
     <maven-dependency-plugin-version>3.1.1</maven-dependency-plugin-version>
     <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
+    <spotbugs-maven-plugin-version>3.1.11</spotbugs-maven-plugin-version>
     <swagger-core-version>1.5.22</swagger-core-version>
     <jodatime-version>2.10.1</jodatime-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/src/integration-tests/bash/krun.sh
+++ b/src/integration-tests/bash/krun.sh
@@ -11,7 +11,7 @@
 #    - This script is an expansion of https://gist.github.com/yuanying/3aa7d59dcce65470804ab43def646ab6
 #
 
-IMAGE='store/oracle/serverjre:8'
+IMAGE='openjdk:11-oracle'
 IMAGEPULLPOLICY='IfNotPresent'
 IMAGEPULLSECRETS=''
 IPSCOMMA=''

--- a/src/integration-tests/introspector/util_krun.sh
+++ b/src/integration-tests/introspector/util_krun.sh
@@ -14,7 +14,7 @@
 #    - Image secret parameter hasn't been tested.
 #
 
-IMAGE='store/oracle/serverjre:8'
+IMAGE='openjdk:11-oracle'
 IMAGEPULLPOLICY='IfNotPresent'
 IMAGEPULLSECRETS=''
 IPSCOMMA=''

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>${exec-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -45,7 +45,18 @@
                     <mainClass>oracle.kubernetes.operator.SwaggerBuildHelper</mainClass>
                 </configuration>
             </plugin>
-      
+
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-compiler-plugin</artifactId>
+           <version>${maven-compiler-plugin-version}</version>
+           <configuration>
+             <release>11</release>
+             <compilerArgs>
+               <arg>-Xpkginfo:always</arg>
+             </compilerArgs>
+           </configuration>
+         </plugin>
       		<plugin>
 				<groupId>com.coveo</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,10 +16,10 @@
 #
 
 box:
-  id: store/oracle/serverjre
+  id: openjdk
   username: $DOCKER_USERNAME
   password: $DOCKER_PASSWORD
-  tag: 8
+  tag: 11-oracle
 
 # This is the main build pipeline that builds the codebase and runs unit tests.
 build:


### PR DESCRIPTION
This change:

- Requires minimum Maven (3.5.2) and JDK (11) versions
- Updates Maven plugin dependencies 
- Updates other dependencies
- Small number of Java code changes for JDK 11 (e.g. asm library)