### PR TITLE
use IP in sans if hostname contains IP address, fix domain in image tests

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1354,9 +1354,15 @@ public class Domain {
     }
 
     if (domainMap.containsKey("domainHomeImageBuildPath")) {
-      domainHomeImageBuildPath = ((String) domainMap.get("domainHomeImageBuildPath")).trim();
+      domainHomeImageBuildPath =
+          BaseTest.getResultDir()
+              + "/"
+              + ((String) domainMap.get("domainHomeImageBuildPath")).trim();
       domainMap.put(
-          "domainHomeImageBuildPath", BaseTest.getResultDir() + "/" + domainHomeImageBuildPath);
+          "domainHomeImageBuildPath",
+          BaseTest.getResultDir()
+              + "/"
+              + ((String) domainMap.get("domainHomeImageBuildPath")).trim());
     }
     if (System.getenv("IMAGE_PULL_SECRET_WEBLOGIC") != null) {
       domainMap.put("imagePullSecretName", System.getenv("IMAGE_PULL_SECRET_WEBLOGIC"));

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Operator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Operator.java
@@ -378,7 +378,13 @@ public class Operator {
         sb.append(operatorNS);
         break;
     }
-    sb.append(" DNS:");
+    // here we are assuming that if the "host name" starts with a digit, then it is actually
+    // an IP address, and so we need to use the "IP" prefix in the SANS.
+    if (Character.isDigit(TestUtils.getHostName().charAt(0))) {
+      sb.append(" IP:");
+    } else {
+      sb.append(" DNS:");
+    }
     sb.append(TestUtils.getHostName());
     sb.append(" >> ");
     sb.append(generatedInputYamlFile);


### PR DESCRIPTION
The first change is required to get the integration tests pass on the new jenkins(shared cluster) setup when IP address is used.
Fixed the intermittent failure for testDomainInImageUsingWLST on Jenkins.

Jenkins passed - http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/1490/console