### PR TITLE
fix typo, jenkins-ignore

### DIFF
--- a/site/v1.1/installation.md
+++ b/site/v1.1/installation.md
@@ -137,7 +137,7 @@ The operator provides some optional features that can be enabled in the configur
 
 ### Load balancing with an Ingress controller or a web server
 
-You can choose a load balancer provider for your WebLogic domains running in a Kubernetes cluster. Please refer to [Load balancing with Voyager/HAProxy](voyager.md), [Load balancing with Traefik](raefik.md), and [Load balancing with the Apache HTTP Server](apache.md) for information about the current capabilities and setup instructions for each of the supported load balancers.
+You can choose a load balancer provider for your WebLogic domains running in a Kubernetes cluster. Please refer to [Load balancing with Voyager/HAProxy](voyager.md), [Load balancing with Traefik](traefik.md), and [Load balancing with the Apache HTTP Server](apache.md) for information about the current capabilities and setup instructions for each of the supported load balancers.
 
 Note these limitations:
 


### PR DESCRIPTION
Fix same typo in the archived install doc on the master branch