### PR TITLE
Recognize v2.0 external channel services

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
@@ -60,22 +60,28 @@ public class AnnotationHelper {
     return service;
   }
 
-  static String getDebugString(V1Pod pod) {
-    return pod.getMetadata().getAnnotations().get(HASHED_STRING);
-  }
-
   static String getHash(V1Pod pod) {
-    return Optional.ofNullable(pod.getMetadata())
-        .map(V1ObjectMeta::getAnnotations)
-        .map(AnnotationHelper::getSha256Annotation)
-        .orElse("");
+    return getAnnotation(pod.getMetadata(), AnnotationHelper::getSha256Annotation);
   }
 
   static String getHash(V1Service service) {
-    return Optional.ofNullable(service.getMetadata())
+    return getAnnotation(service.getMetadata(), AnnotationHelper::getSha256Annotation);
+  }
+
+  static String getDebugString(V1Pod pod) {
+    return getAnnotation(pod.getMetadata(), AnnotationHelper::getDebugHashAnnotation);
+  }
+
+  private static String getAnnotation(
+      V1ObjectMeta metadata, Function<Map<String, String>, String> annotationGetter) {
+    return Optional.ofNullable(metadata)
         .map(V1ObjectMeta::getAnnotations)
-        .map(AnnotationHelper::getSha256Annotation)
+        .map(annotationGetter)
         .orElse("");
+  }
+
+  private static String getDebugHashAnnotation(Map<String, String> annotations) {
+    return annotations.get(HASHED_STRING);
   }
 
   private static String getSha256Annotation(Map<String, String> annotations) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
@@ -8,6 +8,8 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.util.Yaml;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -63,10 +65,20 @@ public class AnnotationHelper {
   }
 
   static String getHash(V1Pod pod) {
-    return pod.getMetadata().getAnnotations().get(SHA256_ANNOTATION);
+    return Optional.ofNullable(pod.getMetadata())
+        .map(V1ObjectMeta::getAnnotations)
+        .map(AnnotationHelper::getSha256Annotation)
+        .orElse("");
   }
 
   static String getHash(V1Service service) {
-    return service.getMetadata().getAnnotations().get(SHA256_ANNOTATION);
+    return Optional.ofNullable(service.getMetadata())
+        .map(V1ObjectMeta::getAnnotations)
+        .map(AnnotationHelper::getSha256Annotation)
+        .orElse("");
+  }
+
+  private static String getSha256Annotation(Map<String, String> annotations) {
+    return annotations.get(SHA256_ANNOTATION);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -290,7 +290,7 @@ public class DomainPresenceInfo {
     return service == null ? null : service.getMetadata();
   }
 
-  V1Service getExternalService(String serverName) {
+  public V1Service getExternalService(String serverName) {
     return getSko(serverName).getExternalService().get();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -36,7 +36,7 @@ public class LegalNames {
     return toDNS1123LegalName(String.format(DOMAIN_INTROSPECTOR_JOB_PATTERN, domainUID));
   }
 
-  static String toExternalServiceName(String domainUID, String serverName) {
+  public static String toExternalServiceName(String domainUID, String serverName) {
     return toDNS1123LegalName(String.format(EXTERNAL_SERVICE_PATTERN, domainUID, serverName));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -53,6 +53,8 @@ import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class ServiceHelper {
+  public static final String CLUSTER_IP_TYPE = "ClusterIP";
+  public static final String NODE_PORT_TYPE = "NodePort";
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private ServiceHelper() {}
@@ -72,23 +74,23 @@ public class ServiceHelper {
   }
 
   public static void addToPresence(DomainPresenceInfo info, V1Service service) {
-    KubernetesServiceType.getType(service).addToPresence(info, service);
+    OperatorServiceType.getType(service).addToPresence(info, service);
   }
 
   public static void updatePresenceFromEvent(DomainPresenceInfo info, V1Service service) {
-    KubernetesServiceType.getType(service).updateFromEvent(info, service);
+    OperatorServiceType.getType(service).updateFromEvent(info, service);
   }
 
   public static V1Service[] getServerServices(DomainPresenceInfo info) {
-    return KubernetesServiceType.SERVER.getServices(info);
+    return OperatorServiceType.SERVER.getServices(info);
   }
 
   public static boolean isServerService(V1Service service) {
-    return KubernetesServiceType.getType(service) == KubernetesServiceType.SERVER;
+    return OperatorServiceType.getType(service) == OperatorServiceType.SERVER;
   }
 
   public static boolean deleteFromEvent(DomainPresenceInfo info, V1Service service) {
-    return KubernetesServiceType.getType(service).deleteFromEvent(info, service);
+    return OperatorServiceType.getType(service).deleteFromEvent(info, service);
   }
 
   public static String getServiceDomainUID(V1Service service) {
@@ -112,6 +114,14 @@ public class ServiceHelper {
 
   public static String getClusterName(V1Service service) {
     return getLabelValue(service, LabelConstants.CLUSTERNAME_LABEL);
+  }
+
+  static boolean isNodePortType(V1Service service) {
+    return NODE_PORT_TYPE.equals(getSpecType(service));
+  }
+
+  private static String getSpecType(V1Service service) {
+    return Optional.ofNullable(service.getSpec()).map(V1ServiceSpec::getType).orElse("");
   }
 
   private static class ForServerStep extends ServiceHelperStep {
@@ -149,7 +159,7 @@ public class ServiceHelper {
     final WlsServerConfig scan;
 
     ServerServiceStepContext(Step conflictStep, Packet packet) {
-      super(conflictStep, packet, KubernetesServiceType.SERVER);
+      super(conflictStep, packet, OperatorServiceType.SERVER);
       serverName = (String) packet.get(ProcessingConstants.SERVER_NAME);
       clusterName = (String) packet.get(ProcessingConstants.CLUSTER_NAME);
       scan = (WlsServerConfig) packet.get(ProcessingConstants.SERVER_SCAN);
@@ -252,7 +262,7 @@ public class ServiceHelper {
 
     @Override
     protected String getSpecType() {
-      return "ClusterIP";
+      return CLUSTER_IP_TYPE;
     }
 
     @Override
@@ -281,9 +291,9 @@ public class ServiceHelper {
     protected List<V1ServicePort> ports;
     DomainPresenceInfo info;
     WlsDomainConfig domainTopology;
-    private KubernetesServiceType serviceType;
+    private OperatorServiceType serviceType;
 
-    ServiceStepContext(Step conflictStep, Packet packet, KubernetesServiceType serviceType) {
+    ServiceStepContext(Step conflictStep, Packet packet, OperatorServiceType serviceType) {
       this.conflictStep = conflictStep;
       info = packet.getSPI(DomainPresenceInfo.class);
       domainTopology = (WlsDomainConfig) packet.get(ProcessingConstants.DOMAIN_TOPOLOGY);
@@ -591,7 +601,7 @@ public class ServiceHelper {
     private final WlsDomainConfig config;
 
     ClusterStepContext(Step conflictStep, Packet packet) {
-      super(conflictStep, packet, KubernetesServiceType.CLUSTER);
+      super(conflictStep, packet, OperatorServiceType.CLUSTER);
       clusterName = (String) packet.get(ProcessingConstants.CLUSTER_NAME);
       config = (WlsDomainConfig) packet.get(ProcessingConstants.DOMAIN_TOPOLOGY);
     }
@@ -624,7 +634,7 @@ public class ServiceHelper {
 
     @Override
     protected String getSpecType() {
-      return "ClusterIP";
+      return CLUSTER_IP_TYPE;
     }
 
     protected V1ObjectMeta createMetadata() {
@@ -719,7 +729,7 @@ public class ServiceHelper {
     private final String adminServerName;
 
     ExternalServiceStepContext(Step conflictStep, Packet packet) {
-      super(conflictStep, packet, KubernetesServiceType.EXTERNAL);
+      super(conflictStep, packet, OperatorServiceType.EXTERNAL);
       adminServerName = (String) packet.get(ProcessingConstants.SERVER_NAME);
     }
 
@@ -741,7 +751,7 @@ public class ServiceHelper {
 
     @Override
     protected String getSpecType() {
-      return "NodePort";
+      return NODE_PORT_TYPE;
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -33,9 +33,9 @@ import java.util.logging.Level;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
-import oracle.kubernetes.operator.helpers.KubernetesServiceType;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.LegalNames;
+import oracle.kubernetes.operator.helpers.OperatorServiceType;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
@@ -142,7 +142,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
         createNamespacedMetadata(uid, namespace)
             .name(LegalNames.toServerServiceName(uid, serverName))
             .putLabelsItem(SERVERNAME_LABEL, serverName);
-    return KubernetesServiceType.SERVER.withTypeLabel(new V1Service().metadata(metadata));
+    return OperatorServiceType.SERVER.withTypeLabel(new V1Service().metadata(metadata));
   }
 
   private V1ObjectMeta createServerMetadata(String uid, String namespace, String serverName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -206,7 +206,7 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
   public void whenCreated_modelKubernetesTypeIsCorrect() {
     V1Service model = testFacade.createServiceModel(testSupport.getPacket());
 
-    assertThat(KubernetesServiceType.getType(model), equalTo(testFacade.getType()));
+    assertThat(OperatorServiceType.getType(model), equalTo(testFacade.getType()));
   }
 
   @Test
@@ -458,7 +458,7 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
     private Map<String, Integer> expectedNapPorts = new HashMap<>();
     private Map<String, Integer> expectedNodePorts = new HashMap<>();
 
-    abstract KubernetesServiceType getType();
+    abstract OperatorServiceType getType();
 
     abstract String getServiceCreateLogMessage();
 
@@ -515,8 +515,8 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
     }
 
     @Override
-    KubernetesServiceType getType() {
-      return KubernetesServiceType.CLUSTER;
+    OperatorServiceType getType() {
+      return OperatorServiceType.CLUSTER;
     }
 
     @Override
@@ -593,8 +593,8 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
   abstract static class ServerTestFacade extends TestFacade {
 
     @Override
-    KubernetesServiceType getType() {
-      return KubernetesServiceType.SERVER;
+    OperatorServiceType getType() {
+      return OperatorServiceType.SERVER;
     }
 
     @Override
@@ -700,8 +700,8 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
     }
 
     @Override
-    KubernetesServiceType getType() {
-      return KubernetesServiceType.EXTERNAL;
+    OperatorServiceType getType() {
+      return OperatorServiceType.EXTERNAL;
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
@@ -23,6 +23,7 @@ import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1ServiceSpec;
 import io.kubernetes.client.util.Watch;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -499,6 +500,22 @@ public class ServicePresenceTest {
     processor.dispatchServiceWatch(event);
 
     assertThat(info.getExternalService(SERVER), nullValue());
+  }
+
+  @Test
+  public void whenEventContainsServiceWithNodePortAndNoTypeLabel_addAsExternalService() {
+    V1Service service =
+        new V1Service()
+            .metadata(
+                createMetadata()
+                    .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true")
+                    .putLabelsItem(SERVERNAME_LABEL, SERVER))
+            .spec(new V1ServiceSpec().type(ServiceHelper.NODE_PORT_TYPE));
+    Watch.Response<V1Service> event = WatchEvent.createAddedEvent(service).toWatchResponse();
+
+    processor.dispatchServiceWatch(event);
+
+    assertThat(info.getExternalService(SERVER), sameInstance(service));
   }
 
   private V1Service createClusterService() {


### PR DESCRIPTION
The operator did not recognize the external channel services defined in 2.0 (and 2.0.1). As a result, it did not add them to the DomainPresenceInfo when it started, and therefore did not delete them as needed on an upgrade. That led the processing step chain to abort, as the newly created service tried to use the same port.

This change uses the spec type "NodePort" to recognize an external service. It also can handle services and pods which did not have any annotations.