### PR TITLE
fix example spacing, jenkins-ignore

### DIFF
--- a/docs-source/content/userguide/managing-domains/configoverrides/_index.md
+++ b/docs-source/content/userguide/managing-domains/configoverrides/_index.md
@@ -277,6 +277,7 @@ The following `jdbc-testDS.xml` override template demonstrates setting the URL, 
   * The configuration map must be in the same Kubernetes namespace as the domain.
   * If the configuration map is going to be used by a single `DOMAIN_UID`, then we recommend adding the `weblogic.domainUID=<mydomainuid>` label to help track the resource.
   * For example, assuming `./mydir` contains your `version.txt` and situation configuration template files:
+
     ```
     kubectl -n MYNAMESPACE create cm MYCMNAME --from-file ./mydir
     kubectl -n MYNAMESPACE label cm MYCMNAME weblogic.domainUID=DOMAIN_UID
@@ -286,6 +287,7 @@ The following `jdbc-testDS.xml` override template demonstrates setting the URL, 
   * Secrets must be in the same Kubernetes namespace as the domain.
   * If a secret is going to be used by a single `DOMAIN_UID`, then we recommend adding the `weblogic.domainUID=<mydomainuid>` label to help track the resource.
   * For example:
+  
     ```
     kubectl -n MYNAMESPACE create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
     kubectl -n MYNAMESPACE label secret my-secret weblogic.domainUID=DOMAIN_UID


### PR DESCRIPTION
Fixed the spacing (onto two lines) of two examples in the step-by-step, bulleted items. 