### PR TITLE
WIP: Fix jenkins archives

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -143,18 +143,24 @@ public class BaseTest {
     }
 
     if (System.getenv("JENKINS") != null) {
-      logger.info("Creating " + resultRoot + "/acceptance_test_tmp");
+      logger.info("Deleting and creating " + resultRoot + "/acceptance_test_tmp");
       TestUtils.exec(
-          "/usr/local/packages/aime/ias/run_as_root \"mkdir -p "
+          "/usr/local/packages/aime/ias/run_as_root \"rm -rf "
+              + resultRoot
+              + "/acceptance_test_tmp\" && "
+              + "/usr/local/packages/aime/ias/run_as_root \"mkdir -p "
               + resultRoot
               + "/acceptance_test_tmp\"");
       TestUtils.exec(
           "/usr/local/packages/aime/ias/run_as_root \"chmod 777 "
               + resultRoot
               + "/acceptance_test_tmp\"");
-      logger.info("Creating " + pvRoot + "/acceptance_test_pv");
+      logger.info("Deleting and Creating " + pvRoot + "/acceptance_test_pv");
       TestUtils.exec(
-          "/usr/local/packages/aime/ias/run_as_root \"mkdir -p "
+          "/usr/local/packages/aime/ias/run_as_root \"rm -rf "
+              + pvRoot
+              + "/acceptance_test_pv\" && "
+              + "/usr/local/packages/aime/ias/run_as_root \"mkdir -p "
               + pvRoot
               + "/acceptance_test_pv\"");
       TestUtils.exec(

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITServerDiscovery.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITServerDiscovery.java
@@ -89,13 +89,15 @@ public class ITServerDiscovery extends BaseTest {
    */
   @AfterClass
   public static void staticUnPrepare() throws Exception {
-    logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
-    logger.info("BEGIN");
-    logger.info("Run once, release cluster lease");
+    if (!QUICKTEST) {
+      logger.info("+++++++++++++++++++++++++++++++++---------------------------------+");
+      logger.info("BEGIN");
+      logger.info("Run once, release cluster lease");
 
-    tearDown(new Object() {}.getClass().getEnclosingClass().getSimpleName());
+      tearDown(new Object() {}.getClass().getEnclosingClass().getSimpleName());
 
-    logger.info("SUCCESS");
+      logger.info("SUCCESS");
+    }
   }
 
   /**

--- a/integration-tests/src/test/resources/statedump.sh
+++ b/integration-tests/src/test/resources/statedump.sh
@@ -108,27 +108,23 @@ function state_dump {
   	if [ "$?" = "0" ]; then
     	$SCRIPTPATH/krun.sh -i openjdk:11-oracle -t 300 -d ${RESULT_DIR} -m  "${PV_ROOT}:/sharedparent" -c 'base64 /sharedparent/pvarchive.jar' > $RESULT_DIR/pvarchive.b64 2>&1
 	 	if [ "$?" = "0" ]; then
+	 		if [ "$JENKINS" = "true" ]; then
+	 			mkdir -p ${JENKINS_RESULTS_DIR}
+	 			ARCHIVE="${JENKINS_RESULTS_DIR}/$ARCHIVE_FILE"
+	 		fi
+	 			
    			base64 -di $RESULT_DIR/pvarchive.b64 > $ARCHIVE
    			if [ "$?" = "0" ]; then
    				echo Run complete. Archived to $ARCHIVE
    			else 
    				echo Run failed. 
    			fi
-   			if [ "$JENKINS" = "true" ]; then
-	   			# Jenkins can only publish logs under the workspace
-				mkdir -p ${JENKINS_RESULTS_DIR}
-				cp $ARCHIVE ${JENKINS_RESULTS_DIR}
-				if [ "$?" = "0" ]; then
-	   				echo Copy complete. Archive $ARCHIVE copied to ${JENKINS_RESULTS_DIR}
-	   			else 
-	   				echo Failed to copy archive $ARCHIVE to ${JENKINS_RESULTS_DIR}
-	   			fi
-	   		fi
+
 	 	else
      		# command failed
   			cat $RESULT_DIR/pvarchive.b64 | head -100
 	 	fi
-	 	# rm $RESULT_DIR/pvarchive.b64
+	 	rm $RESULT_DIR/pvarchive.b64
   	else
     	 echo Job failed.  See ${outfile}.
   	fi	


### PR DESCRIPTION
cleanup.sh which runs at the end of each IT test is unable to delete the directories acceptance_test_tmp and acceptance_test_pv, failing with permission denied errors which makes the log files carried to next IT Test and its log file size will grow.

At the beginning of each test, these directories are created using run_as_root, I modified to delete the directories using run_as_root for jenkins run.