### PR TITLE
OWLS-73109 - Overloaded server handling

### DIFF
--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -389,6 +389,10 @@
     "ProbeTuning": {
       "type": "object",
       "properties": {
+        "httpGetPath": {
+          "description": "Path for httpGet",
+          "type": "string"
+        },
         "periodSeconds": {
           "description": "The number of seconds between checks",
           "type": "number"

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -154,6 +154,7 @@ ServerPod describes the configuration for a Kubernetes pod for a server.
 
 | Name | Type | Description |
 | --- | --- | --- |
+| `httpGetPath` | string | Path for httpGet |
 | `initialDelaySeconds` | number | The number of seconds before the first check is performed |
 | `periodSeconds` | number | The number of seconds between checks |
 | `timeoutSeconds` | number | The number of seconds with no response that indicates a failure |

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1309,6 +1309,10 @@ window.onload = function() {
     "ProbeTuning": {
       "type": "object",
       "properties": {
+        "httpGetPath": {
+          "description": "Path for httpGet",
+          "type": "string"
+        },
         "periodSeconds": {
           "description": "The number of seconds between checks",
           "type": "number"

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/model/ProbeTuning.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/model/ProbeTuning.java
@@ -22,6 +22,10 @@ public class ProbeTuning {
   @SerializedName("timeoutSeconds")
   private Integer timeoutSeconds = null;
 
+  @Description("Path for httpGet")
+  @SerializedName("httpGetPath")
+  private String httpGetPath;
+
   public ProbeTuning() {}
 
   void copyValues(ProbeTuning fromProbe) {
@@ -33,6 +37,9 @@ public class ProbeTuning {
     }
     if (periodSeconds == null) {
       periodSeconds(fromProbe.periodSeconds);
+    }
+    if (httpGetPath == null) {
+      httpGetPath(fromProbe.httpGetPath);
     }
   }
 
@@ -63,12 +70,22 @@ public class ProbeTuning {
     return this;
   }
 
+  public String getHttpGetPath() {
+    return httpGetPath;
+  }
+
+  public ProbeTuning httpGetPath(String httpGetPath) {
+    this.httpGetPath = httpGetPath;
+    return this;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
         .append("initialDelaySeconds", initialDelaySeconds)
         .append("periodSeconds", periodSeconds)
         .append("timeoutSeconds", timeoutSeconds)
+        .append("httpGetPath", httpGetPath)
         .toString();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -777,7 +777,7 @@ public abstract class PodStepContext extends StepContextBase {
         .timeoutSeconds(getReadinessProbeTimeoutSeconds(tuning))
         .periodSeconds(getReadinessProbePeriodSeconds(tuning))
         .failureThreshold(FAILURE_THRESHOLD)
-        .httpGet(httpGetAction(READINESS_PATH, getDefaultPort()));
+        .httpGet(httpGetAction(getReadinessProbeHttpGetPath(), getDefaultPort()));
     return readinessProbe;
   }
 
@@ -801,6 +801,11 @@ public abstract class PodStepContext extends StepContextBase {
   private int getReadinessProbeInitialDelaySeconds(TuningParameters.PodTuning tuning) {
     return Optional.ofNullable(getServerSpec().getReadinessProbe().getInitialDelaySeconds())
         .orElse(tuning.readinessProbeInitialDelaySeconds);
+  }
+
+  private String getReadinessProbeHttpGetPath() {
+    return Optional.ofNullable(getServerSpec().getReadinessProbe().getHttpGetPath())
+        .orElse(READINESS_PATH);
   }
 
   private V1Probe createLivenessProbe(TuningParameters.PodTuning tuning) {


### PR DESCRIPTION
** Draft review for comments - not ready for merging **

The scenario in bug owls-73109 is that the server template for a dynamic cluster is configured with low memory overload protection. When the low memeory threshold is reached,  the server would be in an OVERLOADED state, as reported by ServerRuntimeMBean.getHealthState(). Upon entering the OVERLOADED state, server would start rejecting requests from the Work Manager queue (if a Work Manager is configured), and HTTP requests return a 503 Error (Service Unavailable).
 
Filer of bug expects that the server failure action would take place when the server is in OVERLOADED state and shuts down server. But that is not the expected behavior. Server failure action is not taken when server is in OVERLOADED state, only when the server is in FAILED state. An OVERLOADED server will go back to a OK state once the high free memory threshold is reached. So it is working as designed.

But in kubernetes environment, It is not ideal if a load balancer such as traefik continues to direct traffic to the overloaded server, especially if there are other healthy servers available in the same cluster. So the idea is to update the ingress to exclude the overloaded server, so traffic would be directed to other healthy servers. This can be done through the readiness probe.

Currently in operator the readiness probe hard-coded the httpGet path to "/weblogic/ready". However, this does not return 503 Error when the server is overloaded. Thus this change is making the httpGet path of the readiness probe configurable, with a default value of "/weblogic/ready", so customers are allowed to use the URL to their app for the readiness probe.

Pros:
- when server is overloaded, the HTTP request used in the readiness probe would return 503 Error, and ingress would be updated to exclude the overloaded server. When the server returns back to a healthy state, the readiness probe would be successful and ingress will be updated to include the server again.

- when the customer application is not ready to server requests for any other reasons, the ingress should also be updated to not direct traffic to that server, even though the server is in RUNNING state

Cons:
- server pod would not get to ready state if the httpGet path is misconfigured

Please let me know if there are any concerns with this approach, or suggestions on a better way to deal with overloaded servers in the operator.

