### PR TITLE
Use env. variables for Kubernetes master address

### DIFF
--- a/docs-source/content/userguide/managing-domains/domain-lifecycle/scaling.md
+++ b/docs-source/content/userguide/managing-domains/domain-lifecycle/scaling.md
@@ -163,7 +163,7 @@ The scalingAction.sh script accepts a number of customizable parameters:
 * `kubernetes_master` - Kubernetes master URL, default=https://kubernetes  
 
 {{% notice note %}}
-Set this to https://kubernetes.default.svc when invoking `scalingAction.sh` from the Administration Server pod.
+Set this to https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} when invoking `scalingAction.sh` from the Administration Server pod.
 {{% /notice %}}
 
 * `access_token` - Service Account Bearer token for authentication and authorization for access to REST Resources

--- a/src/scripts/initialize-external-operator-identity.sh
+++ b/src/scripts/initialize-external-operator-identity.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
@@ -29,7 +29,7 @@ LEGACY_KEY_PEM=${OPERATOR_SECRETS_DIR}/${EXTERNAL_KEY}
 
 CACERT='/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
-KUBERNETES_MASTER="https://kubernetes.default.svc"
+KUBERNETES_MASTER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
 
 function cleanup {
   if [[ $SUCCEEDED != "true" ]]; then

--- a/src/scripts/initialize-internal-operator-identity.sh
+++ b/src/scripts/initialize-internal-operator-identity.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright 2018, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
@@ -94,7 +94,7 @@ function generateInternalIdentity {
 function recordInternalIdentity {
   CACERT='/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
   TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
-  KUBERNETES_MASTER="https://kubernetes.default.svc"
+  KUBERNETES_MASTER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
 
   # the request body prints out the atz token
   # don't specify -v so that the token is not printed to the operator log

--- a/src/scripts/scaling/scalingAction.sh
+++ b/src/scripts/scaling/scalingAction.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
@@ -14,7 +14,7 @@ operator_namespace="weblogic-operator"
 operator_service_account="weblogic-operator"
 scaling_size=1
 access_token=""
-kubernetes_master="https://kubernetes"
+kubernetes_master="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
 
 # Parse arguments/parameters
 for arg in "$@"
@@ -69,12 +69,12 @@ done
 # Verify required parameters
 if [ -z "$scaling_action" ] || [ -z "$wls_domain_uid" ] || [ -z "$wls_cluster_name" ]
 then
-    echo "Usage: scalingAction.sh --action=[scaleUp | scaleDown] --domain_uid=<domain uid> --cluster_name=<cluster name> [--kubernetes_master=https://kubernetes] [--access_token=<access_token>] [--wls_domain_namespace=default] [--operator_namespace=weblogic-operator] [--operator_service_name=weblogic-operator] [--scaling_size=1]"
+    echo "Usage: scalingAction.sh --action=[scaleUp | scaleDown] --domain_uid=<domain uid> --cluster_name=<cluster name> [--kubernetes_master=https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}] [--access_token=<access_token>] [--wls_domain_namespace=default] [--operator_namespace=weblogic-operator] [--operator_service_name=weblogic-operator] [--scaling_size=1]"
     echo "  where"
     echo "    action - scaleUp or scaleDown"
     echo "    domain_uid - WebLogic Domain Unique Identifier"
     echo "    cluster_name - WebLogic Cluster Name"
-    echo "    kubernetes_master - Kubernetes master URL, default=https://kubernetes"
+    echo "    kubernetes_master - Kubernetes master URL, default=https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
     echo "    access_token - Service Account Bearer token for authentication and authorization for access to REST Resources"
     echo "    wls_domain_namespace - Kubernetes name space WebLogic Domain is defined in, default=default"
     echo "    operator_service_name - WebLogic Operator Service name, default=internal-weblogic-operator-svc"


### PR DESCRIPTION
I discovered that Kubernetes behavior doesn't match what they document, so updating the scripts to locate the master's REST URL the same way as the clients do.