### PR TITLE
Improvement to non-repeated logging of ReadHealthStep messages

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import oracle.kubernetes.operator.TuningParameters.MainTuning;
 import oracle.kubernetes.operator.calls.CallResponse;
@@ -314,7 +315,9 @@ public class DomainProcessorImpl implements DomainProcessor {
                   new CompletionCallback() {
                     @Override
                     public void onCompletion(Packet packet) {
-                      if (Boolean.TRUE.equals(packet.get(ProcessingConstants.SERVER_HEALTH_READ))) {
+                      AtomicInteger serverHealthRead =
+                          packet.getValue(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ);
+                      if (serverHealthRead == null || serverHealthRead.get() == 0) {
                         loggingFilter.setFiltering(false).resetLogHistory();
                       } else {
                         loggingFilter.setFiltering(true);

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -316,7 +316,7 @@ public class DomainProcessorImpl implements DomainProcessor {
                     @Override
                     public void onCompletion(Packet packet) {
                       AtomicInteger serverHealthRead =
-                          packet.getValue(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ);
+                          packet.getValue(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ);
                       if (serverHealthRead == null || serverHealthRead.get() == 0) {
                         loggingFilter.setFiltering(false).resetLogHistory();
                       } else {

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -32,5 +32,5 @@ public interface ProcessingConstants {
   public static final String DOMAIN_INTROSPECTOR_LOG_RESULT = "domainIntrospectorLogResult";
   public static final String SIT_CONFIG_MAP = "sitConfigMap";
 
-  public static final String REMAINING_SERVERS_HEALTH_READ = "serverHealthRead";
+  public static final String REMAINING_SERVERS_HEALTH_TO_READ = "serverHealthRead";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -32,5 +32,5 @@ public interface ProcessingConstants {
   public static final String DOMAIN_INTROSPECTOR_LOG_RESULT = "domainIntrospectorLogResult";
   public static final String SIT_CONFIG_MAP = "sitConfigMap";
 
-  public static final String SERVER_HEALTH_READ = "serverHealthRead";
+  public static final String REMAINING_SERVERS_HEALTH_READ = "serverHealthRead";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -69,8 +69,8 @@ public class ServerStatusReader {
       packet.put(SERVER_STATE_MAP, new ConcurrentHashMap<String, String>());
       packet.put(SERVER_HEALTH_MAP, new ConcurrentHashMap<String, ServerHealth>());
 
-      AtomicInteger serverHealthRead = new AtomicInteger();
-      packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ, serverHealthRead);
+      AtomicInteger remainingServerHealthToRead = new AtomicInteger();
+      packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ, remainingServerHealthToRead);
 
       Collection<StepAndPacket> startDetails =
           info.getServerPods()
@@ -80,7 +80,7 @@ public class ServerStatusReader {
       if (startDetails.isEmpty()) {
         return doNext(packet);
       } else {
-        serverHealthRead.set(startDetails.size());
+        remainingServerHealthToRead.set(startDetails.size());
         return doForkJoin(getNext(), packet, startDetails);
       }
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -154,9 +154,9 @@ public class ReadHealthStep extends Step {
                 (ConcurrentMap<String, ServerHealth>)
                     packet.get(ProcessingConstants.SERVER_HEALTH_MAP);
             serverHealthMap.put((String) packet.get(ProcessingConstants.SERVER_NAME), health);
-            AtomicInteger serverHealthRead =
-                packet.getValue(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ);
-            serverHealthRead.getAndDecrement();
+            AtomicInteger remainingServersHealthToRead =
+                packet.getValue(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ);
+            remainingServersHealthToRead.getAndDecrement();
           }
         }
         return doNext(packet);

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.http.HttpClient;
@@ -153,7 +154,9 @@ public class ReadHealthStep extends Step {
                 (ConcurrentMap<String, ServerHealth>)
                     packet.get(ProcessingConstants.SERVER_HEALTH_MAP);
             serverHealthMap.put((String) packet.get(ProcessingConstants.SERVER_NAME), health);
-            packet.put(ProcessingConstants.SERVER_HEALTH_READ, Boolean.TRUE);
+            AtomicInteger serverHealthRead =
+                packet.getValue(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ);
+            serverHealthRead.getAndDecrement();
           }
         }
         return doNext(packet);

--- a/operator/src/test/java/oracle/kubernetes/operator/ServerStatusReaderTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ServerStatusReaderTest.java
@@ -9,6 +9,7 @@ import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_STATE_MAP;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import com.meterware.pseudoserver.HttpUserAgentTest;
@@ -27,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import oracle.kubernetes.TestUtils;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
@@ -117,6 +119,19 @@ public class ServerStatusReaderTest extends HttpUserAgentTest {
     Map<String, String> serverStates = getServerStates(packet);
     assertThat(serverStates, hasEntry("server1", "server1 status"));
     assertThat(serverStates, hasEntry("server2", "server2 status"));
+  }
+
+  @Test
+  public void createDomainStatusReaderStep_initializesRemainingServersHealthRead_withNumServers() {
+    info.setServerPod("server1", createPod("server1"));
+    info.setServerPod("server2", createPod("server2"));
+
+    Packet packet =
+        testSupport.runSteps(ServerStatusReader.createDomainStatusReaderStep(info, 0, endStep));
+
+    assertThat(
+        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ)).get(),
+        is(2));
   }
 
   @SuppressWarnings("unchecked")

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ReadHealthStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ReadHealthStepTest.java
@@ -95,7 +95,7 @@ public class ReadHealthStepTest {
     final String SERVER_NAME = ADMIN_NAME;
     Packet packet =
         Stub.createStub(PacketStub.class).withServerName(SERVER_NAME).withGetKeyReturnValue(null);
-    packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ, new AtomicInteger(1));
+    packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ, new AtomicInteger(1));
 
     ReadHealthWithHttpClientStep withHttpClientStep =
         new ReadHealthWithHttpClientStep(service, null, next);
@@ -103,7 +103,7 @@ public class ReadHealthStepTest {
 
     assertThat(logRecords, containsInfo(WLS_HEALTH_READ_FAILED_NO_HTTPCLIENT, SERVER_NAME));
     assertThat(
-        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ)).get(),
+        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ)).get(),
         is(1));
   }
 
@@ -121,14 +121,14 @@ public class ReadHealthStepTest {
             .withGetKeyReturnValue(httpClientStub);
     packet.put(
         ProcessingConstants.SERVER_HEALTH_MAP, new ConcurrentHashMap<String, ServerHealth>());
-    packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ, new AtomicInteger(1));
+    packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ, new AtomicInteger(1));
 
     ReadHealthWithHttpClientStep withHttpClientStep =
         new ReadHealthWithHttpClientStep(service, null, next);
     withHttpClientStep.apply(packet);
 
     assertThat(
-        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ)).get(),
+        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ)).get(),
         is(0));
   }
 
@@ -144,7 +144,7 @@ public class ReadHealthStepTest {
     packet.put(HttpClient.KEY, httpClientStub);
     packet.put(
         ProcessingConstants.SERVER_HEALTH_MAP, new ConcurrentHashMap<String, ServerHealth>());
-    packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ, new AtomicInteger(2));
+    packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ, new AtomicInteger(2));
 
     ReadHealthWithHttpClientStep withHttpClientStep1 =
         new ReadHealthWithHttpClientStep(service, null, next);
@@ -160,7 +160,7 @@ public class ReadHealthStepTest {
     withHttpClientStep2.apply(packet2);
 
     assertThat(
-        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_READ)).get(),
+        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ)).get(),
         is(0));
   }
 


### PR DESCRIPTION
PR #1034 prevents repeated logging of same error messages in periodic invocation of ReadHealthStep by using a new logging filter mechanism that only logs each log message once until ReadHealthStep is successful again. The logging filter remembers what messages were logged and is passed to the Steps via packet.

However, it only enables the logging filter if ReadHealthStep for all WLS servers fail, which was the case if the weblogic credentials secret was missing.

This change modifies the change in PR #1034 by enabling the logging filter and prevent repeated logging of messages if ReadHealthStep for any of the WLS servers fails, such as if one of the managed servers fails to response to the REST request due to it being in overloaded health state.