### PR TITLE
PR (ready to be merged): Voyager JIRA OWLS-73062

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -209,7 +209,7 @@ The tests accepts optional env var overrides:
 | RESULT_ROOT | The root directory to use for the tests temporary files. See "Directory Configuration and Structure" for                  defaults and a detailed description of test directories. |
 | PV_ROOT    |  The root directory on the kubernetes cluster used for persistent volumes. See "Directory Configuration and Structure" for defaults and a detailed description of test directories. |
 | QUICKTEST  | When set to "true", limits testing to a subset of the tests. |
-| LB_TYPE    | The default value is "TRAEFIK". Set to "VOYAGER" if you want to use it as LB. |
+| LB_TYPE    | The default value is "TRAEFIK". Set to "VOYAGER" if you want to use it as LB. Using "VOYAGER" requires unique "voyagerWebPort"|
 | INGRESSPERDOMAIN  | The defult value is true. If you want to test creating TRAEFIK LB by kubectl yaml for multiple domains, set it to false. |
 | SHARED_CLUSTER    | Set to true if invoking on shared cluster, set to false or "" if running stand-alone or from Jenkins. Default is "". |
 | JENKINS    | Set to true if invoking from Jenkins, set to false or "" if running stand-alone or on shared cluster. Default is "". |

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
@@ -142,8 +142,8 @@ public class ITMultipleClusters extends BaseTest {
           "createDomainPyScript",
           "integration-tests/src/test/resources/domain-home-on-pv/" + TWO_MIXED_CLUSTER_SCRIPT);
       if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
-          || (domainMap.containsKey("LB_TYPE")
-              && ((String) domainMap.get("loadBalancer")).equalsIgnoreCase("loadBalancer"))) {
+          || (domainMap.containsKey("loadBalancer")
+              && ((String) domainMap.get("loadBalancer")).equalsIgnoreCase("VOYAGER"))) {
         domainMap.put("voyagerWebPort", new Integer("30377"));
       }
       addCluster2ToDomainTemplate();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
@@ -140,8 +140,9 @@ public class ITMultipleClusters extends BaseTest {
       domainMap.put(
           "createDomainPyScript",
           "integration-tests/src/test/resources/domain-home-on-pv/" + TWO_MIXED_CLUSTER_SCRIPT);
-      if (System.getenv("LB_TYPE") != null
-          && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER")) {
+      if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
+          || (domainMap.containsKey("LB_TYPE")
+              && ((String) domainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"))) {
         domainMap.put("voyagerWebPort", new Integer("30377"));
       }
       addCluster2ToDomainTemplate();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
@@ -93,8 +93,9 @@ public class ITMultipleClusters extends BaseTest {
           "createDomainPyScript",
           "integration-tests/src/test/resources/domain-home-on-pv/"
               + TWO_CONFIGURED_CLUSTER_SCRIPT);
-      if (System.getenv("LB_TYPE") != null
-          && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER")) {
+      if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
+          || (domainMap.containsKey("LB_TYPE")
+              && ((String) domainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"))) {
         domainMap.put("voyagerWebPort", new Integer("30366"));
       }
       addCluster2ToDomainTemplate();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
@@ -93,6 +93,10 @@ public class ITMultipleClusters extends BaseTest {
           "createDomainPyScript",
           "integration-tests/src/test/resources/domain-home-on-pv/"
               + TWO_CONFIGURED_CLUSTER_SCRIPT);
+      if (System.getenv("LB_TYPE") != null
+          && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER")) {
+        domainMap.put("voyagerWebPort", new Integer("30366"));
+      }
       addCluster2ToDomainTemplate();
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
@@ -136,6 +140,10 @@ public class ITMultipleClusters extends BaseTest {
       domainMap.put(
           "createDomainPyScript",
           "integration-tests/src/test/resources/domain-home-on-pv/" + TWO_MIXED_CLUSTER_SCRIPT);
+      if (System.getenv("LB_TYPE") != null
+          && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER")) {
+        domainMap.put("voyagerWebPort", new Integer("30377"));
+      }
       addCluster2ToDomainTemplate();
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITMultipleClusters.java
@@ -94,8 +94,8 @@ public class ITMultipleClusters extends BaseTest {
           "integration-tests/src/test/resources/domain-home-on-pv/"
               + TWO_CONFIGURED_CLUSTER_SCRIPT);
       if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
-          || (domainMap.containsKey("LB_TYPE")
-              && ((String) domainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"))) {
+          || (domainMap.containsKey("loadBalancer")
+              && ((String) domainMap.get("loadBalancer")).equalsIgnoreCase("VOYAGER"))) {
         domainMap.put("voyagerWebPort", new Integer("30366"));
       }
       addCluster2ToDomainTemplate();
@@ -143,7 +143,7 @@ public class ITMultipleClusters extends BaseTest {
           "integration-tests/src/test/resources/domain-home-on-pv/" + TWO_MIXED_CLUSTER_SCRIPT);
       if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
           || (domainMap.containsKey("LB_TYPE")
-              && ((String) domainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"))) {
+              && ((String) domainMap.get("loadBalancer")).equalsIgnoreCase("loadBalancer"))) {
         domainMap.put("voyagerWebPort", new Integer("30377"));
       }
       addCluster2ToDomainTemplate();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITStickySession.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITStickySession.java
@@ -63,7 +63,7 @@ public class ITStickySession extends BaseTest {
         logger.info("Creating WLS Domain & waiting for the script to complete execution");
         Map<String, Object> domainMap = TestUtils.loadYaml(DOMAINONPV_WLST_YAML);
         // Treafik doesn't work due to the bug 28050300. Use Voyager instead
-        domainMap.put("LB_TYPE", "VOYAGER");
+        domainMap.put("loadBalancer", "VOYAGER");
         domainMap.put("voyagerWebPort", new Integer("30355"));
         domain = TestUtils.createDomain(domainMap);
         domain.verifyDomainCreated();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ITStickySession.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ITStickySession.java
@@ -64,6 +64,7 @@ public class ITStickySession extends BaseTest {
         Map<String, Object> domainMap = TestUtils.loadYaml(DOMAINONPV_WLST_YAML);
         // Treafik doesn't work due to the bug 28050300. Use Voyager instead
         domainMap.put("LB_TYPE", "VOYAGER");
+        domainMap.put("voyagerWebPort", new Integer("30355"));
         domain = TestUtils.createDomain(domainMap);
         domain.verifyDomainCreated();
       }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1101,7 +1101,10 @@ public class Domain {
     lbMap.put("serviceName", domainUid + "-cluster-" + domainMap.get("clusterName"));
     if (voyager) {
       lbMap.put("loadBalancer", "VOYAGER");
-      lbMap.put("loadBalancerWebPort", domainMap.get("voyagerWebPort"));
+      //lbMap.put("loadBalancerWebPort", domainMap.get("voyagerWebPort"));
+      lbMap.put(
+              "loadBalancerWebPort",
+              domainMap.getOrDefault("voyagerWebPort", new Integer(loadBalancerWebPort)));
     } else {
       lbMap.put("loadBalancer", domainMap.getOrDefault("loadBalancer", loadBalancer));
       lbMap.put(

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1351,8 +1351,8 @@ public class Domain {
 
     this.voyager =
         (System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
-            || (inputDomainMap.containsKey("LB_TYPE")
-                && ((String) inputDomainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"));
+            || (inputDomainMap.containsKey("loadBalancer")
+                && ((String) inputDomainMap.get("loadBalancer")).equalsIgnoreCase("VOYAGER"));
 
     if (System.getenv("INGRESSPERDOMAIN") != null) {
       INGRESSPERDOMAIN = new Boolean(System.getenv("INGRESSPERDOMAIN")).booleanValue();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1101,10 +1101,9 @@ public class Domain {
     lbMap.put("serviceName", domainUid + "-cluster-" + domainMap.get("clusterName"));
     if (voyager) {
       lbMap.put("loadBalancer", "VOYAGER");
-      //lbMap.put("loadBalancerWebPort", domainMap.get("voyagerWebPort"));
       lbMap.put(
-              "loadBalancerWebPort",
-              domainMap.getOrDefault("voyagerWebPort", new Integer(loadBalancerWebPort)));
+          "loadBalancerWebPort",
+          domainMap.getOrDefault("voyagerWebPort", new Integer(loadBalancerWebPort)));
     } else {
       lbMap.put("loadBalancer", domainMap.getOrDefault("loadBalancer", loadBalancer));
       lbMap.put(

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -884,6 +884,7 @@ public class TestUtils {
     domainMap.put("exposeAdminNodePort", true);
     domainMap.put("adminNodePort", 30700 + number);
     domainMap.put("t3ChannelPort", 30000 + number);
+    domainMap.put("voyagerWebPort", 30344 + number);
     return domainMap;
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -884,7 +884,9 @@ public class TestUtils {
     domainMap.put("exposeAdminNodePort", true);
     domainMap.put("adminNodePort", 30700 + number);
     domainMap.put("t3ChannelPort", 30000 + number);
-    if (System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER")) {
+    if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
+        || (domainMap.containsKey("LB_TYPE")
+            && ((String) domainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"))) {
       domainMap.put("voyagerWebPort", 30344 + number);
       logger.info("For this domain voyagerWebPort is set to: 30344 + " + number);
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -885,8 +885,8 @@ public class TestUtils {
     domainMap.put("adminNodePort", 30700 + number);
     domainMap.put("t3ChannelPort", 30000 + number);
     if ((System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER"))
-        || (domainMap.containsKey("LB_TYPE")
-            && ((String) domainMap.get("LB_TYPE")).equalsIgnoreCase("VOYAGER"))) {
+        || (domainMap.containsKey("loadBalancer")
+            && ((String) domainMap.get("loadBalancer")).equalsIgnoreCase("VOYAGER"))) {
       domainMap.put("voyagerWebPort", 30344 + number);
       logger.info("For this domain voyagerWebPort is set to: 30344 + " + number);
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -884,7 +884,10 @@ public class TestUtils {
     domainMap.put("exposeAdminNodePort", true);
     domainMap.put("adminNodePort", 30700 + number);
     domainMap.put("t3ChannelPort", 30000 + number);
-    domainMap.put("voyagerWebPort", 30344 + number);
+    if (System.getenv("LB_TYPE") != null && System.getenv("LB_TYPE").equalsIgnoreCase("VOYAGER")) {
+      domainMap.put("voyagerWebPort", 30344 + number);
+      logger.info("For this domain voyagerWebPort is set to: 30344 + " + number);
+    }
     return domainMap;
   }
 

--- a/integration-tests/src/test/resources/domaininimagewdt.yaml
+++ b/integration-tests/src/test/resources/domaininimagewdt.yaml
@@ -7,6 +7,7 @@ configuredManagedServerCount: 4
 initialManagedServerReplicas: 2
 exposeAdminT3Channel: true
 exposeAdminNodePort: true
+voyagerWebPort: 30333
 domainHomeImageBuildPath: ./docker-images/OracleWebLogic/samples/12213-domain-home-in-image-wdt
 domainHomeImageBase: "store/oracle/weblogic:12.2.1.3"
 logHomeOnPV: true

--- a/integration-tests/src/test/resources/domaininimagewlst.yaml
+++ b/integration-tests/src/test/resources/domaininimagewlst.yaml
@@ -7,6 +7,7 @@ configuredManagedServerCount: 4
 initialManagedServerReplicas: 2
 exposeAdminT3Channel: true
 exposeAdminNodePort: true
+voyagerWebPort: 30322
 domainHomeImageBuildPath: ./docker-images/OracleWebLogic/samples/12213-domain-home-in-image
 domainHomeImageBase: "store/oracle/weblogic:12.2.1.3"
 logHomeOnPV: true


### PR DESCRIPTION
This PR is to fix full integ test issue with VOYAGER since not like TRAEFIK, VOYAGER requires unique webport because there are multiple voyager instances created for the different domains/backends . The fix includes:
1) resolving NPE if the domain doesn't explicitly set voyagerWebPort
2) ensuring uniqueness of voyagerWebPort if "LB_TYPE" is set to "VOYAGER"
Full test suite Jenkins passed at:  http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/1615/console