### PR TITLE
Wait for other servers to become ready during a cluster rolling

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -473,8 +473,7 @@ public abstract class PodStepContext extends StepContextBase {
         setRecordedPod(newPod);
       }
 
-      PodAwaiterStepFactory pw = PodHelper.getPodAwaiterStepFactory(packet);
-      return doNext(pw.waitForReady(newPod, next), packet);
+      return doNext(next, packet);
     }
   }
 
@@ -504,8 +503,7 @@ public abstract class PodStepContext extends StepContextBase {
         setRecordedPod(newPod);
       }
 
-      PodAwaiterStepFactory pw = PodHelper.getPodAwaiterStepFactory(packet);
-      return doNext(pw.waitForReady(newPod, next), packet);
+      return doNext(next, packet);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
@@ -74,7 +74,7 @@ public abstract class Step {
     String name = getClass().getName();
     int idx = name.lastIndexOf('.');
     if (idx >= 0) {
-      name = name.substring(idx + 1, name.length());
+      name = name.substring(idx + 1);
     }
     name = name.endsWith("Step") ? name.substring(0, name.length() - 4) : name;
     String detail = getDetail();
@@ -83,6 +83,13 @@ public abstract class Step {
 
   protected String getDetail() {
     return null;
+  }
+
+  public String toString() {
+    if (next == null) {
+      return getName();
+    }
+    return getName() + "[" + next.getName() + "]";
   }
 
   /**
@@ -257,12 +264,9 @@ public abstract class Step {
         step,
         (fiber) -> {
           CompletionCallback callback =
-              new CompletionCallback() {
-                final AtomicInteger count = new AtomicInteger(startDetails.size());
-                final List<Throwable> throwables = new ArrayList<Throwable>();
-
+              new JoinCompletionCallback(fiber, packet, startDetails.size()) {
                 @Override
-                public void onCompletion(Packet packet) {
+                public void onCompletion(Packet p) {
                   if (count.decrementAndGet() == 0) {
                     // no need to synchronize throwables as all fibers are done
                     if (throwables.isEmpty()) {
@@ -274,18 +278,68 @@ public abstract class Step {
                     }
                   }
                 }
+              };
+          // start forked fibers
+          for (StepAndPacket sp : startDetails) {
+            fiber.createChildFiber().start(sp.step, sp.packet, callback);
+          }
+        });
+  }
 
+  private abstract static class JoinCompletionCallback implements CompletionCallback {
+    protected final Fiber fiber;
+    protected final Packet packet;
+    protected final AtomicInteger count;
+    protected final List<Throwable> throwables = new ArrayList<Throwable>();
+
+    JoinCompletionCallback(Fiber fiber, Packet packet, int initialCount) {
+      this.fiber = fiber;
+      this.packet = packet;
+      this.count = new AtomicInteger(initialCount);
+    }
+
+    @Override
+    public void onThrowable(Packet p, Throwable throwable) {
+      synchronized (throwables) {
+        throwables.add(throwable);
+      }
+      if (count.decrementAndGet() == 0) {
+        // no need to synchronize throwables as all fibers are done
+        if (throwables.size() == 1) {
+          fiber.terminate(throwable, packet);
+        } else {
+          fiber.terminate(new MultiThrowable(throwables), packet);
+        }
+      }
+    }
+  }
+
+  /**
+   * Create a {@link NextAction} that suspends the current {@link Fiber} and that starts child
+   * fibers for each step and packet pair. When at least one of the created child fibers completes,
+   * then this fiber is resumed with the indicated step and packet and any other child fibers are
+   * cancelled.
+   *
+   * @param step Step to invoke next when resumed after at least one child fiber completes
+   * @param packet Resume packet
+   * @param startDetails Pairs of step and packet to use when starting child fibers
+   * @return Next action
+   */
+  protected NextAction doForkAtLeastOne(
+      Step step, Packet packet, Collection<StepAndPacket> startDetails) {
+    return doSuspend(
+        step,
+        (fiber) -> {
+          Collection<Fiber> createdFibers = new ArrayList<>();
+          CompletionCallback callback =
+              new JoinCompletionCallback(fiber, packet, startDetails.size()) {
                 @Override
-                public void onThrowable(Packet packet, Throwable throwable) {
-                  synchronized (throwables) {
-                    throwables.add(throwable);
-                  }
-                  if (count.decrementAndGet() == 0) {
-                    // no need to synchronize throwables as all fibers are done
-                    if (throwables.size() == 1) {
-                      fiber.terminate(throwable, packet);
-                    } else {
-                      fiber.terminate(new MultiThrowable(throwables), packet);
+                public void onCompletion(Packet p) {
+                  count.decrementAndGet();
+                  fiber.resume(packet);
+                  synchronized (createdFibers) {
+                    for (Fiber f : createdFibers) {
+                      f.cancel(true);
                     }
                   }
                 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
@@ -136,7 +136,6 @@ public class DomainUpPlanTest {
     assertThat(
         plan,
         hasChainWithStepsInOrder(
-            "ProgressingHookStep",
             "DomainPresenceStep",
             // "DeleteIntrospectorJobStep",
             "DomainIntrospectorJobStep",

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -421,14 +421,14 @@ public class ManagedServersUpStepTest {
   }
 
   @Test
-  public void whenShuttingDown_insertCreateAvailableHookStep() {
+  public void whenShuttingDown_insertCreateAvailableStep() {
     configurator.setShuttingDown(true);
 
-    assertThat(createNextStep().getClass().getSimpleName(), equalTo("AvailableHookStep"));
+    assertThat(createNextStep().getClass().getSimpleName(), equalTo("AvailableStep"));
   }
 
   @Test
-  public void whenNotShuttingDown_dontInsertCreateAvailableHookStep() {
+  public void whenNotShuttingDown_dontInsertCreateAvailableStep() {
     configurator.setShuttingDown(false);
 
     assertThat(createNextStep(), instanceOf(ClusterServicesStep.class));


### PR DESCRIPTION
There were several broken use cases where cluster rolling would not honor the minimum unavailability setting.  One significant problem was that the cluster rolling support assumed that it could always roll at least one server.  With this change, this code will wait if there are not-yet-ready servers that are in the process of starting.  Also, servers that are terminating, but still ready, are not counted as ready for the purpose of maintaining the minimum availability.