### PR TITLE
OWLS-74223 : Missing DomainName test fails

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Operator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Operator.java
@@ -483,12 +483,14 @@ public class Operator {
       // create domain namespaces
 
       ArrayList<String> domainNamespaces = (ArrayList<String>) operatorMap.get("domainNamespaces");
-      for (int i = 0; i < domainNamespaces.size(); i++) {
-        String domainNS = domainNamespaces.get(i);
-        logger.info("domainNamespace " + domainNS);
-        if (!domainNS.equals("default")) {
-          logger.info("Creating domain namespace " + domainNS);
-          ExecCommand.exec("kubectl create namespace " + domainNS);
+      if (domainNamespaces != null) {
+        for (int i = 0; i < domainNamespaces.size(); i++) {
+          String domainNS = domainNamespaces.get(i);
+          logger.info("domainNamespace " + domainNS);
+          if (!domainNS.equals("default")) {
+            logger.info("Creating domain namespace " + domainNS);
+            ExecCommand.exec("kubectl create namespace " + domainNS);
+          }
         }
       }
     }


### PR DESCRIPTION
OWLS-74223 : ITUsabilityOperatorHelmChart.testCreateWithMissingTargetDomainInstall test fails.
The problem was that the override file had domainNamespaces:[], which is an empty set and causes the .domain-namespaces.tpl to skip the generation of the namespace role binding.  This, in turn, caused the operator HealthCheckHelper to take much longer and timeout.  Fix the test so that it generates the helm override values.yaml file without a domainNamespace at all so that he operator default value is used.  Also, add a new test which passes an empty string as the domainNamespaces entry, this simulates the QuickStart install instructions where --set "domainNamespaces={}" is used.