### PR TITLE
OWLS-74827 : DEBUG listen address must use wildcard instead of hostname

### DIFF
--- a/src/scripts/operator.sh
+++ b/src/scripts/operator.sh
@@ -20,7 +20,7 @@ trap relay_SIGTERM SIGTERM
 /operator/initialize-external-operator-identity.sh
 
 if [[ ! -z "$REMOTE_DEBUG_PORT" ]]; then
-  DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$HOSTNAME:$REMOTE_DEBUG_PORT"
+  DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$REMOTE_DEBUG_PORT"
   echo "DEBUG=$DEBUG"
 else
   DEBUG=""


### PR DESCRIPTION
For JDK 11, the debug listen address specified in operator.sh must use a wildcard hostname or else you cannot connect with a remote debugger.  I tested this fix with both OKE and Mac Docker Desktop with Kubernetes.