### PR TITLE
removed welcome1, jenkins-ignore

### DIFF
--- a/docs-source/content/quickstart/create-domain.md
+++ b/docs-source/content/quickstart/create-domain.md
@@ -10,7 +10,7 @@ weight: 6
 
     ```bash
     $ kubernetes/samples/scripts/create-weblogic-domain-credentials/create-weblogic-credentials.sh \
-      -u weblogic -p welcome1 -n sample-domain1-ns -d sample-domain1
+      -u <username> -p <password> -n sample-domain1-ns -d sample-domain1
     ```
 
     The sample will create a secret named `domainUID-weblogic-credentials` where the `domainUID` is replaced
@@ -35,7 +35,7 @@ If you set the `domainHomeImageBuildPath` property to `./docker-images/OracleWeb
 
     ```bash
     $ cd kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image
-    $ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -u weblogic -p welcome1 -e
+    $ ./create-domain.sh -i my-inputs.yaml -o /some/output/directory -u <username> -p <password> -e
     ```
 
     You need to provide the WebLogic administration user name and password in the `-u` and `-p` options

--- a/docs-source/content/samples/simple/credentials/_index.md
+++ b/docs-source/content/samples/simple/credentials/_index.md
@@ -17,7 +17,7 @@ that the domain will run in.
 To use the sample, run the command:
 
 ```
-$ ./create-weblogic-credentials.sh -u username -p password -d domainUID -n namespace -s secretName
+$ ./create-weblogic-credentials.sh -u <username> -p <password> -d domainUID -n namespace -s secretName
 ```
 
 The parameters are as follows:

--- a/docs-source/content/samples/simple/domains/domain-home-in-image/_index.md
+++ b/docs-source/content/samples/simple/domains/domain-home-in-image/_index.md
@@ -22,8 +22,8 @@ The following prerequisites must be handled prior to running the create domain s
 ```
 $ cd ./kubernetes/samples/scripts/create-weblogic-domain-credentials
 $ create-weblogic-credentials.sh
-   -u weblogic
-   -p welcome1
+   -u <username>
+   -p <password>
    -d domain1
    -n default
    -s domain1-weblogic-credentials

--- a/docs-source/content/userguide/managing-domains/prepare.md
+++ b/docs-source/content/userguide/managing-domains/prepare.md
@@ -24,15 +24,15 @@ Perform these steps to prepare your Kubernetes cluster to run a WebLogic domain:
     ```
     $ kubectl -n domain-namespace-1 \
             create secret generic domain1-weblogic-credentials \
-            --from-literal=username=weblogic \
-            --from-literal=password=welcome1
+            --from-literal=username=username \
+            --from-literal=password=password
     ```
 
     * Replace `domain-namespace-1` with the namespace that the domain will be in.
     * Replace `domain1-weblogic-credentials` with the name of the secret.  The operator expects the secret name to be
       the `domainUID` followed by the literal string `-weblogic-credentials` and many of the samples assume this name.
-    * Replace the string `weblogic` in the third line with the user name for the administrative user.
-    * Replace the string `welcome1` in the fourth line with the password.
+    * Replace the string `username` in the third line with the user name for the administrative user.
+    * Replace the string `password` in the fourth line with the password.
 
 1. Optionally, [create a PV & persistent volume claim (PVC)]({{< relref "/samples/simple/storage/_index.md" >}}) which can hold the domain home, logs, and application binaries.
    Even if you put your domain in a Docker image, you may want to put the logs on a persistent volume so that they are available after the pods terminate.


### PR DESCRIPTION
Fixed docs to meet Oracle style guidelines with regard to passwords. "Don't use: welcome1" "To indicate a password in Oracle documentation, use the word password in italic." In markdown, because I couldn't format italics inside a code block, I used angle brackets instead.