### PR TITLE
WIP: Fix SSL Managed Server start issue due to incorrect ADMIN_URL

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -177,7 +177,25 @@ public abstract class PodStepContext extends StepContextBase {
         .getLocalAdminProtocolChannelPort();
   }
 
+  /**
+   * Check if the server is listening on a secure port. NOTE: If the targetted server is a managed
+   * server, this methd is overriden to check if the managed server has a secure listen port rather
+   * than the admin server. See PodHelper.ManagedPodStepContext
+   *
+   * @return true if server is listening on a secure port
+   */
   boolean isLocalAdminProtocolChannelSecure() {
+    return domainTopology
+        .getServerConfig(domainTopology.getAdminServerName())
+        .isLocalAdminProtocolChannelSecure();
+  }
+
+  /**
+   * Check if the admin server is listening on a secure port.
+   *
+   * @return true if admin server is listening on a secure port
+   */
+  private boolean isAdminServerProtocolChannelSecure() {
     return domainTopology
         .getServerConfig(domainTopology.getAdminServerName())
         .isLocalAdminProtocolChannelSecure();
@@ -805,6 +823,9 @@ public abstract class PodStepContext extends StepContextBase {
     addEnvVar(vars, "ADMIN_PORT", getAsPort().toString());
     if (isLocalAdminProtocolChannelSecure()) {
       addEnvVar(vars, "ADMIN_PORT_SECURE", "true");
+    }
+    if (isAdminServerProtocolChannelSecure()) {
+      addEnvVar(vars, "ADMIN_SERVER_PORT_SECURE", "true");
     }
     addEnvVar(vars, "SERVER_NAME", getServerName());
     addEnvVar(vars, "DOMAIN_UID", getDomainUID());

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -246,14 +246,11 @@ EOF
   [ ! $? -eq 0 ] && trace "Failed to create '${wl_props_file}'." && exit 1
 
   if [ ! "${ADMIN_NAME}" = "${SERVER_NAME}" ]; then
-    admin_protocol="http"
-    if [ "${ADMIN_PORT_SECURE}" = "true" ]; then
-      admin_protocol="https"
-    fi  
-    echo "AdminURL=$admin_protocol\\://${AS_SERVICE_NAME}\\:${ADMIN_PORT}" >> ${wl_props_file}
+    ADMIN_URL=$(getAdminUrl)
+    export ADMIN_URL
+    trace "ADMIN_URL"=$ADMIN_URL >> ${wl_props_file}
   fi
 fi
-
 
 
 ###############################################################################

--- a/operator/src/main/resources/scripts/traceUtils.sh
+++ b/operator/src/main/resources/scripts/traceUtils.sh
@@ -104,6 +104,19 @@ function checkEnv() {
   return 0
 }
 
+#
+# getAdminUrl
+#   purpose: Get the ADMIN_URL used to connect to the admin server internally.
+#   sample:
+#     ADMIN_URL=$(getAdminUrl)
+#
+function getAdminUrl() {
+  admin_protocol="http"
+  if [ "${ADMIN_SERVER_PORT_SECURE}" = "true" ]; then
+    admin_protocol="https"
+  fi
+  echo ${admin_protocol}://${AS_SERVICE_NAME}:${ADMIN_PORT}
+}
 
 #
 # exportEffectiveDomainHome


### PR DESCRIPTION
Fix SSL by generating a correct ADMIN_URL, which is used by the managed server to connect to the admin server.  The existing code uses http with the SSL port resulting in a connection failure.

This is WIP, do not merge