### PR TITLE
Add WebLogic version and WebLogic patch checks

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -87,7 +87,7 @@ import shutil
 import re
 from datetime import datetime
 
-# Include this script's current directory in the import path (so we can import traceUtils, etc.)
+# Include this script's current directory in the import path (so we can import utils, etc.)
 # sys.path.append('/weblogic-operator/scripts')
 
 # Alternative way to dynamically get script's current directory
@@ -96,7 +96,7 @@ tmp_info = inspect.getframeinfo(tmp_callerframerecord[0])
 tmp_scriptdir=os.path.dirname(tmp_info[0])
 sys.path.append(tmp_scriptdir)
 
-from traceUtils import *
+from utils import *
 
 class OfflineWlstEnv(object):
 

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -58,6 +58,7 @@ export MW_HOME=${MW_HOME:-/u01/oracle}
 checkEnv DOMAIN_UID \
          NAMESPACE \
          DOMAIN_HOME \
+         ORACLE_HOME \
          JAVA_HOME \
          NODEMGR_HOME \
          WL_HOME \
@@ -70,13 +71,18 @@ for script_file in "${SCRIPTPATH}/wlst.sh" \
   [ ! -f "$script_file" ] && trace "Error: missing file '${script_file}'." && exit 1 
 done 
 
-for dir_var in DOMAIN_HOME JAVA_HOME WL_HOME MW_HOME; do
+for dir_var in DOMAIN_HOME JAVA_HOME WL_HOME MW_HOME ORACLE_HOME; do
   [ ! -d "${!dir_var}" ] && trace "Error: missing ${dir_var} directory '${!dir_var}'." && exit 1
 done
 
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed
 
 exportEffectiveDomainHome || exit 1
+
+# check if we're using a supported WebLogic version
+# (the check  will log a message if it fails)
+
+checkWebLogicVersion || exit 1
 
 # start node manager
 

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -40,8 +40,8 @@ SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 
 # setup tracing
 
-source ${SCRIPTPATH}/traceUtils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1 
+source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1 
 
 trace "Introspecting the domain"
 

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -12,8 +12,8 @@
 RETVAL=$(test -f /weblogic-operator/debug/livenessProbeSuccessOverride ; echo $?)
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-source ${SCRIPTPATH}/traceUtils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit $RETVAL
+source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit $RETVAL
 
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
 exportEffectiveDomainHome || exit $RETVAL

--- a/operator/src/main/resources/scripts/monitorLog.sh
+++ b/operator/src/main/resources/scripts/monitorLog.sh
@@ -14,7 +14,7 @@
 echo $$ > /tmp/monitorLog-pid
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-source ${SCRIPTPATH}/traceUtils.sh
+source ${SCRIPTPATH}/utils.sh
 
 trace "Monitoring server log file $1 every $2 seconds for selected known log messages."
 

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -8,8 +8,8 @@
 # file which is updated by the node manager.
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-source ${SCRIPTPATH}/traceUtils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1
+source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1
 
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
 exportEffectiveDomainHome || exit 1

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -47,8 +47,8 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 
-source ${SCRIPTPATH}/traceUtils.sh 
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1 
+source ${SCRIPTPATH}/utils.sh 
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1 
 
 export WL_HOME="${WL_HOME:-/u01/oracle/wlserver}"
 

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -10,8 +10,8 @@
 #
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-source ${SCRIPTPATH}/traceUtils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exitOrLoop
+source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exitOrLoop
 
 trace "Starting WebLogic Server '${SERVER_NAME}'."
 

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -175,6 +175,7 @@ checkEnv \
   DOMAIN_NAME \
   DOMAIN_HOME \
   NODEMGR_HOME \
+  ORACLE_HOME \
   SERVER_NAME \
   SERVICE_NAME \
   ADMIN_NAME \
@@ -190,6 +191,7 @@ trace "JAVA_OPTIONS=${JAVA_OPTIONS}"
 #
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
 #
+
 exportEffectiveDomainHome || exitOrLoop
 
 #
@@ -199,6 +201,15 @@ exportEffectiveDomainHome || exitOrLoop
 
 if [ ! -f /weblogic-operator/introspector/boot.properties ]; then
   trace "Error:  Missing introspector file '${bootpfile}'.  Introspector failed to run."
+  exitOrLoop
+fi
+
+#
+# Check if we're using a supported WebLogic version. The check  will
+# log a message if it fails.
+#
+
+if ! checkWebLogicVersion ; then
   exitOrLoop
 fi
 

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -10,8 +10,8 @@
 #
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-source ${SCRIPTPATH}/traceUtils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1
+source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1
 
 trace "Stop server ${SERVER_NAME}" &>> /weblogic-operator/stopserver.out
 

--- a/operator/src/main/resources/scripts/traceUtils.sh
+++ b/operator/src/main/resources/scripts/traceUtils.sh
@@ -231,7 +231,8 @@ getWebLogicVersion()
 
   [ ! -f $reg_file ] && echo "9999.9999.9999.9999" && return
 
-  local wlver="`grep 'name="WebLogic Server".*version=' $reg_file \
+  # The following grep captures both "WebLogic Server" and "WebLogic Server for FMW"
+  local wlver="`grep 'name="WebLogic Server.*version=' $reg_file \
                | sed 's/.*version="\([0-9.]*\)".*/\1/g'`"
 
   echo ${wlver:-"9999.9999.9999.9999"}

--- a/operator/src/main/resources/scripts/traceUtils.sh
+++ b/operator/src/main/resources/scripts/traceUtils.sh
@@ -164,3 +164,107 @@ function exportEffectiveDomainHome() {
   trace "Error: More than one config.xml found at DOMAIN_HOME/config/config.xml and DOMAIN_HOME/*/config/config.xml, DOMAIN_HOME='$DOMAIN_HOME': ${found_configs}. Configure your 'domainHome' setting in your WebLogic Operator Domain resource to reference a single WebLogic domain."
   return 1
 }
+
+
+# versionCmp
+#   Compares two wl versions $1 $2 up to the length of $2
+#     Expects form N.N.N.N
+#     Uses '0' for an N in $1 if $1 is shorter than $2
+#   echo "1"  if v1 >  v2
+#   echo "-1" if v1 <  v2
+#   echo "0"  if v1 == v2
+versionCmp()
+{
+  IFS='.' read -r -a v1_arr <<< "`echo $1`"
+  IFS='.' read -r -a v2_arr <<< "`echo $2`"
+
+  for i in "${!v2_arr[@]}"
+  do
+    [ ${v1_arr[i]:-0} -gt ${v2_arr[i]:-0} ] && echo "1" && return
+    [ ${v1_arr[i]:-0} -lt ${v2_arr[i]:-0} ] && echo "-1" && return
+  done
+  echo "0"
+}
+
+# versionGE
+#   return success if WL v1 >= v2
+versionGE()
+{
+  [ `versionCmp "$1" "$2"` -ge 0 ] && return 0
+  return 1
+}
+
+# versionEQ
+#   return success if v1 == v2
+versionEQ()
+{
+  [ `versionCmp "$1" "$2"` -eq 0 ] && return 0
+  return 1
+}
+
+# hasWebLogicPatches
+#   check for the given patch numbers in the install inventory, 
+#   and return 1 if not found
+#   - if we can't find the install inventory then we 
+#     assume the patch is there...
+#   - we parse the install inventory as this is far faster than
+#     using opatch or weblogic.version
+hasWebLogicPatches()
+{
+  local reg_file=$ORACLE_HOME/inventory/registry.xml
+  [ ! -f $reg_file ] && return 0
+  for pnum in "$@"; do
+    grep --silent "patch-id=\"$1\"" $reg_file || return 1
+  done
+}
+
+# getWebLogicVersion
+#   parse wl version from install inventory
+#   - if we can't get a version number then we return
+#     a high dummy version number that's sufficient
+#     to pass version checks "9999.9999.9999.9999"
+#   - we parse the install inventory as this is far faster than
+#     using opatch or weblogic.version
+getWebLogicVersion()
+{
+  local reg_file=$ORACLE_HOME/inventory/registry.xml
+
+  [ ! -f $reg_file ] && echo "9999.9999.9999.9999" && return
+
+  local wlver="`grep 'name="WebLogic Server".*version=' $reg_file \
+               | sed 's/.*version="\([0-9.]*\)".*/\1/g'`"
+
+  echo ${wlver:-"9999.9999.9999.9999"}
+}
+
+
+# checkWebLogicVersion
+#   check if the WL version is supported by the Operator
+#   - skip check if SKIP_WL_VERSION_CHECK = "true"
+#   - log an error if WL version < 12.2.1.3
+#   - log an error if WL version == 12.2.1.3 && patch 29135930 is missing
+#     - you can override the required 12.2.1.3 patches by exporting
+#       global WL12213REQUIREDPATCHES to an empty string or to other
+#       patch number(s)
+#   - return 1 if logged an error
+#   - return 0 otherwise
+checkWebLogicVersion()
+{
+  [ "$SKIP_WL_VERSION_CHECK" = "true" ] && return 0
+  local cur_wl_ver="`getWebLogicVersion`"
+  local exp_wl_ver="12.2.1.3" 
+  local exp_wl_12213_patches="${WL12213REQUIREDPATCHES:-"29135930"}"
+  if versionEQ "$cur_wl_ver" "12.2.1.3" ; then
+    if ! hasWebLogicPatches $exp_wl_12213_patches ; then
+      trace "Error: The Operator requires that WebLogic version '12.2.1.3' have patch '$exp_wl_12213_patches'. To bypass this check, set env var SKIP_WL_VERSION_CHECK to 'true'."
+      return 1
+    fi
+  fi
+  if versionGE "$cur_wl_ver" "${exp_wl_ver}" ; then
+    trace "Info: WebLogic version='$cur_wl_ver'. Version check passed. (The Operator requires WebLogic version '${exp_wl_ver}' or higher)."
+  else
+    trace "Error: WebLogic version='$cur_wl_ver' and the Operator requires WebLogic version '${exp_wl_ver}' or higher. To bypass this check, set env var SKIP_WL_VERSION_CHECK to 'true'."
+    return 1
+  fi
+  return 0
+}

--- a/operator/src/main/resources/scripts/utils.py
+++ b/operator/src/main/resources/scripts/utils.py
@@ -3,7 +3,7 @@
 
 # Usage: trace('string')
 #
-# This matches format of bash trace_utils.sh trace, and the operator's log format.
+# This matches format of bash utils.sh trace, and the operator's log format.
 #
 # Sample output:   @[2018-09-28T17:23:55.335 UTC][introspectDomain.py:614] Domain introspection complete.
 #

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -3,13 +3,15 @@
 
 #
 # Purpose:
-#   Define a trace functions that match format of the trace function
-#   in traceUtils.py and of the logging in the java operator.
+#   Define trace functions that match format of the trace function
+#   in utils.py and of the logging in the java operator.
+#
+#   Define various shared utility functions.
 #
 # Load this file via the following pattern:
 #   SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-#   source ${SCRIPTPATH}/traceUtils.sh
-#   [ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1
+#   source ${SCRIPTPATH}/utils.sh
+#   [ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1
 #
 
 # timestamp

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -263,6 +263,10 @@ checkWebLogicVersion()
       return 1
     fi
   fi
+  if versionEQ "$cur_wl_ver" "9999.9999.9999.9999" ; then
+    trace "Info: Could not determine WebLogic version. Assuming version is fine. (The Operator requires WebLogic version '${exp_wl_ver}' or higher, and also requires patches '$exp_wl_12213_patches' for version '12.2.1.3'.)."
+    return 0
+  fi
   if versionGE "$cur_wl_ver" "${exp_wl_ver}" ; then
     trace "Info: WebLogic version='$cur_wl_ver'. Version check passed. (The Operator requires WebLogic version '${exp_wl_ver}' or higher)."
   else

--- a/operator/src/main/resources/scripts/wlst.sh
+++ b/operator/src/main/resources/scripts/wlst.sh
@@ -18,8 +18,8 @@
 #
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-source ${SCRIPTPATH}/traceUtils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/traceUtils.sh" && exit 1 
+source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1 
 
 wlst_script=${1?}
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -64,8 +64,8 @@ public class ConfigMapHelperTest {
     "introspectDomain.sh",
     "introspectDomain.py",
     "startNodeManager.sh",
-    "traceUtils.py",
-    "traceUtils.sh",
+    "utils.py",
+    "utils.sh",
     "wlst.sh",
     "tailLog.sh",
     "monitorLog.sh"

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -34,7 +34,7 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 SOURCEPATH="`echo $SCRIPTPATH | sed 's/weblogic-kubernetes-operator.*/weblogic-kubernetes-operator/'`"
-traceFile=${SOURCEPATH}/operator/src/main/resources/scripts/traceUtils.sh
+traceFile=${SOURCEPATH}/operator/src/main/resources/scripts/utils.sh
 source ${traceFile}
 source ${SCRIPTPATH}/util_dots.sh
 [ $? -ne 0 ] && echo "Error: missing file ${traceFile}" && exit 1
@@ -256,7 +256,7 @@ function deployTestScriptConfigMap() {
 
   mkdir -p ${test_home}/test-scripts
 
-  cp ${SOURCEPATH}/operator/src/main/resources/scripts/traceUtils* ${test_home}/test-scripts || exit 1
+  cp ${SOURCEPATH}/operator/src/main/resources/scripts/utils* ${test_home}/test-scripts || exit 1
   cp ${SCRIPTPATH}/wl-create-domain-pod.sh ${test_home}/test-scripts || exit 1
   cp ${SCRIPTPATH}/createTestRoot.sh ${test_home}/test-scripts || exit 1
   cp ${SCRIPTPATH}/wl-introspect-pod.sh ${test_home}/test-scripts || exit 1

--- a/src/integration-tests/introspector/util_fsplit.sh
+++ b/src/integration-tests/introspector/util_fsplit.sh
@@ -28,7 +28,7 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 SOURCEPATH="`echo $SCRIPTPATH | sed 's/weblogic-kubernetes-operator.*/weblogic-kubernetes-operator/'`"
-traceFile=${SOURCEPATH}/operator/src/main/resources/scripts/traceUtils.sh
+traceFile=${SOURCEPATH}/operator/src/main/resources/scripts/utils.sh
 source ${traceFile}
 [ $? -ne 0 ] && echo "Error: missing file ${traceFile}" && exit 1
 

--- a/src/integration-tests/introspector/util_subst.sh
+++ b/src/integration-tests/introspector/util_subst.sh
@@ -29,7 +29,7 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 SOURCEPATH="`echo $SCRIPTPATH | sed 's/weblogic-kubernetes-operator.*/weblogic-kubernetes-operator/'`"
-traceFile=${SOURCEPATH}/operator/src/main/resources/scripts/traceUtils.sh
+traceFile=${SOURCEPATH}/operator/src/main/resources/scripts/utils.sh
 source ${traceFile}
 [ $? -ne 0 ] && echo "Error: missing file ${traceFile}" && exit 1
 

--- a/src/integration-tests/introspector/util_testwlversion.sh
+++ b/src/integration-tests/introspector/util_testwlversion.sh
@@ -41,7 +41,7 @@ test_checkWebLogicVersion()
     versionGE "$WLVER" "12.2.1.3" || echo "ERROR wl version too low, got $WLVER"
     checkWebLogicVersion
 
-  ) 2<&1 > $testout 2>&1
+  ) 2>&1 > $testout 2>&1
   cat $testout
   grep --silent -i ERROR $testout && return 1
   rm -f $testout

--- a/src/integration-tests/introspector/util_testwlversion.sh
+++ b/src/integration-tests/introspector/util_testwlversion.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# Copyright 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+#
+# Description:
+# ------------
+#
+# This helper utility tests the operator's wl version check code. 
+# It's intended to be run on an image with an oracle install
+# and assumes the ORACLE_HOME env var has been set.
+#
+# Usage:
+# ------
+#
+# ./util_testwlversion.sh input_file_name output_dir
+#
+
+traceFile=/weblogic-operator/scripts/traceUtils.sh
+source ${traceFile}
+[ $? -ne 0 ] && echo "Error: missing file ${traceFile}" && exit 1
+
+test_checkWebLogicVersion()
+{
+  local testout="/tmp/unit_test_checkWebLogicVersion"
+  rm -f $testout
+  (
+
+    local WLVER="12.2.1.3"
+    versionGE "$WLVER" "12.2.1.3" || echo "ERROR not GE 12.2.1.3"
+    versionGE "$WLVER" "12.2.1.2" || echo "ERROR not GE 12.2.1.2"
+    versionGE "$WLVER" "11"       || echo "ERROR not GE 11.9.9"
+    versionGE "$WLVER" "11.9.9"   || echo "ERROR not GE 11.9.9"
+    versionGE "$WLVER" "11.9.9.9" || echo "ERROR not GE 11.9.9.9"
+    versionEQ "$WLVER" "12.2.1.3" || echo "ERROR not EQ 12.2.1.3"
+    versionGE "$WLVER" "12.2.1.4" && echo "ERROR GE 12.2.1.4"
+    versionEQ "$WLVER" "12.2.1"   || echo "ERROR EQ 12.2.1"
+    versionEQ "$WLVER" "12.2.1.4" && echo "ERROR EQ 12.2.1.4"
+    versionEQ "$WLVER" "12.2.1.2" && echo "ERROR EQ 12.2.1.2"
+    # hasWebLogicPatches returns success if entire inventory file is missing
+    hasWebLogicPatches 999767676         && echo "ERROR has impossible patch"
+    local WLVER="`getWebLogicVersion`"
+    # WLVER will be 9999.9999.9999.9999 if the version can't be retrieved
+    versionGE "$WLVER" "888"      && echo "ERROR could not get WLVER, got $WLVER"
+    versionGE "$WLVER" "12.2.1.3" || echo "ERROR wl version too low, got $WLVER"
+    checkWebLogicVersion
+
+  ) 2<&1 > $testout 2>&1
+  cat $testout
+  grep --silent -i ERROR $testout && return 1
+  rm -f $testout
+  return 0
+}
+
+# TBD move this to the unit test script
+test_checkWebLogicVersion || exit 1
+trace Test passed.
+exit 0

--- a/src/integration-tests/introspector/util_testwlversion.sh
+++ b/src/integration-tests/introspector/util_testwlversion.sh
@@ -35,7 +35,7 @@ test_checkWebLogicVersion()
     versionGE "$WLVER" "11.9.9.9" || echo "ERROR not GE 11.9.9.9"
     versionEQ "$WLVER" "12.2.1.3" || echo "ERROR not EQ 12.2.1.3"
     versionGE "$WLVER" "12.2.1.4" && echo "ERROR GE 12.2.1.4"
-    versionEQ "$WLVER" "12.2.1"   || echo "ERROR EQ 12.2.1"
+    versionEQ "$WLVER" "12.2.1"   || echo "ERROR not EQ 12.2.1"
     versionEQ "$WLVER" "12.2.1.4" && echo "ERROR EQ 12.2.1.4"
     versionEQ "$WLVER" "12.2.1.2" && echo "ERROR EQ 12.2.1.2"
     # hasWebLogicPatches returns success if entire inventory file is missing

--- a/src/integration-tests/introspector/util_testwlversion.sh
+++ b/src/integration-tests/introspector/util_testwlversion.sh
@@ -12,7 +12,7 @@
 # and assumes the ORACLE_HOME env var has been set.
 #
 
-traceFile=/weblogic-operator/scripts/traceUtils.sh
+traceFile=/weblogic-operator/scripts/utils.sh
 source ${traceFile}
 [ $? -ne 0 ] && echo "Error: missing file ${traceFile}" && exit 1
 

--- a/src/integration-tests/introspector/util_testwlversion.sh
+++ b/src/integration-tests/introspector/util_testwlversion.sh
@@ -11,11 +11,6 @@
 # It's intended to be run on an image with an oracle install
 # and assumes the ORACLE_HOME env var has been set.
 #
-# Usage:
-# ------
-#
-# ./util_testwlversion.sh input_file_name output_dir
-#
 
 traceFile=/weblogic-operator/scripts/traceUtils.sh
 source ${traceFile}
@@ -53,7 +48,6 @@ test_checkWebLogicVersion()
   return 0
 }
 
-# TBD move this to the unit test script
 test_checkWebLogicVersion || exit 1
 trace Test passed.
 exit 0

--- a/src/integration-tests/introspector/wl-create-domain-pod.sh
+++ b/src/integration-tests/introspector/wl-create-domain-pod.sh
@@ -9,7 +9,7 @@
 
 while [ 1 -eq 1 ] ; do
   SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
-  traceFile=${SCRIPTPATH}/traceUtils.sh
+  traceFile=${SCRIPTPATH}/utils.sh
   source ${traceFile}
   [ $? -ne 0 ] && echo "Error: missing file ${traceFile}" && break
 


### PR DESCRIPTION
 This change adds WebLogic version and WebLogic patch checks.

- It fails the introspector job and wl pod startup for unsupported versions.

   - Requires 12.2.1.3 or higher.

   - If 12.2.1.3, also requires patch 29135930.  

- The failure messages are logged to job/pod's log and include the name of an env var users can specify in the Domain resource to bypass checks: 

  - `"Error: WebLogic version='$cur_wl_ver' and the Operator requires WebLogic version '${exp_wl_ver}' or higher. To bypass this check, set env var SKIP_WL_VERSION_CHECK to 'true'."` 

  - `Error: The Operator requires that WebLogic version '12.2.1.3' have patch '$exp_wl_12213_patches'. To bypass this check, set env var SKIP_WL_VERSION_CHECK to 'true'.`

- Instead of using `weblogic.version` or `opatch`, this check determines the WebLogic version by parsing the installer's inventory file at `$ORACLE_HOME/inventory/registry.xml`.  This is because `weblogic.version` or `opatch` can take a few seconds to run, which is too long.  _If the parse itself fails, it ignores the problem and simply assumes the version is fine and reports the following Info message._

  - `@[2019-07-12T17:45:03.584 UTC][bash:65] Info: Could not determine WebLogic version. Assuming version is fine. (The Operator requires WebLogic version '12.2.1.3' or higher, and also requires patches '29135930' for version '12.2.1.3'.).`