### PR TITLE
upgraded ELS Stack from 5.6.16 to 6.8.0

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
@@ -124,37 +124,60 @@ public class ItElasticLogging extends BaseTest {
       logger.info("SUCCESS");
     }
   }
-
+  
   private static void verifyElasticStackReady() throws Exception {
     // Get Logstash info
     String healthStatus = execElasticStackStatusCheck("*logstash*", "$1");
     String indexStatus = execElasticStackStatusCheck("*logstash*", "$2");
     String indexName = execElasticStackStatusCheck("*logstash*", "$3");
 
-    // Verify that the health status of Logstash
     Assume.assumeNotNull(healthStatus);
+    Assume.assumeNotNull(indexStatus);
+    Assume.assumeNotNull(indexName);
+    // Verify that the health status of Logstash
     Assume.assumeTrue(
         "Logstash is not ready!",
-        healthStatus.equalsIgnoreCase("yellow") || healthStatus.equalsIgnoreCase("green"));
+        healthStatus.equalsIgnoreCase("yellow") || 
+        healthStatus.equalsIgnoreCase("green"));
     // Verify that the index is open for use
-    Assume.assumeNotNull(indexStatus);
-    Assume.assumeTrue("Logstash index is not open!", indexStatus.equalsIgnoreCase("open"));
+    Assume.assumeTrue("Logstash index is not open!", 
+                      indexStatus.equalsIgnoreCase("open"));
     // Add the index name to a Map
-    Assume.assumeNotNull(indexName);
     testVarMap.put("indexName", indexName);
 
     // Get Kibana info
     healthStatus = execElasticStackStatusCheck("*kibana*", "$1");
     indexStatus = execElasticStackStatusCheck("*kibana*", "$2");
-
-    // Verify that the health status of Kibana
+    indexName = execElasticStackStatusCheck("*kibana*", "$3");
+    
     Assume.assumeNotNull(healthStatus);
-    Assume.assumeTrue(
-        "Kibana is not ready!",
-        healthStatus.equalsIgnoreCase("yellow") || healthStatus.equalsIgnoreCase("green"));
-    // Verify that the index is open for use
     Assume.assumeNotNull(indexStatus);
-    Assume.assumeTrue("Kibana index is not open!", indexStatus.equalsIgnoreCase("open"));
+    Assume.assumeNotNull(indexName);
+
+    //There are multiple indexes from Kibana 6.8.0
+    String[] kibanahealthStatusArr = 
+      healthStatus.split(System.getProperty("line.separator"));
+    String[] kibanaindexStatusArr = 
+      indexStatus.split(System.getProperty("line.separator"));
+    String[] kibanaindexNameArr = 
+      indexName.split(System.getProperty("line.separator"));
+    
+    for(int i = 0; i < kibanaindexStatusArr.length; i++) {
+      logger.info("Health status of " + kibanaindexNameArr[i] + 
+                  "is:" + kibanahealthStatusArr[i]);
+      logger.info("Index status of " + kibanaindexNameArr[i] + 
+                  "is:" + kibanaindexStatusArr[i]);
+      // Verify that the health status of Kibana
+      Assume.assumeTrue(
+          "Kibana is not ready!",
+          kibanahealthStatusArr[i].trim().equalsIgnoreCase("yellow") || 
+          kibanahealthStatusArr[i].trim().equalsIgnoreCase("green"));
+      // Verify that the index is open for use
+      Assume.assumeTrue("Kibana index is not open!", 
+                        kibanaindexStatusArr[i].trim().equalsIgnoreCase("open"));
+    }
+    
+    logger.info("ELK Stack is up and running and ready to use!");
   }
 
   private static String execElasticStackStatusCheck(String indexName, String varLoc)

--- a/integration-tests/src/test/resources/operator_elk.yaml
+++ b/integration-tests/src/test/resources/operator_elk.yaml
@@ -9,6 +9,6 @@ domainNamespaces: [ "default", "test1" ]
 externalRestEnabled: true
 javaLoggingLevel: INFO
 elkIntegrationEnabled: true
-logStashImage: "logstash:6.6.0"
+logStashImage: "logstash:6.8.0"
 elasticSearchHost: "elasticsearch.default.svc.cluster.local"
 elasticSearchPort: 9200

--- a/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
+++ b/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
@@ -43,15 +43,13 @@ spec:
     spec:
       containers:
       - name: "elasticsearch"
-        image: "elasticsearch:5"
+        image: "elasticsearch:6.8.0"
         ports:
         - containerPort: 9200
         - containerPort: 9300
         env:
         - name: ES_JAVA_OPTS
           value: -Xms1024m -Xmx1024m
-        - name: bootstrap.memory_lock
-          value: "true"
 
 ---
 kind: "Service"
@@ -92,7 +90,7 @@ spec:
     spec:
       containers:
       - name: "kibana"
-        image: "kibana:5"
+        image: "kibana:6.8.0"
         ports:
         - containerPort: 5601
 


### PR DESCRIPTION
have tested 5 scenarios:

1.	ELK Stack 5.6.16 + Exporter doc type = “_doc”
            Test failed. No WLS logs pushed to Elasticsearch repository
2.	ELK Stack 5.6.16 + Exporter doc type = “doc”
            Test passed. WLS logs pushed to Elasticsearch repository
3.	ELK Stack 6.8.0 + + Exporter doc type = “_doc”
            Test passed. WLS logs pushed to Elasticsearch repository
4.	ELK Stack 6.8.0 + Exporter doc type = “doc”
            Test passed. WLS logs pushed to Elasticsearch repository
5.      ItElasticLogging also passed using ELK Stack 6.8.0 + Exporter doc type = “doc”
            [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 250.547 s - in oracle.kubernetes.operator.ItElasticLogging
