### PR TITLE
Owls 75227 - simplify debugging the operator

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -40,7 +40,7 @@ spec:
         - name: "REMOTE_DEBUG_PORT"
           value: {{ .internalDebugHttpPort | quote }}
         - name: "DEBUG_SUSPEND"
-          {{- if .haltOnDebugStartup }}
+          {{- if .suspendOnDebugStartup }}
           value: "y"
           {{- else }}
           value: "n"

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -67,6 +67,7 @@ spec:
           name: "log-dir"
           readOnly: false
         {{- end }}
+        {{- if not .remoteDebugNodePortEnabled }}
         livenessProbe:
           exec:
             command:
@@ -81,6 +82,7 @@ spec:
               - "/operator/readinessProbe.sh"
           initialDelaySeconds: 2
           periodSeconds: 10
+        {{- end }}
       {{- if .elkIntegrationEnabled }}
       - name: "logstash"
         image: {{ .logStashImage | quote }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -39,6 +39,12 @@ spec:
         {{- if .remoteDebugNodePortEnabled }}
         - name: "REMOTE_DEBUG_PORT"
           value: {{ .internalDebugHttpPort | quote }}
+        - name: "DEBUG_SUSPEND"
+          {{- if .haltOnDebugStartup }}
+          value: "y"
+          {{- else }}
+          value: "n"
+          {{- end }}
         {{- end }}
         {{- if .mockWLS }}
         - name: "MOCK_WLS"

--- a/kubernetes/charts/weblogic-operator/templates/_validate-inputs.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_validate-inputs.tpl
@@ -26,6 +26,7 @@
 {{- end -}}
 {{- if include "utils.verifyBoolean" (list $scope "remoteDebugNodePortEnabled") -}}
 {{-   if $scope.remoteDebugNodePortEnabled -}}
+{{-     $ignore := include "utils.verifyBoolean" (list $scope "suspendOnDebugStartup") -}}
 {{-     $ignore := include "utils.verifyInteger" (list $scope "internalDebugHttpPort") -}}
 {{-     $ignore := include "utils.verifyInteger" (list $scope "externalDebugHttpPort") -}}
 {{-   end -}}

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -59,14 +59,18 @@ externalRestHttpsPort: 31001
 # kubernetes/samples/scripts/rest/generate-external-rest-identity.sh
 #externalRestIdentitySecret: 
 
-# remoteDebugNodePortEnabled specifies whether or not the operator will start a Java remote debug server
-# on the provided port and suspend execution until a remote debugger has attached.
+# remoteDebugNodePortEnabled specifies whether or not the operator will start a Java remote debug server on the
+# provided port. If the 'haltOnDebugStartup' property is specified, the operator will suspend execution
+# until a remote debugger has attached.
 # The 'internalDebugHttpPort' property controls the port number inside the Kubernetes
 # cluster and the 'externalDebugHttpPort' property controls the port number outside
 # the Kubernetes cluster.
 remoteDebugNodePortEnabled: false
 
-# internalDebugHttpPort specifes the port number inside the Kubernetes cluster for the operator's Java
+#haltOnDebugStartup specifies whether the operator will halt on startup when a Java remote debug server is started.
+haltOnDebugStartup: true
+
+# internalDebugHttpPort specifies the port number inside the Kubernetes cluster for the operator's Java
 # remote debug server.
 # This parameter is required if 'remoteDebugNodePortEnabled' is true.
 # Otherwise, it is ignored.

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -60,15 +60,15 @@ externalRestHttpsPort: 31001
 #externalRestIdentitySecret: 
 
 # remoteDebugNodePortEnabled specifies whether or not the operator will start a Java remote debug server on the
-# provided port. If the 'haltOnDebugStartup' property is specified, the operator will suspend execution
+# provided port. If the 'suspendOnDebugStartup' property is specified, the operator will suspend execution
 # until a remote debugger has attached.
 # The 'internalDebugHttpPort' property controls the port number inside the Kubernetes
 # cluster and the 'externalDebugHttpPort' property controls the port number outside
 # the Kubernetes cluster.
 remoteDebugNodePortEnabled: false
 
-#haltOnDebugStartup specifies whether the operator will halt on startup when a Java remote debug server is started.
-haltOnDebugStartup: true
+#suspendOnDebugStartup specifies whether the operator will suspend on startup when a Java remote debug server is started.
+suspendOnDebugStartup: false
 
 # internalDebugHttpPort specifies the port number inside the Kubernetes cluster for the operator's Java
 # remote debug server.

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
@@ -4,10 +4,7 @@
 
 package oracle.kubernetes.operator.create;
 
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newEnvVar;
-
 import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
-import io.kubernetes.client.models.V1Container;
 import io.kubernetes.client.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
@@ -36,11 +33,7 @@ public abstract class CreateOperatorGeneratedFilesDebugEnabledTestBase
   @Override
   public ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
     ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
-    V1Container operatorContainer =
-        expected.getSpec().getTemplate().getSpec().getContainers().get(0);
-    operatorContainer.addEnvItem(
-        newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
-    operatorContainer.addEnvItem(newEnvVar().name("DEBUG_SUSPEND").value("y"));
+    expectRemoteDebug(expected.getSpec().getTemplate().getSpec().getContainers().get(0), "y");
     return expected;
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
@@ -40,6 +40,7 @@ public abstract class CreateOperatorGeneratedFilesDebugEnabledTestBase
         expected.getSpec().getTemplate().getSpec().getContainers().get(0);
     operatorContainer.addEnvItem(
         newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
+    operatorContainer.addEnvItem(newEnvVar().name("DEBUG_SUSPEND").value("y"));
     return expected;
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
@@ -33,7 +33,7 @@ public abstract class CreateOperatorGeneratedFilesDebugEnabledTestBase
   @Override
   public ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
     ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
-    expectRemoteDebug(expected.getSpec().getTemplate().getSpec().getContainers().get(0), "y");
+    expectRemoteDebug(expected.getSpec().getTemplate().getSpec().getContainers().get(0), "n");
     return expected;
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBase.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.operator.create;
 
+import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
@@ -17,6 +18,13 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBa
 
   protected static void defineOperatorYamlFactory(OperatorYamlFactory factory) throws Exception {
     setup(factory, factory.newOperatorValues());
+  }
+
+  @Override
+  protected ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
+    ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
+    expectProbes(expected.getSpec().getTemplate().getSpec().getContainers().get(0));
+    return expected;
   }
 
   @Override

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -56,11 +56,9 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
     ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
     V1Container operatorContainer =
         expected.getSpec().getTemplate().getSpec().getContainers().get(0);
-    operatorContainer
-        .addVolumeMountsItem(newVolumeMount().name("log-dir").mountPath("/logs").readOnly(false))
-        .addEnvItem(
-            newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()))
-        .addEnvItem(newEnvVar().name("DEBUG_SUSPEND").value("n"));
+    operatorContainer.addVolumeMountsItem(
+        newVolumeMount().name("log-dir").mountPath("/logs").readOnly(false));
+    expectRemoteDebug(operatorContainer, "n");
     expected
         .getSpec()
         .getTemplate()

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -31,7 +31,7 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
             .newOperatorValues()
             .setupExternalRestEnabled()
             .enableDebugging()
-            .haltOnDebugStartup("false")
+            .suspendOnDebugStartup("true")
             .elkIntegrationEnabled("true")
             .weblogicOperatorImagePullSecretName("test-operator-image-pull-secret-name"));
   }
@@ -58,7 +58,7 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
         expected.getSpec().getTemplate().getSpec().getContainers().get(0);
     operatorContainer.addVolumeMountsItem(
         newVolumeMount().name("log-dir").mountPath("/logs").readOnly(false));
-    expectRemoteDebug(operatorContainer, "n");
+    expectRemoteDebug(operatorContainer, "y");
     expected
         .getSpec()
         .getTemplate()

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -31,6 +31,7 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
             .newOperatorValues()
             .setupExternalRestEnabled()
             .enableDebugging()
+            .haltOnDebugStartup("false")
             .elkIntegrationEnabled("true")
             .weblogicOperatorImagePullSecretName("test-operator-image-pull-secret-name"));
   }
@@ -58,7 +59,8 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
     operatorContainer
         .addVolumeMountsItem(newVolumeMount().name("log-dir").mountPath("/logs").readOnly(false))
         .addEnvItem(
-            newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
+            newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()))
+        .addEnvItem(newEnvVar().name("DEBUG_SUSPEND").value("n"));
     expected
         .getSpec()
         .getTemplate()

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -49,7 +49,9 @@ import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.models.V1ClusterRole;
 import io.kubernetes.client.models.V1ClusterRoleBinding;
 import io.kubernetes.client.models.V1ConfigMap;
+import io.kubernetes.client.models.V1Container;
 import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1Probe;
 import io.kubernetes.client.models.V1ResourceRequirements;
 import io.kubernetes.client.models.V1Role;
 import io.kubernetes.client.models.V1RoleBinding;
@@ -229,25 +231,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                                             newVolumeMount()
                                                 .name("weblogic-operator-secrets-volume")
                                                 .mountPath("/operator/secrets")
-                                                .readOnly(true))
-                                        .livenessProbe(
-                                            newProbe()
-                                                .initialDelaySeconds(20)
-                                                .periodSeconds(5)
-                                                .exec(
-                                                    newExecAction()
-                                                        .addCommandItem("bash")
-                                                        .addCommandItem(
-                                                            "/operator/livenessProbe.sh")))
-                                        .readinessProbe(
-                                            newProbe()
-                                                .initialDelaySeconds(2)
-                                                .periodSeconds(10)
-                                                .exec(
-                                                    newExecAction()
-                                                        .addCommandItem("bash")
-                                                        .addCommandItem(
-                                                            "/operator/readinessProbe.sh"))))
+                                                .readOnly(true)))
                                 .addVolumesItem(
                                     newVolume()
                                         .name("weblogic-operator-cm-volume")
@@ -267,6 +251,19 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                                         .secret(
                                             newSecretVolumeSource()
                                                 .secretName("weblogic-operator-secrets"))))));
+  }
+
+  void expectProbes(V1Container container) {
+    container
+        .livenessProbe(createProbe(20, 5, "/operator/livenessProbe.sh"))
+        .readinessProbe(createProbe(2, 10, "/operator/readinessProbe.sh"));
+  }
+
+  private V1Probe createProbe(int initialDelaySeconds, int periodSeconds, String shellScript) {
+    return newProbe()
+        .initialDelaySeconds(initialDelaySeconds)
+        .periodSeconds(periodSeconds)
+        .exec(newExecAction().addCommandItem("bash").addCommandItem(shellScript));
   }
 
   @Test
@@ -813,5 +810,11 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                 .putLabelsItem(RESOURCE_VERSION_LABEL, OPERATOR_V2)
                 .putLabelsItem(OPERATORNAME_LABEL, getInputs().getNamespace()))
         .spec(spec);
+  }
+
+  protected void expectRemoteDebug(V1Container operatorContainer, String debugSuspend) {
+    operatorContainer.addEnvItem(
+        newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
+    operatorContainer.addEnvItem(newEnvVar().name("DEBUG_SUSPEND").value(debugSuspend));
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValues.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValues.java
@@ -13,7 +13,6 @@ import static oracle.kubernetes.operator.helm.MapUtils.loadBooleanFromMap;
 import static oracle.kubernetes.operator.helm.MapUtils.loadFromMap;
 import static oracle.kubernetes.operator.helm.MapUtils.loadIntegerFromMap;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +36,7 @@ class HelmOperatorValues extends OperatorValues {
 
     loadBooleanFromMap(map, this::setExternalRestEnabled, "externalRestEnabled");
     loadBooleanFromMap(map, this::setRemoteDebugNodePortEnabled, "remoteDebugNodePortEnabled");
+    loadBooleanFromMap(map, this::setHaltOnDebugStartup, "haltOnDebugStartup");
     loadBooleanFromMap(map, this::setElkIntegrationEnabled, "elkIntegrationEnabled");
 
     loadIntegerFromMap(map, this::setExternalRestHttpsPort, "externalRestHttpsPort");
@@ -57,6 +57,12 @@ class HelmOperatorValues extends OperatorValues {
   private void setRemoteDebugNodePortEnabled(Boolean enabled) {
     if (enabled != null) {
       setRemoteDebugNodePortEnabled(enabled.toString());
+    }
+  }
+
+  private void setHaltOnDebugStartup(Boolean enabled) {
+    if (enabled != null) {
+      setHaltOnDebugStartup(enabled.toString());
     }
   }
 
@@ -82,7 +88,7 @@ class HelmOperatorValues extends OperatorValues {
         (List<Map<String, String>>) map.get("imagePullSecrets");
     if (imagePullSecrets != null) {
       // TBD - enhance OperatorValues to have an array of image pull secrets, instead of just one
-      String secretName = (String) imagePullSecrets.get(0).get("name");
+      String secretName = imagePullSecrets.get(0).get("name");
       if (secretName != null) {
         setWeblogicOperatorImagePullSecretName(secretName);
       }
@@ -104,7 +110,8 @@ class HelmOperatorValues extends OperatorValues {
     addStringMapEntry(map, this::getElasticSearchHost, "elasticSearchHost");
 
     addMapEntry(map, this::isExternalRestEnabled, "externalRestEnabled");
-    addMapEntry(map, this::isRemoteDebugNotPortEnabled, "remoteDebugNodePortEnabled");
+    addMapEntry(map, this::isRemoteDebugNodePortEnabled, "remoteDebugNodePortEnabled");
+    addMapEntry(map, this::isHaltOnDebugStartup, "haltOnDebugStartup");
     addMapEntry(map, this::isElkIntegrationEnabled, "elkIntegrationEnabled");
 
     addMapEntry(map, this::getExternalRestHttpsPortNum, "externalRestHttpsPort");
@@ -120,11 +127,7 @@ class HelmOperatorValues extends OperatorValues {
   private void addDomainNamespaces(HashMap<String, Object> map) {
     String targetNamespaces = getTargetNamespaces();
     if (targetNamespaces.length() > 0) {
-      List<String> namespaces = new ArrayList<>();
-      for (String namespace : targetNamespaces.split(",")) {
-        namespaces.add(namespace);
-      }
-      map.put("domainNamespaces", namespaces);
+      map.put("domainNamespaces", Arrays.asList(targetNamespaces.split(",")));
     }
   }
 
@@ -139,8 +142,12 @@ class HelmOperatorValues extends OperatorValues {
     return MapUtils.valueOf(getExternalRestEnabled());
   }
 
-  private Boolean isRemoteDebugNotPortEnabled() {
+  private Boolean isRemoteDebugNodePortEnabled() {
     return MapUtils.valueOf(getRemoteDebugNodePortEnabled());
+  }
+
+  private Boolean isHaltOnDebugStartup() {
+    return MapUtils.valueOf(getHaltOnDebugStartup());
   }
 
   private Boolean isElkIntegrationEnabled() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValues.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValues.java
@@ -36,7 +36,7 @@ class HelmOperatorValues extends OperatorValues {
 
     loadBooleanFromMap(map, this::setExternalRestEnabled, "externalRestEnabled");
     loadBooleanFromMap(map, this::setRemoteDebugNodePortEnabled, "remoteDebugNodePortEnabled");
-    loadBooleanFromMap(map, this::setHaltOnDebugStartup, "haltOnDebugStartup");
+    loadBooleanFromMap(map, this::setSuspendOnDebugStartup, "suspendOnDebugStartup");
     loadBooleanFromMap(map, this::setElkIntegrationEnabled, "elkIntegrationEnabled");
 
     loadIntegerFromMap(map, this::setExternalRestHttpsPort, "externalRestHttpsPort");
@@ -60,9 +60,9 @@ class HelmOperatorValues extends OperatorValues {
     }
   }
 
-  private void setHaltOnDebugStartup(Boolean enabled) {
+  private void setSuspendOnDebugStartup(Boolean enabled) {
     if (enabled != null) {
-      setHaltOnDebugStartup(enabled.toString());
+      setSuspendOnDebugStartup(enabled.toString());
     }
   }
 
@@ -111,7 +111,7 @@ class HelmOperatorValues extends OperatorValues {
 
     addMapEntry(map, this::isExternalRestEnabled, "externalRestEnabled");
     addMapEntry(map, this::isRemoteDebugNodePortEnabled, "remoteDebugNodePortEnabled");
-    addMapEntry(map, this::isHaltOnDebugStartup, "haltOnDebugStartup");
+    addMapEntry(map, this::isSuspendOnDebugStartup, "suspendOnDebugStartup");
     addMapEntry(map, this::isElkIntegrationEnabled, "elkIntegrationEnabled");
 
     addMapEntry(map, this::getExternalRestHttpsPortNum, "externalRestHttpsPort");
@@ -146,8 +146,8 @@ class HelmOperatorValues extends OperatorValues {
     return MapUtils.valueOf(getRemoteDebugNodePortEnabled());
   }
 
-  private Boolean isHaltOnDebugStartup() {
-    return MapUtils.valueOf(getHaltOnDebugStartup());
+  private Boolean isSuspendOnDebugStartup() {
+    return MapUtils.valueOf(getSuspendOnDebugStartup());
   }
 
   private Boolean isElkIntegrationEnabled() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
@@ -242,47 +242,48 @@ public class HelmOperatorValuesTest {
     assertThat(values.getRemoteDebugNodePortEnabled(), equalTo("false"));
   }
 
-  // --------------- haltOnDebugStartup
+  // --------------- suspendOnDebugStartup
 
   @Test
-  public void whenHaltOnDebugStartupTrue_createdMapContainsValue() {
-    operatorValues.haltOnDebugStartup("true");
+  public void whenSuspendOnDebugStartupTrue_createdMapContainsValue() {
+    operatorValues.suspendOnDebugStartup("true");
 
-    assertThat(operatorValues.createMap(), hasEntry("haltOnDebugStartup", true));
+    assertThat(operatorValues.createMap(), hasEntry("suspendOnDebugStartup", true));
   }
 
   @Test
-  public void whenHaltOnDebugStartupFalse_createdMapContainsValue() {
-    operatorValues.haltOnDebugStartup("false");
+  public void whenSuspendOnDebugStartupFalse_createdMapContainsValue() {
+    operatorValues.suspendOnDebugStartup("false");
 
-    assertThat(operatorValues.createMap(), hasEntry("haltOnDebugStartup", false));
+    assertThat(operatorValues.createMap(), hasEntry("suspendOnDebugStartup", false));
   }
 
   @Test
-  public void whenHaltOnDebugStartupNotSet_createdMapLacksValue() {
-    assertThat(operatorValues.createMap(), not(hasKey("haltOnDebugStartup")));
+  public void whenSuspendOnDebugStartupNotSet_createdMapLacksValue() {
+    assertThat(operatorValues.createMap(), not(hasKey("suspendOnDebugStartup")));
   }
 
   @Test
-  public void whenCreatedFromMapWithoutHaltOnDebugStartup_hasEmptyString() {
+  public void whenCreatedFromMapWithoutSuspendOnDebugStartup_hasEmptyString() {
     HelmOperatorValues values = new HelmOperatorValues(ImmutableMap.of());
 
-    assertThat(values.getHaltOnDebugStartup(), equalTo(""));
+    assertThat(values.getSuspendOnDebugStartup(), equalTo(""));
   }
 
   @Test
-  public void whenCreatedFromMapWithHaltOnDebugStartupTrue_hasSpecifiedValue() {
-    HelmOperatorValues values = new HelmOperatorValues(ImmutableMap.of("haltOnDebugStartup", true));
-
-    assertThat(values.getHaltOnDebugStartup(), equalTo("true"));
-  }
-
-  @Test
-  public void whenCreatedFromMapWithHaltOnDebugStartupFalse_hasSpecifiedValue() {
+  public void whenCreatedFromMapWithSuspendOnDebugStartupTrue_hasSpecifiedValue() {
     HelmOperatorValues values =
-        new HelmOperatorValues(ImmutableMap.of("haltOnDebugStartup", false));
+        new HelmOperatorValues(ImmutableMap.of("suspendOnDebugStartup", true));
 
-    assertThat(values.getHaltOnDebugStartup(), equalTo("false"));
+    assertThat(values.getSuspendOnDebugStartup(), equalTo("true"));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithSuspendOnDebugStartupFalse_hasSpecifiedValue() {
+    HelmOperatorValues values =
+        new HelmOperatorValues(ImmutableMap.of("suspendOnDebugStartup", false));
+
+    assertThat(values.getSuspendOnDebugStartup(), equalTo("false"));
   }
 
   // --------------- elkIntegrationEnabled
@@ -519,14 +520,14 @@ public class HelmOperatorValuesTest {
         .append("externalDebugHttpPort: 30999\n")
         .append("externalRestEnabled: false\n")
         .append("externalRestHttpsPort: 31001\n")
-        .append("haltOnDebugStartup: true\n")
         .append("image: oracle/weblogic-kubernetes-operator:2.2.1\n")
         .append("imagePullPolicy: IfNotPresent\n")
         .append("internalDebugHttpPort: 30999\n")
         .append("javaLoggingLevel: INFO\n")
         .append("logStashImage: logstash:6.6.0\n")
         .append("remoteDebugNodePortEnabled: false\n")
-        .append("serviceAccount: default\n");
+        .append("serviceAccount: default\n")
+        .append("suspendOnDebugStartup: false\n");
     return sb.toString();
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
@@ -242,6 +242,49 @@ public class HelmOperatorValuesTest {
     assertThat(values.getRemoteDebugNodePortEnabled(), equalTo("false"));
   }
 
+  // --------------- haltOnDebugStartup
+
+  @Test
+  public void whenHaltOnDebugStartupTrue_createdMapContainsValue() {
+    operatorValues.haltOnDebugStartup("true");
+
+    assertThat(operatorValues.createMap(), hasEntry("haltOnDebugStartup", true));
+  }
+
+  @Test
+  public void whenHaltOnDebugStartupFalse_createdMapContainsValue() {
+    operatorValues.haltOnDebugStartup("false");
+
+    assertThat(operatorValues.createMap(), hasEntry("haltOnDebugStartup", false));
+  }
+
+  @Test
+  public void whenHaltOnDebugStartupNotSet_createdMapLacksValue() {
+    assertThat(operatorValues.createMap(), not(hasKey("haltOnDebugStartup")));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithoutHaltOnDebugStartup_hasEmptyString() {
+    HelmOperatorValues values = new HelmOperatorValues(ImmutableMap.of());
+
+    assertThat(values.getHaltOnDebugStartup(), equalTo(""));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithHaltOnDebugStartupTrue_hasSpecifiedValue() {
+    HelmOperatorValues values = new HelmOperatorValues(ImmutableMap.of("haltOnDebugStartup", true));
+
+    assertThat(values.getHaltOnDebugStartup(), equalTo("true"));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithHaltOnDebugStartupFalse_hasSpecifiedValue() {
+    HelmOperatorValues values =
+        new HelmOperatorValues(ImmutableMap.of("haltOnDebugStartup", false));
+
+    assertThat(values.getHaltOnDebugStartup(), equalTo("false"));
+  }
+
   // --------------- elkIntegrationEnabled
 
   @Test
@@ -476,6 +519,7 @@ public class HelmOperatorValuesTest {
         .append("externalDebugHttpPort: 30999\n")
         .append("externalRestEnabled: false\n")
         .append("externalRestHttpsPort: 31001\n")
+        .append("haltOnDebugStartup: true\n")
         .append("image: oracle/weblogic-kubernetes-operator:2.2.1\n")
         .append("imagePullPolicy: IfNotPresent\n")
         .append("internalDebugHttpPort: 30999\n")

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/OperatorValues.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/OperatorValues.java
@@ -33,7 +33,7 @@ public class OperatorValues {
   private String externalOperatorSecret = "";
   private String externalOperatorKey = "";
   private String remoteDebugNodePortEnabled = "";
-  private String haltOnDebugStartup = "";
+  private String suspendOnDebugStartup = "";
   private String internalDebugHttpPort = "";
   private String externalDebugHttpPort = "";
   private String javaLoggingLevel = "";
@@ -239,16 +239,16 @@ public class OperatorValues {
     return this;
   }
 
-  public String getHaltOnDebugStartup() {
-    return haltOnDebugStartup;
+  public String getSuspendOnDebugStartup() {
+    return suspendOnDebugStartup;
   }
 
-  public void setHaltOnDebugStartup(String val) {
-    haltOnDebugStartup = convertNullToEmptyString(val);
+  protected void setSuspendOnDebugStartup(String val) {
+    suspendOnDebugStartup = convertNullToEmptyString(val);
   }
 
-  public OperatorValues haltOnDebugStartup(String val) {
-    setHaltOnDebugStartup(val);
+  public OperatorValues suspendOnDebugStartup(String val) {
+    setSuspendOnDebugStartup(val);
     return this;
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/OperatorValues.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/OperatorValues.java
@@ -33,6 +33,7 @@ public class OperatorValues {
   private String externalOperatorSecret = "";
   private String externalOperatorKey = "";
   private String remoteDebugNodePortEnabled = "";
+  private String haltOnDebugStartup = "";
   private String internalDebugHttpPort = "";
   private String externalDebugHttpPort = "";
   private String javaLoggingLevel = "";
@@ -235,6 +236,19 @@ public class OperatorValues {
 
   public OperatorValues remoteDebugNodePortEnabled(String val) {
     setRemoteDebugNodePortEnabled(val);
+    return this;
+  }
+
+  public String getHaltOnDebugStartup() {
+    return haltOnDebugStartup;
+  }
+
+  public void setHaltOnDebugStartup(String val) {
+    haltOnDebugStartup = convertNullToEmptyString(val);
+  }
+
+  public OperatorValues haltOnDebugStartup(String val) {
+    setHaltOnDebugStartup(val);
     return this;
   }
 

--- a/src/scripts/operator.sh
+++ b/src/scripts/operator.sh
@@ -20,7 +20,7 @@ trap relay_SIGTERM SIGTERM
 /operator/initialize-external-operator-identity.sh
 
 if [[ ! -z "$REMOTE_DEBUG_PORT" ]]; then
-  DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$REMOTE_DEBUG_PORT"
+  DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=$DEBUG_SUSPEND,address=*:$REMOTE_DEBUG_PORT"
   echo "DEBUG=$DEBUG"
 else
   DEBUG=""


### PR DESCRIPTION
This change:
* simplifies putting the operator into debug by disabling the probes when debug is enabled, and
* allows the operator to be set not to suspend, meaning that a developer can attach after it is running. This is controlled by the `haltOnDebugStartup` setting.

Note that the default behavior is, as before, that the operator halts on startup when debug is enabled. I think that the default should be changed to _not_ halt, but did not make that change, here. @rjeberhard what do you think?