### PR TITLE
Pod/job script logging improvements

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -476,7 +476,7 @@ public class JobHelper {
         }
       }
     } catch (IOException ioe) {
-      LOGGER.fine("Unexpected exception " + ioe + " while parsing string:\n" + jobLogs);
+      LOGGER.fine(MessageKeys.JOB_LOG_PARSE_FAILURE, ioe.toString(), jobLogs);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -4,6 +4,9 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.List;
 
 import io.kubernetes.client.models.V1DeleteOptions;
@@ -33,6 +36,7 @@ import oracle.kubernetes.weblogic.domain.model.ConfigurationConstants;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
+
 
 public class JobHelper {
 
@@ -329,6 +333,11 @@ public class JobHelper {
       // Log output to Operator log
       LOGGER.fine("+++++ ReadDomainIntrospectorPodLogResponseStep: \n" + result);
 
+      // Parse out each job log message and log to Operator as SEVERE, FINE, etc...
+      if (result != null) {
+        convertJobLogsToOperatorLogs(result);
+      }
+
       V1Job domainIntrospectorJob = (V1Job) packet.get(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB);
       if (domainIntrospectorJob != null && JobWatcher.isComplete(domainIntrospectorJob)) {
         if (result != null) {
@@ -404,6 +413,70 @@ public class JobHelper {
       }
 
       return doNext(packet);
+    }
+  }
+
+  // Convert a job log message to an operator log message
+  //   - assumes the messages contins a string like '[SEVERE]', etc, if
+  //     not, then assumes the log level is 'FINE'.
+  private static void logToOperator(StringBuffer logStr, StringBuffer extraStr) {
+    String logMsg = "Introspector Job Log: " 
+                    + logStr 
+                    + (extraStr.length() == 0 ? "" : "\n")
+                    + extraStr;
+    String regExp = ".*\\[(SEVERE|ERROR|WARNING|INFO|FINE|FINER|FINEST)\\].*";
+    String logLevel = logStr.toString().toUpperCase().replaceAll(regExp,"$1");
+    switch (logLevel) {
+      case "ERROR":   LOGGER.severe(logMsg);  
+                      break;
+      case "SEVERE":  LOGGER.severe(logMsg);  
+                      break;
+      case "WARNING": LOGGER.warning(logMsg); 
+                      break;
+      case "INFO":    LOGGER.info(logMsg);    
+                      break;
+      case "FINE":    LOGGER.fine(logMsg);    
+                      break;
+      case "FINER":   LOGGER.finer(logMsg);   
+                      break;
+      case "FINEST":  LOGGER.finest(logMsg);  
+                      break;
+      default:        LOGGER.fine(logMsg);    
+                      break;
+    }
+  }
+
+  // Parse log messages out of a Job Log 
+  //  - assumes each job log message starts with '@['
+  //  - assumes any lines that don't start with '@[' are part 
+  //    of the previous log message
+  //  - ignores all lines in the log up to the first line that starts with '@['
+  private static void convertJobLogsToOperatorLogs(String jobLogs) {
+    try { 
+      StringBuffer logString = new StringBuffer(1000);
+      StringBuffer logExtra = new StringBuffer(1000);
+      try (BufferedReader reader = new BufferedReader(new StringReader(jobLogs))) {
+        for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+          if (line.startsWith("@[")) {
+            if (logString.length() > 0) { 
+              logToOperator(logString, logExtra);
+              logString.setLength(0);
+              logExtra.setLength(0);
+            }
+            logString.append(line);
+          } else if (logString.length() != 0) {
+            if (logExtra.length() > 0) { 
+              logExtra.append('\n');
+            }
+            logExtra.append(line);
+          }
+        }
+        if (logString.length() > 0) { 
+          logToOperator(logString, logExtra);
+        }
+      }
+    } catch (IOException ioe) {
+      LOGGER.fine("Unexpected exception " + ioe + " while parsing string:\n" + jobLogs);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -154,6 +154,7 @@ public class MessageKeys {
   public static final String EXTERNAL_CHANNEL_SERVICE_EXISTS = "WLSKO-0152";
   public static final String WLS_HEALTH_READ_FAILED_NO_HTTPCLIENT = "WLSKO-0153";
   public static final String JOB_DEADLINE_EXCEEDED_MESSAGE = "WLSKO-0154";
+  public static final String JOB_LOG_PARSE_FAILURE = "WLSKO-0155";
 
   private MessageKeys() {
   }

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -160,4 +160,4 @@ WLSKO-0154=Job {0} failed due to reason: DeadlineExceeded. \
   The job may be retried by the operator up to {3} \
   times with longer ActiveDeadlineSeconds value in each subsequent retry. \
   Use tuning parameter 'domainPresenceFailureRetryMaxCount' to configure max retries.
-
+WLSKO-0155=Unexpected exception, {0}, while parsing introspect job log [{1}].

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -210,7 +210,7 @@ class OfflineWlstEnv(object):
   def getEnv(self, name):
     val = os.getenv(name)
     if val is None or val == "null":
-      trace("ERROR: Env var "+name+" not set.")
+      trace("SEVERE","Env var "+name+" not set.")
       sys.exit(1)
     return val
 
@@ -930,7 +930,7 @@ class CustomSitConfigIntrospector(SecretManager):
         self.macroStr+=', '
       self.macroStr+='${' + key + '}'
 
-    trace("available macros: '" + self.macroStr + "'")
+    trace("Available macros: '" + self.macroStr + "'")
 
     # Populate module maps with known module files and names, log them
 
@@ -1149,19 +1149,21 @@ def main(env):
       env.close()
     exit(exitcode=0)
   except WLSTException, e:
+    trace("SEVERE","Domain introspection failed with WLST exception: " + str(e))
     print e
-    trace("Domain introspection failed with WLST exception:")
     traceback.print_exc()
+    dumpStack()
     exit(exitcode=1)
   except UndeclaredThrowableException, f:
-    dumpStack()
+    trace("SEVERE","Domain introspection failed with undeclared exception: " + str(f))
     print f
-    trace("Domain introspection failed with undeclared exception:")
     traceback.print_exc()
+    dumpStack()
     exit(exitcode=1)
   except:
-    trace("Domain introspection unexpectedly failed:")
+    trace("SEVERE","Domain introspection unexpectedly failed:")
     traceback.print_exc()
+    dumpStack()
     exit(exitcode=1)
 
 main(OfflineWlstEnv())

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -41,12 +41,11 @@ SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 # setup tracing
 
 source ${SCRIPTPATH}/utils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1 
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1 
 
 trace "Introspecting the domain"
 
-trace "Current environment:"
-env
+env | tracePipe "Current environment:"
 
 # set defaults
 
@@ -68,11 +67,11 @@ checkEnv DOMAIN_UID \
 for script_file in "${SCRIPTPATH}/wlst.sh" \
                    "${SCRIPTPATH}/startNodeManager.sh"  \
                    "${SCRIPTPATH}/introspectDomain.py"; do
-  [ ! -f "$script_file" ] && trace "Error: missing file '${script_file}'." && exit 1 
+  [ ! -f "$script_file" ] && trace SEVERE "Missing file '${script_file}'." && exit 1 
 done 
 
 for dir_var in DOMAIN_HOME JAVA_HOME WL_HOME MW_HOME ORACLE_HOME; do
-  [ ! -d "${!dir_var}" ] && trace "Error: missing ${dir_var} directory '${!dir_var}'." && exit 1
+  [ ! -d "${!dir_var}" ] && trace SEVERE "Missing ${dir_var} directory '${!dir_var}'." && exit 1
 done
 
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed
@@ -93,7 +92,6 @@ ${SCRIPTPATH}/startNodeManager.sh || exit 1
 # run instrospector wlst script
 
 trace "Running introspector WLST script ${SCRIPTPATH}/introspectDomain.py"
-
 
 ${SCRIPTPATH}/wlst.sh ${SCRIPTPATH}/introspectDomain.py || exit 1
 

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -13,7 +13,7 @@ RETVAL=$(test -f /weblogic-operator/debug/livenessProbeSuccessOverride ; echo $?
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit $RETVAL
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit $RETVAL
 
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
 exportEffectiveDomainHome || exit $RETVAL
@@ -26,12 +26,12 @@ STATEFILE=${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
 if [ "${MOCK_WLS}" != 'true' ]; then
   if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
-    trace "Error: WebLogic NodeManager process not found."
+    trace SEVERE "WebLogic NodeManager process not found."
     exit $RETVAL
   fi
 fi
 if [ -f ${STATEFILE} ] && [ `grep -c "FAILED_NOT_RESTARTABLE" ${STATEFILE}` -eq 1 ]; then
-  trace "Error: WebLogic Server state is FAILED_NOT_RESTARTABLE."
+  trace SEVERE "WebLogic Server state is FAILED_NOT_RESTARTABLE."
   exit $RETVAL
 fi
 exit 0

--- a/operator/src/main/resources/scripts/monitorLog.sh
+++ b/operator/src/main/resources/scripts/monitorLog.sh
@@ -15,6 +15,7 @@ echo $$ > /tmp/monitorLog-pid
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1
 
 trace "Monitoring server log file $1 every $2 seconds for selected known log messages."
 
@@ -27,7 +28,7 @@ while true; do
          "For details, please search your pod log or"
          "${SERVER_OUT_FILE} for the keyword 'situational'."
         )
-    trace "${msg[*]}"
+    trace SEVERE "${msg[*]}"
     exit 0
   fi
   if grep -q "BEA-000360" $1 ; then

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -9,7 +9,7 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1
 
 # check DOMAIN_HOME for a config/config.xml, reset DOMAIN_HOME if needed:
 exportEffectiveDomainHome || exit 1
@@ -26,7 +26,7 @@ if [ `jps -v | grep -c " -Dweblogic.Name=${SERVER_NAME} "` -eq 0 ]; then
 fi
 
 if [ ! -f ${STATEFILE} ]; then
-  trace "Error: WebLogic Server state file not found."
+  trace "WebLogic Server state file not found."
   exit 2
 fi
 

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -48,7 +48,7 @@
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 
 source ${SCRIPTPATH}/utils.sh 
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1 
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1 
 
 export WL_HOME="${WL_HOME:-/u01/oracle/wlserver}"
 
@@ -67,11 +67,11 @@ else
   checkEnv SERVER_NAME ADMIN_NAME AS_SERVICE_NAME SERVICE_NAME USER_MEM_ARGS || exit 1
 fi
 
-[ ! -d "${JAVA_HOME}" ]                     && trace "Error: JAVA_HOME directory not found '${JAVA_HOME}'."           && exit 1 
-[ ! -d "${DOMAIN_HOME}" ]                   && trace "Error: DOMAIN_HOME directory not found '${DOMAIN_HOME}'."       && exit 1 
-[ ! -f "${DOMAIN_HOME}/config/config.xml" ] && trace "Error: '${DOMAIN_HOME}/config/config.xml' not found."           && exit 1 
-[ ! -d "${WL_HOME}" ]                       && trace "Error: WL_HOME '${WL_HOME}' not found."                         && exit 1 
-[ ! -f "${stm_script}" ]                    && trace "Error: Missing script '${stm_script}' in WL_HOME '${WL_HOME}'." && exit 1 
+[ ! -d "${JAVA_HOME}" ]                     && trace SEVERE "JAVA_HOME directory not found '${JAVA_HOME}'."           && exit 1 
+[ ! -d "${DOMAIN_HOME}" ]                   && trace SEVERE "DOMAIN_HOME directory not found '${DOMAIN_HOME}'."       && exit 1 
+[ ! -f "${DOMAIN_HOME}/config/config.xml" ] && trace SEVERE "'${DOMAIN_HOME}/config/config.xml' not found."           && exit 1 
+[ ! -d "${WL_HOME}" ]                       && trace SEVERE "WL_HOME '${WL_HOME}' not found."                         && exit 1 
+[ ! -f "${stm_script}" ]                    && trace SEVERE "Missing script '${stm_script}' in WL_HOME '${WL_HOME}'." && exit 1 
 
 #
 # Helper fn to create a folder
@@ -80,7 +80,7 @@ fi
 function createFolder {
   mkdir -m 750 -p "$1"
   if [ ! -d "$1" ]; then
-    trace "Unable to create folder '$1'."
+    trace SEVERE "Unable to create folder '$1'."
     exit 1
   fi
 }
@@ -118,12 +118,12 @@ createFolder ${NODEMGR_HOME}
 NODEMGR_LOG_HOME=${NODEMGR_LOG_HOME:-${LOG_HOME:-${NODEMGR_HOME}/${DOMAIN_UID}}}
 FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR=${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR:-true}
 
-trace "Info: NODEMGR_HOME='${NODEMGR_HOME}'"
-trace "Info: LOG_HOME='${LOG_HOME}'"
-trace "Info: SERVER_NAME='${SERVER_NAME}'"
-trace "Info: DOMAIN_UID='${DOMAIN_UID}'"
-trace "Info: NODEMGR_LOG_HOME='${NODEMGR_LOG_HOME}'"
-trace "Info: FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR='${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR}'"
+trace "NODEMGR_HOME='${NODEMGR_HOME}'"
+trace "LOG_HOME='${LOG_HOME}'"
+trace "SERVER_NAME='${SERVER_NAME}'"
+trace "DOMAIN_UID='${DOMAIN_UID}'"
+trace "NODEMGR_LOG_HOME='${NODEMGR_LOG_HOME}'"
+trace "FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR='${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR}'"
 
 createFolder ${NODEMGR_LOG_HOME}
 
@@ -153,7 +153,7 @@ rm -f ${nodemgr_lck_file}
 # is the domain name:
 domain_name=`cat ${DOMAIN_HOME}/config/config.xml | sed 's/[[:space:]]//g' | grep '^<name>' | head -1 | awk -F'<|>' '{print $3}'`
 if [ "$domain_name" = "" ]; then
-  trace "Could not determine domain name"
+  trace SEVERE "Could not determine domain name"
   exit 1
 fi
 
@@ -170,7 +170,7 @@ cat <<EOF > ${nm_domains_file}
   ${domain_name}=${DOMAIN_HOME}
 EOF
 
-  [ ! $? -eq 0 ] && trace "Failed to create '${nm_domains_file}'." && exit 1
+  [ ! $? -eq 0 ] && trace SEVERE "Failed to create '${nm_domains_file}'." && exit 1
 
 cat <<EOF > ${nm_props_file}
   #Node manager properties
@@ -202,7 +202,7 @@ cat <<EOF > ${nm_props_file}
 
 EOF
 
-  [ ! $? -eq 0 ] && trace "Failed to create '${nm_props_file}'." && exit 1
+  [ ! $? -eq 0 ] && trace SEVERE "Failed to create '${nm_props_file}'." && exit 1
 
 ###############################################################################
 #
@@ -225,7 +225,8 @@ if [ ! "${SERVER_NAME}" = "introspector" ]; then
   
   if [ -f "$wl_state_file" ]; then
     trace "Removing stale file '$wl_state_file'."
-    rm -f ${wl_state_file} || exit 1
+    rm -f ${wl_state_file} 
+    [ ! $? -eq 0 ] && trace SEVERE "Could not remove stale file '$wl_state_file'." && exit 1
   fi
 
 
@@ -248,7 +249,7 @@ Arguments=${USER_MEM_ARGS} -XX\\:+UnlockExperimentalVMOptions -XX\\:+UseCGroupMe
 
 EOF
  
-  [ ! $? -eq 0 ] && trace "Failed to create '${wl_props_file}'." && exit 1
+  [ ! $? -eq 0 ] && trace SEVERE "Failed to create '${wl_props_file}'." && exit 1
 
   if [ ! "${ADMIN_NAME}" = "${SERVER_NAME}" ]; then
     admin_protocol="http"
@@ -295,8 +296,10 @@ export JAVA_OPTIONS="${JAVA_OPTIONS} -Dweblogic.RootDirectory=${DOMAIN_HOME}"
 
 trace "Start the nodemanager, node manager home is '${NODEMGR_HOME}', log file is '${nodemgr_log_file}', out file is '${nodemgr_out_file}'."
 
-rm -f ${nodemgr_log_file} || exit 1
-rm -f ${nodemgr_out_file} || exit 1
+rm -f ${nodemgr_log_file}
+[ ! $? -eq 0 ] && trace SEVERE "Could not remove old file '$nodemgr_log_file'." && exit 1
+rm -f ${nodemgr_out_file}
+[ ! $? -eq 0 ] && trace SEVERE "Could not remove old file '$nodemgr_out_file'." && exit 1
 
 ${stm_script} > ${nodemgr_out_file} 2>&1 &
 
@@ -309,11 +312,11 @@ while [ 1 -eq 1 ]; do
     break
   fi
   if [ $((SECONDS - $start_secs)) -ge $max_wait_secs ]; then
-    trace "Info: Contents of node manager log '$nodemgr_log_file':"
+    trace INFO "Contents of node manager log '$nodemgr_log_file':"
     cat ${nodemgr_log_file}
-    trace "Info: Contents of node manager out '$nodemgr_out_file':"
+    trace INFO "Contents of node manager out '$nodemgr_out_file':"
     cat ${NODEMGR_OUT_FILE}
-    trace "Error: node manager failed to start within $max_wait_secs seconds."
+    trace SEVERE "Node manager failed to start within $max_wait_secs seconds."
     exit 1
   fi
   wait_count=$((wait_count + 1))

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -11,7 +11,7 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1
 
 trace "Stop server ${SERVER_NAME}" &>> /weblogic-operator/stopserver.out
 
@@ -23,7 +23,7 @@ if [ "${MOCK_WLS}" == 'true' ]; then
 fi
 
 function check_for_shutdown() {
-  [ ! -f "${SCRIPTPATH}/readState.sh" ] && trace "Error: missing file '${SCRIPTPATH}/readState.sh'." && exit 1
+  [ ! -f "${SCRIPTPATH}/readState.sh" ] && trace SEVERE "Missing file '${SCRIPTPATH}/readState.sh'." && exit 1
 
   state=`${SCRIPTPATH}/readState.sh`
   exit_status=$?
@@ -51,7 +51,7 @@ check_for_shutdown
 [ $? -eq 0 ] && trace "Server already shutdown or failed" &>> /weblogic-operator/stopserver.out && exit 0
 
 # Otherwise, connect to the node manager and stop the server instance
-[ ! -f "${SCRIPTPATH}/wlst.sh" ] && trace "Error: missing file '${SCRIPTPATH}/wlst.sh'." && exit 1
+[ ! -f "${SCRIPTPATH}/wlst.sh" ] && trace SEVERE "Missing file '${SCRIPTPATH}/wlst.sh'." && exit 1
 
 # Arguments for shutdown
 export SHUTDOWN_PORT_ARG=${LOCAL_ADMIN_PORT:-${MANAGED_SERVER_PORT:-8001}}
@@ -70,7 +70,7 @@ trace "After stop-server.py" &>> /weblogic-operator/stopserver.out
 # just in case we failed to stop it via wlst
 pid=$(jps -v | grep " -Dweblogic.Name=${SERVER_NAME} " | awk '{print $1}')
 if [ ! -z $pid ]; then
-  echo "Killing the server process $pid" &>> /weblogic-operator/stopserver.out
+  trace "Killing the server process $pid" &>> /weblogic-operator/stopserver.out
   kill -15 $pid
 fi
 

--- a/operator/src/main/resources/scripts/utils.py
+++ b/operator/src/main/resources/scripts/utils.py
@@ -2,10 +2,15 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 # Usage: trace('string')
+#        trace(logLevel,'string')
 #
-# This matches format of bash utils.sh trace, and the operator's log format.
+# Valid values for logLevel are SEVERE|WARNING|ERROR|INFO|CONFIG|FINE|FINER|FINEST
+#    'ERROR' is converted to 'SEVERE' 
+#    Unknown logLevels are converted to 'FINE'.
 #
-# Sample output:   @[2018-09-28T17:23:55.335 UTC][introspectDomain.py:614] Domain introspection complete.
+# This matches format of bash utils.sh trace, and rougly matches the operator's log format.
+#
+# Sample output:   @[2018-09-28T17:23:55.335 UTC][introspectDomain.py:614][FINE] Domain introspection complete.
 #
 # Importing this file when it's not in sys.path of the calling script:
 #
@@ -15,19 +20,44 @@
 #   tmp_scriptdir=os.path.dirname(tmp_info[0])
 #   sys.path.append(tmp_scriptdir)
 #
+#   from utils import *
+#
 
 import sys
 import inspect
 import os
 from datetime import datetime
 
-def trace(object):
-  callerframerecord = inspect.stack()[1]    # 0 represents this line
+# NOTE: This may be parsed by the operator. Do not change the date or log format without 
+#       also updating the parser.
+
+def traceInner(logLevel,object):
+  callerframerecord = inspect.stack()[2]    # 0 represents this line
                                             # 1 represents line at caller
+                                            # 2 represents line at caller's caller
   info = inspect.getframeinfo(callerframerecord[0])
   dt=datetime.utcnow()
   filename=os.path.basename(info[0])
   lineno=info[1]
-  print("@[%d-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d UTC][%s:%s] %s"
+  # convert ERROR to SEVERE as operator has no ERROR level
+  switcher = {
+    'SEVERE'  : 'SEVERE',
+    'ERROR'   : 'SEVERE',
+    'WARNING' : 'WARNING',
+    'INFO'    : 'INFO',
+    'CONFIG'  : 'CONFIG',
+    'FINE'    : 'FINE',
+    'FINER'   : 'FINER',
+    'FINEST'  : 'FINEST',
+  }
+  # use FINE as logLevel if logLevel is not a known type
+  logLevel=switcher.get(logLevel.upper(),'FINE')
+  print("@[%d-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d UTC][%s:%s][%s] %s"
         % (dt.year,dt.month,dt.day,dt.hour,dt.minute,dt.second,dt.microsecond/1000,
-           filename,lineno,object))
+           filename,lineno,logLevel,object))
+
+def trace(arg1,arg2='SENTINEL'):
+  if arg2 == 'SENTINEL': 
+    traceInner('FINE',arg1)
+  else:
+    traceInner(arg1,arg2)

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -97,8 +97,9 @@ function trace() {
 
   # Support log-levels in operator, if unknown then assume FINE
   #  SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST
+  #  (The '^^' trick below converts the var to upper case.)
   local logLevel='FINE'
-  case $1 in
+  case ${1^^} in
     SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST)
       logLevel=$1
       shift
@@ -107,26 +108,26 @@ function trace() {
       logLevel='SEVERE'
       shift
       ;;
-    warning*|Warning*|WARNING*)
+    WARNING*)
       logLevel='WARNING'
       ;;
-    error*|Error*|ERROR*|severe*|Severe*|SEVERE*)
+    ERROR*|SEVERE*)
       logLevel='SEVERE'
       ;;
-    info*|Info*|INFO*)
+    INFO*)
       logLevel='INFO'
       ;;
-    config*|Config*|CONFIG*)
+    CONFIG*)
       logLevel='CONFIG'
       ;;
-    finest*|Finest*|FINEST*)
-      logLevel='FINE'
+    FINEST*)
+      logLevel='FINEST'
       ;;
-    finer*|Finer*|FINER*)
+    FINER*)
       logLevel='FINER'
       ;;
-    fine*|Fine*|FINE*)
-      logLevel='FINEST'
+    FINE*)
+      logLevel='FINE'
       ;;
   esac
 

--- a/operator/src/main/resources/scripts/wlst.sh
+++ b/operator/src/main/resources/scripts/wlst.sh
@@ -19,11 +19,11 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
-[ $? -ne 0 ] && echo "Error: missing file ${SCRIPTPATH}/utils.sh" && exit 1 
+[ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1 
 
 wlst_script=${1?}
 
-trace "Running wlst script '${wlst_script}'"
+trace "About to run wlst script '${wlst_script}'"
 
 export WL_HOME=${WL_HOME:-/u01/oracle/wlserver}
 export MW_HOME=${MW_HOME:-/u01/oracle}
@@ -33,22 +33,24 @@ checkEnv JAVA_HOME \
          MW_HOME \
          || exit 1
 
-[ ! -f "$wlst_script" ] && trace "Error: missing file '$wlst_script'." && exit 1 
+[ ! -f "$wlst_script" ] && trace SEVERE "Missing file '$wlst_script'." && exit 1 
 
 wlst_sh=""
 wlst_loc1="${WL_HOME}/../oracle_common/common/bin/wlst.sh"
 wlst_loc2="${MW_HOME}/oracle_common/common/bin/wlst.sh"
 [ -f "$wlst_loc2" ]   && wlst_sh="$wlst_loc2"
 [ -f "$wlst_loc1" ]   && wlst_sh="$wlst_loc1"
-[ -z "$wlst_sh" ] && trace "Error: '${wlst_loc1}' or '${wlst_loc2}' not found, make sure WL_HOME or MW_HOME is set correctly." && exit 1
+[ -z "$wlst_sh" ] && trace SEVERE "'${wlst_loc1}' or '${wlst_loc2}' not found, make sure WL_HOME or MW_HOME is set correctly." && exit 1
+
+trace "Running wlst script '${wlst_script}'"
 
 ${wlst_sh} -skipWLSModuleScanning ${wlst_script} "${@:2}"
 res="$?"
 
 if [ $res -eq 0 ]; then
-  trace "Info: WLST script '${wlst_script}' completed."
+  trace "WLST script '${wlst_script}' completed."
 else
-  trace "Error: WLST script '${wlst_script}' failed with exit code '$res'." 
+  trace SEVERE "WLST script '${wlst_script}' failed with exit code '$res'." 
 fi
 
 exit $res


### PR DESCRIPTION
- Reflect each introspector job log message in the operator log using the same log-level
- Ensure job/pod log messages that are generated by scripts (a) use same log-levels as the operator, and (b) can be parsed by the operator if needed
- If a bash script 'trace' call doesn't specify a log-level, try deduce it from the first word in the log text, and if that doesn't help, assume the log-level is FINE
- **Note:** Since the Operator does not have an 'error' log level, we convert any 'error' to a 'severe'.
- **Note:** If a script log message has no log level, we assume it's a 'fine'.

Sample Operator output when job fails due to a missing DOMAIN_HOME:
```
[slc16okc weblogic-kubernetes-operator]$ ../notes/oplog.sh -ll SEVERE
@@ Reading log from 'kubectl logs weblogic-operator-5c96bb9489-794vs -n weblogic-operator1 ':
 1:"07-24-2019T15:03:57.782" 4:"" 5:"SEVERE" 9:"Job domainonpvwlst-introspect-domain-job has failed" 10:""
 1:"07-24-2019T15:03:57.854" 4:"domainonpvwlst" 5:"SEVERE" 9:"Introspector Job Log: @[2019-07-24T15:03:57.523 UTC][introspectDomain.sh:74][SEVERE] Missing DOMAIN_HOME directory '/shared/domains/domainonpvwlstDNE'." 10:""
```