### PR TITLE
Owls 75227 - simplify debugging the operator

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -39,6 +39,12 @@ spec:
         {{- if .remoteDebugNodePortEnabled }}
         - name: "REMOTE_DEBUG_PORT"
           value: {{ .internalDebugHttpPort | quote }}
+        - name: "DEBUG_SUSPEND"
+          {{- if .suspendOnDebugStartup }}
+          value: "y"
+          {{- else }}
+          value: "n"
+          {{- end }}
         {{- end }}
         {{- if .mockWLS }}
         - name: "MOCK_WLS"
@@ -61,6 +67,7 @@ spec:
           name: "log-dir"
           readOnly: false
         {{- end }}
+        {{- if not .remoteDebugNodePortEnabled }}
         livenessProbe:
           exec:
             command:
@@ -75,6 +82,7 @@ spec:
               - "/operator/readinessProbe.sh"
           initialDelaySeconds: 2
           periodSeconds: 10
+        {{- end }}
       {{- if .elkIntegrationEnabled }}
       - name: "logstash"
         image: {{ .logStashImage | quote }}

--- a/kubernetes/charts/weblogic-operator/templates/_validate-inputs.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_validate-inputs.tpl
@@ -26,6 +26,7 @@
 {{- end -}}
 {{- if include "utils.verifyBoolean" (list $scope "remoteDebugNodePortEnabled") -}}
 {{-   if $scope.remoteDebugNodePortEnabled -}}
+{{-     $ignore := include "utils.verifyBoolean" (list $scope "suspendOnDebugStartup") -}}
 {{-     $ignore := include "utils.verifyInteger" (list $scope "internalDebugHttpPort") -}}
 {{-     $ignore := include "utils.verifyInteger" (list $scope "externalDebugHttpPort") -}}
 {{-   end -}}

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -59,14 +59,18 @@ externalRestHttpsPort: 31001
 # kubernetes/samples/scripts/rest/generate-external-rest-identity.sh
 #externalRestIdentitySecret: 
 
-# remoteDebugNodePortEnabled specifies whether or not the operator will start a Java remote debug server
-# on the provided port and suspend execution until a remote debugger has attached.
+# remoteDebugNodePortEnabled specifies whether or not the operator will start a Java remote debug server on the
+# provided port. If the 'suspendOnDebugStartup' property is specified, the operator will suspend execution
+# until a remote debugger has attached.
 # The 'internalDebugHttpPort' property controls the port number inside the Kubernetes
 # cluster and the 'externalDebugHttpPort' property controls the port number outside
 # the Kubernetes cluster.
 remoteDebugNodePortEnabled: false
 
-# internalDebugHttpPort specifes the port number inside the Kubernetes cluster for the operator's Java
+#suspendOnDebugStartup specifies whether the operator will suspend on startup when a Java remote debug server is started.
+suspendOnDebugStartup: false
+
+# internalDebugHttpPort specifies the port number inside the Kubernetes cluster for the operator's Java
 # remote debug server.
 # This parameter is required if 'remoteDebugNodePortEnabled' is true.
 # Otherwise, it is ignored.

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
@@ -5,11 +5,8 @@
 package oracle.kubernetes.operator.create;
 
 import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
-import io.kubernetes.client.models.V1Container;
 import io.kubernetes.client.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
-
-import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newEnvVar;
 
 public abstract class CreateOperatorGeneratedFilesDebugEnabledTestBase
     extends CreateOperatorGeneratedFilesTestBase {
@@ -36,10 +33,7 @@ public abstract class CreateOperatorGeneratedFilesDebugEnabledTestBase
   @Override
   public ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
     ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
-    V1Container operatorContainer =
-        expected.getSpec().getTemplate().getSpec().getContainers().get(0);
-    operatorContainer.addEnvItem(
-        newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
+    expectRemoteDebug(expected.getSpec().getTemplate().getSpec().getContainers().get(0), "n");
     return expected;
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBase.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.operator.create;
 
+import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
@@ -17,6 +18,13 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBa
 
   protected static void defineOperatorYamlFactory(OperatorYamlFactory factory) throws Exception {
     setup(factory, factory.newOperatorValues());
+  }
+
+  @Override
+  protected ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
+    ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
+    expectProbes(expected.getSpec().getTemplate().getSpec().getContainers().get(0));
+    return expected;
   }
 
   @Override

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -4,17 +4,17 @@
 
 package oracle.kubernetes.operator.create;
 
-import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
-import io.kubernetes.client.models.V1Container;
-import io.kubernetes.client.models.V1Service;
-import oracle.kubernetes.operator.utils.OperatorYamlFactory;
-
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newContainer;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newEmptyDirVolumeSource;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newEnvVar;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newLocalObjectReference;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newVolume;
 import static oracle.kubernetes.operator.utils.KubernetesArtifactUtils.newVolumeMount;
+
+import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1Service;
+import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
 /**
  * Tests that the artifacts in the yaml files that create-weblogic-operator.sh creates are correct
@@ -31,6 +31,7 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
             .newOperatorValues()
             .setupExternalRestEnabled()
             .enableDebugging()
+            .suspendOnDebugStartup("true")
             .elkIntegrationEnabled("true")
             .weblogicOperatorImagePullSecretName("test-operator-image-pull-secret-name"));
   }
@@ -55,10 +56,9 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
     ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
     V1Container operatorContainer =
         expected.getSpec().getTemplate().getSpec().getContainers().get(0);
-    operatorContainer
-        .addVolumeMountsItem(newVolumeMount().name("log-dir").mountPath("/logs").readOnly(false))
-        .addEnvItem(
-            newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
+    operatorContainer.addVolumeMountsItem(
+        newVolumeMount().name("log-dir").mountPath("/logs").readOnly(false));
+    expectRemoteDebug(operatorContainer, "y");
     expected
         .getSpec()
         .getTemplate()

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -4,26 +4,6 @@
 
 package oracle.kubernetes.operator.create;
 
-import io.kubernetes.client.custom.Quantity;
-import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
-import io.kubernetes.client.models.V1ClusterRole;
-import io.kubernetes.client.models.V1ClusterRoleBinding;
-import io.kubernetes.client.models.V1ConfigMap;
-import io.kubernetes.client.models.V1Namespace;
-import io.kubernetes.client.models.V1ResourceRequirements;
-import io.kubernetes.client.models.V1Role;
-import io.kubernetes.client.models.V1RoleBinding;
-import io.kubernetes.client.models.V1Secret;
-import io.kubernetes.client.models.V1Service;
-import io.kubernetes.client.models.V1ServiceAccount;
-import io.kubernetes.client.models.V1ServiceSpec;
-import oracle.kubernetes.operator.utils.GeneratedOperatorObjects;
-import oracle.kubernetes.operator.utils.KubernetesArtifactUtils;
-import oracle.kubernetes.operator.utils.OperatorValues;
-import oracle.kubernetes.operator.utils.OperatorYamlFactory;
-import org.apache.commons.codec.binary.Base64;
-import org.junit.Test;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static oracle.kubernetes.operator.LabelConstants.APP_LABEL;
@@ -64,17 +44,36 @@ import static oracle.kubernetes.operator.utils.YamlUtils.yamlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
+import io.kubernetes.client.custom.Quantity;
+import io.kubernetes.client.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.models.V1ClusterRole;
+import io.kubernetes.client.models.V1ClusterRoleBinding;
+import io.kubernetes.client.models.V1ConfigMap;
+import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1Namespace;
+import io.kubernetes.client.models.V1Probe;
+import io.kubernetes.client.models.V1ResourceRequirements;
+import io.kubernetes.client.models.V1Role;
+import io.kubernetes.client.models.V1RoleBinding;
+import io.kubernetes.client.models.V1Secret;
+import io.kubernetes.client.models.V1Service;
+import io.kubernetes.client.models.V1ServiceAccount;
+import io.kubernetes.client.models.V1ServiceSpec;
+import oracle.kubernetes.operator.utils.GeneratedOperatorObjects;
+import oracle.kubernetes.operator.utils.KubernetesArtifactUtils;
+import oracle.kubernetes.operator.utils.OperatorValues;
+import oracle.kubernetes.operator.utils.OperatorYamlFactory;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Test;
+
 /**
  * Base class for testing that the all artifacts in the yaml files that create-weblogic-operator.sh
  * generates
  */
 public abstract class CreateOperatorGeneratedFilesTestBase {
 
-  private static String OPERATOR_RELEASE = "weblogic-operator";
-
   private static OperatorValues inputs;
   private static GeneratedOperatorObjects generatedFiles;
-  private static OperatorYamlFactory factory;
 
   protected static OperatorValues getInputs() {
     return inputs;
@@ -84,8 +83,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
     return generatedFiles;
   }
 
-  protected static void setup(OperatorYamlFactory factory, OperatorValues val) throws Exception {
-    CreateOperatorGeneratedFilesTestBase.factory = factory;
+  static void setup(OperatorYamlFactory factory, OperatorValues val) throws Exception {
     inputs = val;
     generatedFiles = factory.generate(val);
   }
@@ -229,25 +227,7 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                                             newVolumeMount()
                                                 .name("weblogic-operator-secrets-volume")
                                                 .mountPath("/operator/secrets")
-                                                .readOnly(true))
-                                        .livenessProbe(
-                                            newProbe()
-                                                .initialDelaySeconds(20)
-                                                .periodSeconds(5)
-                                                .exec(
-                                                    newExecAction()
-                                                        .addCommandItem("bash")
-                                                        .addCommandItem(
-                                                            "/operator/livenessProbe.sh")))
-                                        .readinessProbe(
-                                            newProbe()
-                                                .initialDelaySeconds(2)
-                                                .periodSeconds(10)
-                                                .exec(
-                                                    newExecAction()
-                                                        .addCommandItem("bash")
-                                                        .addCommandItem(
-                                                            "/operator/readinessProbe.sh"))))
+                                                .readOnly(true)))
                                 .addVolumesItem(
                                     newVolume()
                                         .name("weblogic-operator-cm-volume")
@@ -267,6 +247,19 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                                         .secret(
                                             newSecretVolumeSource()
                                                 .secretName("weblogic-operator-secrets"))))));
+  }
+
+  void expectProbes(V1Container container) {
+    container
+        .livenessProbe(createProbe(20, 5, "/operator/livenessProbe.sh"))
+        .readinessProbe(createProbe(2, 10, "/operator/readinessProbe.sh"));
+  }
+
+  private V1Probe createProbe(int initialDelaySeconds, int periodSeconds, String shellScript) {
+    return newProbe()
+        .initialDelaySeconds(initialDelaySeconds)
+        .periodSeconds(periodSeconds)
+        .exec(newExecAction().addCommandItem("bash").addCommandItem(shellScript));
   }
 
   @Test
@@ -814,5 +807,11 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
                 .putLabelsItem(RESOURCE_VERSION_LABEL, OPERATOR_V2)
                 .putLabelsItem(OPERATORNAME_LABEL, getInputs().getNamespace()))
         .spec(spec);
+  }
+
+  protected void expectRemoteDebug(V1Container operatorContainer, String debugSuspend) {
+    operatorContainer.addEnvItem(
+        newEnvVar().name("REMOTE_DEBUG_PORT").value(getInputs().getInternalDebugHttpPort()));
+    operatorContainer.addEnvItem(newEnvVar().name("DEBUG_SUSPEND").value(debugSuspend));
   }
 }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValues.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValues.java
@@ -4,14 +4,6 @@
 
 package oracle.kubernetes.operator.helm;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import oracle.kubernetes.operator.utils.OperatorValues;
-
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -21,9 +13,14 @@ import static oracle.kubernetes.operator.helm.MapUtils.loadBooleanFromMap;
 import static oracle.kubernetes.operator.helm.MapUtils.loadFromMap;
 import static oracle.kubernetes.operator.helm.MapUtils.loadIntegerFromMap;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import oracle.kubernetes.operator.utils.OperatorValues;
+
 class HelmOperatorValues extends OperatorValues {
-  HelmOperatorValues() {
-  }
+  HelmOperatorValues() {}
 
   HelmOperatorValues(Map<String, Object> map) {
     loadFromMap(map, this::setServiceAccount, "serviceAccount");
@@ -39,6 +36,7 @@ class HelmOperatorValues extends OperatorValues {
 
     loadBooleanFromMap(map, this::setExternalRestEnabled, "externalRestEnabled");
     loadBooleanFromMap(map, this::setRemoteDebugNodePortEnabled, "remoteDebugNodePortEnabled");
+    loadBooleanFromMap(map, this::setSuspendOnDebugStartup, "suspendOnDebugStartup");
     loadBooleanFromMap(map, this::setElkIntegrationEnabled, "elkIntegrationEnabled");
 
     loadIntegerFromMap(map, this::setExternalRestHttpsPort, "externalRestHttpsPort");
@@ -59,6 +57,12 @@ class HelmOperatorValues extends OperatorValues {
   private void setRemoteDebugNodePortEnabled(Boolean enabled) {
     if (enabled != null) {
       setRemoteDebugNodePortEnabled(enabled.toString());
+    }
+  }
+
+  private void setSuspendOnDebugStartup(Boolean enabled) {
+    if (enabled != null) {
+      setSuspendOnDebugStartup(enabled.toString());
     }
   }
 
@@ -84,7 +88,7 @@ class HelmOperatorValues extends OperatorValues {
         (List<Map<String, String>>) map.get("imagePullSecrets");
     if (imagePullSecrets != null) {
       // TBD - enhance OperatorValues to have an array of image pull secrets, instead of just one
-      String secretName = (String) imagePullSecrets.get(0).get("name");
+      String secretName = imagePullSecrets.get(0).get("name");
       if (secretName != null) {
         setWeblogicOperatorImagePullSecretName(secretName);
       }
@@ -106,7 +110,8 @@ class HelmOperatorValues extends OperatorValues {
     addStringMapEntry(map, this::getElasticSearchHost, "elasticSearchHost");
 
     addMapEntry(map, this::isExternalRestEnabled, "externalRestEnabled");
-    addMapEntry(map, this::isRemoteDebugNotPortEnabled, "remoteDebugNodePortEnabled");
+    addMapEntry(map, this::isRemoteDebugNodePortEnabled, "remoteDebugNodePortEnabled");
+    addMapEntry(map, this::isSuspendOnDebugStartup, "suspendOnDebugStartup");
     addMapEntry(map, this::isElkIntegrationEnabled, "elkIntegrationEnabled");
 
     addMapEntry(map, this::getExternalRestHttpsPortNum, "externalRestHttpsPort");
@@ -122,11 +127,7 @@ class HelmOperatorValues extends OperatorValues {
   private void addDomainNamespaces(HashMap<String, Object> map) {
     String targetNamespaces = getTargetNamespaces();
     if (targetNamespaces.length() > 0) {
-      List<String> namespaces = new ArrayList<>();
-      for (String namespace : targetNamespaces.split(",")) {
-        namespaces.add(namespace);
-      }
-      map.put("domainNamespaces", namespaces);
+      map.put("domainNamespaces", Arrays.asList(targetNamespaces.split(",")));
     }
   }
 
@@ -141,8 +142,12 @@ class HelmOperatorValues extends OperatorValues {
     return MapUtils.valueOf(getExternalRestEnabled());
   }
 
-  private Boolean isRemoteDebugNotPortEnabled() {
+  private Boolean isRemoteDebugNodePortEnabled() {
     return MapUtils.valueOf(getRemoteDebugNodePortEnabled());
+  }
+
+  private Boolean isSuspendOnDebugStartup() {
+    return MapUtils.valueOf(getSuspendOnDebugStartup());
   }
 
   private Boolean isElkIntegrationEnabled() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/helm/HelmOperatorValuesTest.java
@@ -4,12 +4,6 @@
 
 package oracle.kubernetes.operator.helm;
 
-import java.util.List;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
@@ -17,6 +11,11 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.junit.Test;
 
 public class HelmOperatorValuesTest {
 
@@ -240,6 +239,50 @@ public class HelmOperatorValuesTest {
         new HelmOperatorValues(ImmutableMap.of("remoteDebugNodePortEnabled", false));
 
     assertThat(values.getRemoteDebugNodePortEnabled(), equalTo("false"));
+  }
+
+  // --------------- suspendOnDebugStartup
+
+  @Test
+  public void whenSuspendOnDebugStartupTrue_createdMapContainsValue() {
+    operatorValues.suspendOnDebugStartup("true");
+
+    assertThat(operatorValues.createMap(), hasEntry("suspendOnDebugStartup", true));
+  }
+
+  @Test
+  public void whenSuspendOnDebugStartupFalse_createdMapContainsValue() {
+    operatorValues.suspendOnDebugStartup("false");
+
+    assertThat(operatorValues.createMap(), hasEntry("suspendOnDebugStartup", false));
+  }
+
+  @Test
+  public void whenSuspendOnDebugStartupNotSet_createdMapLacksValue() {
+    assertThat(operatorValues.createMap(), not(hasKey("suspendOnDebugStartup")));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithoutSuspendOnDebugStartup_hasEmptyString() {
+    HelmOperatorValues values = new HelmOperatorValues(ImmutableMap.of());
+
+    assertThat(values.getSuspendOnDebugStartup(), equalTo(""));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithSuspendOnDebugStartupTrue_hasSpecifiedValue() {
+    HelmOperatorValues values =
+        new HelmOperatorValues(ImmutableMap.of("suspendOnDebugStartup", true));
+
+    assertThat(values.getSuspendOnDebugStartup(), equalTo("true"));
+  }
+
+  @Test
+  public void whenCreatedFromMapWithSuspendOnDebugStartupFalse_hasSpecifiedValue() {
+    HelmOperatorValues values =
+        new HelmOperatorValues(ImmutableMap.of("suspendOnDebugStartup", false));
+
+    assertThat(values.getSuspendOnDebugStartup(), equalTo("false"));
   }
 
   // --------------- elkIntegrationEnabled
@@ -482,7 +525,8 @@ public class HelmOperatorValuesTest {
         .append("javaLoggingLevel: INFO\n")
         .append("logStashImage: logstash:6.6.0\n")
         .append("remoteDebugNodePortEnabled: false\n")
-        .append("serviceAccount: default\n");
+        .append("serviceAccount: default\n")
+        .append("suspendOnDebugStartup: false\n");
     return sb.toString();
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/OperatorValues.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/OperatorValues.java
@@ -5,7 +5,6 @@
 package oracle.kubernetes.operator.utils;
 
 import java.util.Objects;
-
 import org.apache.commons.codec.binary.Base64;
 
 public class OperatorValues {
@@ -34,6 +33,7 @@ public class OperatorValues {
   private String externalOperatorSecret = "";
   private String externalOperatorKey = "";
   private String remoteDebugNodePortEnabled = "";
+  private String suspendOnDebugStartup = "";
   private String internalDebugHttpPort = "";
   private String externalDebugHttpPort = "";
   private String javaLoggingLevel = "";
@@ -236,6 +236,19 @@ public class OperatorValues {
 
   public OperatorValues remoteDebugNodePortEnabled(String val) {
     setRemoteDebugNodePortEnabled(val);
+    return this;
+  }
+
+  public String getSuspendOnDebugStartup() {
+    return suspendOnDebugStartup;
+  }
+
+  protected void setSuspendOnDebugStartup(String val) {
+    suspendOnDebugStartup = convertNullToEmptyString(val);
+  }
+
+  public OperatorValues suspendOnDebugStartup(String val) {
+    setSuspendOnDebugStartup(val);
     return this;
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/YamlUtils.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/YamlUtils.java
@@ -4,12 +4,12 @@
 
 package oracle.kubernetes.operator.utils;
 
+import io.kubernetes.client.custom.IntOrString;
+import io.kubernetes.client.custom.Quantity;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-
-import io.kubernetes.client.custom.IntOrString;
-import io.kubernetes.client.custom.Quantity;
+import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.yaml.snakeyaml.DumperOptions;
@@ -22,9 +22,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Represent;
 import org.yaml.snakeyaml.representer.Representer;
 
-/**
- * Yaml utilities for the create script tests.
- */
+/** Yaml utilities for the create script tests. */
 public class YamlUtils {
 
   public static Yaml newYaml() {
@@ -110,26 +108,42 @@ public class YamlUtils {
   // Anyway, it doesn't hurt to always just convert to yaml and compare the strings so that
   // we don't have to write type-dependent code.
   private static class YamlMatcher extends TypeSafeDiagnosingMatcher<Object> {
-    private Object expectedObject;
+    private String expectedString;
 
     private YamlMatcher(Object expectedObject) {
-      this.expectedObject = expectedObject;
+      expectedString = objectToYaml(expectedObject);
     }
 
     @Override
     protected boolean matchesSafely(Object returnedObject, Description description) {
       String returnedString = objectToYaml(returnedObject);
-      String expectedString = objectToYaml(expectedObject);
-      if (!Objects.equals(returnedString, expectedString)) {
-        description.appendText("\nwas\n").appendText(returnedString);
-        return false;
-      }
-      return true;
+      if (Objects.equals(expectedString, returnedString)) return true;
+
+      int index = StringUtils.indexOfDifference(expectedString, returnedString);
+      if (index < 10) description.appendText("\nwas\n").appendText(returnedString);
+      else
+        description
+            .appendText("\ndiffers at position ")
+            .appendValue(index)
+            .appendText(toDifference(index, returnedString));
+      return false;
+    }
+
+    private String toDifference(int diffIndex, String returnedString) {
+      StringBuilder sb = new StringBuilder(":\n");
+      int firstDiffLineIndex =
+          Math.max(0, returnedString.substring(0, diffIndex).lastIndexOf('\n'));
+      int lastMatchLineIndex =
+          Math.max(0, returnedString.substring(0, firstDiffLineIndex).lastIndexOf('\n'));
+      sb.append(returnedString, lastMatchLineIndex, firstDiffLineIndex);
+      if (sb.length() > 0) sb.append("\n-----\n");
+      sb.append(returnedString, firstDiffLineIndex, firstDiffLineIndex + 100);
+      return sb.toString();
     }
 
     @Override
     public void describeTo(Description description) {
-      description.appendText("\n").appendText(objectToYaml(expectedObject));
+      description.appendText("\n").appendText(expectedString);
     }
 
     private String objectToYaml(Object object) {

--- a/src/scripts/operator.sh
+++ b/src/scripts/operator.sh
@@ -20,7 +20,7 @@ trap relay_SIGTERM SIGTERM
 /operator/initialize-external-operator-identity.sh
 
 if [[ ! -z "$REMOTE_DEBUG_PORT" ]]; then
-  DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$REMOTE_DEBUG_PORT"
+  DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=$DEBUG_SUSPEND,address=*:$REMOTE_DEBUG_PORT"
   echo "DEBUG=$DEBUG"
 else
   DEBUG=""


### PR DESCRIPTION
Replaces PR #1154, which had been done against `master`

* simplifies putting the operator into debug by disabling the probes when debug is enabled, and
* allows the operator to be set not to suspend, meaning that a developer can attach after it is running. This is controlled by the `suspendOnDebugStartup` setting, which defaults to `false`.