### PR TITLE
WIP: OWLS-75425 fix if existing logic in PVPVC creation sample 

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -915,9 +915,9 @@ public class Domain {
     logger.info("pvSharing for this domain is: " + pvSharing);
     if (!pvSharing) {
       pvMap.put("domainUID", domainUid);
-    } else {
+    } /*else {
       pvMap.put("baseName", "weblogic-sharing");
-    }
+    }*/
     logger.info("baseName of PVPVC for this domain is: " + (String) pvMap.get("baseName"));
 
     // Now there is only one pvSharing test case and we just use parameter "baseName"+"-pvc" as PVC

--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -141,7 +141,7 @@ function checkPvState {
 function checkPvExists {
 
   echo "Checking if the persistent volume ${1} exists"
-  PV_EXISTS=`kubectl get pv | grep ${1} | wc | awk ' { print $1; } '`
+  PV_EXISTS=`kubectl get pv | grep ^${1} | wc | awk ' { print $1; } '`
   if [ "${PV_EXISTS}" = "1" ]; then
     echo "The persistent volume ${1} already exists"
     PV_EXISTS="true"
@@ -157,7 +157,7 @@ function checkPvExists {
 # $2 - namespace
 function checkPvcExists {
   echo "Checking if the persistent volume claim ${1} in namespace ${2} exists"
-  PVC_EXISTS=`kubectl get pvc -n ${2} | grep ${1} | wc | awk ' { print $1; } '`
+  PVC_EXISTS=`kubectl get pvc -n ${2} | grep ^${1} | wc | awk ' { print $1; } '`
   if [ "${PVC_EXISTS}" = "1" ]; then
     echo "The persistent volume claim ${1} already exists in namespace ${2}"
     PVC_EXISTS="true"


### PR DESCRIPTION
Under current sample pv/pvc creation logic, we will check if pv/pvc exists
before creation. However that checking logic is not smart enough to detect
the difference between 2 pv/pvc names if one name is the substring of another
one. This PR is to fix this issue.
 