### PR TITLE
skip test which depends on thinclient.jar for slim image

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -184,17 +184,17 @@ K8sTestUtils - uses k8s java client api, this is used only for delete domain use
 * Setup docker access to WebLogic 12c Images 
 
   * Method 1 
-  - Setup a personal account on container-registry.oracle.com
-  - Then sign in to container-registry.oracle.com and signup for access to WebLogic 12.2.1.3 images from container-registry.oracle.com/middleware/weblogic:12.2.1.3
-  - Then export the following before running the tests: 
+    - Setup a personal account on container-registry.oracle.com
+    - Then sign in to container-registry.oracle.com and signup for access to WebLogic 12.2.1.3 images from container-registry.oracle.com/middleware/weblogic:12.2.1.3
+    - Then export the following before running the tests: 
 	```
 	export OCR_USERNAME=<ocr_username>
 	export OCR_PASSWORD=<ocr_password>
 	```
  
   * Method 2 
-  - Make sure the weblogic image i.e. container-registry.oracle.com/middleware/weblogic:12.2.1.3 already exists locally in a docker repository the k8s cluster can access
-  - Make sure the weblogic image has patch p29135930 (required for the WebLogic Kubernetes Operator). 
+    - Make sure the weblogic image i.e. container-registry.oracle.com/middleware/weblogic:12.2.1.3 already exists locally in a docker repository the k8s cluster can access
+    - Make sure the weblogic image has patch p29135930 (required for the WebLogic Kubernetes Operator). 
 		
 		
 * Command to run the tests: 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -193,8 +193,8 @@ K8sTestUtils - uses k8s java client api, this is used only for delete domain use
 	```
  
   * Method 2 
- - Make sure the weblogic image i.e. container-registry.oracle.com/middleware/weblogic:12.2.1.3 already exists locally in a docker repository the k8s cluster can access
- - Make sure the weblogic image has patch p29135930 (required for the WebLogic Kubernetes Operator). 
+  - Make sure the weblogic image i.e. container-registry.oracle.com/middleware/weblogic:12.2.1.3 already exists locally in a docker repository the k8s cluster can access
+  - Make sure the weblogic image has patch p29135930 (required for the WebLogic Kubernetes Operator). 
 		
 		
 * Command to run the tests: 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -8,7 +8,7 @@ The tests currently run in three modes: "shared cluster", "Jenkins", and "standa
 
 * "Standalone" Oracle Linux, i.e, run the tests manually with the `mvn` command.
 * Shared cluster(remote k8s cluster) - http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/
-* Jenkins - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/ - Jenkins Run is restricted to Oracle Internal development process. K8S is installed for every run.
+* Jenkins - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/ - Jenkins Run is restricted to Oracle Internal development process. 
 
 Shared cluster runs only Quick test use cases, Jenkins runs both Quick and Full test use cases.
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -7,8 +7,8 @@ This documentation describes the functional use cases that are covered in integr
 The tests currently run in three modes: "shared cluster", "Jenkins", and "standalone" Oracle Linux, where the mode is controlled by the `SHARED_CLUSTER` and `JENKINS` environment variables described below. The default is "standalone".
 
 * "Standalone" Oracle Linux, i.e, run the tests manually with the `mvn` command.
-* Shared cluster - http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/
-* Jenkins - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/ - Jenkins Run is restricted to Oracle Internal development process.
+* Shared cluster(remote k8s cluster) - http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/
+* Jenkins - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/ - Jenkins Run is restricted to Oracle Internal development process. k8s is installed for every run.
 
 Shared cluster runs only Quick test use cases, Jenkins runs both Quick and Full test use cases.
 
@@ -183,7 +183,7 @@ K8sTestUtils - uses k8s java client api, this is used only for delete domain use
 * export WEBLOGIC_IMAGE_NAME and WEBLOGIC_IMAGE_TAG if different from container-registry.oracle.com/middleware/weblogic and 12.2.1.3
 * Setup docker access to WebLogic 12c Images 
 
- Method 1 
+  * Method 1 
   - Setup a personal account on container-registry.oracle.com
   - Then sign in to container-registry.oracle.com and signup for access to WebLogic 12.2.1.3 images from container-registry.oracle.com/middleware/weblogic:12.2.1.3
   - Then export the following before running the tests: 
@@ -192,7 +192,7 @@ K8sTestUtils - uses k8s java client api, this is used only for delete domain use
 	export OCR_PASSWORD=<ocr_password>
 	```
  
- Method 2 
+  * Method 2 
  - Make sure the weblogic image i.e. container-registry.oracle.com/middleware/weblogic:12.2.1.3 already exists locally in a docker repository the k8s cluster can access
  - Make sure the weblogic image has patch p29135930 (required for the WebLogic Kubernetes Operator). 
 		
@@ -296,20 +296,19 @@ JUnit test results can be seen at "integration-tests/target/failsafe-reports/TES
 
 # How to run JRF domain In Operator related tests
 * Setup docker access to FMW Infrastructure 12c Image and Oracle Database 12c Image
-
- Method 1 
-  - Setup a personal account on container-registry.oracle.com
-  - Then sign in to container-registry.oracle.com and accept license for access to Oracle Database 12c Images:  **_container-registry.oracle.com/database/enterprise:12.2.0.1-slim_**
-  - And get access to FMW Infrastructure 12c Image: **_container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.3_**
-  - export the following before running the tests:
+   * Method 1 
+      - Setup a personal account on container-registry.oracle.com
+      - Then sign in to container-registry.oracle.com and accept license for access to Oracle Database 12c Images:  **_container-registry.oracle.com/database/enterprise:12.2.0.1-slim_**
+      - And get access to FMW Infrastructure 12c Image: **_container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.3_**
+      - export the following before running the tests:
     ```
     export REPO_USERNAME=<ocr_username>
     export REPO_PASSWORD=<ocr_password>
     export REPO_EMAIL=<ocr_email>
     ```
  
- Method 2 
- - Make sure the FMW Infrastructure image i.e. **_container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.3_** and the Oracle database image i.e. **_container-registry.oracle.com/database/enterprise:12.2.0.1-slim_** already exist locally in a docker repository the k8s cluster can access
+   * Method 2 
+     - Make sure the FMW Infrastructure image i.e. **_container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.3_** and the Oracle database image i.e. **_container-registry.oracle.com/database/enterprise:12.2.0.1-slim_** already exist locally in a docker repository the k8s cluster can access
 		
 * Command to run the tests: 
 ```

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -8,7 +8,7 @@ The tests currently run in three modes: "shared cluster", "Jenkins", and "standa
 
 * "Standalone" Oracle Linux, i.e, run the tests manually with the `mvn` command.
 * Shared cluster(remote k8s cluster) - http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/
-* Jenkins - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/ - Jenkins Run is restricted to Oracle Internal development process. k8s is installed for every run.
+* Jenkins - http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/ - Jenkins Run is restricted to Oracle Internal development process. K8S is installed for every run.
 
 Shared cluster runs only Quick test use cases, Jenkins runs both Quick and Full test use cases.
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -31,7 +31,6 @@ public class BaseTest {
   public static final String TESTWEBAPP = "testwebapp";
   public static final String TESTWSAPP = "testwsapp";
   public static final String TESTWSSERVICE = "TestWsApp";
-  public static final String PS4_SLIM_TAG = "12.2.1.4-slim";
 
   // property file used to customize operator properties for operator inputs yaml
 
@@ -539,7 +538,7 @@ public class BaseTest {
 
   /**
    * Verify t3channel port by a JMS connection.
-   *
+   * This method is not used. See OWLS-76081
    * @throws Exception exception
    */
   public void testAdminT3ChannelWithJms(Domain domain) throws Exception {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -31,6 +31,7 @@ public class BaseTest {
   public static final String TESTWEBAPP = "testwebapp";
   public static final String TESTWSAPP = "testwsapp";
   public static final String TESTWSSERVICE = "TestWsApp";
+  public static final String PS4_SLIM_TAG = "12.2.1.4-slim";
 
   // property file used to customize operator properties for operator inputs yaml
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
@@ -468,9 +468,8 @@ public class ItOperator extends BaseTest {
       domain11 = TestUtils.createDomain(domainMap);
       domain11.verifyDomainCreated();
       testBasicUseCases(domain11);
-      if(!getWeblogicImageTag().equalsIgnoreCase(PS4_SLIM_TAG)) {
-        testAdminT3ChannelWithJms(domain11);
-      }
+      // OWLS-76081 - commenting the below check as its not a generic usecase that works for all images, it needs wlthint3client.jar 
+      // testAdminT3ChannelWithJms(domain11);
       testCompletedSuccessfully = true;
 
     } finally {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
@@ -468,7 +468,9 @@ public class ItOperator extends BaseTest {
       domain11 = TestUtils.createDomain(domainMap);
       domain11.verifyDomainCreated();
       testBasicUseCases(domain11);
-      testAdminT3ChannelWithJms(domain11);
+      if(!getWeblogicImageTag().equalsIgnoreCase(PS4_SLIM_TAG)) {
+        testAdminT3ChannelWithJms(domain11);
+      }
       testCompletedSuccessfully = true;
 
     } finally {

--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -269,7 +269,7 @@ elif [ "$JENKINS" = "true" ]; then
   /usr/local/packages/aime/ias/run_as_root "mkdir -p $PV_ROOT/acceptance_test_pv_archive"
   /usr/local/packages/aime/ias/run_as_root "chmod 777 $PV_ROOT/acceptance_test_pv_archive"
   
-  if [ "$JRF_ENABLED" = false ] && [ "$IMAGE_TAG_WEBLOGIC" != "12.2.1.4-slim"];  then
+  if [ "$JRF_ENABLED" = false ] && [ "$IMAGE_TAG_WEBLOGIC" != "12.2.1.4-slim" ];  then
   	get_wlthint3client_from_image
   fi
 else
@@ -288,7 +288,7 @@ else
   docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --build-arg no_proxy=$no_proxy -t "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}"  --build-arg VERSION=$JAR_VERSION --no-cache=true .
   docker tag "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" weblogic-kubernetes-operator:latest
   
-  if [ "$JRF_ENABLED" = false ] && [ "$IMAGE_TAG_WEBLOGIC" != "12.2.1.4-slim"]; then
+  if [ "$JRF_ENABLED" = false ] && [ "$IMAGE_TAG_WEBLOGIC" != "12.2.1.4-slim" ]; then
   	get_wlthint3client_from_image
   fi
 fi

--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -2,23 +2,7 @@
 # Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
-function clean_jenkins {
-  echo "Cleaning."
-  /usr/local/packages/aime/ias/run_as_root "${PROJECT_ROOT}/src/integration-tests/bash/clean_docker_k8s.sh -y"
-}
-
-function setup_jenkins {
-  echo "Setting up."
-  /usr/local/packages/aime/ias/run_as_root "sh ${PROJECT_ROOT}/src/integration-tests/bash/install_docker_k8s.sh -y -u wls -v ${K8S_VERSION}"
-  if [ $? -ne 0 ]; then
-	  echo "k8s installation is not successful"
-	  exit 1
-  fi
-  set +x
-  . ~/.dockerk8senv
-  set -x
-  id
-
+function pull_tag_build_images {
   docker images
 
   if [ "$JRF_ENABLED" = true ] ; then
@@ -33,16 +17,7 @@ function setup_jenkins {
   docker tag "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" weblogic-kubernetes-operator:latest
   
   docker images
-    
-  echo "Helm installation starts" 
-  wget -q -O  /tmp/helm-v2.8.2-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.8.2-linux-amd64.tar.gz
-  mkdir /tmp/helm
-  tar xzf /tmp/helm-v2.8.2-linux-amd64.tar.gz -C /tmp/helm
-  chmod +x /tmp/helm/linux-amd64/helm
-  /usr/local/packages/aime/ias/run_as_root "cp /tmp/helm/linux-amd64/helm /usr/bin/"
-  rm -rf /tmp/helm
-  helm init
-  echo "Helm is configured."
+
 }
 
 function docker_login {
@@ -275,9 +250,7 @@ elif [ "$JENKINS" = "true" ]; then
   export M2_HOME=${M2_HOME:?}
   export K8S_VERSION=${K8S_VERSION}
 
-  clean_jenkins
-
-  setup_jenkins
+  pull_tag_build_images
 
   /usr/local/packages/aime/ias/run_as_root "mkdir -p $PV_ROOT"
   /usr/local/packages/aime/ias/run_as_root "mkdir -p $RESULT_ROOT"

--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -296,7 +296,7 @@ elif [ "$JENKINS" = "true" ]; then
   /usr/local/packages/aime/ias/run_as_root "mkdir -p $PV_ROOT/acceptance_test_pv_archive"
   /usr/local/packages/aime/ias/run_as_root "chmod 777 $PV_ROOT/acceptance_test_pv_archive"
   
-  if [ "$JRF_ENABLED" = false ]; then
+  if [ "$JRF_ENABLED" = false ] && [ "$IMAGE_TAG_WEBLOGIC" != "12.2.1.4-slim"];  then
   	get_wlthint3client_from_image
   fi
 else

--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -315,7 +315,7 @@ else
   docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --build-arg no_proxy=$no_proxy -t "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}"  --build-arg VERSION=$JAR_VERSION --no-cache=true .
   docker tag "${IMAGE_NAME_OPERATOR}:${IMAGE_TAG_OPERATOR}" weblogic-kubernetes-operator:latest
   
-  if [ "$JRF_ENABLED" = false ]; then
+  if [ "$JRF_ENABLED" = false ] && [ "$IMAGE_TAG_WEBLOGIC" != "12.2.1.4-slim"]; then
   	get_wlthint3client_from_image
   fi
 fi

--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -2,37 +2,6 @@
 # Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 
-# the below function is not used 
-function docker_login {
-
-  set +x 
-  if [ -z "$DOCKER_USERNAME" ] || [ -z "$DOCKER_PASSWORD" ]; then
-        echo "DOCKER_USERNAME and DOCKER_PASSWORD not set !!!"
-	exit 1
-  fi
-  
-  if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then  
-	  echo "Creating Docker Secret"
-	  
-	  kubectl create secret docker-registry $IMAGE_PULL_SECRET_WEBLOGIC  \
-	    --docker-server=index.docker.io/v1/ \
-	    --docker-username=$DOCKER_USERNAME \
-	    --docker-password=$DOCKER_PASSWORD \
-            --dry-run -o yaml | kubectl apply -f -
-	  
-	  echo "Checking Secret"
-	  SECRET="`kubectl get secret $IMAGE_PULL_SECRET_WEBLOGIC | grep $IMAGE_PULL_SECRET_WEBLOGIC | wc | awk ' { print $1; }'`"
-	  if [ "$SECRET" != "1" ]; then
-	    echo "secret $IMAGE_PULL_SECRET_WEBLOGIC was not created successfully"
-	    exit 1
-	  fi
-	  # below docker pull is needed to get wlthint3client.jar from image to put in the classpath
-	  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  fi
-  set -x
-
-}
-
 function setup_shared_cluster {
   echo "Perform setup for running on shared cluster"
   echo "Install tiller"
@@ -116,18 +85,6 @@ function pull_tag_images_jrf {
   set -x
 }
 
-# the below function is not used 
-function get_wlthint3client_from_image {
-  # Get wlthint3client.jar from image
-  id=$(docker create $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC)
-  docker cp $id:/u01/oracle/wlserver/server/lib/wlthint3client.jar $SCRIPTPATH
-  if [ ! "$?" = "0" ] ; then
-  	echo "Docker Copy failed for wlthint3client.jar"
-  	exit 1
-  fi
-  docker rm -v $id
-  
-}
 export OCR_SERVER="${OCR_SERVER:-container-registry.oracle.com}"
 export WLS_IMAGE_URI=/middleware/weblogic
 export SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"


### PR DESCRIPTION
This PR contains changes ..

- remove call to testAdminT3ChannelWithJms which depends on thinclient.jar, so that the integration tests can be run on slim images too. See JIRA OWLS-76081
- fix readme format
- setupenv.sh change - remove k8s installation step from tests for Jenkins run as its done in the Jenkins configuration before the tests are called
- setupenv.sh change - remove code which pulls the WL image to copy the thinclient jar as its not needed now.
