### PR TITLE
Fix introspector to handle WL config templates that don't reference a cluster.

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -177,6 +177,14 @@ class OfflineWlstEnv(object):
   def getErrors(self):
     return self.errors
 
+  def getClusterOrNone(self,serverOrTemplate):
+    try:
+      ret = serverOrTemplate.getCluster()
+    except:
+      trace("Ignoring getCluster() exception, this is expected.")
+      ret = None
+    return ret
+
   def addGeneratedFile(self, filePath):
     self.generatedFiles.append(filePath)
 
@@ -311,14 +319,6 @@ class TopologyGenerator(Generator):
       ret = None
     return ret
 
-  def getClusterOrNone(self,server):
-    try:
-      ret = server.getCluster()
-    except:
-      trace("Ignoring getCluster() exception, this is expected.")
-      ret = None
-    return ret
-
   def getSSLOrNone(self,server):
     try:
       ret = server.getSSL()
@@ -339,7 +339,7 @@ class TopologyGenerator(Generator):
     if adminServer is None:
       addError("The admin server '" + adminServerName + "' does not exist.")
       return
-    cluster = self.getClusterOrNone(adminServer)
+    cluster = self.env.getClusterOrNone(adminServer)
     if cluster is not None:
       self.addError("The admin server " + self.name(adminServer) + " belongs to the cluster " + self.name(cluster) + ".")
 
@@ -361,13 +361,13 @@ class TopologyGenerator(Generator):
 
   def validateNonDynamicClusterReferencedByAtLeastOneServer(self, cluster):
     for server in self.env.getDomain().getServers():
-      if self.getClusterOrNone(server) is cluster:
+      if self.env.getClusterOrNone(server) is cluster:
         return
     self.addError("The non-dynamic cluster " + self.name(cluster) + " is not referenced by any servers.")
 
   def validateNonDynamicClusterNotReferencedByAnyServerTemplates(self, cluster):
     for template in self.env.getDomain().getServerTemplates():
-      if template.getCluster() is cluster:
+      if self.env.getClusterOrNone(template) is cluster:
         self.addError("The non-dynamic cluster " + self.name(cluster) + " is referenced by the server template " + self.name(template) + ".")
 
   LISTEN_PORT = 'listen port'
@@ -403,7 +403,7 @@ class TopologyGenerator(Generator):
     firstAdminPort = None
     firstAdminPortEnabled = None
     for server in self.env.getDomain().getServers():
-      if cluster is self.getClusterOrNone(server):
+      if cluster is self.env.getClusterOrNone(server):
         listenPort = server.getListenPort()
         listenPortEnabled = server.isListenPortEnabled()
         ssl = self.getSSLOrNone(server)
@@ -442,7 +442,7 @@ class TopologyGenerator(Generator):
     firstServer = None
     firstListenPortProperty = None
     for server in self.env.getDomain().getServers():
-      if cluster is self.getClusterOrNone(server):
+      if cluster is self.env.getClusterOrNone(server):
         listenPortProperty = getServerClusterPortPropertyValue(self, server, clusterListenPortProperty)
         if firstServer is None:
           firstServer = server
@@ -456,7 +456,7 @@ class TopologyGenerator(Generator):
      firstServer = None
      serverNap = {}
      for server in self.env.getDomain().getServers():
-       if cluster is self.getClusterOrNone(server):
+       if cluster is self.env.getClusterOrNone(server):
          if firstServer is None:
            for nap in server.getNetworkAccessPoints():
              serverNap[nap.getName()] = nap.getProtocol() + "~" + str(nap.getListenPort());
@@ -485,7 +485,7 @@ class TopologyGenerator(Generator):
   def validateDynamicClusterReferencedByOneServerTemplate(self, cluster):
     server_template=None
     for template in self.env.getDomain().getServerTemplates():
-      if template.getCluster() is cluster:
+      if self.env.getClusterOrNone(template) is cluster:
         if server_template is None:
           server_template = template
         else:
@@ -497,7 +497,7 @@ class TopologyGenerator(Generator):
 
   def validateDynamicClusterNotReferencedByAnyServers(self, cluster):
     for server in self.env.getDomain().getServers():
-      if self.getClusterOrNone(server) is cluster:
+      if self.env.getClusterOrNone(server) is cluster:
         self.addError("The dynamic cluster " + self.name(cluster) + " is referenced by the server " + self.name(server) + ".")
 
   def validateDynamicClusterDynamicServersDoNotUseCalculatedListenPorts(self, cluster):
@@ -587,7 +587,7 @@ class TopologyGenerator(Generator):
   def getClusteredServers(self, cluster):
     rtn = []
     for server in self.env.getDomain().getServers():
-      if self.getClusterOrNone(server) is cluster:
+      if self.env.getClusterOrNone(server) is cluster:
         rtn.append(server)
     return rtn
 
@@ -619,7 +619,8 @@ class TopologyGenerator(Generator):
     self.writeln("serverTemplates:")
     self.indent()
     for serverTemplate in serverTemplates:
-      self.addServerTemplate(serverTemplate)
+      if not (self.env.getClusterOrNone(serverTemplate) is None):
+        self.addServerTemplate(serverTemplate)
     self.undent()
 
   def addServerTemplate(self, serverTemplate):
@@ -655,7 +656,7 @@ class TopologyGenerator(Generator):
 
   def findDynamicClusterServerTemplate(self, cluster):
     for template in cmo.getServerTemplates():
-      if template.getCluster() is cluster:
+      if self.env.getClusterOrNone(template) is cluster:
         return template
     # should never get here - the domain validator already checked that
     # one server template references the cluster
@@ -667,7 +668,7 @@ class TopologyGenerator(Generator):
     self.writeln("servers:")
     self.indent()
     for server in self.env.getDomain().getServers():
-      if self.getClusterOrNone(server) is None:
+      if self.env.getClusterOrNone(server) is None:
         self.addServer(server)
     self.undent()
 
@@ -827,7 +828,8 @@ class SitConfigGenerator(Generator):
 
   def customizeServerTemplates(self):
     for template in self.env.getDomain().getServerTemplates():
-      self.customizeServerTemplate(template)
+      if not (self.env.getClusterOrNone(template) is None):
+        self.customizeServerTemplate(template)
 
   def customizeServerTemplate(self, template):
     name=template.getName()
@@ -1151,12 +1153,6 @@ def main(env):
   except WLSTException, e:
     trace("SEVERE","Domain introspection failed with WLST exception: " + str(e))
     print e
-    traceback.print_exc()
-    dumpStack()
-    exit(exitcode=1)
-  except UndeclaredThrowableException, f:
-    trace("SEVERE","Domain introspection failed with undeclared exception: " + str(f))
-    print f
     traceback.print_exc()
     dumpStack()
     exit(exitcode=1)

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -66,6 +66,8 @@ checkEnv JAVA_HOME NODEMGR_HOME DOMAIN_HOME DOMAIN_UID ORACLE_HOME MW_HOME WL_HO
 
 if [ "${SERVER_NAME}" = "introspector" ]; then
   SERVICE_NAME=localhost
+  trace "Contents of '${DOMAIN_HOME}/config/config.xml':"
+  cat ${DOMAIN_HOME}/config/config.xml
 else
   checkEnv SERVER_NAME ADMIN_NAME AS_SERVICE_NAME SERVICE_NAME USER_MEM_ARGS || exit 1
 fi

--- a/src/integration-tests/introspector/wl-create-domain-pod.pyt
+++ b/src/integration-tests/introspector/wl-create-domain-pod.pyt
@@ -245,7 +245,7 @@ else:
 
   templateName = '${CLUSTER_NAME}' + "-template-dummy1"
   print('Creating Server Template: %s' % templateName)
-  st1=create(templateName, 'ServerTemplate')
+  st2=create(templateName, 'ServerTemplate')
   print('Done creating Server Template: %s' % templateName)
   cd('/ServerTemplates/%s' % templateName)
   cmo.setListenPort(${MANAGED_SERVER_PORT})
@@ -255,7 +255,7 @@ else:
  
   templateName = '${CLUSTER_NAME}' + "-template-dummy2"
   print('Creating Server Template: %s' % templateName)
-  st1=create(templateName, 'ServerTemplate')
+  st3=create(templateName, 'ServerTemplate')
   print('Done creating Server Template: %s' % templateName)
   cd('/ServerTemplates/%s' % templateName)
   cmo.setListenPort(${MANAGED_SERVER_PORT})

--- a/src/integration-tests/introspector/wl-create-domain-pod.pyt
+++ b/src/integration-tests/introspector/wl-create-domain-pod.pyt
@@ -243,6 +243,25 @@ else:
   cmo.setCluster(cl)
   print('Done setting attributes for Server Template: %s' % templateName);
 
+  templateName = '${CLUSTER_NAME}' + "-template-dummy1"
+  print('Creating Server Template: %s' % templateName)
+  st1=create(templateName, 'ServerTemplate')
+  print('Done creating Server Template: %s' % templateName)
+  cd('/ServerTemplates/%s' % templateName)
+  cmo.setListenPort(${MANAGED_SERVER_PORT})
+  #cmo.setListenAddress('${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE}${id}') # subst-ignore-missing
+  #cmo.setCluster(cl)
+  print('Done setting attributes for Server Template: %s' % templateName);
+ 
+  templateName = '${CLUSTER_NAME}' + "-template-dummy2"
+  print('Creating Server Template: %s' % templateName)
+  st1=create(templateName, 'ServerTemplate')
+  print('Done creating Server Template: %s' % templateName)
+  cd('/ServerTemplates/%s' % templateName)
+  cmo.setListenPort(${MANAGED_SERVER_PORT})
+  #cmo.setListenAddress('${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE}${id}') # subst-ignore-missing
+  #cmo.setCluster(cl)
+  print('Done setting attributes for Server Template: %s' % templateName);
 
   cd('/Clusters/%s' % '${CLUSTER_NAME}')
   create('${CLUSTER_NAME}', 'DynamicServers')


### PR DESCRIPTION
- Fix introspector so that it properly skips WL config templates that don't reference a cluster (currently it throws an exception), as requested by internal customer via internal bug OWLS-76014 
- Expand introspector 'mock' test to include such templates
- Echo config.xml to introspector log as a FINE (to aid in debugging), this will also show up in the operator log if operator log level is FINE/FINER/FINEST.
- Remove use of unknown jython name 'UndeclaredThrowableException'