### PR TITLE
Update dependencies, including jackson-databind for CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.21</version>
+              <version>8.23</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -133,7 +133,7 @@
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
               <artifactId>pmd-java</artifactId>
-              <version>6.13.0</version>
+              <version>6.17.0</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -615,7 +615,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson-version}</version>
+        <version>${jackson-databind-version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -640,7 +640,7 @@
       <dependency>
         <groupId>net.sourceforge.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
-        <version>2.32</version>
+        <version>2.35.0</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
@@ -676,7 +676,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.12</version>
+        <version>1.13</version>
       </dependency>
       <dependency>
         <groupId>org.httpunit</groupId>
@@ -721,14 +721,15 @@
     <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
     <spotbugs-maven-plugin-version>3.1.11</spotbugs-maven-plugin-version>
     <swagger-core-version>1.5.22</swagger-core-version>
-    <jodatime-version>2.10.2</jodatime-version>
+    <jodatime-version>2.10.3</jodatime-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <junit-version>4.12</junit-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jersey-version>2.28</jersey-version> <!-- switched from 2.23 to 2.26 to get the RestServer to work -->
+    <jersey-version>2.29</jersey-version> <!-- switched from 2.23 to 2.26 to get the RestServer to work -->
     <jackson-version>2.9.9</jackson-version>
+    <jackson-databind-version>2.9.9.2</jackson-databind-version>
     <snakeyaml-version>1.24</snakeyaml-version>
-    <guava-version>27.0.1-jre</guava-version>
+    <guava-version>28.0-jre</guava-version>
     <root-generated-swagger>${project.basedir}/src-generated-swagger</root-generated-swagger>
     <src-generated-swagger>${root-generated-swagger}/main/java</src-generated-swagger>
     <domain-swagger-file>${project.basedir}/swagger/domain.json</domain-swagger-file>


### PR DESCRIPTION
We received the following:

Details:

CVE-2019-14379
More information
moderate severity
Vulnerable versions: < 2.9.9.2
Patched version: 2.9.9.2

SubTypeValidator.java in FasterXML jackson-databind before 2.9.9.2 mishandles default typing when ehcache is used, leading to remote code execution.

CVE-2019-14439
More information
moderate severity
Vulnerable versions: < 2.9.9.2
Patched version: 2.9.9.2

A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath.

This PR updates jackson-databind to take the patch for this CVE and also updates any other out-of-date dependency ahead of a 2.3.0 release.