### PR TITLE
Owls76144 - use custom weblogic image in domain home in image tests

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
@@ -226,8 +226,12 @@ public class ItOperator extends BaseTest {
       if (!domainUidsToBeDeleted.equals("")) {
         logger.info("About to delete domains: " + domainUidsToBeDeleted);
         TestUtils.deleteWeblogicDomainResources(domainUidsToBeDeleted);
-        TestUtils.verifyAfterDeletion(domain1);
-        TestUtils.verifyAfterDeletion(domain2);
+        if(domain1 != null) {
+          TestUtils.verifyAfterDeletion(domain1);
+        }
+        if(domain2 != null) {
+          TestUtils.verifyAfterDeletion(domain2);
+        }
       }
     }
     logger.info("SUCCESS - " + testMethodName);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperator.java
@@ -312,8 +312,12 @@ public class ItOperator extends BaseTest {
       if (!domainUidsToBeDeleted.equals("")) {
         logger.info("About to delete domains: " + domainUidsToBeDeleted);
         TestUtils.deleteWeblogicDomainResources(domainUidsToBeDeleted);
-        TestUtils.verifyAfterDeletion(domain1);
+        if(domain1 != null) {
+          TestUtils.verifyAfterDeletion(domain1);
+        }
+        if(domain2 != null) {
         TestUtils.verifyAfterDeletion(domain2);
+        }
       }
     }
     logger.info("SUCCESS - " + testMethodName);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1569,6 +1569,9 @@ public class Domain {
           BaseTest.getResultDir()
               + "/"
               + ((String) domainMap.get("domainHomeImageBuildPath")).trim());
+      
+      domainMap.put("domainHomeImageBase", 
+          BaseTest.getWeblogicImageName()+":"+BaseTest.getWeblogicImageTag());
     }
 
     // remove null values if any attributes


### PR DESCRIPTION
This PR has changes -

to allow custom weblogic image in domain home in image tests. Weblogic image specified using the env variables IMAGE_NAME_WEBLOGIC and IMAGE_TAG_WEBLOGIC should be used when creating domain home in image.

fix intermittent NPE

internal jenkins is clean - http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/2148/consoleFull
external jenkins is clean - http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/482/consoleFull