### PR TITLE
WIP: OWLS-76084 add a profile to include both jrf and regular WLS domain integ test s…

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -302,5 +302,13 @@
                 <jrf_enabled>false</jrf_enabled>
             </properties>
         </profile>
+        <profile>
+            <id>full-integration-tests</id>
+            <properties>
+                <skipITs>false</skipITs>
+                <includes-failsafe>**/*.java</includes-failsafe>
+                <jrf_enabled>true</jrf_enabled>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This PR is to add a new profile (full-integration-tests ) to include both JRF and regular WLS domain integ test suites. Command "mvn clean verify -P full-integration-tests" will run both test suites. We can also run individual JRF or regular WLS domain test class by specifying "full-integration-test" as PROFILE_NAME with configured individual test class name.

Jenkins run test results:
full test suite including both JRF and regular WLS domain integ test: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2156/

JRF individual JrfInOperatorTest: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2158/

ItOperator: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2157/

Not all the run passed but the new added profile works as expected. 