### PR TITLE
Fixing the secrets change

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItSitConfig.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItSitConfig.java
@@ -14,7 +14,6 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.logging.Level;
-
 import oracle.kubernetes.operator.utils.Domain;
 import oracle.kubernetes.operator.utils.ExecResult;
 import oracle.kubernetes.operator.utils.Operator;
@@ -82,7 +81,14 @@ public class ItSitConfig extends BaseTest {
       fqdn = TestUtils.getHostName();
       JDBC_URL = "jdbc:mysql://" + fqdn + ":" + MYSQL_DB_PORT + "/";
       // copy the configuration override files to replacing the JDBC_URL token
-      copySitConfigFiles();
+      String[] files = {
+        "config.xml",
+        "jdbc-JdbcTestDataSource-0.xml",
+        "diagnostics-WLDF-MODULE-0.xml",
+        "jms-ClusterJmsSystemResource.xml",
+        "version.txt"
+      };
+      copySitConfigFiles(files, "test-secrets");
       // create weblogic domain with configOverrides
       domain = createSitConfigDomain();
       Assert.assertNotNull(domain);
@@ -132,7 +138,6 @@ public class ItSitConfig extends BaseTest {
    * @throws Exception - if it cannot create the domain
    */
   private static Domain createSitConfigDomain() throws Exception {
-    String createDomainScript = TEST_RES_DIR + "/domain-home-on-pv/create-domain.py";
     // load input yaml to map and add configOverrides
     Map<String, Object> domainMap = TestUtils.loadYaml(DOMAINONPV_WLST_YAML);
     domainMap.put("configOverrides", "sitconfigcm");
@@ -168,22 +173,17 @@ public class ItSitConfig extends BaseTest {
    *
    * @throws IOException when copying files from source location to staging area fails
    */
-  private static void copySitConfigFiles() throws IOException {
+  private static void copySitConfigFiles(String files[], String secretName) throws IOException {
     String srcDir = TEST_RES_DIR + "/sitconfig/configoverrides";
     String dstDir = configOverrideDir;
-    String[] files = {
-      "config.xml",
-      "jdbc-JdbcTestDataSource-0.xml",
-      "diagnostics-WLDF-MODULE-0.xml",
-      "jms-ClusterJmsSystemResource.xml",
-      "version.txt"
-    };
+
+    Charset charset = StandardCharsets.UTF_8;
     for (String file : files) {
       Path path = Paths.get(srcDir, file);
       logger.log(Level.INFO, "Copying {0}", path.toString());
-      Charset charset = StandardCharsets.UTF_8;
       String content = new String(Files.readAllBytes(path), charset);
       content = content.replaceAll("JDBC_URL", JDBC_URL);
+      content = content.replaceAll("test-secrets", secretName);
       if (getWeblogicImageTag().contains(PS3_TAG)) {
         content = content.replaceAll(JDBC_DRIVER_NEW, JDBC_DRIVER_OLD);
       }
@@ -387,7 +387,7 @@ public class ItSitConfig extends BaseTest {
         Paths.get(srcDir, "config_1.xml"),
         Paths.get(dstDir, "config.xml"),
         StandardCopyOption.REPLACE_EXISTING);
-    recreateCrdWithNewConfigMap();
+    recreateConfigMapandRestart("test-secrets");
     transferTests();
     ExecResult result =
         TestUtils.exec(
@@ -423,7 +423,7 @@ public class ItSitConfig extends BaseTest {
         Paths.get(srcDir, "jdbc-JdbcTestDataSource-1.xml"),
         Paths.get(dstDir, "jdbc-JdbcTestDataSource-1.xml"),
         StandardCopyOption.REPLACE_EXISTING);
-    recreateCrdWithNewConfigMap();
+    recreateConfigMapandRestart("test-secrets");
     transferTests();
     ExecResult result =
         TestUtils.exec(
@@ -453,44 +453,28 @@ public class ItSitConfig extends BaseTest {
     // recreate the map with new situational config files
     String[] files = {"config.xml", "jdbc-JdbcTestDataSource-0.xml"};
     String secretName = "test-secrets-new";
-    for (String file : files) {
-      Path path = Paths.get(sitconfigTmpDir, "configoverridefiles", file);
-      String content = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
-      content = content.replaceAll("test-secrets", secretName);
-      if (getWeblogicImageTag().contains(PS3_TAG)) {
-        content = content.replaceAll(JDBC_DRIVER_NEW, JDBC_DRIVER_OLD);
-      }
-      Files.write(
-          Paths.get(sitconfigTmpDir, "configoverridefiles", file),
-          content.getBytes(StandardCharsets.UTF_8),
-          StandardOpenOption.TRUNCATE_EXISTING);
+    try {
+      copySitConfigFiles(files, secretName);
+      recreateConfigMapandRestart(secretName);
+      transferTests();
+      ExecResult result =
+          TestUtils.exec(
+              KUBE_EXEC_CMD
+                  + " 'sh runSitConfigTests.sh "
+                  + fqdn
+                  + " "
+                  + T3CHANNELPORT
+                  + " weblogic welcome1 "
+                  + testMethod
+                  + " "
+                  + JDBC_URL
+                  + "'");
+      assertResult(result);
+      logger.log(Level.INFO, "SUCCESS - {0}", testMethod);
+    } finally {
+      copySitConfigFiles(files, "test-secrets");
+      recreateConfigMapandRestart(secretName);
     }
-    String content = new String(Files.readAllBytes(Paths.get(domainYaml)), StandardCharsets.UTF_8);
-    content = content.replaceAll("test-secrets", secretName);
-    Files.write(
-        Paths.get(domainYaml),
-        content.getBytes(StandardCharsets.UTF_8),
-        StandardOpenOption.TRUNCATE_EXISTING);
-
-    TestUtils.exec("kubectl delete secret " + domain.getDomainUid() + "-test-secrets", true);
-    createNewSecret(secretName);
-    TestUtils.exec("kubectl apply -f " + domainYaml, true);
-    recreateCrdWithNewConfigMap();
-    transferTests();
-    ExecResult result =
-        TestUtils.exec(
-            KUBE_EXEC_CMD
-                + " 'sh runSitConfigTests.sh "
-                + fqdn
-                + " "
-                + T3CHANNELPORT
-                + " weblogic welcome1 "
-                + testMethod
-                + " "
-                + JDBC_URL
-                + "'");
-    assertResult(result);
-    logger.log(Level.INFO, "SUCCESS - {0}", testMethod);
   }
 
   /**
@@ -522,28 +506,15 @@ public class ItSitConfig extends BaseTest {
    *
    * @throws Exception when pods restart fail
    */
-  private void recreateCrdWithNewConfigMap() throws Exception {
-    int clusterReplicas =
-        TestUtils.getClusterReplicas(DOMAINUID, domain.getClusterName(), domain.getDomainNs());
+  private void recreateConfigMapandRestart(String secretName) throws Exception {
+    String content = new String(Files.readAllBytes(Paths.get(domainYaml)), StandardCharsets.UTF_8);
+    content = content.replaceAll("test-secrets", secretName);
+    Files.write(
+        Paths.get(domainYaml),
+        content.getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.TRUNCATE_EXISTING);
 
-    String patchStr = "'{\"spec\":{\"serverStartPolicy\":\"NEVER\"}}'";
-    TestUtils.kubectlpatch(DOMAINUID, domain.getDomainNs(), patchStr);
-    domain.verifyServerPodsDeleted(clusterReplicas);
-
-    String cmd =
-        "kubectl create configmap "
-            + DOMAINUID
-            + "-sitconfigcm --from-file="
-            + configOverrideDir
-            + " -o yaml --dry-run | kubectl replace -f -";
-    TestUtils.exec(cmd, true);
-
-    patchStr = "'{\"spec\":{\"serverStartPolicy\":\"IF_NEEDED\"}}'";
-    TestUtils.kubectlpatch(DOMAINUID, domain.getDomainNs(), patchStr);
-    domain.verifyDomainCreated();
-  }
-
-  private void createNewSecret(String secretName) throws Exception {
+    TestUtils.exec("kubectl delete secret " + domain.getDomainUid() + "-test-secrets", true);
     String cmd =
         "kubectl -n "
             + domain.getDomainNs()
@@ -556,6 +527,26 @@ public class ItSitConfig extends BaseTest {
             + " --from-literal=dbusername=root"
             + " --from-literal=dbpassword=root123";
     TestUtils.exec(cmd, true);
+    TestUtils.exec("kubectl apply -f " + domainYaml, true);
+
+    int clusterReplicas =
+        TestUtils.getClusterReplicas(DOMAINUID, domain.getClusterName(), domain.getDomainNs());
+
+    String patchStr = "'{\"spec\":{\"serverStartPolicy\":\"NEVER\"}}'";
+    TestUtils.kubectlpatch(DOMAINUID, domain.getDomainNs(), patchStr);
+    domain.verifyServerPodsDeleted(clusterReplicas);
+
+    cmd =
+        "kubectl create configmap "
+            + DOMAINUID
+            + "-sitconfigcm --from-file="
+            + configOverrideDir
+            + " -o yaml --dry-run | kubectl replace -f -";
+    TestUtils.exec(cmd, true);
+
+    patchStr = "'{\"spec\":{\"serverStartPolicy\":\"IF_NEEDED\"}}'";
+    TestUtils.kubectlpatch(DOMAINUID, domain.getDomainNs(), patchStr);
+    domain.verifyDomainCreated();
   }
 
   /**


### PR DESCRIPTION
The fix will cleanup the k8s secret created for JDBC override tests and will restore the original secret name after the test is done.