### PR TITLE
added link to integration tests page

### DIFF
--- a/docs-source/content/developerguide/integration-tests.md
+++ b/docs-source/content/developerguide/integration-tests.md
@@ -15,6 +15,8 @@ You will need to obtain the `kube.config` file for an administrative user and ma
 $ mvn clean verify -P java-integration-tests
 ```
 
+For more detailed information, see [How to run the Java integration tests ](https://github.com/oracle/weblogic-kubernetes-operator/tree/master/integration-tests#how-to-run-the-java-integration-tests).
+
 {{% notice note %}}
 When you run the integrations tests, they do a cleanup of any operator or domains on that cluster.   
 {{% /notice %}}


### PR DESCRIPTION
I added a link to the integration test page in the repo. I considered adding the specific information that @vanajamukkara specified ("At a minimum OCR_USERNAME and OCR_PASSWORD need to be supplied as ENV variables. OCR_SERVER - if you are not using container-registry.oracle.com"), however, it was different from the advice given in https://jira.oraclecorp.com/jira/browse/OWLS-76361 ("I would recommend removing OCR_USERNAME, OCR_PASSWORD from the equation. Jenkins provides the login capability and protects the credentials.  Passing them as ENV variables complicates the environment unnecessarily. For running outside of Jenkins, just make the first step "Do docker login to phx.ocir...")

I suggest putting the correct details in the integration test page in the repo to which this doc is pointing. If you think otherwise, please let me know.
