### PR TITLE
Pass admin server info as env vars to additional runs of the introspector

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -263,7 +263,7 @@ public class JobHelper {
         if (isLocalAdminProtocolChannelSecure()) {
           addEnvVar(vars, "ADMIN_PORT_SECURE", "true");
         }
-        addEnvVar(vars, "AS_SERVICE_NAME", LegalNames.toServerServiceName(getDomainUid(), getAsName()));
+        addEnvVar(vars, "AS_SERVICE_NAME", getAsServiceName());
 
         // TBD Tom Barnes, Johnny Shum
         //     Do we need to pass to the jobwhether the admin server (or any pods)


### PR DESCRIPTION
This change passes ADMIN_NAME, ADMIN_PORT, ADMIN_PORT_SECURE, and AS_SERVICE_NAME env vars to an introspector job when the job is being rerun on an existing domain (the original job is what gathers this information).