### PR TITLE
Validate domain resource before running introspector

### DIFF
--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -4,6 +4,7 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -379,7 +380,13 @@ public class DomainSpec extends BaseConfiguration {
   }
 
   public void setLogHome(String logHome) {
-    this.logHome = logHome;
+    this.logHome = Optional.ofNullable(logHome).map(this::validatePath).orElse(null);
+  }
+
+  private String validatePath(String s) {
+    if (s.isBlank()) return null;
+    if (s.endsWith(File.separator)) return s;
+    return s + File.separator;
   }
 
   /**
@@ -388,7 +395,7 @@ public class DomainSpec extends BaseConfiguration {
    * @since 2.0
    * @return log home enabled
    */
-  boolean getLogHomeEnabled() {
+  boolean isLogHomeEnabled() {
     return Optional.ofNullable(logHomeEnabled).orElse(!isDomainHomeInImage());
   }
 
@@ -510,10 +517,10 @@ public class DomainSpec extends BaseConfiguration {
    *
    * @return istioEnabled
    */
-  boolean istioEnabled() {
+  boolean isIstioEnabled() {
     return Optional.ofNullable(experimental)
-        .map(e -> e.getIstio())
-        .map(i -> i.getEnabled())
+        .map(Experimental::getIstio)
+        .map(Istio::getEnabled)
         .orElse(false);
   }
 
@@ -524,8 +531,8 @@ public class DomainSpec extends BaseConfiguration {
    */
   int getIstioReadinessPort() {
     return Optional.ofNullable(experimental)
-        .map(e -> e.getIstio())
-        .map(i -> i.getReadinessPort())
+        .map(Experimental::getIstio)
+        .map(Istio::getReadinessPort)
         .orElse(8888);
   }
 

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationFailure.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationFailure.java
@@ -1,0 +1,34 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+/**
+ * Describes a problem with a domain resource.
+ */
+public class DomainValidationFailure {
+  private String reason;
+  private String message;
+
+  DomainValidationFailure(String reason, String message) {
+    this.reason = reason;
+    this.message = message;
+  }
+
+  /**
+   * Returns the reason for the failure. This is a camel-cased string with no spaces.
+   * @return the reason code
+   */
+  public String getReason() {
+    return reason;
+  }
+
+  /**
+   * Returns a human-readable description of the problem.
+   * @return the descriptive message
+   */
+  public String getMessage() {
+    return message;
+  }
+}

--- a/model/src/main/java/oracle/kubernetes/weblogic/domain/model/ManagedServer.java
+++ b/model/src/main/java/oracle/kubernetes/weblogic/domain/model/ManagedServer.java
@@ -30,7 +30,7 @@ public class ManagedServer extends Server implements Comparable<ManagedServer> {
     this.serverName = serverName;
   }
 
-  ManagedServer withServerName(@Nonnull String serverName) {
+  public ManagedServer withServerName(@Nonnull String serverName) {
     setServerName(serverName);
     return this;
   }

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -42,7 +42,7 @@ public abstract class DomainTestBase {
   private static final String VALUE2 = "value2";
   private static final V1SecretReference SECRET = new V1SecretReference().name("secret");
   private static final String NS = "test-namespace";
-  private static final String DOMAIN_UID = "uid1";
+  protected static final String DOMAIN_UID = "uid1";
   private static final String DOMAIN_V2_SAMPLE_YAML = "model/domain-sample.yaml";
   private static final String IMAGE = "myimage";
   private static final String PULL_SECRET_NAME = "pull-secret";

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
@@ -70,6 +70,76 @@ public class DomainV2Test extends DomainTestBase {
   }
 
   @Test
+  public void whenDomainOnPV_logHomeDefaultsToEnabled() {
+    configureDomain(domain).withDomainHomeInImage(false);
+
+    assertThat(domain.isLogHomeEnabled(), is(true));
+  }
+
+  @Test
+  public void whenDomainOnPVAndLogHomeDisabled_returnOverride() {
+    configureDomain(domain).withDomainHomeInImage(false).withLogHomeEnabled(false);
+
+    assertThat(domain.isLogHomeEnabled(), is(false));
+  }
+
+  @Test
+  public void whenDomainInImage_logHomeDefaultsToDisabled() {
+    configureDomain(domain).withDomainHomeInImage(true);
+
+    assertThat(domain.isLogHomeEnabled(), is(false));
+  }
+
+  @Test
+  public void whenDomainInImageAndLogHomeEnabled_returnOverride() {
+    configureDomain(domain).withDomainHomeInImage(true).withLogHomeEnabled(true);
+
+    assertThat(domain.isLogHomeEnabled(), is(true));
+  }
+
+  @Test
+  public void whenLogHomeSet_returnIt() {
+    configureDomain(domain).withLogHome("/my/logs/");
+
+    assertThat(domain.getLogHome(), equalTo("/my/logs/"));
+  }
+
+  @Test
+  public void whenLogHomeSetWithoutTrailingSlash_appendOne() {
+    configureDomain(domain).withLogHome("/my/logs");
+
+    assertThat(domain.getLogHome(), equalTo("/my/logs/"));
+  }
+
+  @Test
+  public void whenLogHomeSetNull_returnDefaultLogHome() {
+    configureDomain(domain).withLogHome(null);
+
+    assertThat(domain.getLogHome(), equalTo("/shared/logs/" + DOMAIN_UID));
+  }
+
+  @Test
+  public void whenLogHomeSetToBlanks_returnDefaultLogHome() {
+    configureDomain(domain).withLogHome("   ");
+
+    assertThat(domain.getLogHome(), equalTo("/shared/logs/" + DOMAIN_UID));
+  }
+
+  @Test
+  public void whenLogHomeDisabled_effectiveLogHomeIsNull() {
+    configureDomain(domain).withLogHomeEnabled(false).withLogHome("/my/logs/");
+
+    assertThat(domain.getEffectiveLogHome(), nullValue());
+  }
+
+  @Test
+  public void whenLogHomeEnabled_effectiveLogHomeEqualsLogHome() {
+    configureDomain(domain).withLogHomeEnabled(true).withLogHome("/my/logs/");
+
+    assertThat(domain.getEffectiveLogHome(), equalTo("/my/logs/"));
+  }
+
+  @Test
   public void whenClusterNotConfiguredAndNoDomainReplicaCount_countIsZero() {
     assertThat(domain.getReplicaCount("nosuchcluster"), equalTo(0));
   }
@@ -1363,30 +1433,30 @@ public class DomainV2Test extends DomainTestBase {
 
   @Test
   public void whenLogHomeSet_useValue() {
-    configureDomain(domain).withLogHome("/custom/logs");
+    configureDomain(domain).withLogHome("/custom/logs/");
 
-    assertThat(domain.getLogHome(), equalTo("/custom/logs"));
+    assertThat(domain.getLogHome(), equalTo("/custom/logs/"));
   }
 
   @Test
   public void whenDomainHomeInImage_logHomeNotEnabled() {
     configureDomain(domain).withDomainHomeInImage(true);
 
-    assertThat(domain.getSpec().getLogHomeEnabled(), is(false));
+    assertThat(domain.getSpec().isLogHomeEnabled(), is(false));
   }
 
   @Test
   public void whenDomainHomeNotInImage_logHomeEnabled() {
     configureDomain(domain).withDomainHomeInImage(false);
 
-    assertThat(domain.getSpec().getLogHomeEnabled(), is(true));
+    assertThat(domain.getSpec().isLogHomeEnabled(), is(true));
   }
 
   @Test
   public void whenLogHomeEnabledSet_useValue() {
     configureDomain(domain).withLogHomeEnabled(true);
 
-    assertThat(domain.getSpec().getLogHomeEnabled(), is(true));
+    assertThat(domain.getSpec().isLogHomeEnabled(), is(true));
   }
 
   @Test

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -29,7 +29,15 @@ public class DomainValidationTest {
     domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
     domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
 
-    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("server", "ms1")));
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("managedServers", "ms1")));
+  }
+
+  @Test
+  public void whenManagerServerSpecsHaveDns1123DuplicateNames_reportError() {
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("Server-1"));
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("server_1"));
+
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("managedServers", "server-1")));
   }
 
   @Test
@@ -45,7 +53,15 @@ public class DomainValidationTest {
     domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster1"));
     domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster1"));
 
-    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("cluster", "cluster1")));
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("clusters", "cluster1")));
+  }
+
+  @Test
+  public void whenClusterSpecsHaveDns1123DuplicateNames_reportError() {
+    domain.getSpec().getClusters().add(new Cluster().withClusterName("Cluster-1"));
+    domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster_1"));
+
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("clusters", "cluster-1")));
   }
 
   @Test
@@ -53,6 +69,13 @@ public class DomainValidationTest {
     configureDomain(domain).withLogHomeEnabled(false);
 
     assertThat(domain.getValidationFailures(), empty());
+  }
+
+  @Test
+  public void whenVolumeMountHasNonValidPath_reportError() {
+    configureDomain(domain).withAdditionalVolumeMount("sharedlogs", "shared/logs");
+
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("shared/logs", "sharedlogs")));
   }
 
   @Test

--- a/model/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/model/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -1,0 +1,77 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import oracle.kubernetes.weblogic.domain.DomainConfigurator;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class DomainValidationTest {
+  private Domain domain = new Domain();
+
+  @Test
+  public void whenManagerServerSpecsHaveUniqueNames_dontReportError() {
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms2"));
+
+    assertThat(domain.getValidationFailures(), empty());
+  }
+
+  @Test
+  public void whenManagerServerSpecsHaveDuplicateNames_reportError() {
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
+
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("server", "ms1")));
+  }
+
+  @Test
+  public void whenClusterSpecsHaveUniqueNames_dontReportError() {
+    domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster1"));
+    domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster2"));
+
+    assertThat(domain.getValidationFailures(), empty());
+  }
+
+  @Test
+  public void whenClusterSpecsHaveDuplicateNames_reportError() {
+    domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster1"));
+    domain.getSpec().getClusters().add(new Cluster().withClusterName("cluster1"));
+
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("cluster", "cluster1")));
+  }
+
+  @Test
+  public void whenLogHomeDisabled_dontReportError() {
+    configureDomain(domain).withLogHomeEnabled(false);
+
+    assertThat(domain.getValidationFailures(), empty());
+  }
+
+  @Test
+  public void whenVolumeMountHasLogHomeDirectory_dontReportError() {
+    configureDomain(domain).withLogHomeEnabled(true).withLogHome("/shared/logs/mydomain");
+    configureDomain(domain).withAdditionalVolumeMount("sharedlogs", "/shared/logs");
+
+    assertThat(domain.getValidationFailures(), empty());
+  }
+
+  @Test
+  public void whenNoVolumeMountHasLogHomeDirectory_reportError() {
+    configureDomain(domain).withLogHomeEnabled(true).withLogHome("/private/log/mydomain");
+    configureDomain(domain).withAdditionalVolumeMount("sharedlogs", "/shared/logs");
+
+    assertThat(domain.getValidationFailures(), contains(containsStringIgnoringCase("log home")));
+  }
+
+  private DomainConfigurator configureDomain(Domain domain) {
+    return new DomainCommonConfigurator(domain);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
@@ -1,0 +1,49 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import javax.json.Json;
+import javax.json.JsonPatchBuilder;
+
+import io.kubernetes.client.ApiException;
+import oracle.kubernetes.weblogic.domain.model.Domain;
+
+public class DomainStatusPatch {
+  private Domain domain;
+
+  /**
+   * Update the domain status. This may involve either replacing the current status or adding to it.
+   * @param domain the domain to update
+   * @param reason the reason, a camel-cased string with no spaces
+   * @param message a text description of the new status; may include multiple lines
+   */
+  public static void updateDomainStatus(Domain domain, String reason, String message) {
+    new DomainStatusPatch(domain).update(reason, message);
+  }
+
+  private DomainStatusPatch(Domain domain) {
+    this.domain = domain;
+  }
+
+  private void update(String reason, String message) {
+    if (reason == null || message == null) return;
+
+    try {
+      JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
+      if (domain.getStatus() != null && domain.getStatus().getReason() != null) {
+        patchBuilder.replace("/status/reason", reason);
+        patchBuilder.replace("/status/message", message);
+      } else {
+        patchBuilder.add("/status/reason", reason);
+        patchBuilder.add("/status/message", message);
+      }
+      new CallBuilder()
+            .patchDomain(
+                  domain.getDomainUid(), domain.getMetadata().getNamespace(), patchBuilder.build());
+    } catch (ApiException ignored) {
+      /* extraneous comment to fool checkstyle into thinking that this is not an empty catch block. */
+    }
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationStep.java
@@ -1,0 +1,33 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import java.util.List;
+
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.model.Domain;
+
+import static java.lang.System.lineSeparator;
+
+public class DomainValidationStep extends Step {
+  private Domain domain;
+
+  public DomainValidationStep(Domain domain, Step next) {
+    super(next);
+    this.domain = domain;
+  }
+
+  @Override
+  public NextAction apply(Packet packet) {
+    List<String> validationFailures = domain.getValidationFailures();
+
+    if (validationFailures.isEmpty()) return doNext(packet);
+
+    DomainStatusPatch.updateDomainStatus(domain, "ErrBadDomain", String.join(lineSeparator(), validationFailures));
+    return doEnd(packet);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -406,7 +406,7 @@ public class JobHelper {
     }
 
     private void updateStatus(DomainPresenceInfo domainPresenceInfo) {
-      KubernetesUtils.updateStatus(
+      DomainStatusPatch.updateDomainStatus(
             domainPresenceInfo.getDomain(), "ErrIntrospector", onSeparateLines(severeStatuses));
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -4,7 +4,6 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
@@ -114,28 +113,12 @@ public abstract class JobStepContext extends StepContextBase {
     return NODEMGR_HOME;
   }
 
-  protected String getLogHome() {
-    return getDomain().getLogHome();
-  }
-
-  protected boolean isDomainHomeInImage() {
-    return getDomain().isDomainHomeInImage();
-  }
-
-  protected boolean istioEnabled() {
-    return getDomain().istioEnabled();
+  private boolean isIstioEnabled() {
+    return getDomain().isIstioEnabled();
   }
 
   String getEffectiveLogHome() {
-    if (!getDomain().getLogHomeEnabled()) {
-      return null;
-    }
-    String logHome = getLogHome();
-    if (logHome == null || "".equals(logHome.trim())) {
-      // logHome not specified, use default value
-      return DEFAULT_LOG_HOME + File.separator + getDomainUid();
-    }
-    return logHome;
+    return getDomain().getEffectiveLogHome();
   }
 
   String getIncludeServerOutInPodLog() {
@@ -206,7 +189,7 @@ public abstract class JobStepContext extends StepContextBase {
           .putLabelsItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
           .putLabelsItem(
                 LabelConstants.JOBNAME_LABEL, LegalNames.toJobIntrospectorName(getDomainUid()));
-    if (istioEnabled()) metadata.putAnnotationsItem("sidecar.istio.io/inject", "false");
+    if (isIstioEnabled()) metadata.putAnnotationsItem("sidecar.istio.io/inject", "false");
     return metadata;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
@@ -8,10 +8,8 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import javax.json.Json;
 import javax.json.JsonPatchBuilder;
 
-import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ObjectMeta;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.weblogic.domain.model.Domain;
@@ -153,23 +151,4 @@ public class KubernetesUtils {
           .orElse("false");
   }
 
-  public static void updateStatus(Domain domain, String reason, String message) {
-    if (reason == null) return;
-
-    try {
-      JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
-      if (domain.getStatus() != null && domain.getStatus().getReason() != null) {
-        patchBuilder.replace("/status/reason", reason);
-        patchBuilder.replace("/status/message", message);
-      } else {
-        patchBuilder.add("/status/reason", reason);
-        patchBuilder.add("/status/message", message);
-      }
-      new CallBuilder()
-            .patchDomain(
-                  domain.getDomainUid(), domain.getMetadata().getNamespace(), patchBuilder.build());
-    } catch (ApiException ignored) {
-      /* extraneous comment to fool checkstyle into thinking that this is not an empty catch block. */
-    }
-  }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -4,7 +4,6 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -154,18 +153,8 @@ public abstract class PodStepContext extends StepContextBase {
         .getLocalAdminProtocolChannelPort();
   }
 
-  private String getLogHome() {
-    return getDomain().getLogHome();
-  }
-
   private String getEffectiveLogHome() {
-    if (!getDomain().getLogHomeEnabled()) return null;
-    String logHome = getLogHome();
-    if (logHome == null || "".equals(logHome.trim())) {
-      // logHome not specified, use default value
-      return DEFAULT_LOG_HOME + File.separator + getDomainUid();
-    }
-    return logHome;
+    return getDomain().getEffectiveLogHome();
   }
 
   private String getIncludeServerOutInPodLog() {
@@ -651,7 +640,7 @@ public abstract class PodStepContext extends StepContextBase {
         .periodSeconds(getReadinessProbePeriodSeconds(tuning))
         .failureThreshold(FAILURE_THRESHOLD);
     try {
-      boolean istioEnabled = getDomain().istioEnabled();
+      boolean istioEnabled = getDomain().isIstioEnabled();
       if (istioEnabled) {
         int istioReadinessPort = getDomain().getIstioReadinessPort();
         readinessProbe =

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -36,20 +37,26 @@ import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.Domain;
+import oracle.kubernetes.weblogic.domain.model.DomainStatus;
+import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.RESOURCE_VERSION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.VersionConstants.DEFAULT_DOMAIN_VERSION;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class DomainProcessorTest {
@@ -91,6 +98,8 @@ public class DomainProcessorTest {
     mementos.add(UnitTestHash.install());
 
     domainConfigurator = DomainConfiguratorFactory.forDomain(domain);
+    domain.setStatus(new DomainStatus());
+    testSupport.defineResources(domain);
     new DomainProcessorTestSetup(testSupport).defineKubernetesResources(createDomainConfig());
   }
 
@@ -248,5 +257,47 @@ public class DomainProcessorTest {
   private void assertServerPodAndServicePresent(DomainPresenceInfo info, String serverName) {
     assertThat(serverName + " server service", info.getServerService(serverName), notNullValue());
     assertThat(serverName + " pod", info.getServerPod(serverName), notNullValue());
+  }
+
+  @Test
+  public void whenDomainIsNotValid_dontBringUpServers() {
+    defineDuplicateServerNames();
+
+    DomainPresenceInfo info = new DomainPresenceInfo(domain);
+    processor.makeRightDomainPresence(info, true, false, false);
+
+    assertServerPodAndServiceNotPresent(info, ADMIN_NAME);
+    for (String serverName : MANAGED_SERVER_NAMES)
+      assertServerPodAndServiceNotPresent(info, serverName);
+  }
+
+  private void assertServerPodAndServiceNotPresent(DomainPresenceInfo info, String serverName) {
+    assertThat(serverName + " server service", info.getServerService(serverName), nullValue());
+    assertThat(serverName + " pod", info.getServerPod(serverName), nullValue());
+  }
+
+  @Test
+  public void whenDomainIsNotValid_updateStatus() {
+    defineDuplicateServerNames();
+
+    DomainPresenceInfo info = new DomainPresenceInfo(domain);
+    processor.makeRightDomainPresence(info, true, false, false);
+
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
+    assertThat(getStatusReason(updatedDomain), equalTo("ErrBadDomain"));
+    assertThat(getStatusMessage(updatedDomain), stringContainsInOrder("server", "ms1"));
+  }
+
+  private String getStatusReason(Domain updatedDomain) {
+    return Optional.ofNullable(updatedDomain).map(Domain::getStatus).map(DomainStatus::getReason).orElse(null);
+  }
+
+  private String getStatusMessage(Domain updatedDomain) {
+    return Optional.ofNullable(updatedDomain).map(Domain::getStatus).map(DomainStatus::getMessage).orElse(null);
+  }
+
+  private void defineDuplicateServerNames() {
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -285,7 +285,7 @@ public class DomainProcessorTest {
 
     Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
     assertThat(getStatusReason(updatedDomain), equalTo("ErrBadDomain"));
-    assertThat(getStatusMessage(updatedDomain), stringContainsInOrder("server", "ms1"));
+    assertThat(getStatusMessage(updatedDomain), stringContainsInOrder("managedServers", "ms1"));
   }
 
   private String getStatusReason(Domain updatedDomain) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
@@ -1,0 +1,96 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.meterware.simplestub.Memento;
+import oracle.kubernetes.TestUtils;
+import oracle.kubernetes.operator.DomainProcessorTestSetup;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.operator.work.TerminalStep;
+import oracle.kubernetes.weblogic.domain.model.Domain;
+import oracle.kubernetes.weblogic.domain.model.DomainStatus;
+import oracle.kubernetes.weblogic.domain.model.ManagedServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class DomainValidationStepTest {
+  private Domain domain = DomainProcessorTestSetup.createTestDomain();
+  private TerminalStep terminalStep = new TerminalStep();
+  private DomainValidationStep step = new DomainValidationStep(domain, terminalStep);
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private List<Memento> mementos = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(testSupport.install());
+
+    domain.setStatus(new DomainStatus());
+    testSupport.defineResources(domain);
+  }
+
+  @After
+  public void tearDown() {
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  public void stepImplementsStepClass() {
+    assertThat(step, instanceOf(Step.class));
+  }
+
+  @Test
+  public void whenDomainIsValid_runNextStep() {
+    testSupport.runStepsToCompletion(step);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @Test
+  public void whenDomainIsNotValid_dontRunNextStep() {
+    defineDuplicateServerNames();
+
+    testSupport.runStepsToCompletion(step);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  @Test
+  public void whenDomainIsNotValid_updateStatus() {
+    defineDuplicateServerNames();
+
+    testSupport.runStepsToCompletion(step);
+
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
+    assertThat(getStatusReason(updatedDomain), equalTo("ErrBadDomain"));
+    assertThat(getStatusMessage(updatedDomain), stringContainsInOrder("server", "ms1"));
+  }
+
+  private String getStatusReason(Domain updatedDomain) {
+    return Optional.ofNullable(updatedDomain).map(Domain::getStatus).map(DomainStatus::getReason).orElse(null);
+  }
+
+  private String getStatusMessage(Domain updatedDomain) {
+    return Optional.ofNullable(updatedDomain).map(Domain::getStatus).map(DomainStatus::getMessage).orElse(null);
+  }
+
+  private void defineDuplicateServerNames() {
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
+    domain.getSpec().getManagedServers().add(new ManagedServer().withServerName("ms1"));
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
@@ -78,7 +78,7 @@ public class DomainValidationStepTest {
 
     Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
     assertThat(getStatusReason(updatedDomain), equalTo("ErrBadDomain"));
-    assertThat(getStatusMessage(updatedDomain), stringContainsInOrder("server", "ms1"));
+    assertThat(getStatusMessage(updatedDomain), stringContainsInOrder("managedServers", "ms1"));
   }
 
   private String getStatusReason(Domain updatedDomain) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
@@ -24,6 +24,7 @@ import static oracle.kubernetes.LogMatcher.containsWarning;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.ProcessingConstants.JOB_POD_NAME;
 import static oracle.kubernetes.operator.helpers.JobHelper.INTROSPECTOR_LOG_PREFIX;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -99,7 +100,7 @@ public class IntrospectionLoggingTest {
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
     logRecords.clear();
 
-    Domain updatedDomain = testSupport.getResourceWithName(KubernetesTestSupport.DOMAIN, UID);
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
     assertThat(updatedDomain.getStatus().getReason(), equalTo("ErrIntrospector"));
     assertThat(updatedDomain.getStatus().getMessage(), equalTo(SEVERE_PROBLEM_1));
   }
@@ -113,7 +114,7 @@ public class IntrospectionLoggingTest {
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
     logRecords.clear();
 
-    Domain updatedDomain = testSupport.getResourceWithName(KubernetesTestSupport.DOMAIN, UID);
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
     assertThat(updatedDomain.getStatus().getReason(), equalTo("ErrIntrospector"));
     assertThat(
         updatedDomain.getStatus().getMessage(),

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -481,18 +481,17 @@ public abstract class PodHelperTestBase {
 
   @Test
   public void whenPodCreated_withLogHomeSpecified_hasLogHomeEnvVariable() {
-    final String myLogHome = "/shared/mylogs";
+    final String myLogHome = "/shared/mylogs/";
     domainPresenceInfo.getDomain().getSpec().setLogHomeEnabled(true);
-    domainPresenceInfo.getDomain().getSpec().setLogHome("/shared/mylogs");
-    assertThat(getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("LOG_HOME", myLogHome)));
+    domainPresenceInfo.getDomain().getSpec().setLogHome("/shared/mylogs/");
+    assertThat(getCreatedPodSpecContainer().getEnv(), hasEnvVar("LOG_HOME", myLogHome));
   }
 
   @Test
   public void whenPodCreated_withoutLogHomeSpecified_hasDefaultLogHomeEnvVariable() {
     domainPresenceInfo.getDomain().getSpec().setLogHomeEnabled(true);
     domainPresenceInfo.getDomain().getSpec().setLogHome(null);
-    assertThat(
-        getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("LOG_HOME", LOG_HOME + "/" + UID)));
+    assertThat(getCreatedPodSpecContainer().getEnv(), hasEnvVar("LOG_HOME", LOG_HOME + "/" + UID));
   }
 
   @Test


### PR DESCRIPTION
Adds semantic validation of the domain resource itself. If it fails, updates the domain status. If it succeeds, allows the introspection to run.