### PR TITLE
remove reference to operator-model

### DIFF
--- a/buildtime-reports/pom.xml
+++ b/buildtime-reports/pom.xml
@@ -54,11 +54,6 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>operator-model</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>weblogic-kubernetes-operator</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -72,11 +72,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>operator-model</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>


### PR DESCRIPTION
Remove leftover references to the defunct operator-model module.

Jenkins job http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/2375/