### PR TITLE
Fix secure protocol in AdminURL

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -141,11 +141,30 @@ public abstract class PodStepContext extends StepContextBase {
         .getLocalAdminProtocolChannelPort();
   }
 
+  /**
+   * Check if the server is listening on a secure port. NOTE: If the targetted server is a managed
+   * server, this method is overridden to check if the managed server has a secure listen port rather
+   * than the admin server. See PodHelper.ManagedPodStepContext
+   *
+   * @return true if server is listening on a secure port
+   */
   boolean isLocalAdminProtocolChannelSecure() {
     return domainTopology
         .getServerConfig(domainTopology.getAdminServerName())
         .isLocalAdminProtocolChannelSecure();
   }
+
+  /**
+   * Check if the admin server is listening on a secure port.
+   *
+   * @return true if admin server is listening on a secure port
+   */
+  private boolean isAdminServerProtocolChannelSecure() {
+    return domainTopology
+        .getServerConfig(domainTopology.getAdminServerName())
+        .isLocalAdminProtocolChannelSecure();
+  }
+
 
   Integer getLocalAdminProtocolChannelPort() {
     return domainTopology
@@ -602,6 +621,13 @@ public abstract class PodStepContext extends StepContextBase {
     addEnvVar(vars, "ADMIN_PORT", getAsPort().toString());
     if (isLocalAdminProtocolChannelSecure()) {
       addEnvVar(vars, "ADMIN_PORT_SECURE", "true");
+    }
+    if (isAdminServerProtocolChannelSecure()) {
+      // The following env variable determines whether to set a secure protocol(https/t3s) in the "AdminURL" property 
+      // in NM startup.properties.
+      // WebLogic Node Manager then sets the ADMIN_URL env variable(based on the "AdminURL") before starting
+      // the managed server
+      addEnvVar(vars, "ADMIN_SERVER_PORT_SECURE", "true");
     }
     addEnvVar(vars, "SERVER_NAME", getServerName());
     addEnvVar(vars, "DOMAIN_UID", getDomainUid());

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -245,9 +245,9 @@ public class WlsDomainConfig implements WlsDomain {
   }
 
   /**
-   * Return the name of the WLS domain.
+   * Return the name of the admin server.
    *
-   * @return Name of the WLS domain
+   * @return Name of the admin server
    */
   public String getAdminServerName() {
     return this.adminServerName;

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -260,15 +260,8 @@ EOF
   [ ! $? -eq 0 ] && trace SEVERE "Failed to create '${wl_props_file}'." && exit 1
 
   if [ ! "${ADMIN_NAME}" = "${SERVER_NAME}" ]; then
-    admin_protocol="http"
-    if [ "${ADMIN_PORT_SECURE}" = "true" ]; then
-      admin_protocol="https"
-    fi  
-    if [ "${ISTIO_ENABLED}" == "true" ]; then
-      echo "AdminURL=t3\\://${AS_SERVICE_NAME}\\:${ADMIN_PORT}" >> ${wl_props_file}
-    else
-      echo "AdminURL=$admin_protocol\\://${AS_SERVICE_NAME}\\:${ADMIN_PORT}" >> ${wl_props_file}
-    fi
+    ADMIN_URL=$(getAdminUrl)
+    echo "AdminURL=$ADMIN_URL" >> ${wl_props_file}
   fi
 fi
 

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -395,3 +395,26 @@ checkWebLogicVersion()
   fi
   return 0
 }
+
+
+#
+# getAdminUrl
+#   purpose: Get the ADMIN_URL used to connect to the admin server internally, e.g. when starting a managed server
+#   sample:
+#     ADMIN_URL=$(getAdminUrl)
+#
+function getAdminUrl() {
+  admin_protocol="http"
+  if [ "${ISTIO_ENABLED}" = "true" ]; then
+    admin_protocol="t3"
+  fi 
+
+  if [ "${ADMIN_SERVER_PORT_SECURE}" = "true" ]; then
+    if [ "${ISTIO_ENABLED}" = "true" ]; then
+      admin_protocol="t3s"
+    else
+      admin_protocol="https"
+    fi
+  fi
+  echo ${admin_protocol}://${AS_SERVICE_NAME}:${ADMIN_PORT}
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -219,6 +219,34 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   }
 
   @Test
+  public void whenAdminPodCreatedWithAdminPortEnabled_adminServerPortSecureEnvVarIsTrue() {
+    final Integer adminPort = 9002;
+    getServerTopology().setAdminPort(adminPort);
+    assertThat(getCreatedPodSpecContainer().getEnv(), hasEnvVar("ADMIN_SERVER_PORT_SECURE", "true"));
+  }
+
+  @Test
+  public void whenAdminPodCreatedWithNullAdminPort_adminServerPortSecureEnvVarIsNotSet() {
+    final Integer adminPort = null;
+    getServerTopology().setAdminPort(adminPort);
+    assertThat(getCreatedPodSpecContainer().getEnv(), not(hasEnvVar("ADMIN_SERVER_PORT_SECURE", "true")));
+  }
+
+  @Test
+  public void whenAdminPodCreatedWithAdminServerHasSSLPortEnabled_adminServerPortSecureEnvVarIsTrue() {
+    final Integer adminServerSSLPort = 9999;
+    getServerTopology().setSslListenPort(adminServerSSLPort);
+    assertThat(getCreatedPodSpecContainer().getEnv(), hasEnvVar("ADMIN_SERVER_PORT_SECURE", "true"));
+  }
+
+  @Test
+  public void whenAdminPodCreatedWithAdminServerHasNullSSLPort_adminServerPortSecureEnvVarIsNotSet() {
+    final Integer adminServerSSLPort = null;
+    getServerTopology().setSslListenPort(adminServerSSLPort);
+    assertThat(getCreatedPodSpecContainer().getEnv(), not(hasEnvVar("ADMIN_SERVER_PORT_SECURE", "true")));
+  }
+
+  @Test
   public void whenDomainPresenceHasNoEnvironmentItems_createAdminPodStartupWithDefaultItems() {
     assertThat(getCreatedPodSpecContainer().getEnv(), not(empty()));
   }


### PR DESCRIPTION
I picked up the work from Paul's https://github.com/oracle/weblogic-kubernetes-operator/pull/1130.
This change makes sure the AdminURL is constructed with the correct protocol if the admin port is enabled or the admin server has an SSL port enabled.