### PR TITLE
Validate specified environment variables

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -207,10 +207,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -33,7 +33,9 @@ import oracle.kubernetes.weblogic.domain.model.Cluster;
 import oracle.kubernetes.weblogic.domain.model.ConfigurationConstants;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
+import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
+import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 
 public class JobHelper {
 
@@ -215,14 +217,14 @@ public class JobHelper {
       List<V1EnvVar> vars =
             PodHelper.createCopy(getDomain().getAdminServerSpec().getEnvironmentVariables());
 
-      addEnvVar(vars, "NAMESPACE", getNamespace());
-      addEnvVar(vars, "DOMAIN_UID", getDomainUid());
-      addEnvVar(vars, "DOMAIN_HOME", getDomainHome());
-      addEnvVar(vars, "NODEMGR_HOME", getNodeManagerHome());
-      addEnvVar(vars, "LOG_HOME", getEffectiveLogHome());
-      addEnvVar(vars, "INTROSPECT_HOME", getIntrospectHome());
-      addEnvVar(vars, "SERVER_OUT_IN_POD_LOG", getIncludeServerOutInPodLog());
-      addEnvVar(vars, "CREDENTIALS_SECRET_NAME", getWebLogicCredentialsSecretName());
+      addEnvVar(vars, ServerEnvVars.DOMAIN_UID, getDomainUid());
+      addEnvVar(vars, ServerEnvVars.DOMAIN_HOME, getDomainHome());
+      addEnvVar(vars, ServerEnvVars.NODEMGR_HOME, getNodeManagerHome());
+      addEnvVar(vars, ServerEnvVars.LOG_HOME, getEffectiveLogHome());
+      addEnvVar(vars, ServerEnvVars.SERVER_OUT_IN_POD_LOG, getIncludeServerOutInPodLog());
+      addEnvVar(vars, IntrospectorJobEnvVars.NAMESPACE, getNamespace());
+      addEnvVar(vars, IntrospectorJobEnvVars.INTROSPECT_HOME, getIntrospectHome());
+      addEnvVar(vars, IntrospectorJobEnvVars.CREDENTIALS_SECRET_NAME, getWebLogicCredentialsSecretName());
 
       return vars;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -251,7 +251,7 @@ public class PodHelper {
     @Override
     List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
       List<V1EnvVar> vars = createCopy(getServerSpec().getEnvironmentVariables());
-      overrideContainerWeblogicEnvVars(vars);
+      addStartupEnvVars(vars);
       return vars;
     }
 
@@ -407,7 +407,7 @@ public class PodHelper {
       if (envVars != null) {
         vars.addAll(envVars);
       }
-      overrideContainerWeblogicEnvVars(vars);
+      addStartupEnvVars(vars);
       return vars;
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -52,6 +52,7 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
+import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -157,7 +158,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     return getDomain().getEffectiveLogHome();
   }
 
-  private String getIncludeServerOutInPodLog() {
+  private String isIncludeServerOutInPodLog() {
     return Boolean.toString(getDomain().isIncludeServerOutInPodLog());
   }
 
@@ -241,7 +242,7 @@ public abstract class PodStepContext extends BasePodStepContext {
    */
   private Step deletePod(Step next) {
     return new CallBuilder()
-        .deletePodAsync(getPodName(), getNamespace(), new V1DeleteOptions(), deleteResponse(next));
+          .deletePodAsync(getPodName(), getNamespace(), new V1DeleteOptions(), deleteResponse(next));
   }
 
   /**
@@ -337,7 +338,7 @@ public abstract class PodStepContext extends BasePodStepContext {
   private boolean canUseCurrentPod(V1Pod currentPod) {
     boolean useCurrent =
         AnnotationHelper.getHash(getPodModel()).equals(AnnotationHelper.getHash(currentPod));
-    if (!useCurrent && AnnotationHelper.getDebugString(currentPod) != null)
+    if (!useCurrent && AnnotationHelper.getDebugString(currentPod).length() > 0)
       LOGGER.info(
           MessageKeys.POD_DUMP,
           AnnotationHelper.getDebugString(currentPod),
@@ -399,7 +400,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     return vars;
   }
 
-  final void updateForStartupMode(V1Pod pod) {
+  private void updateForStartupMode(V1Pod pod) {
     ServerSpec serverSpec = getServerSpec();
     if (serverSpec != null) {
       String desiredState = serverSpec.getDesiredState();
@@ -420,7 +421,7 @@ public abstract class PodStepContext extends BasePodStepContext {
    *
    * @param pod The pod
    */
-  final void updateForShutdown(V1Pod pod) {
+  private void updateForShutdown(V1Pod pod) {
     String shutdownType;
     Long timeout;
     boolean ignoreSessions;
@@ -576,23 +577,25 @@ public abstract class PodStepContext extends BasePodStepContext {
     return mounts;
   }
 
-  void overrideContainerWeblogicEnvVars(List<V1EnvVar> vars) {
-    // Override the domain name, domain directory, admin server name and admin server port.
-    addEnvVar(vars, "DOMAIN_NAME", getDomainName());
-    addEnvVar(vars, "DOMAIN_HOME", getDomainHome());
-    addEnvVar(vars, "ADMIN_NAME", getAsName());
-    addEnvVar(vars, "ADMIN_PORT", getAsPort().toString());
+  /**
+   * Sets the environment variables used by operator/src/main/resources/scripts/startServer.sh
+   * @param vars a list to which new variables are to be added
+   */
+  void addStartupEnvVars(List<V1EnvVar> vars) {
+    addEnvVar(vars, ServerEnvVars.DOMAIN_NAME, getDomainName());
+    addEnvVar(vars, ServerEnvVars.DOMAIN_HOME, getDomainHome());
+    addEnvVar(vars, ServerEnvVars.ADMIN_NAME, getAsName());
+    addEnvVar(vars, ServerEnvVars.ADMIN_PORT, getAsPort().toString());
     if (isLocalAdminProtocolChannelSecure()) {
-      addEnvVar(vars, "ADMIN_PORT_SECURE", "true");
+      addEnvVar(vars, ServerEnvVars.ADMIN_PORT_SECURE, "true");
     }
-    addEnvVar(vars, "SERVER_NAME", getServerName());
-    addEnvVar(vars, "DOMAIN_UID", getDomainUid());
-    addEnvVar(vars, "NODEMGR_HOME", NODEMGR_HOME);
-    addEnvVar(vars, "LOG_HOME", getEffectiveLogHome());
-    addEnvVar(vars, "SERVER_OUT_IN_POD_LOG", getIncludeServerOutInPodLog());
-    addEnvVar(
-        vars, "SERVICE_NAME", LegalNames.toServerServiceName(getDomainUid(), getServerName()));
-    addEnvVar(vars, "AS_SERVICE_NAME", LegalNames.toServerServiceName(getDomainUid(), getAsName()));
+    addEnvVar(vars, ServerEnvVars.SERVER_NAME, getServerName());
+    addEnvVar(vars, ServerEnvVars.DOMAIN_UID, getDomainUid());
+    addEnvVar(vars, ServerEnvVars.NODEMGR_HOME, NODEMGR_HOME);
+    addEnvVar(vars, ServerEnvVars.LOG_HOME, getEffectiveLogHome());
+    addEnvVar(vars, ServerEnvVars.SERVER_OUT_IN_POD_LOG, isIncludeServerOutInPodLog());
+    addEnvVar(vars, ServerEnvVars.SERVICE_NAME, LegalNames.toServerServiceName(getDomainUid(), getServerName()));
+    addEnvVar(vars, ServerEnvVars.AS_SERVICE_NAME, LegalNames.toServerServiceName(getDomainUid(), getAsName()));
     if (mockWls()) {
       addEnvVar(vars, "MOCK_WLS", "true");
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -156,6 +156,13 @@ public class MessageKeys {
   public static final String JOB_DEADLINE_EXCEEDED_MESSAGE = "WLSKO-0154";
   public static final String JOB_LOG_PARSE_FAILURE = "WLSKO-0155";
 
+  // domain status messages
+  public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";
+  public static final String DUPLICATE_CLUSTER_NAME_FOUND = "WLSDO-0002";
+  public static final String LOG_HOME_NOT_MOUNTED = "WLSDO-0003";
+  public static final String BAD_VOLUME_MOUNT_PATH = "WLSDO-0004";
+  public static final String RESERVED_ENVIRONMENT_VARIABLES = "WLSDO-0005";
+
   private MessageKeys() {
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/utils/OperatorUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/utils/OperatorUtils.java
@@ -1,0 +1,23 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.utils;
+
+import java.util.List;
+
+public class OperatorUtils {
+  /**
+   * Converts a list of strings to a comma-separated list, using "and" for the last item.
+   *
+   * @param list the list to convert
+   * @return the resultant string
+   */
+  public static String joinListGrammatically(final List<String> list) {
+    return list.size() > 1
+        ? String.join(", ", list.subList(0, list.size() - 1))
+            .concat(String.format("%s and ", list.size() > 2 ? "," : ""))
+            .concat(list.get(list.size() - 1))
+        : list.get(0);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -13,12 +13,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.validation.Valid;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1SecretReference;
 import io.kubernetes.client.models.V1VolumeMount;
@@ -30,11 +32,15 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-/** Domain represents a WebLogic domain and how it will be realized in the Kubernetes cluster. */
+/**
+ * Domain represents a WebLogic domain and how it will be realized in the Kubernetes cluster.
+ */
 @Description(
     "Domain represents a WebLogic domain and how it will be realized in the Kubernetes cluster.")
 public class Domain {
-  /** The pattern for computing the default shared logs directory. */
+  /**
+   * The pattern for computing the default shared logs directory.
+   */
   private static final String LOG_HOME_DEFAULT_PATTERN = "/shared/logs/%s";
 
   /**
@@ -68,7 +74,9 @@ public class Domain {
   @Nonnull
   private V1ObjectMeta metadata = new V1ObjectMeta();
 
-  /** DomainSpec is a description of a domain. */
+  /**
+   * DomainSpec is a description of a domain.
+   */
   @SerializedName("spec")
   @Expose
   @Valid
@@ -222,7 +230,7 @@ public class Domain {
   /**
    * Returns the specification applicable to a particular server/cluster combination.
    *
-   * @param serverName the name of the server
+   * @param serverName  the name of the server
    * @param clusterName the name of the cluster; may be null or empty if no applicable cluster.
    * @return the effective configuration for the server
    */
@@ -356,13 +364,14 @@ public class Domain {
 
   /**
    * Returns the path to the log home to be used by this domain. Null if the log home is disabled.
+   *
    * @return a path on a persistent volume, or null
    */
-  public @Nullable String getEffectiveLogHome() {
+  public String getEffectiveLogHome() {
     return isLogHomeEnabled() ? getLogHome() : null;
   }
 
-  @Nonnull String getLogHome() {
+  String getLogHome() {
     return Optional.ofNullable(spec.getLogHome())
         .orElse(String.format(LOG_HOME_DEFAULT_PATTERN, getDomainUid()));
   }
@@ -480,15 +489,6 @@ public class Domain {
   }
 
   class Validator {
-    static final String DUPLICATE_SERVER_NAME_FOUND
-          = "More than one item under spec.managedServers in the domain resource has DNS-1123 name '%s'";
-    static final String DUPLICATE_CLUSTER_NAME_FOUND
-          = "More than one item under spec.clusters in the domain resource has DNS-1123 name '%s'";
-    static final String LOG_HOME_PATH_NOT_MOUNTED
-          = "No volume mount contains path for log home '%s', %s in the domain resource";
-    static final String BAD_VOLUME_MOUNT_PATH
-          = "The mount path '%s', in entry '%s' of domain resource additionalVolumeMounts, is not valid";
-    
     private List<String> failures = new ArrayList<>();
     private Set<String> clusterNames = new HashSet<>();
     private Set<String> serverNames = new HashSet<>();
@@ -497,21 +497,22 @@ public class Domain {
       addDuplicateNames();
       addInvalidMountPaths();
       addUnmappedLogHome();
+      addReservedEnvironmentVariables();
 
       return failures;
     }
 
     private void addDuplicateNames() {
       getSpec().getManagedServers()
-            .stream()
-            .map(ManagedServer::getServerName)
-            .map(this::toDns1123LegalName)
-            .forEach(this::checkDuplicateServerName);
+          .stream()
+          .map(ManagedServer::getServerName)
+          .map(this::toDns1123LegalName)
+          .forEach(this::checkDuplicateServerName);
       getSpec().getClusters()
-            .stream()
-            .map(Cluster::getClusterName)
-            .map(this::toDns1123LegalName)
-            .forEach(this::checkDuplicateClusterName);
+          .stream()
+          .map(Cluster::getClusterName)
+          .map(this::toDns1123LegalName)
+          .forEach(this::checkDuplicateClusterName);
     }
 
     /**
@@ -524,18 +525,18 @@ public class Domain {
       return value.toLowerCase().replace('_', '-');
     }
 
-    private void checkDuplicateServerName(String s) {
-      if (serverNames.contains(s))
-        failures.add(String.format(DUPLICATE_SERVER_NAME_FOUND, s));
+    private void checkDuplicateServerName(String serverName) {
+      if (serverNames.contains(serverName))
+        failures.add(DomainValidationMessages.duplicateServerName(serverName));
       else
-        serverNames.add(s);
+        serverNames.add(serverName);
     }
 
-    private void checkDuplicateClusterName(String s) {
-      if (clusterNames.contains(s))
-        failures.add(String.format(DUPLICATE_CLUSTER_NAME_FOUND, s));
+    private void checkDuplicateClusterName(String clusterName) {
+      if (clusterNames.contains(clusterName))
+        failures.add(DomainValidationMessages.duplicateClusterName(clusterName));
       else
-        clusterNames.add(s);
+        clusterNames.add(clusterName);
     }
 
     private void addInvalidMountPaths() {
@@ -544,18 +545,14 @@ public class Domain {
 
     private void checkValidMountPath(V1VolumeMount mount) {
       if (!new File(mount.getMountPath()).isAbsolute())
-        failures.add(String.format(BAD_VOLUME_MOUNT_PATH, mount.getMountPath(), mount.getName()));
+        failures.add(DomainValidationMessages.badVolumeMountPath(mount));
     }
 
     private void addUnmappedLogHome() {
       if (!isLogHomeEnabled()) return;
 
       if (getSpec().getAdditionalVolumeMounts().stream().map(V1VolumeMount::getMountPath).noneMatch(this::mapsLogHome))
-        failures.add(String.format(LOG_HOME_PATH_NOT_MOUNTED, getLogHome(), getLogHomeSource()));
-    }
-
-    private String getLogHomeSource() {
-      return getSpec().getLogHome() == null ? "implicit" : "specified";
+        failures.add(DomainValidationMessages.logHomeNotMounted(getLogHome()));
     }
 
     private boolean mapsLogHome(String mountPath) {
@@ -567,5 +564,47 @@ public class Domain {
       else return path + File.separator;
     }
 
+    private void addReservedEnvironmentVariables() {
+      checkReservedIntrospectorVariables(spec, "spec");
+      Optional.ofNullable(spec.getAdminServer())
+          .ifPresent(a -> checkReservedIntrospectorVariables(a, "spec.adminServer"));
+      
+      spec.getManagedServers()
+          .forEach(s -> checkReservedEnvironmentVariables(s, "spec.managedServers[" + s.getServerName() + "]"));
+      spec.getClusters()
+          .forEach(s -> checkReservedEnvironmentVariables(s, "spec.clusters[" + s.getClusterName() + "]"));
+    }
+
+    class EnvironmentVariableCheck {
+      private Predicate<String> isReserved;
+
+      EnvironmentVariableCheck(Predicate<String> isReserved) {
+        this.isReserved = isReserved;
+      }
+
+      void checkEnvironmentVariables(@Nonnull BaseConfiguration configuration, String prefix) {
+        if (configuration.getEnv() == null) return;
+
+        List<String> reservedNames = configuration.getEnv()
+            .stream()
+            .map(V1EnvVar::getName)
+            .filter(isReserved)
+            .collect(Collectors.toList());
+
+        if (!reservedNames.isEmpty())
+          failures.add(DomainValidationMessages.reservedVariableNames(prefix, reservedNames));
+      }
+    }
+
+    private void checkReservedEnvironmentVariables(BaseConfiguration configuration, String prefix) {
+      new EnvironmentVariableCheck(ServerEnvVars::isReserved).checkEnvironmentVariables(configuration, prefix);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void checkReservedIntrospectorVariables(BaseConfiguration configuration, String prefix) {
+      new EnvironmentVariableCheck(IntrospectorJobEnvVars::isReserved).checkEnvironmentVariables(configuration, prefix);
+    }
+
   }
+
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
@@ -1,0 +1,90 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import java.text.ChoiceFormat;
+import java.text.Format;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.ResourceBundle;
+import javax.annotation.Nonnull;
+
+import io.kubernetes.client.models.V1VolumeMount;
+import oracle.kubernetes.operator.logging.MessageKeys;
+import oracle.kubernetes.utils.OperatorUtils;
+
+class DomainValidationMessages {
+
+  /**
+   * Returns a validation message indicating that more than one managed server spec has the same effective name
+   * after DNS-1123 conversion.
+   * @param serverName the duplicate server name
+   * @return the localized message
+   */
+  static String duplicateServerName(@Nonnull String serverName) {
+    return getMessage(MessageKeys.DUPLICATE_SERVER_NAME_FOUND, serverName);
+  }
+
+  /**
+   * Returns a validation message indicating that more than one cluster spec has the same effective name
+   * after DNS-1123 conversion.
+   * @param clusterName the duplicate cluster name
+   * @return the localized message
+   */
+  static String duplicateClusterName(@Nonnull String clusterName) {
+    return getMessage(MessageKeys.DUPLICATE_CLUSTER_NAME_FOUND, clusterName);
+  }
+
+  /**
+   * Returns a validation message indicating that a specified volume mount's path is not absolute.
+   * @param mount the problematic volume mount
+   * @return the localized message
+   */
+  static String badVolumeMountPath(@Nonnull V1VolumeMount mount) {
+    return getMessage(MessageKeys.BAD_VOLUME_MOUNT_PATH, mount.getMountPath(), mount.getName());
+  }
+
+  /**
+   * Returns a validation message indicating that none of the additional volume mounts contains a path which
+   * includes the log home.
+   * @param logHome the log home to be used
+   * @return the localized message
+   */
+  static String logHomeNotMounted(@Nonnull String logHome) {
+    return getMessage(MessageKeys.LOG_HOME_NOT_MOUNTED, logHome);
+  }
+
+  private static String getMessage(String key, Object... parameters) {
+    MessageFormat formatter = new MessageFormat("");
+    formatter.applyPattern(getBundleString(key));
+    return formatter.format(parameters);
+  }
+
+  private static String getBundleString(String key) {
+    return ResourceBundle.getBundle("operator").getString(key);
+  }
+
+  static String reservedVariableNames(String prefix, List<String> reservedNames) {
+    MessageFormat formatter = new MessageFormat("");
+    formatter.applyPattern(getBundleString(MessageKeys.RESERVED_ENVIRONMENT_VARIABLES));
+    formatter.setFormats(new Format[]{getEnvNoun(), null, null, getToBe()});
+    return formatter.format(new Object[] {
+        reservedNames.size(),
+        OperatorUtils.joinListGrammatically(reservedNames),
+        prefix + ".serverPod.env",
+        reservedNames.size()});
+  }
+
+  private static ChoiceFormat getEnvNoun() {
+    return new ChoiceFormat(new double[] {1, 2},
+                            new String[] {getBundleString("oneEnvVar"), getBundleString("multipleEnvVars")});
+  }
+
+  private static ChoiceFormat getToBe() {
+    return new ChoiceFormat(new double[] {1, 2},
+                            new String[] {getBundleString("singularToBe"), getBundleString("pluralToBe")});
+  }
+
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/IntrospectorJobEnvVars.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/IntrospectorJobEnvVars.java
@@ -1,0 +1,40 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Environment variables used in the introspection job.
+ */
+public class IntrospectorJobEnvVars {
+  /**
+   * The namespace in which the introspection job will run.
+   */
+  public static final String NAMESPACE = "NAMESPACE";
+
+  /**
+   * The path to the home directory for the introspection job.
+   */
+  public static final String INTROSPECT_HOME = "INTROSPECT_HOME";
+
+  /**
+   * The credentials used by the introspection job.
+   */
+  public static final String CREDENTIALS_SECRET_NAME = "CREDENTIALS_SECRET_NAME";
+
+  /**
+   * Returns true if the specified environment variable name is reserved by the operator for communication with
+   * the introspection job.
+   * @param name an environment variable name
+   * @return true if the name is reserved
+   */
+  static boolean isReserved(String name) {
+    return ServerEnvVars.isReserved(name) || RESERVED_NAMES.contains(name);
+  }
+
+  private static List<String> RESERVED_NAMES = Arrays.asList(NAMESPACE, INTROSPECT_HOME, CREDENTIALS_SECRET_NAME);
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerEnvVars.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerEnvVars.java
@@ -1,0 +1,58 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Environment variables defined for the startup script at operator/src/main/resources/scripts/startServer.sh.
+ */
+public class ServerEnvVars {
+
+  public static final String DOMAIN_UID = "DOMAIN_UID";
+
+  /** The name of a WebLogic domain. */
+  public static final String DOMAIN_NAME = "DOMAIN_NAME";
+
+  /** The path to the domain home, either in a PV or image. */
+  public static final String DOMAIN_HOME = "DOMAIN_HOME";
+  
+  /** The path to the node manager home, either in a PV or image. */
+  public static final String NODEMGR_HOME = "NODEMGR_HOME";
+
+  /** The name of the managed server. */
+  public static final String SERVER_NAME = "SERVER_NAME";
+
+  /** The name of the server service. */
+  public static final String SERVICE_NAME = "SERVICE_NAME";
+
+  /** The name of the admin instance. */
+  public static final String ADMIN_NAME = "ADMIN_NAME";
+
+  /** The name of the server service for the admin server. */
+  public static final String AS_SERVICE_NAME = "AS_SERVICE_NAME";
+
+  /** The plaintext port on which the admin server is listening. */
+  public static final String ADMIN_PORT = "ADMIN_PORT";
+
+  /** The secure port on which the admin server is listening. */
+  public static final String ADMIN_PORT_SECURE = "ADMIN_PORT_SECURE";
+
+  /** The location for the logs. */
+  public static final String LOG_HOME = "LOG_HOME";
+
+  /** 'true' or 'false' to indicate whether the server output should be included in the pod log. */
+  public static final String SERVER_OUT_IN_POD_LOG = "SERVER_OUT_IN_POD_LOG";
+
+  private static final List<String> RESERVED_NAMES = Arrays.asList(
+        DOMAIN_UID, DOMAIN_NAME, DOMAIN_HOME, NODEMGR_HOME, SERVER_NAME, SERVICE_NAME,
+        ADMIN_NAME, AS_SERVICE_NAME, ADMIN_PORT, ADMIN_PORT_SECURE,
+        LOG_HOME, SERVER_OUT_IN_POD_LOG);
+
+  static boolean isReserved(String name) {
+    return RESERVED_NAMES.contains(name);
+  }
+}

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -161,3 +161,15 @@ WLSKO-0154=Job {0} failed due to reason: DeadlineExceeded. \
   times with longer ActiveDeadlineSeconds value in each subsequent retry. \
   Use tuning parameter 'domainPresenceFailureRetryMaxCount' to configure max retries.
 WLSKO-0155=Unexpected exception, {0}, while parsing introspect job log [{1}].
+
+# Domain status messages
+
+WLSDO-0001=More than one item under spec.managedServers in the domain resource has DNS-1123 name ''{0}''"
+WLSDO-0002=More than one item under spec.clusters in the domain resource has DNS-1123 name ''{0}''
+WLSDO-0003=No volume mount contains path for log home ''{0}''
+WLSDO-0004=The mount path ''{0}'', in entry ''{1}'' of domain resource additionalVolumeMounts, is not valid
+WLSDO-0005=Environment {0} {1}, specified under {2}, {3} reserved for use by the operator
+oneEnvVar=variable
+multipleEnvVars=variables
+singularToBe=is
+pluralToBe=are

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainConditionMatcher.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainConditionMatcher.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.utils.OperatorUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainConditionType;
@@ -76,7 +76,7 @@ class DomainConditionMatcher extends TypeSafeDiagnosingMatcher<Domain> {
     if (expectedMessage != null) expectations.add(expectation("reason", expectedMessage));
     description
         .appendText("domain containing condition: ")
-        .appendText(TestUtils.joinListGrammatically(expectations));
+        .appendText(OperatorUtils.joinListGrammatically(expectations));
   }
 
   private String expectation(String description, String value) {

--- a/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
@@ -46,20 +46,6 @@ public class TestUtils {
   }
 
   /**
-   * Converts a list of strings to a comma-separated list, using "and" for the last item.
-   *
-   * @param list the list to convert
-   * @return the resultant string
-   */
-  public static String joinListGrammatically(final List<String> list) {
-    return list.size() > 1
-        ? String.join(", ", list.subList(0, list.size() - 1))
-            .concat(String.format("%s and ", list.size() > 2 ? "," : ""))
-            .concat(list.get(list.size() - 1))
-        : list.get(0);
-  }
-
-  /**
    * Removes the console handlers from the specified logger, in order to silence them during a test.
    *
    * @param logger a logger to silence

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainConditionMatcher.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainConditionMatcher.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
-import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.utils.OperatorUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
@@ -72,7 +72,7 @@ class DomainConditionMatcher extends TypeSafeDiagnosingMatcher<DomainStatus> {
     if (expectedMessage != null) expectations.add(expectation("reason", expectedMessage));
     description
         .appendText("domain containing condition: ")
-        .appendText(TestUtils.joinListGrammatically(expectations));
+        .appendText(OperatorUtils.joinListGrammatically(expectations));
   }
 
   private String expectation(String description, String value) {

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -5,20 +5,17 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
-import oracle.kubernetes.weblogic.domain.model.Cluster;
-import oracle.kubernetes.weblogic.domain.model.Domain;
-import oracle.kubernetes.weblogic.domain.model.DomainCommonConfigurator;
-import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import org.junit.Test;
 
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.createTestDomain;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class DomainValidationTest {
-  private Domain domain = new Domain();
+  private Domain domain = createTestDomain();
 
   @Test
   public void whenManagerServerSpecsHaveUniqueNames_dontReportError() {
@@ -91,11 +88,66 @@ public class DomainValidationTest {
   }
 
   @Test
-  public void whenNoVolumeMountHasLogHomeDirectory_reportError() {
+  public void whenNoVolumeMountHasSpecifiedLogHomeDirectory_reportError() {
     configureDomain(domain).withLogHomeEnabled(true).withLogHome("/private/log/mydomain");
     configureDomain(domain).withAdditionalVolumeMount("sharedlogs", "/shared/logs");
 
-    assertThat(domain.getValidationFailures(), contains(containsStringIgnoringCase("log home")));
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("log home", "/private/log/mydomain")));
+  }
+
+  @Test
+  public void whenNoVolumeMountHasImplicitLogHomeDirectory_reportError() {
+    configureDomain(domain).withLogHomeEnabled(true);
+
+    assertThat(domain.getValidationFailures(), contains(stringContainsInOrder("log home", "/shared/logs/" + UID)));
+  }
+
+  @Test
+  public void whenNonReservedEnvironmentVariableSpecifiedAtDomainLevel_dontReportError() {
+    configureDomain(domain).withEnvironmentVariable("testname", "testValue");
+
+    assertThat(domain.getValidationFailures(), empty());
+  }
+
+  @Test
+  public void whenReservedEnvironmentVariablesSpecifiedAtDomainLevel_reportError() {
+    configureDomain(domain)
+        .withEnvironmentVariable("ADMIN_NAME", "testValue")
+        .withEnvironmentVariable("INTROSPECT_HOME", "/shared/home/introspection");
+
+    assertThat(domain.getValidationFailures(),
+        contains(stringContainsInOrder("variables", "ADMIN_NAME", "INTROSPECT_HOME", "spec.serverPod.env", "are")));
+  }
+
+  @Test
+  public void whenReservedEnvironmentVariablesSpecifiedForAdminServer_reportError() {
+    configureDomain(domain)
+        .configureAdminServer()
+        .withEnvironmentVariable("LOG_HOME", "testValue")
+        .withEnvironmentVariable("NAMESPACE", "badValue");
+
+    assertThat(domain.getValidationFailures(),
+        contains(stringContainsInOrder("variables", "LOG_HOME", "NAMESPACE", "spec.adminServer.serverPod.env", "are")));
+  }
+
+  @Test
+  public void whenReservedEnvironmentVariablesSpecifiedAtServerLevel_reportError() {
+    configureDomain(domain)
+        .configureServer("ms1")
+        .withEnvironmentVariable("SERVER_NAME", "testValue");
+
+    assertThat(domain.getValidationFailures(),
+        contains(stringContainsInOrder("variable", "SERVER_NAME", "spec.managedServers[ms1].serverPod.env", "is")));
+  }
+
+  @Test
+  public void whenReservedEnvironmentVariablesSpecifiedAtClusterLevel_reportError() {
+    configureDomain(domain)
+        .configureCluster("cluster1")
+        .withEnvironmentVariable("DOMAIN_HOME", "testValue");
+
+    assertThat(domain.getValidationFailures(),
+        contains(stringContainsInOrder("variable", "DOMAIN_HOME", "spec.clusters[cluster1].serverPod.env", "is")));
   }
 
   private DomainConfigurator configureDomain(Domain domain) {


### PR DESCRIPTION
This PR adds internationalization for domain validation messages and adds validation of the environment variables.

Some points to note:

- While domain validation is not logging, Tom B has suggested that we might want to log those issues as well as add them to the status message. I have therefore added message keys.
- I used a different message prefix for these keys, as they seem separate to me. Possibly they should use the same prefix and just start a higher sequence number
- to handle grammatical issues such as "is"/"are" I added some non-sequence keys
- environment variables that affect the admin servers cannot use some additional values reserved by the introspection job