### PR TITLE
OWLS-76347 New sample scripts to manage DB service and RCU Schema

### DIFF
--- a/kubernetes/samples/scripts/create-rcu-schema/README.md
+++ b/kubernetes/samples/scripts/create-rcu-schema/README.md
@@ -1,0 +1,200 @@
+# Creating Oracle DB service and RCU Schema for a Fusion Middleware domain
+
+This sample demonstrates how to create a Oracle DB service on Kubernetes clusterand create RCU schema on the Oracle DB being used by Fusion Middleware domain.  
+
+The directory contain following sample scripts to (a) Start a Oracle DB service in default namespace (b) Stop the Oracle DB service (c) Create RCU schema (d) Drop RCU schema
+
+```
+$ ./start-db-service.sh   
+Trying to pull repository container-registry.oracle.com/database/enterprise ... 
+12.2.0.1-slim: Pulling from container-registry.oracle.com/database/enterprise
+Digest: sha256:25b0ec7cc3987f86b1e754fc214e7f06761c57bc11910d4be87b0d42ee12d254
+Status: Image is up to date for container-registry.oracle.com/database/enterprise:12.2.0.1-slim
+deployment.extensions/oracle-db created
+service/oracle-db created
+[oracle-db-756f9b99fd-r6ghb] already initialized .. 
+Checking Pod READY column for State [1/1]
+NAME                         READY   STATUS    RESTARTS   AGE
+oracle-db-756f9b99fd-r6ghb   1/1     Running   0          3s
+NAME                         READY   STATUS    RESTARTS   AGE
+oracle-db-756f9b99fd-r6ghb   1/1     Running   0          4s
+NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP          16d
+oracle-db    NodePort    10.100.148.17   <none>        1521:30011/TCP   3s
+Oracle DB service is RUNNING with external NodePort [30011]
+
+```
+The parameters are as follows:
+
+```  
+  -p external NodePort for the Service (default is 30011) 
+```
+```
+The script create a Oracle DB Service in default Namesapce with default Credential that comes with the Oracle Database Slim image.
+$ kubectl get po
+NAME                         READY   STATUS    RESTARTS   AGE
+oracle-db-756f9b99fd-ch7xt   1/1     Running   0          33m
+$ kubectl get svc
+NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
+oracle-db    NodePort    10.99.94.157   <none>        1521:30011/TCP   32m
+
+The DB Connection String is oracle-db.default.svc.cluster.local:1521/devpdb.k8s which can be used as  rcuDatabaseURL parameter to domain.input.yaml file while creating a Fusion Middleware domain in Operator Environment 
+
+The Database can be accessed thru external NodePort outside of Kubernates cluster using the URL String <hostmachine>:30011/devpdb.k8s
+
+Note : Domain-in-Image model need public DB url as rcuDatabaseURL parameter to configure Fusion Middleware domain in Operator Environment
+
+```
+
+```
+$ ./create-rcu-schema.sh -s <schemaPrefix> -d <dburl> 
+
+
+```
+The parameters are as follows:
+
+```  
+  -s  RCU Schema Prefix, Must be specified
+  -d  RCU Oracle Database URL (default oracle-db.default.svc.cluster.local:1521/devpdb.k8s) 
+```
+```
+The script Generates the RCU schema based Schema Prefix and RCU DB URL
+$ ./create-rcu-schema.sh -s domain1
+[oracle-db-756f9b99fd-r6ghb] already initialized .. 
+Checking Pod READY column for State [1/1]
+NAME                         READY   STATUS    RESTARTS   AGE
+oracle-db-756f9b99fd-r6ghb   1/1     Running   0          109s
+Trying to pull repository container-registry.oracle.com/middleware/fmw-infrastructure ... 
+12.2.1.3: Pulling from container-registry.oracle.com/middleware/fmw-infrastructure
+Digest: sha256:215d05d7543cc5d500eb213fa661753ae420d53e704baabeab89600827a61131
+Status: Image is up to date for container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.3
+pod/rcu created
+[rcu] already initialized .. 
+Checking Pod READY column for State [1/1]
+Pod [rcu] Status is Ready Iter [1/60]
+NAME   READY   STATUS    RESTARTS   AGE
+rcu    1/1     Running   0          7s
+NAME                         READY   STATUS    RESTARTS   AGE
+oracle-db-756f9b99fd-r6ghb   1/1     Running   0          2m2s
+rcu                          1/1     Running   0          12s
+CLASSPATH=/usr/java/jdk1.8.0_211/lib/tools.jar:/u01/oracle/wlserver/modules/features/wlst.wls.classpath.jar:
+
+PATH=/u01/oracle/wlserver/server/bin:/u01/oracle/wlserver/../oracle_common/modules/thirdparty/org.apache.ant/1.9.8.0.0/apache-ant-1.9.8/bin:/usr/java/jdk1.8.0_211/jre/bin:/usr/java/jdk1.8.0_211/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/java/default/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:/u01/oracle/container-scripts:/u01/oracle/wlserver/../oracle_common/modules/org.apache.maven_3.2.5/bin
+
+Your environment has been set.
+Check if the DB Service is Ready to accept Connection ?
+DB Connection URL [oracle-db.default.svc.cluster.local:1521/devpdb.k8s] and schemaPrefix is [domain1]
+[1/20] Retrying the DB Connection ...
+[2/20] Retrying the DB Connection ...
+[3/20] Retrying the DB Connection ...
+
+**** Success!!! ****
+
+You can connect to the database in your app using:
+
+  java.util.Properties props = new java.util.Properties();
+  props.put("user", "scott");
+  props.put("password", "tiger");
+  java.sql.Driver d =
+    Class.forName("oracle.jdbc.OracleDriver").newInstance();
+  java.sql.Connection conn =
+    Driver.connect("scott", props);
+
+	RCU Logfile: /tmp/RCU2019-08-23_21-13_1202784079/logs/rcu.log
+
+Enter the database password(User:sys):
+ 
+
+Processing command line ....
+Repository Creation Utility - Checking Prerequisites
+Checking Global Prerequisites
+The selected Oracle database is not configured to use the AL32UTF8 character set. Oracle strongly recommends using the AL32UTF8 character set for databases that support Oracle Fusion Middleware.
+Enter the schema password. This password will be used for all schema users of following components:MDS,IAU,IAU_APPEND,IAU_VIEWER,OPSS,WLS,STB.
+ 
+
+Repository Creation Utility - Checking Prerequisites
+Checking Component Prerequisites
+Repository Creation Utility - Creating Tablespaces
+Validating and Creating Tablespaces
+Repository Creation Utility - Create
+Repository Create in progress.
+Percent Complete: 12
+Percent Complete: 30
+Percent Complete: 30
+Percent Complete: 32
+Percent Complete: 34
+Percent Complete: 36
+Percent Complete: 36
+Percent Complete: 36
+Percent Complete: 45
+Percent Complete: 45
+Percent Complete: 55
+Percent Complete: 55
+Percent Complete: 55
+Percent Complete: 63
+Percent Complete: 63
+Percent Complete: 73
+Percent Complete: 73
+Percent Complete: 73
+Percent Complete: 81
+Percent Complete: 81
+Percent Complete: 83
+Percent Complete: 83
+Percent Complete: 85
+Percent Complete: 85
+Percent Complete: 94
+Percent Complete: 94
+Percent Complete: 94
+Percent Complete: 95
+Percent Complete: 96
+Percent Complete: 97
+Percent Complete: 97
+Percent Complete: 100
+
+Repository Creation Utility: Create - Completion Summary
+
+Database details:
+-----------------------------
+Host Name                                    : oracle-db.default.svc.cluster.local
+Port                                         : 1521
+Service Name                                 : DEVPDB.K8S
+Connected As                                 : sys
+Prefix for (prefixable) Schema Owners        : DOMAIN1
+RCU Logfile                                  : /tmp/RCU2019-08-23_21-13_1202784079/logs/rcu.log
+
+Component schemas created:
+-----------------------------
+Component                                    Status         Logfile		
+
+Common Infrastructure Services               Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/stb.log 
+Oracle Platform Security Services            Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/opss.log 
+Audit Services                               Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/iau.log 
+Audit Services Append                        Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/iau_append.log 
+Audit Services Viewer                        Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/iau_viewer.log 
+Metadata Services                            Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/mds.log 
+WebLogic Services                            Success        /tmp/RCU2019-08-23_21-13_1202784079/logs/wls.log 
+
+Repository Creation Utility - Create : Operation Completed
+[INFO] Modify the domain.input.yaml to use [oracle-db.default.svc.cluster.local:1521/devpdb.k8s] as rcuDatabaseURL and [domain1] as rcuSchemaPrefix
+
+```
+
+```
+$ ./drop-rcu-schema.sh -s <schemaPrefix> -d <dburl> 
+```
+The parameters are as follows:
+
+```  
+  -s  RCU Schema Prefix, Must be specified
+  -d  RCU Oracle Database URL (default oracle-db.default.svc.cluster.local:1521/devpdb.k8s) 
+```
+```
+The script drop RCU schema based Schema Prefix and RCU DB URL
+```
+
+```
+$ ./stop-db-service.sh  
+```
+```
+The script stop the DB service created thru start-db-service.sh
+```

--- a/kubernetes/samples/scripts/create-rcu-schema/common/checkPodDelete.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/checkPodDelete.sh
@@ -1,0 +1,47 @@
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+#
+# Description
+# This sample script check if a given pod in a namespace is deleted 
+
+#!/bin/bash
+
+function checkPodDelete(){
+
+pod=$1
+ns=$2
+
+status="Terminating"
+
+if [ -z ${1} ]; then 
+ echo "Either No Pod Name is provided or Pod has been Terminated ..."
+ exit -1 
+fi
+
+echo "Checking Status for Pod [$pod] in namesapce [${ns}]"
+
+max=10
+count=1
+while [ $count -le $max ] ; do
+  sleep 5 
+  pod=`kubectl get po/$1 -n ${ns} | grep -v NAME | awk '{print $1}'`
+  if [ -z ${pod} ]; then 
+    status="Terminated"
+    echo "Pod [$1] removed from nameSpace [${ns}]"
+    break;
+  fi
+  count=`expr $count + 1`
+  echo "Pod [$pod] Status [${status}]"
+done
+
+if [ $count -gt $max ] ; then
+   echo "[ERROR] The Pod[$1] in namespace [$ns] could not be deleted in 50s"; 
+   exit 1
+ fi 
+}
+
+pod=${1:-rcu}
+ns=${2:-default}
+
+checkPodDelete ${pod} ${ns}

--- a/kubernetes/samples/scripts/create-rcu-schema/common/checkPodReady.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/checkPodReady.sh
@@ -1,0 +1,89 @@
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+#
+# Description
+# This sample script check the state of a given pod in a namespace 
+# based on READY column String
+#NAME                READY     STATUS    RESTARTS   AGE
+#domain1-adminserver 1/1       Running   0          4m
+
+function checkPodState(){
+
+status="NotReady"
+max=60
+count=1
+
+pod=$1
+ns=$2
+state=${3:-1/1}
+
+echo "Checking Pod READY column for State [$state]"
+
+pname=`kubectl get po -n ${ns} | grep -w ${pod} | awk '{print $1}'`
+if [ -z ${pname} ]; then 
+ echo "No such pod [$pod] exists in NameSpace [$ns] "
+ exit -1
+fi 
+
+rcode=`kubectl get po ${pname} -n ${ns} | grep -w ${pod} | awk '{print $2}'`
+[[ ${rcode} -eq "${state}"  ]] && status="Ready"
+
+while [ ${status} != "Ready" -a $count -le $max ] ; do
+  sleep 5 
+  rcode=`kubectl get po/$pod -n ${ns} | grep -v NAME | awk '{print $2}'`
+  [[ ${rcode} -eq "1/1"  ]] && status="Ready"
+  echo "Pod [$1] Status is ${status} Iter [$count/$max]"
+  count=`expr $count + 1`
+done
+if [ $count -gt $max ] ; then
+   echo "[ERROR] Unable to start the Pod [$pod] after 300s "; 
+   exit 1
+ fi 
+
+pname=`kubectl get po -n ${ns} | grep -w ${pod} | awk '{print $1}'`
+kubectl -n ${ns} get po ${pname}
+}
+
+function checkPod(){
+
+max=20
+count=1
+
+pod=$1
+ns=$2
+
+pname=`kubectl get po -n ${ns} | grep -w ${pod} | awk '{print $1}'`
+if [ -z ${pname} ]; then 
+ echo "No such pod [$pod] exists in NameSpace [$ns]"
+ sleep 10
+ #exit -1
+fi 
+
+rcode=`kubectl get po -n ${ns} | grep -w ${pod} | awk '{print $1}'`
+if [ ! -z ${rcode} ]; then 
+  echo "[$pod] already initialized .. "
+  return 0
+fi
+
+echo "The POD [${pod}] has not been initialized ..."
+while [ -z ${rcode} ]; do
+ [[ $count -gt $max ]] && break
+ echo "Pod[$pod] is being initialized ..."
+ sleep 5
+ rcode=`kubectl get po -n ${ns} | grep $pod | awk '{print $1}'`
+ count=`expr $count + 1`
+done
+
+if [ $count -gt $max ] ; then
+ echo "[ERROR] Could not find Pod [$pod] after 120s";
+ exit 1
+fi
+}
+
+pod=${1:-domain1-adminserver}
+ns=${2:-weblogic-domain}
+state=${3:-1/1}
+
+checkPod ${pod} ${ns}
+checkPodState ${pod} ${ns} ${state}

--- a/kubernetes/samples/scripts/create-rcu-schema/common/createRepository.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/createRepository.sh
@@ -1,0 +1,38 @@
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+#
+
+. /u01/oracle/wlserver/server/bin/setWLSEnv.sh
+
+echo "Check if the DB Service is Ready to accept Connection ?"
+connectString=${1:-oracle-db.default.svc.cluster.local:1521/devpdb.k8s}
+schemaPrefix=${2:-domain1}
+echo "DB Connection URL [$connectString] and schemaPrefix is [${schemaPrefix}]"
+
+max=20
+counter=0
+while [ $counter -le ${max} ]
+do
+ #java utils.dbping ORACLE_THIN "sys as sysdba" Oradoc_db1 ${connectString}
+ java utils.dbping ORACLE_THIN scott tiger ${connectString} > dbping.err 2>&1
+ [[ $? == 0 ]] && break;
+ ((counter++))
+ echo "[$counter/${max}] Retrying the DB Connection ..."
+ sleep 10
+done
+
+if [ $counter -gt ${max} ]; then
+ echo "[ERRORR] Oracle DB Service is not ready after [${max}] iterations ..."
+ exit -1
+else
+ java utils.dbping ORACLE_THIN scott tiger ${connectString}
+fi
+
+/u01/oracle/oracle_common/bin/rcu -silent -createRepository \
+ -databaseType ORACLE -connectString ${connectString} \
+ -dbUser sys  -dbRole sysdba -useSamePasswordForAllSchemaUsers true \
+ -selectDependentsForComponents true \
+ -schemaPrefix ${schemaPrefix} \
+ -component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER \
+ -component OPSS  -component WLS -component STB < /u01/oracle/pwd.txt

--- a/kubernetes/samples/scripts/create-rcu-schema/common/dropRepository.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/dropRepository.sh
@@ -1,0 +1,38 @@
+# Copyright 2019, Oracle Corporation and/or its affiliates.All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+#
+
+. /u01/oracle/wlserver/server/bin/setWLSEnv.sh
+
+echo "Check if the DB Service is Ready to accept Connection ?"
+connectString=${1:-oracle-db.default.svc.cluster.local:1521/devpdb.k8s}
+schemaPrefix=${2:-domain1}
+echo "DB Connection URL [$connectString] and schemaPrefix is [${schemaPrefix}]"
+
+max=20
+counter=0
+while [ $counter -le ${max} ]
+do
+ #java utils.dbping ORACLE_THIN "sys as sysdba" Oradoc_db1 ${connectString} 
+ java utils.dbping ORACLE_THIN scott tiger ${connectString} > dbping.err 2>&1 
+ [[ $? == 0 ]] && break;
+ ((counter++))
+ echo "[$counter/${max}] Retrying the DB Connection ..."
+ sleep 10
+done
+
+if [ $counter -gt ${max} ]; then 
+ echo "[ERRORR] Oracle DB Service is not ready after [${max}] iterations ..."
+ exit -1
+else 
+ java utils.dbping ORACLE_THIN scott tiger ${connectString} 
+fi 
+
+/u01/oracle/oracle_common/bin/rcu -silent -dropRepository \
+ -databaseType ORACLE -connectString ${connectString} \
+ -dbUser sys  -dbRole sysdba \
+ -selectDependentsForComponents true \
+ -schemaPrefix ${schemaPrefix} \
+ -component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER \
+ -component OPSS  -component WLS -component STB < /u01/oracle/pwd.txt

--- a/kubernetes/samples/scripts/create-rcu-schema/common/oradb.yaml
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/oradb.yaml
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: oracle-db
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dev
+      app.kubernetes.io/name: oracle-db
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: dev
+        app.kubernetes.io/name: oracle-db
+    spec:
+      containers:
+      - env:
+        - name: DB_SID
+          value: devcdb
+        - name: DB_PDB
+          value: devpdb
+        - name: DB_DOMAIN
+          value: k8s
+        image: container-registry.oracle.com/database/enterprise:12.2.0.1-slim
+        imagePullPolicy: IfNotPresent
+        name: oracle-db
+        ports:
+        - containerPort: 1521
+          name: tns
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 200m
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/samples/scripts/create-rcu-schema/common/orasvc.yaml
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/orasvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oracle-db
+  namespace: default
+spec:
+  ports:
+  - name: tns
+    port: 1521
+    protocol: TCP
+    targetPort: 1521
+    nodePort: 30011
+  selector:
+    app.kubernetes.io/instance: dev
+    app.kubernetes.io/name: oracle-db
+  sessionAffinity: None
+  type: NodePort

--- a/kubernetes/samples/scripts/create-rcu-schema/create-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/create-rcu-schema.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+
+# Configure RCU schema based on schemaPreifix and rcuDatabaseURL
+
+script="${BASH_SOURCE[0]}"
+scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+
+function usage {
+  echo "usage: ${script} -s <schemaPrefix> -d <dburl>  [-h]"
+  echo "  -s RCU Schema Prefix, must be specified."
+  echo "  -d RCU Oracle Database URL"
+  echo "  -h Help"
+  exit $1
+}
+
+while getopts "h:s:d:" opt; do
+  case $opt in
+    s) schemaPrefix="${OPTARG}"
+    ;;
+    d) dburl="${OPTARG}"
+    ;;
+    h) usage 0
+    ;;
+    *) usage 1
+    ;;
+  esac
+done
+
+if [ -z ${schemaPrefix} ]; then
+  echo "${script}: -s <schemaPrefix> must be specified."
+  missingRequiredOption="true"
+  usage 1
+fi
+
+if [ -z ${dburl} ]; then
+  dburl="oracle-db.default.svc.cluster.local:1521/devpdb.k8s"
+fi
+
+ocr_pfx=container-registry.oracle.com
+jrf_image=${ocr_pfx}/middleware/fmw-infrastructure:12.2.1.3
+
+dbpod=`kubectl get po | grep oracle | cut -f1 -d " " `
+if [ -z ${dbpod} ]; then
+  echo "!!!! Oracle Service Pod not found in [default] namespace !!!"
+  echo "!!!! Execute the script create-db-service.sh !!!"
+  exit -1
+fi
+
+sh ${scriptDir}/common/checkPodReady.sh ${dbpod} default
+
+docker pull ${jrf_image}
+kubectl run rcu --generator=run-pod/v1 --image ${jrf_image} -- sleep infinity
+sh ${scriptDir}/common/checkPodReady.sh rcu default
+
+sleep 5
+kubectl get po 
+
+# Generate the default password files for rcu command
+echo "Oradoc_db1" > pwd.txt
+echo "Oradoc_db1" >> pwd.txt
+
+kubectl cp ${scriptDir}/common/createRepository.sh  rcu:/u01/oracle
+kubectl cp pwd.txt rcu:/u01/oracle
+rm -rf createRepository.sh pwd.txt
+
+kubectl exec -it rcu /bin/bash /u01/oracle/createRepository.sh ${dburl} ${schemaPrefix}
+
+echo "[INFO] Modify the domain.input.yaml to use [$dburl] as rcuDatabaseURL and [${schemaPrefix}] as rcuSchemaPrefix "

--- a/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+
+# Drop the RCU schema based on schemaPreifix and DbUrl
+
+script="${BASH_SOURCE[0]}"
+scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+
+function usage {
+  echo "usage: ${script} -s <schemaPrefix> -d <dburl>  [-h]"
+  echo "  -s RCU Schema Prefix, must be specified."
+  echo "  -d Oracle Database URL"
+  echo "  -h Help"
+  exit $1
+}
+
+while getopts "h:s:d:" opt; do
+  case $opt in
+    s) schemaPrefix="${OPTARG}"
+    ;;
+    d) dburl="${OPTARG}"
+    ;;
+    h) usage 0
+    ;;
+    *) usage 1
+    ;;
+  esac
+done
+
+if [ -z ${schemaPrefix} ]; then
+  echo "${script}: -s <schemaPrefix> must be specified."
+  missingRequiredOption="true"
+  usage 1
+fi
+
+if [ -z ${dburl} ]; then
+  dburl="oracle-db.default.svc.cluster.local:1521/devpdb.k8s"
+fi
+
+echo "Oradoc_db1" > pwd.txt
+echo "Oradoc_db1" >> pwd.txt
+
+kubectl cp ${scriptDir}/common/dropRepository.sh  rcu:/u01/oracle
+kubectl cp pwd.txt rcu:/u01/oracle
+rm -rf dropRepository.sh pwd.txt
+
+kubectl exec -it rcu /bin/bash /u01/oracle/dropRepository.sh ${dburl} ${schemaPrefix}
+
+kubectl delete pod rcu
+sh ${scriptDir}/common/checkPodDelete.sh rcu default

--- a/kubernetes/samples/scripts/create-rcu-schema/start-db-service.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/start-db-service.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+
+# Bring up Oracle DB Instance in [default] NameSpace with a NodePort Service 
+
+script="${BASH_SOURCE[0]}"
+scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+
+function usage {
+  echo "usage: ${script} -p <nodeport> [-h]"
+  echo "  -p DBService External NodePort"
+  echo "  -h Help"
+  exit $1
+}
+
+while getopts "h:p:" opt; do
+  case $opt in
+    p) nodeport="${OPTARG}"
+    ;;
+    h) usage 0
+    ;;
+    *) usage 1
+    ;;
+  esac
+done
+
+if [ -z ${nodeport} ]; then
+  nodeport=30011
+fi
+
+
+ocr_pfx=container-registry.oracle.com
+db_image=${ocr_pfx}/database/enterprise:12.2.0.1-slim
+docker pull ${db_image}
+
+kubectl apply -f ${scriptDir}/common/oradb.yaml
+# Modify the NodePort based on input 
+sed -i -e "s?nodePort:.*?nodePort: ${nodeport}?g" ${scriptDir}/common/orasvc.yaml
+kubectl apply -f ${scriptDir}/common/orasvc.yaml
+
+dbpod=`kubectl get po | grep oracle-db | cut -f1 -d " " `
+sh ${scriptDir}/common/checkPodReady.sh ${dbpod} default
+
+kubectl get po
+kubectl get service
+
+echo "Oracle DB service is RUNNING with external NodePort [${nodeport}]"

--- a/kubernetes/samples/scripts/create-rcu-schema/stop-db-service.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/stop-db-service.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+# Drop the DB Service created by start-db-service.sh
+
+script="${BASH_SOURCE[0]}"
+scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+
+dbpod=`kubectl get po | grep oracle-db | cut -f1 -d " " `
+kubectl delete -f ${scriptDir}/common/oradb.yaml --ignore-not-found
+kubectl delete -f ${scriptDir}/common/orasvc.yaml --ignore-not-found
+
+if [ -z ${dbpod} ]; then
+  echo "Couldn't find oarcle-db pod in [default] namesapce"
+else
+  sh ${scriptDir}/common/checkPodDelete.sh ${dbpod} default
+fi


### PR DESCRIPTION
Create a new script directory to manage Oracle DB and RCU schema. Following convenient scripts are added into a new directory (create-rcu-schema)  under wblogic-kubernetes-operator/kubernetes/samples/scripts

a. start-db-service.sh
b. stop-db-service.sh
c. create-rcu-schema.sh   
d. drop-rcu-schema.sh 

User can invoke the requited scripts to before invoking create-domain.sh in create-fmw-infrastructure-domain directory as a per-requisite.  No need to copy-n-paste the yaml file/script from the user guide to have a OOTB experience with FMW Infrastructure Domain 