### PR TITLE
PR: owls-76450 fix the JRF domain creation issue

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorTest.java
@@ -93,8 +93,8 @@ public class JrfInOperatorTest extends BaseTest {
    */
   @Test
   public void testJrfDomainOnPvUsingWlst() throws Exception {
-  	Assume.assumeTrue(QUICKTEST);
-  	String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
+    Assume.assumeTrue(QUICKTEST);
+    String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
     logger.info("Creating Operator & waiting for the script to complete execution");
     // create operator1

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1535,7 +1535,7 @@ public class Domain {
       sampleDomainInputsFile =
           "/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml";
     } else if (domainMap.containsKey("rcuDatabaseURL")) {
-    	sampleDomainInputsFile =
+      sampleDomainInputsFile =
           "/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/create-domain-inputs.yaml";
     }
     logger.info("For this domain sampleDomainInputsFile is: " + sampleDomainInputsFile);


### PR DESCRIPTION
This PR includes  1) fixing the originally missing JRF  sampleDomainInputsFile in the Domain.java; 2) adding JrfInOperatorTest.testJrfDomainOnPvUsingWlst into QUICKTEST suite

Latest JRF Jenkins run
http://****/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2421/console

There are still 2 failures which I will continue to work on. But without 1) fix of this PR the JRF domain can not even be created properly. 