### PR TITLE
eliminate duplication logger creation

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -40,8 +40,6 @@ import oracle.kubernetes.operator.helpers.KubernetesUtils;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.LoggingFilter;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.logging.OncePerMessageLoggingFilter;
@@ -65,18 +63,17 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 
 import static oracle.kubernetes.operator.helpers.LegalNames.toJobIntrospectorName;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 public class DomainProcessorImpl implements DomainProcessor {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private static final Map<String, FiberGate> makeRightFiberGates = new ConcurrentHashMap<>();
   private static final Map<String, FiberGate> statusFiberGates = new ConcurrentHashMap<>();
   // Map from namespace to map of domainUID to Domain
   private static final Map<String, Map<String, DomainPresenceInfo>> DOMAINS =
-        new ConcurrentHashMap<>();
+      new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, ConcurrentMap<String, ScheduledFuture<?>>>
-        statusUpdaters = new ConcurrentHashMap<>();
+      statusUpdaters = new ConcurrentHashMap<>();
   private DomainProcessorDelegate delegate;
 
   public DomainProcessorImpl(DomainProcessorDelegate delegate) {
@@ -89,8 +86,8 @@ public class DomainProcessorImpl implements DomainProcessor {
 
   private static void registerDomainPresenceInfo(DomainPresenceInfo info) {
     DOMAINS
-          .computeIfAbsent(info.getNamespace(), k -> new ConcurrentHashMap<>())
-          .put(info.getDomainUid(), info);
+        .computeIfAbsent(info.getNamespace(), k -> new ConcurrentHashMap<>())
+        .put(info.getDomainUid(), info);
   }
 
   private static void unregisterPresenceInfo(String ns, String domainUid) {
@@ -101,9 +98,9 @@ public class DomainProcessorImpl implements DomainProcessor {
   }
 
   private static void registerStatusUpdater(
-        String ns, String domainUid, ScheduledFuture<?> future) {
+      String ns, String domainUid, ScheduledFuture<?> future) {
     ScheduledFuture<?> existing =
-          statusUpdaters.computeIfAbsent(ns, k -> new ConcurrentHashMap<>()).put(domainUid, future);
+        statusUpdaters.computeIfAbsent(ns, k -> new ConcurrentHashMap<>()).put(domainUid, future);
     if (existing != null) {
       existing.cancel(false);
     }
@@ -130,29 +127,29 @@ public class DomainProcessorImpl implements DomainProcessor {
     if (status == null) return;
 
     Optional.ofNullable(DOMAINS.get(event.getMetadata().getNamespace()))
-          .map(m -> m.get(domainUid))
-          .ifPresent(info -> info.updateLastKnownServerStatus(serverName, status));
+        .map(m -> m.get(domainUid))
+        .ifPresent(info -> info.updateLastKnownServerStatus(serverName, status));
   }
 
   private static String getReadinessStatus(V1Event event) {
     return Optional.ofNullable(event.getMessage())
-          .filter(m -> m.contains(WebLogicConstants.READINESS_PROBE_NOT_READY_STATE))
-          .map(m -> m.substring(m.lastIndexOf(':') + 1).trim())
-          .orElse(null);
+        .filter(m -> m.contains(WebLogicConstants.READINESS_PROBE_NOT_READY_STATE))
+        .map(m -> m.substring(m.lastIndexOf(':') + 1).trim())
+        .orElse(null);
   }
 
   private static Step readExistingPods(DomainPresenceInfo info) {
     return new CallBuilder()
-          .withLabelSelectors(
-                LabelConstants.forDomainUidSelector(info.getDomainUid()),
-                LabelConstants.CREATEDBYOPERATOR_LABEL)
-          .listPodAsync(info.getNamespace(), new PodListStep(info));
+        .withLabelSelectors(
+            LabelConstants.forDomainUidSelector(info.getDomainUid()),
+            LabelConstants.CREATEDBYOPERATOR_LABEL)
+        .listPodAsync(info.getNamespace(), new PodListStep(info));
   }
 
   // pre-conditions: DomainPresenceInfo SPI
   // "principal"
   static Step bringAdminServerUp(
-        DomainPresenceInfo info, PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
+      DomainPresenceInfo info, PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
     return Step.chain(bringAdminServerUpSteps(info, podAwaiterStepFactory, next));
   }
 
@@ -164,7 +161,7 @@ public class DomainProcessorImpl implements DomainProcessor {
   }
 
   private static Step[] bringAdminServerUpSteps(
-        DomainPresenceInfo info, PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
+      DomainPresenceInfo info, PodAwaiterStepFactory podAwaiterStepFactory, Step next) {
     List<Step> resources = new ArrayList<>();
     resources.add(new BeforeAdminServiceStep(null));
     resources.add(PodHelper.createAdminPodStep(null));
@@ -472,8 +469,7 @@ public class DomainProcessorImpl implements DomainProcessor {
       Step strategy =
           new StartPlanStep(
               info, isDeleting ? createDomainDownPlan(info) : createDomainUpPlan(info));
-      if (!isDeleting && dom != null)
-        strategy = new DomainValidationStep(dom, strategy);
+      if (!isDeleting && dom != null) strategy = new DomainValidationStep(dom, strategy);
 
       runDomainPlan(
           dom,
@@ -632,8 +628,8 @@ public class DomainProcessorImpl implements DomainProcessor {
     @Override
     public NextAction onFailure(Packet packet, CallResponse<V1PodList> callResponse) {
       return callResponse.getStatusCode() == CallBuilder.NOT_FOUND
-            ? onSuccess(packet, callResponse)
-            : super.onFailure(packet, callResponse);
+          ? onSuccess(packet, callResponse)
+          : super.onFailure(packet, callResponse);
     }
 
     @Override
@@ -689,8 +685,8 @@ public class DomainProcessorImpl implements DomainProcessor {
     @Override
     public NextAction onFailure(Packet packet, CallResponse<V1ServiceList> callResponse) {
       return callResponse.getStatusCode() == CallBuilder.NOT_FOUND
-            ? onSuccess(packet, callResponse)
-            : super.onFailure(packet, callResponse);
+          ? onSuccess(packet, callResponse)
+          : super.onFailure(packet, callResponse);
     }
 
     @Override
@@ -724,10 +720,10 @@ public class DomainProcessorImpl implements DomainProcessor {
       PodAwaiterStepFactory pw = delegate.getPodAwaiterStepFactory(info.getNamespace());
       info.setDeleting(false);
       packet
-            .getComponents()
-            .put(
-                  ProcessingConstants.DOMAIN_COMPONENT_NAME,
-                  Component.createFor(info, delegate.getVersion(), PodAwaiterStepFactory.class, pw));
+          .getComponents()
+          .put(
+              ProcessingConstants.DOMAIN_COMPONENT_NAME,
+              Component.createFor(info, delegate.getVersion(), PodAwaiterStepFactory.class, pw));
       return doNext(packet);
     }
   }
@@ -767,10 +763,10 @@ public class DomainProcessorImpl implements DomainProcessor {
       unregisterStatusUpdater(ns, info.getDomainUid());
       PodAwaiterStepFactory pw = delegate.getPodAwaiterStepFactory(ns);
       packet
-            .getComponents()
-            .put(
-                  ProcessingConstants.DOMAIN_COMPONENT_NAME,
-                  Component.createFor(info, delegate.getVersion(), PodAwaiterStepFactory.class, pw));
+          .getComponents()
+          .put(
+              ProcessingConstants.DOMAIN_COMPONENT_NAME,
+              Component.createFor(info, delegate.getVersion(), PodAwaiterStepFactory.class, pw));
       return doNext(packet);
     }
   }
@@ -788,9 +784,9 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     public void invoke() {
       Optional.ofNullable(getMatchingContainerStatus())
-            .map(V1ContainerStatus::getState)
-            .map(V1ContainerState::getWaiting)
-            .ifPresent(waiting -> updateStatus(waiting.getReason(), waiting.getMessage()));
+          .map(V1ContainerStatus::getState)
+          .map(V1ContainerState::getWaiting)
+          .ifPresent(waiting -> updateStatus(waiting.getReason(), waiting.getMessage()));
     }
 
     private void updateStatus(String reason, String message) {
@@ -799,12 +795,13 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     private V1ContainerStatus getMatchingContainerStatus() {
       return Optional.ofNullable(pod.getStatus())
-            .map(V1PodStatus::getContainerStatuses)
-            .flatMap(this::getMatchingContainerStatus)
-            .orElse(null);
+          .map(V1PodStatus::getContainerStatuses)
+          .flatMap(this::getMatchingContainerStatus)
+          .orElse(null);
     }
 
-    private Optional<V1ContainerStatus> getMatchingContainerStatus(Collection<V1ContainerStatus> statuses) {
+    private Optional<V1ContainerStatus> getMatchingContainerStatus(
+        Collection<V1ContainerStatus> statuses) {
       return statuses.stream().filter(this::hasInstrospectorJobName).findFirst();
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -23,8 +23,6 @@ import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo.ServerStartupInfo;
 import oracle.kubernetes.operator.helpers.PodHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.rest.Scan;
 import oracle.kubernetes.operator.rest.ScanCache;
@@ -47,6 +45,7 @@ import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_STATE_MAP;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Available;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Progressing;
@@ -57,11 +56,12 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Progre
  * processing flow can use to explicitly set the condition to Progressing or Failed.
  */
 public class DomainStatusUpdater {
-  public static final String INSPECTING_DOMAIN_PROGRESS_REASON = "InspectingDomainPrescence";
   public static final String MANAGED_SERVERS_STARTING_PROGRESS_REASON = "ManagedServersStarting";
-  public static final String SERVERS_READY_REASON = "ServersReady";
   public static final String ALL_STOPPED_AVAILABLE_REASON = "AllServersStopped";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  static final String INSPECTING_DOMAIN_PROGRESS_REASON = "InspectingDomainPresence";
+  static final String SERVERS_READY_REASON = "ServersReady";
+
   private static final String TRUE = "True";
   private static final String FALSE = "False";
 
@@ -129,7 +129,7 @@ public class DomainStatusUpdater {
                 meta.getName(),
                 meta.getNamespace(),
                 dom,
-                new DefaultResponseStep<Domain>(next) {
+                new DefaultResponseStep<>(next) {
                   @Override
                   public NextAction onFailure(Packet packet, CallResponse<Domain> callResponse) {
                     if (callResponse.getStatusCode() == CallBuilder.NOT_FOUND) {
@@ -159,7 +159,7 @@ public class DomainStatusUpdater {
         .readDomainAsync(
             meta.getName(),
             meta.getNamespace(),
-            new DefaultResponseStep<Domain>(next) {
+            new DefaultResponseStep<>(next) {
               @Override
               public NextAction onSuccess(Packet packet, CallResponse<Domain> callResponse) {
                 info.setDomain(callResponse.getResult());
@@ -290,9 +290,8 @@ public class DomainStatusUpdater {
       }
 
       private Stream<ServerStartupInfo> getServerStartupInfos() {
-        return Optional.ofNullable(getInfo().getServerStartupInfo())
-            .map(Collection::stream)
-            .orElse(Stream.empty());
+        return Optional.ofNullable(getInfo().getServerStartupInfo()).stream()
+            .flatMap(Collection::stream);
       }
 
       private Optional<WlsDomainConfig> getDomainConfig() {
@@ -302,7 +301,7 @@ public class DomainStatusUpdater {
       private Optional<WlsDomainConfig> getScanCacheDomainConfig() {
         DomainPresenceInfo info = getInfo();
         Scan scan = ScanCache.INSTANCE.lookupScan(info.getNamespace(), info.getDomainUid());
-        return Optional.ofNullable(scan).map(s -> s.getWlsDomainConfig());
+        return Optional.ofNullable(scan).map(Scan::getWlsDomainConfig);
       }
 
       private boolean shouldBeRunning(ServerStartupInfo startupInfo) {
@@ -322,7 +321,9 @@ public class DomainStatusUpdater {
       }
 
       private boolean hasReadyServerPod(String serverName) {
-        return Optional.ofNullable(getInfo().getServerPod(serverName)).filter(PodHelper::getReadyStatus).isPresent();
+        return Optional.ofNullable(getInfo().getServerPod(serverName))
+            .filter(PodHelper::getReadyStatus)
+            .isPresent();
       }
 
       Map<String, ServerStatus> getServerStatuses() {
@@ -376,12 +377,16 @@ public class DomainStatusUpdater {
       private ClusterStatus createClusterStatus(String clusterName) {
         return new ClusterStatus()
             .withClusterName(clusterName)
-            .withReplicas(Optional.ofNullable(getClusterCounts().get(clusterName)).map(Long::intValue).orElse(null))
+            .withReplicas(
+                Optional.ofNullable(getClusterCounts().get(clusterName))
+                    .map(Long::intValue)
+                    .orElse(null))
             .withReadyReplicas(
-                Optional.ofNullable(getClusterCounts(true).get(clusterName)).map(Long::intValue).orElse(null))
+                Optional.ofNullable(getClusterCounts(true).get(clusterName))
+                    .map(Long::intValue)
+                    .orElse(null))
             .withMaximumReplicas(getClusterMaximumSize(clusterName));
       }
-
 
       private String getNodeName(String serverName) {
         return Optional.ofNullable(getInfo().getServerPod(serverName))
@@ -403,26 +408,34 @@ public class DomainStatusUpdater {
 
       private Collection<String> getServerNames() {
         Set<String> result = new HashSet<>();
-        getDomainConfig().stream().forEach(config -> {
-          result.addAll(config.getServerConfigs().keySet());
-          for (WlsClusterConfig cluster : config.getConfiguredClusters()) {
-            Optional.ofNullable(cluster.getDynamicServersConfig())
-                .ifPresent(dynamicConfig -> Optional.ofNullable(dynamicConfig.getServerConfigs())
-                    .ifPresent(servers -> servers.stream().forEach(item -> result.add(item.getName()))));
-          }
-        });
+        getDomainConfig()
+            .ifPresent(
+                config -> {
+                  result.addAll(config.getServerConfigs().keySet());
+                  for (WlsClusterConfig cluster : config.getConfiguredClusters()) {
+                    Optional.ofNullable(cluster.getDynamicServersConfig())
+                        .ifPresent(
+                            dynamicConfig ->
+                                Optional.ofNullable(dynamicConfig.getServerConfigs())
+                                    .ifPresent(
+                                        servers ->
+                                            servers.forEach(item -> result.add(item.getName()))));
+                  }
+                });
         return result;
       }
 
       private Collection<String> getClusterNames() {
         Set<String> result = new HashSet<>();
-        getDomainConfig().stream().forEach(config -> result.addAll(config.getClusterConfigs().keySet()));
+        getDomainConfig().ifPresent(config -> result.addAll(config.getClusterConfigs().keySet()));
         return result;
       }
 
       private Integer getClusterMaximumSize(String clusterName) {
-        return getDomainConfig().map(config -> Optional.ofNullable(config.getClusterConfig(clusterName)))
-            .map(cluster -> cluster.map(c -> c.getMaxClusterSize()).orElse(0)).get();
+        return getDomainConfig()
+            .map(config -> Optional.ofNullable(config.getClusterConfig(clusterName)))
+            .map(cluster -> cluster.map(WlsClusterConfig::getMaxClusterSize).orElse(0))
+            .get();
       }
     }
   }
@@ -529,7 +542,8 @@ public class DomainStatusUpdater {
     }
   }
 
-  private static boolean modifyDomainStatus(DomainStatus domainStatus, Consumer<DomainStatus> statusUpdateConsumer) {
+  private static boolean modifyDomainStatus(
+      DomainStatus domainStatus, Consumer<DomainStatus> statusUpdateConsumer) {
     final DomainStatus currentStatus = new DomainStatus(domainStatus);
     synchronized (domainStatus) {
       statusUpdateConsumer.accept(domainStatus);
@@ -565,7 +579,6 @@ public class DomainStatusUpdater {
                   s.addCondition(new DomainCondition(Progressing).withStatus(FALSE));
                 }
               });
-
 
       LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomain().getDomainUid(), status);
       LOGGER.exiting();

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -45,8 +45,6 @@ import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.rest.RestConfigImpl;
 import oracle.kubernetes.operator.rest.RestServer;
@@ -67,16 +65,18 @@ import oracle.kubernetes.weblogic.domain.model.DomainList;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /** A Kubernetes Operator for WebLogic. */
 public class Main {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private static final String DPI_MAP = "DPI_MAP";
+  private static final String THREAD_FACTORY_ID = "operator";
 
   private static final Container container = new Container();
   private static final ThreadFactory threadFactory = new WrappedThreadFactory();
   private static final ScheduledExecutorService wrappedExecutorService =
-      Engine.wrappedExecutorService("operator", container);
+      Engine.wrappedExecutorService(THREAD_FACTORY_ID, container);
   private static final TuningParameters tuningAndConfig;
   private static final CallBuilderFactory callBuilderFactory = new CallBuilderFactory();
   private static final Map<String, AtomicBoolean> isNamespaceStarted = new ConcurrentHashMap<>();

--- a/operator/src/main/java/oracle/kubernetes/operator/OperatorLiveness.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/OperatorLiveness.java
@@ -8,9 +8,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * This task maintains the "liveness" indicator so that Kubernetes knows the Operator is still
@@ -18,9 +18,9 @@ import oracle.kubernetes.operator.logging.MessageKeys;
  */
 public class OperatorLiveness implements Runnable {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private final File livenessFile = new File("/operator/.alive");
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override
   public void run() {
     if (!livenessFile.exists()) {

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -25,8 +25,6 @@ import oracle.kubernetes.operator.helpers.ClientPool;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.LastKnownStatus;
 import oracle.kubernetes.operator.helpers.PodHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.steps.ReadHealthStep;
 import oracle.kubernetes.operator.utils.KubernetesExec;
@@ -41,10 +39,10 @@ import org.joda.time.DateTime;
 import static oracle.kubernetes.operator.KubernetesConstants.CONTAINER_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_STATE_MAP;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** Creates an asynchronous step to read the WebLogic server state from a particular pod. */
 public class ServerStatusReader {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static KubernetesExecFactory EXEC_FACTORY = new KubernetesExecFactoryImpl();
   private static Function<Step, Step> STEP_FACTORY = ReadHealthStep::createReadHealthStep;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
@@ -10,12 +10,11 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import oracle.kubernetes.operator.helpers.ConfigMapConsumer;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public class TuningParametersImpl extends ConfigMapConsumer implements TuningParameters {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static TuningParameters INSTANCE = null;
 
   private final ReadWriteLock lock = new ReentrantReadWriteLock();

--- a/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
@@ -15,12 +15,12 @@ import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.builders.WatchI;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.watcher.WatchListener;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.net.HttpURLConnection.HTTP_GONE;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * This class handles the Watching interface and drives the watch support for a specific type of
@@ -30,7 +30,6 @@ import static java.net.HttpURLConnection.HTTP_GONE;
  */
 abstract class Watcher<T> {
   static final String HAS_NEXT_EXCEPTION_MESSAGE = "IO Exception during hasNext method.";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final long IGNORED_RESOURCE_VERSION = 0;
 
   private final AtomicBoolean isDraining = new AtomicBoolean(false);
@@ -50,8 +49,7 @@ abstract class Watcher<T> {
    * @param stopping an atomic boolean to watch to determine when to stop the watcher
    */
   Watcher(String resourceVersion, WatchTuning tuning, AtomicBoolean stopping) {
-    this.resourceVersion =
-        !isNullOrEmptyString(resourceVersion) ? Long.parseLong(resourceVersion) : 0;
+    this.resourceVersion = isNullOrEmpty(resourceVersion) ? 0 : Long.parseLong(resourceVersion);
     this.tuning = tuning;
     this.stopping = stopping;
   }
@@ -71,10 +69,6 @@ abstract class Watcher<T> {
       WatchListener<T> listener) {
     this(resourceVersion, tuning, stopping);
     this.listener = listener;
-  }
-
-  private static boolean isNullOrEmptyString(String s) {
-    return s == null || s.equals("");
   }
 
   /** Waits for this watcher's thread to exit. For unit testing only. */
@@ -219,7 +213,7 @@ abstract class Watcher<T> {
         int index2 = message.indexOf(')', index1 + 1);
         if (index2 > 0) {
           String val = message.substring(index1 + 1, index2);
-          if (!isNullOrEmptyString(val)) {
+          if (!isNullOrEmpty(val)) {
             return Long.parseLong(val);
           }
         }
@@ -254,7 +248,7 @@ abstract class Watcher<T> {
       Method getMetadata = object.getClass().getDeclaredMethod("getMetadata");
       V1ObjectMeta metadata = (V1ObjectMeta) getMetadata.invoke(object);
       String val = metadata.getResourceVersion();
-      return !isNullOrEmptyString(val) ? Long.parseLong(val) : 0;
+      return isNullOrEmpty(val) ? 0 : Long.parseLong(val);
     } catch (Exception e) {
       LOGGER.warning(MessageKeys.EXCEPTION, e);
       return IGNORED_RESOURCE_VERSION;

--- a/operator/src/main/java/oracle/kubernetes/operator/authentication/Authenticator.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/authentication/Authenticator.java
@@ -17,8 +17,8 @@ import io.kubernetes.client.models.V1ObjectReference;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.util.Config;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * This class contains methods to authenticate to the Kubernetes API Server in different ways and to
@@ -30,7 +30,6 @@ public class Authenticator {
   private static final String SERVICE_PORT = "KUBERNETES_SERVICE_PORT";
   // private final String _TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
   // private final String _CACERT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private final ApiClient apiClient;
   private final Helpers helper;
   private String serviceToken;

--- a/operator/src/main/java/oracle/kubernetes/operator/authentication/Helpers.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/authentication/Helpers.java
@@ -15,9 +15,9 @@ import io.kubernetes.client.models.V1ObjectReference;
 import io.kubernetes.client.models.V1Secret;
 import io.kubernetes.client.models.V1ServiceAccount;
 import io.kubernetes.client.models.V1ServiceAccountList;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import org.apache.commons.codec.binary.Base64;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * This class provides helper methods for getting Service Accounts and Secrets for authentication
@@ -25,9 +25,9 @@ import org.apache.commons.codec.binary.Base64;
  */
 public class Helpers {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   @SuppressWarnings("unused")
   private final Authenticator authenticator;
+
   private final ApiClient apiClient;
   private final CoreV1Api coreApi;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
@@ -20,13 +20,13 @@ import io.kubernetes.client.models.V1ListMeta;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.ClientPool;
 import oracle.kubernetes.operator.helpers.ResponseStep;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * A Step driven by an asynchronous call to the Kubernetes API, which results in a series of
@@ -39,7 +39,6 @@ public class AsyncRequestStep<T> extends Step {
   private static final int LOW = 10;
   private static final int SCALE = 100;
   private static final int MAX = 10000;
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private final ClientPool helper;
   private final RequestParams requestParams;
@@ -148,7 +147,7 @@ public class AsyncRequestStep<T> extends Step {
     return doSuspend(
         (fiber) -> {
           ApiCallback<T> callback =
-              new BaseApiCallback<T>() {
+              new BaseApiCallback<>() {
                 @Override
                 public void onFailure(
                     ApiException ae, int statusCode, Map<String, List<String>> responseHeaders) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AuthenticationProxy.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AuthenticationProxy.java
@@ -8,14 +8,12 @@ import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1TokenReview;
 import io.kubernetes.client.models.V1TokenReviewSpec;
 import io.kubernetes.client.models.V1TokenReviewStatus;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** Delegate authentication decisions to Kubernetes. */
 public class AuthenticationProxy {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private static final AuthorizationProxy authorizationProxy = new AuthorizationProxy();
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AuthorizationProxy.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AuthorizationProxy.java
@@ -16,13 +16,12 @@ import io.kubernetes.client.models.V1SelfSubjectRulesReviewSpec;
 import io.kubernetes.client.models.V1SubjectAccessReview;
 import io.kubernetes.client.models.V1SubjectAccessReviewSpec;
 import io.kubernetes.client.models.V1SubjectAccessReviewStatus;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** Delegate authorization decisions to Kubernetes ABAC and/or RBAC. */
 public class AuthorizationProxy {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /**
    * Check if the specified principal is allowed to perform the specified operation on the specified

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ClientPool.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ClientPool.java
@@ -16,14 +16,13 @@ import com.squareup.okhttp.Dispatcher;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.Configuration;
 import io.kubernetes.client.util.Config;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.Container;
 import oracle.kubernetes.operator.work.ContainerResolver;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public class ClientPool extends Pool<ApiClient> {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final ClientFactory FACTORY = new DefaultClientFactory();
   private static ClientPool SINGLETON = new ClientPool();
   private static ThreadFactory threadFactory;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapConsumer.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapConsumer.java
@@ -16,9 +16,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * Kubernetes mounts ConfigMaps in the Pod's file-system as directories where the contained files
@@ -26,8 +26,6 @@ import oracle.kubernetes.operator.logging.MessageKeys;
  * parsing this data and representing it as a Map.
  */
 public class ConfigMapConsumer implements Map<String, String> {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private final File mountPointDir;
   private final ScheduledExecutorService threadPool;
   private final AtomicReference<ScheduledFuture<?>> future = new AtomicReference<>(null);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -22,8 +22,6 @@ import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.rest.Scan;
 import oracle.kubernetes.operator.rest.ScanCache;
@@ -37,10 +35,9 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.VersionConstants.DEFAULT_DOMAIN_VERSION;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 public class ConfigMapHelper {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private static final String SCRIPT_LOCATION = "/scripts";
   private static final ConfigMapComparator COMPARATOR = new ConfigMapComparatorImpl();
 
@@ -134,11 +131,10 @@ public class ConfigMapHelper {
 
   static String extractFilename(String line) {
     int lastSlash = line.lastIndexOf('/');
-    String fname = line.substring(lastSlash + 1, line.length());
-    return fname;
+    return line.substring(lastSlash + 1, line.length());
   }
 
-  public static DomainTopology parseDomainTopologyYaml(String topologyYaml) {
+  static DomainTopology parseDomainTopologyYaml(String topologyYaml) {
     ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
     try {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -25,8 +25,6 @@ import io.kubernetes.client.models.V1beta1JSONSchemaProps;
 import oracle.kubernetes.json.SchemaGenerator;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
@@ -35,10 +33,10 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /** Helper class to ensure Domain CRD is created. */
 public class CrdHelper {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private static final CrdComparator COMPARATOR = new CrdComparatorImpl();
 
   private CrdHelper() {
@@ -110,8 +108,7 @@ public class CrdHelper {
     }
 
     static V1ObjectMeta createMetadata() {
-      return new V1ObjectMeta()
-          .name(KubernetesConstants.CRD_NAME);
+      return new V1ObjectMeta().name(KubernetesConstants.CRD_NAME);
     }
 
     static V1beta1CustomResourceDefinitionSpec createSpec(KubernetesVersion version) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/FileGroupReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/FileGroupReader.java
@@ -18,17 +18,15 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * This class can load a group of files under a specified classpath directory into a map. It handles
  * both files on the file system and in a JAR.
  */
 class FileGroupReader {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private String pathToGroup;
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
@@ -13,15 +13,12 @@ import io.kubernetes.client.models.V1ResourceRule;
 import io.kubernetes.client.models.V1SelfSubjectRulesReview;
 import io.kubernetes.client.models.V1SubjectRulesReviewStatus;
 import io.kubernetes.client.models.VersionInfo;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** A Helper Class for checking the health of the WebLogic Operator. */
 public final class HealthCheckHelper {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private static final Map<AuthorizationProxy.Resource, AuthorizationProxy.Operation[]>
       namespaceAccessChecks = new HashMap<>();
   private static final Map<AuthorizationProxy.Resource, AuthorizationProxy.Operation[]>

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -19,8 +19,6 @@ import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.steps.ManagedServersUpStep;
@@ -37,10 +35,11 @@ import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public class JobHelper {
 
   static final String START_TIME = "WlsRetriever-startTime";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   static final String INTROSPECTOR_LOG_PREFIX = "Introspector Job Log: ";
   private static final String EOL_PATTERN = "\\r?\\n";
 
@@ -96,15 +95,15 @@ public class JobHelper {
       int replicaCount = dom.getReplicaCount(cluster.getClusterName());
       String clusterServerStartPolicy = cluster.getServerStartPolicy();
       LOGGER.fine(
-            "Start Policy: "
-                  + clusterServerStartPolicy
-                  + ", replicaCount: "
-                  + replicaCount
-                  + " for cluster: "
-                  + cluster);
+          "Start Policy: "
+              + clusterServerStartPolicy
+              + ", replicaCount: "
+              + replicaCount
+              + " for cluster: "
+              + cluster);
       if ((clusterServerStartPolicy == null
-            || !clusterServerStartPolicy.equals(ConfigurationConstants.START_NEVER))
-            && replicaCount > 0) {
+              || !clusterServerStartPolicy.equals(ConfigurationConstants.START_NEVER))
+          && replicaCount > 0) {
         return true;
       }
     }
@@ -114,7 +113,7 @@ public class JobHelper {
     // NOTE: domainServerStartPolicy == null indicates default policy
     String domainServerStartPolicy = dom.getSpec().getServerStartPolicy();
     if (domainServerStartPolicy == null
-          || !domainServerStartPolicy.equals(ConfigurationConstants.START_NEVER)) {
+        || !domainServerStartPolicy.equals(ConfigurationConstants.START_NEVER)) {
       return true;
     }
 
@@ -123,7 +122,7 @@ public class JobHelper {
     for (ManagedServer server : servers) {
       String serverStartPolicy = server.getServerStartPolicy();
       if (serverStartPolicy == null
-            || !serverStartPolicy.equals(ConfigurationConstants.START_NEVER)) {
+          || !serverStartPolicy.equals(ConfigurationConstants.START_NEVER)) {
         return true;
       }
     }
@@ -153,7 +152,7 @@ public class JobHelper {
    */
   private static Step readDomainIntrospectorPodLogStep(Step next) {
     return createWatchDomainIntrospectorJobReadyStep(
-          readDomainIntrospectorPodStep(readDomainIntrospectorPodLog(next)));
+        readDomainIntrospectorPodStep(readDomainIntrospectorPodLog(next)));
   }
 
   /**
@@ -215,7 +214,7 @@ public class JobHelper {
     List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
       // Pod for introspector job would use same environment variables as for admin server
       List<V1EnvVar> vars =
-            PodHelper.createCopy(getDomain().getAdminServerSpec().getEnvironmentVariables());
+          PodHelper.createCopy(getDomain().getAdminServerSpec().getEnvironmentVariables());
 
       addEnvVar(vars, ServerEnvVars.DOMAIN_UID, getDomainUid());
       addEnvVar(vars, ServerEnvVars.DOMAIN_HOME, getDomainHome());
@@ -224,7 +223,8 @@ public class JobHelper {
       addEnvVar(vars, ServerEnvVars.SERVER_OUT_IN_POD_LOG, getIncludeServerOutInPodLog());
       addEnvVar(vars, IntrospectorJobEnvVars.NAMESPACE, getNamespace());
       addEnvVar(vars, IntrospectorJobEnvVars.INTROSPECT_HOME, getIntrospectHome());
-      addEnvVar(vars, IntrospectorJobEnvVars.CREDENTIALS_SECRET_NAME, getWebLogicCredentialsSecretName());
+      addEnvVar(
+          vars, IntrospectorJobEnvVars.CREDENTIALS_SECRET_NAME, getWebLogicCredentialsSecretName());
 
       return vars;
     }
@@ -245,11 +245,11 @@ public class JobHelper {
         packet.putIfAbsent(START_TIME, System.currentTimeMillis());
 
         return doNext(
-              context.createNewJob(
-                    readDomainIntrospectorPodLogStep(
-                          deleteDomainIntrospectorJobStep(
-                                ConfigMapHelper.createSitConfigMapStep(getNext())))),
-              packet);
+            context.createNewJob(
+                readDomainIntrospectorPodLogStep(
+                    deleteDomainIntrospectorJobStep(
+                        ConfigMapHelper.createSitConfigMapStep(getNext())))),
+            packet);
       }
 
       return doNext(getNext(), packet);
@@ -282,11 +282,11 @@ public class JobHelper {
       String jobName = JobHelper.createJobName(domainUid);
       logJobDeleted(domainUid, namespace, jobName);
       return new CallBuilder()
-            .deleteJobAsync(
-                  jobName,
-                  namespace,
-                  new V1DeleteOptions().propagationPolicy("Foreground"),
-                  new DefaultResponseStep<>(next));
+          .deleteJobAsync(
+              jobName,
+              namespace,
+              new V1DeleteOptions().propagationPolicy("Foreground"),
+              new DefaultResponseStep<>(next));
     }
   }
 
@@ -312,8 +312,8 @@ public class JobHelper {
 
     private Step readDomainIntrospectorPodLog(String jobPodName, String namespace, Step next) {
       return new CallBuilder()
-            .readPodLogAsync(
-                  jobPodName, namespace, new ReadDomainIntrospectorPodLogResponseStep(next));
+          .readPodLogAsync(
+              jobPodName, namespace, new ReadDomainIntrospectorPodLogResponseStep(next));
     }
   }
 
@@ -337,7 +337,7 @@ public class JobHelper {
       }
 
       V1Job domainIntrospectorJob =
-            (V1Job) packet.remove(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB);
+          (V1Job) packet.remove(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB);
       if (isNotComplete(domainIntrospectorJob)) return onFailure(packet, callResponse);
 
       return doNext(packet);
@@ -409,7 +409,7 @@ public class JobHelper {
 
     private void updateStatus(DomainPresenceInfo domainPresenceInfo) {
       DomainStatusPatch.updateDomainStatus(
-            domainPresenceInfo.getDomain(), "ErrIntrospector", onSeparateLines(severeStatuses));
+          domainPresenceInfo.getDomain(), "ErrIntrospector", onSeparateLines(severeStatuses));
     }
 
     private String onSeparateLines(List<String> lines) {
@@ -434,8 +434,8 @@ public class JobHelper {
 
     private Step readDomainIntrospectorPod(String domainUid, String namespace, Step next) {
       return new CallBuilder()
-            .withLabelSelectors(LabelConstants.JOBNAME_LABEL)
-            .listPodAsync(namespace, new PodListStep(domainUid, next));
+          .withLabelSelectors(LabelConstants.JOBNAME_LABEL)
+          .listPodAsync(namespace, new PodListStep(domainUid, next));
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -24,19 +24,17 @@ import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public abstract class JobStepContext extends BasePodStepContext {
-  static final long DEFAULT_ACTIVE_DEADLINE_SECONDS = 120L;
   static final long DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS = 60L;
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final String WEBLOGIC_OPERATOR_SCRIPTS_INTROSPECT_DOMAIN_SH =
-        "/weblogic-operator/scripts/introspectDomain.sh";
+      "/weblogic-operator/scripts/introspectDomain.sh";
   private final DomainPresenceInfo info;
   private V1Job jobModel;
 
@@ -83,8 +81,10 @@ public abstract class JobStepContext extends BasePodStepContext {
 
   @Override
   protected Map<String, String> augmentSubVars(Map<String, String> vars) {
-    // For other introspector job pod content, we use the values that would apply administration server; however,
-    // since we won't know the name of the administation server from the domain configuration until introspection
+    // For other introspector job pod content, we use the values that would apply administration
+    // server; however,
+    // since we won't know the name of the administation server from the domain configuration until
+    // introspection
     // has run, we will use the hardcoded value "introspector" as the server name.
     vars.put("SERVER_NAME", "introspector");
     return vars;
@@ -160,51 +160,53 @@ public abstract class JobStepContext extends BasePodStepContext {
 
   private V1Job createJobModel() {
     return new V1Job()
-          .metadata(createMetadata())
-          .spec(createJobSpec(TuningParameters.getInstance()));
+        .metadata(createMetadata())
+        .spec(createJobSpec(TuningParameters.getInstance()));
   }
 
   V1ObjectMeta createMetadata() {
     return new V1ObjectMeta()
-          .name(getJobName())
-          .namespace(getNamespace())
-          .putLabelsItem(LabelConstants.RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1)
-          .putLabelsItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
-          .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
+        .name(getJobName())
+        .namespace(getNamespace())
+        .putLabelsItem(LabelConstants.RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1)
+        .putLabelsItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
+        .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
   }
 
   private long getActiveDeadlineSeconds(TuningParameters.PodTuning podTuning) {
     return podTuning.introspectorJobActiveDeadlineSeconds
-          + (DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS * info.getRetryCount());
+        + (DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS * info.getRetryCount());
   }
 
   V1JobSpec createJobSpec(TuningParameters tuningParameters) {
     LOGGER.fine(
-          "Creating job "
-                + getJobName()
-                + " with activeDeadlineSeconds = "
-                + getActiveDeadlineSeconds(tuningParameters.getPodTuning()));
+        "Creating job "
+            + getJobName()
+            + " with activeDeadlineSeconds = "
+            + getActiveDeadlineSeconds(tuningParameters.getPodTuning()));
 
     return new V1JobSpec()
-          .backoffLimit(0)
-          .activeDeadlineSeconds(getActiveDeadlineSeconds(tuningParameters.getPodTuning()))
-          .template(createPodTemplateSpec(tuningParameters));
+        .backoffLimit(0)
+        .activeDeadlineSeconds(getActiveDeadlineSeconds(tuningParameters.getPodTuning()))
+        .template(createPodTemplateSpec(tuningParameters));
   }
 
   private V1PodTemplateSpec createPodTemplateSpec(TuningParameters tuningParameters) {
-    V1PodTemplateSpec podTemplateSpec = new V1PodTemplateSpec()
-          .metadata(createPodTemplateMetadata())
-          .spec(createPodSpec(tuningParameters));
+    V1PodTemplateSpec podTemplateSpec =
+        new V1PodTemplateSpec()
+            .metadata(createPodTemplateMetadata())
+            .spec(createPodSpec(tuningParameters));
 
     return updateForDeepSubstitution(podTemplateSpec.getSpec(), podTemplateSpec);
   }
 
   private V1ObjectMeta createPodTemplateMetadata() {
-    V1ObjectMeta metadata = new V1ObjectMeta()
-          .name(getJobName())
-          .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true")
-          .putLabelsItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
-          .putLabelsItem(
+    V1ObjectMeta metadata =
+        new V1ObjectMeta()
+            .name(getJobName())
+            .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true")
+            .putLabelsItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
+            .putLabelsItem(
                 LabelConstants.JOBNAME_LABEL, LegalNames.toJobIntrospectorName(getDomainUid()));
     if (isIstioEnabled()) metadata.putAnnotationsItem("sidecar.istio.io/inject", "false");
     return metadata;
@@ -212,13 +214,13 @@ public abstract class JobStepContext extends BasePodStepContext {
 
   private V1PodSpec createPodSpec(TuningParameters tuningParameters) {
     V1PodSpec podSpec =
-          new V1PodSpec()
-                .activeDeadlineSeconds(getActiveDeadlineSeconds(tuningParameters.getPodTuning()))
-                .restartPolicy("Never")
-                .addContainersItem(createContainer(tuningParameters))
-                .addVolumesItem(new V1Volume().name(SECRETS_VOLUME).secret(getSecretsVolume()))
-                .addVolumesItem(
-                      new V1Volume().name(SCRIPTS_VOLUME).configMap(getConfigMapVolumeSource()));
+        new V1PodSpec()
+            .activeDeadlineSeconds(getActiveDeadlineSeconds(tuningParameters.getPodTuning()))
+            .restartPolicy("Never")
+            .addContainersItem(createContainer(tuningParameters))
+            .addVolumesItem(new V1Volume().name(SECRETS_VOLUME).secret(getSecretsVolume()))
+            .addVolumesItem(
+                new V1Volume().name(SCRIPTS_VOLUME).configMap(getConfigMapVolumeSource()));
 
     podSpec.setImagePullSecrets(info.getDomain().getSpec().getImagePullSecrets());
 
@@ -229,15 +231,15 @@ public abstract class JobStepContext extends BasePodStepContext {
     List<String> configOverrideSecrets = getConfigOverrideSecrets();
     for (String secretName : configOverrideSecrets) {
       podSpec.addVolumesItem(
-            new V1Volume()
-                  .name(secretName + "-volume")
-                  .secret(getOverrideSecretVolumeSource(secretName)));
+          new V1Volume()
+              .name(secretName + "-volume")
+              .secret(getOverrideSecretVolumeSource(secretName)));
     }
     if (getConfigOverrides() != null && getConfigOverrides().length() > 0) {
       podSpec.addVolumesItem(
-            new V1Volume()
-                  .name(getConfigOverrides() + "-volume")
-                  .configMap(getOverridesVolumeSource(getConfigOverrides())));
+          new V1Volume()
+              .name(getConfigOverrides() + "-volume")
+              .configMap(getOverridesVolumeSource(getConfigOverrides())));
     }
 
     return podSpec;
@@ -245,14 +247,14 @@ public abstract class JobStepContext extends BasePodStepContext {
 
   private V1Container createContainer(TuningParameters tuningParameters) {
     V1Container container =
-          new V1Container()
-                .name(getJobName())
-                .image(getImageName())
-                .imagePullPolicy(getImagePullPolicy())
-                .command(getContainerCommand())
-                .env(getEnvironmentVariables(tuningParameters))
-                .addVolumeMountsItem(readOnlyVolumeMount(SECRETS_VOLUME, SECRETS_MOUNT_PATH))
-                .addVolumeMountsItem(readOnlyVolumeMount(SCRIPTS_VOLUME, SCRIPTS_MOUNTS_PATH));
+        new V1Container()
+            .name(getJobName())
+            .image(getImageName())
+            .imagePullPolicy(getImagePullPolicy())
+            .command(getContainerCommand())
+            .env(getEnvironmentVariables(tuningParameters))
+            .addVolumeMountsItem(readOnlyVolumeMount(SECRETS_VOLUME, SECRETS_MOUNT_PATH))
+            .addVolumeMountsItem(readOnlyVolumeMount(SCRIPTS_VOLUME, SCRIPTS_MOUNTS_PATH));
 
     for (V1VolumeMount additionalVolumeMount : getAdditionalVolumeMounts()) {
       container.addVolumeMountsItem(additionalVolumeMount);
@@ -260,14 +262,14 @@ public abstract class JobStepContext extends BasePodStepContext {
 
     if (getConfigOverrides() != null && getConfigOverrides().length() > 0) {
       container.addVolumeMountsItem(
-            readOnlyVolumeMount(getConfigOverrides() + "-volume", OVERRIDES_CM_MOUNT_PATH));
+          readOnlyVolumeMount(getConfigOverrides() + "-volume", OVERRIDES_CM_MOUNT_PATH));
     }
 
     List<String> configOverrideSecrets = getConfigOverrideSecrets();
     for (String secretName : configOverrideSecrets) {
       container.addVolumeMountsItem(
-            readOnlyVolumeMount(
-                  secretName + "-volume", OVERRIDE_SECRETS_MOUNT_PATH + '/' + secretName));
+          readOnlyVolumeMount(
+              secretName + "-volume", OVERRIDE_SECRETS_MOUNT_PATH + '/' + secretName));
     }
     return container;
   }
@@ -298,14 +300,14 @@ public abstract class JobStepContext extends BasePodStepContext {
 
   private V1SecretVolumeSource getSecretsVolume() {
     return new V1SecretVolumeSource()
-          .secretName(getWebLogicCredentialsSecretName())
-          .defaultMode(420);
+        .secretName(getWebLogicCredentialsSecretName())
+        .defaultMode(420);
   }
 
   private V1ConfigMapVolumeSource getConfigMapVolumeSource() {
     return new V1ConfigMapVolumeSource()
-          .name(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
-          .defaultMode(ALL_READ_AND_EXECUTE);
+        .name(KubernetesConstants.DOMAIN_CONFIG_MAP_NAME)
+        .defaultMode(ALL_READ_AND_EXECUTE);
   }
 
   private V1SecretVolumeSource getOverrideSecretVolumeSource(String name) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -21,8 +21,6 @@ import oracle.kubernetes.operator.PodAwaiterStepFactory;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.utils.Certificates;
@@ -33,9 +31,10 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public class PodHelper {
   static final long DEFAULT_ADDITIONAL_DELETE_TIME = 10;
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private PodHelper() {
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -41,8 +41,6 @@ import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.WebLogicConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
@@ -57,15 +55,14 @@ import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static oracle.kubernetes.operator.KubernetesConstants.GRACEFUL_SHUTDOWNTYPE;
 import static oracle.kubernetes.operator.LabelConstants.forDomainUidSelector;
 import static oracle.kubernetes.operator.VersionConstants.DEFAULT_DOMAIN_VERSION;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 @SuppressWarnings("deprecation")
 public abstract class PodStepContext extends BasePodStepContext {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private static final String STOP_SERVER = "/weblogic-operator/scripts/stopServer.sh";
   private static final String START_SERVER = "/weblogic-operator/scripts/startServer.sh";
   private static final String LIVENESS_PROBE = "/weblogic-operator/scripts/livenessProbe.sh";
@@ -357,7 +354,7 @@ public abstract class PodStepContext extends BasePodStepContext {
   private boolean canUseCurrentPod(V1Pod currentPod) {
     boolean useCurrent =
         AnnotationHelper.getHash(getPodModel()).equals(AnnotationHelper.getHash(currentPod));
-    if (!useCurrent && AnnotationHelper.getDebugString(currentPod).length() > 0)
+    if (!useCurrent && !isNullOrEmpty(AnnotationHelper.getDebugString(currentPod)))
       LOGGER.info(
           MessageKeys.POD_DUMP,
           AnnotationHelper.getDebugString(currentPod),
@@ -919,7 +916,7 @@ public abstract class PodStepContext extends BasePodStepContext {
           new CallBuilder()
               .withLabelSelectors(forDomainUidSelector(domainUid))
               .listPersistentVolumeAsync(
-                  new DefaultResponseStep<V1PersistentVolumeList>(getNext()) {
+                  new DefaultResponseStep<>(getNext()) {
                     @Override
                     public NextAction onSuccess(
                         Packet packet,

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/Pool.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/Pool.java
@@ -7,13 +7,10 @@ package oracle.kubernetes.operator.helpers;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** General-purpose object pool. */
 public abstract class Pool<T> {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private final Queue<T> queue = new ConcurrentLinkedQueue<>();
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -11,22 +11,21 @@ import io.kubernetes.client.ApiException;
 import oracle.kubernetes.operator.calls.AsyncRequestStep;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.calls.RetryStrategy;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /**
  * Step to receive response of Kubernetes API server call.
  *
- * <p>Most implementations will only need to implement {@link #onSuccess(Packet, Object, int, Map)}.
+ * <p>Most implementations will only need to implement {@link #onSuccess(Packet, CallResponse)}.
  *
  * @param <T> Response type
  */
 public abstract class ResponseStep<T> extends Step {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private final Step conflictStep;
   private Step previousStep = null;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
@@ -15,8 +15,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import io.kubernetes.client.models.V1Pod;
 import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
@@ -27,6 +25,8 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.Step.StepAndPacket;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /**
  * After the {@link PodHelper} identifies servers that are presently running, but that are using an
  * out-of-date specification, it defers the processing of these servers to the RollingHelper. This
@@ -34,8 +34,6 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
  * rolling process.
  */
 public class RollingHelper {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   private RollingHelper() {
   }
 
@@ -149,8 +147,7 @@ public class RollingHelper {
   private static class ServersThatCanRestartNowStep extends Step {
     private final Collection<StepAndPacket> serversThatCanRestartNow;
 
-    public ServersThatCanRestartNowStep(
-        Collection<StepAndPacket> serversThatCanRestartNow, Step next) {
+    ServersThatCanRestartNowStep(Collection<StepAndPacket> serversThatCanRestartNow, Step next) {
       super(next);
       this.serversThatCanRestartNow = serversThatCanRestartNow;
     }
@@ -165,7 +162,7 @@ public class RollingHelper {
     private final String clusterName;
     private final Queue<StepAndPacket> servers;
 
-    public RollSpecificClusterStep(
+    RollSpecificClusterStep(
         String clusterName, Queue<StepAndPacket> clusteredServerRestarts, Step next) {
       super(next);
       this.clusterName = clusterName;
@@ -219,7 +216,7 @@ public class RollingHelper {
   private static class RestartOneClusteredServerStep extends Step {
     private final Queue<StepAndPacket> servers;
 
-    public RestartOneClusteredServerStep(Queue<StepAndPacket> servers, Step next) {
+    RestartOneClusteredServerStep(Queue<StepAndPacket> servers, Step next) {
       super(next);
       this.servers = servers;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
@@ -5,19 +5,18 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1Secret;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.logging.LoggingFilter;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.ContainerResolver;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** A Helper Class for retrieving Kubernetes Secrets used by the WebLogic Operator. */
 public class SecretHelper {
@@ -26,7 +25,6 @@ public class SecretHelper {
   // has 2 fields (username and password)
   public static final String ADMIN_SERVER_CREDENTIALS_USERNAME = "username";
   public static final String ADMIN_SERVER_CREDENTIALS_PASSWORD = "password";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private final String namespace;
 
   /**
@@ -122,7 +120,7 @@ public class SecretHelper {
     private final String secretName;
     private final String namespace;
 
-    public SecretDataStep(SecretType secretType, String secretName, String namespace, Step next) {
+    SecretDataStep(SecretType secretType, String secretName, String namespace, Step next) {
       super(next);
       this.secretType = secretType;
       this.secretName = secretName;
@@ -138,41 +136,36 @@ public class SecretHelper {
       }
 
       LOGGER.fine(MessageKeys.RETRIEVING_SECRET, secretName);
-      final LoggingFilter loggingFilter = packet.getValue(LoggingFilter.LOGGING_FILTER_PACKET_KEY);
-      CallBuilderFactory factory =
-          ContainerResolver.getInstance().getContainer().getSpi(CallBuilderFactory.class);
       Step read =
-          factory
-              .create()
-              .readSecretAsync(
-                  secretName,
-                  namespace,
-                  new ResponseStep<V1Secret>(getNext()) {
-                    @Override
-                    public NextAction onFailure(
-                        Packet packet,
-                        ApiException e,
-                        int statusCode,
-                        Map<String, List<String>> responseHeaders) {
-                      if (statusCode == CallBuilder.NOT_FOUND) {
-                        LOGGER.warning(loggingFilter, MessageKeys.SECRET_NOT_FOUND, secretName);
-                        return doNext(packet);
-                      }
-                      return super.onFailure(packet, e, statusCode, responseHeaders);
-                    }
-
-                    @Override
-                    public NextAction onSuccess(
-                        Packet packet,
-                        V1Secret result,
-                        int statusCode,
-                        Map<String, List<String>> responseHeaders) {
-                      packet.put(SECRET_DATA_KEY, harvestAdminSecretData(result, loggingFilter));
-                      return doNext(packet);
-                    }
-                  });
+          new CallBuilder()
+              .readSecretAsync(secretName, namespace, new SecretResponseStep(packet, getNext()));
 
       return doNext(read, packet);
+    }
+
+    private class SecretResponseStep extends ResponseStep<V1Secret> {
+      private final LoggingFilter loggingFilter;
+
+      SecretResponseStep(Packet packet, Step next) {
+        super(next);
+        this.loggingFilter = packet.getValue(LoggingFilter.LOGGING_FILTER_PACKET_KEY);
+      }
+
+      @Override
+      public NextAction onFailure(Packet packet, CallResponse<V1Secret> callResponse) {
+        if (callResponse.getStatusCode() == CallBuilder.NOT_FOUND) {
+          LOGGER.warning(loggingFilter, MessageKeys.SECRET_NOT_FOUND, secretName);
+          return doNext(packet);
+        }
+        return super.onFailure(packet, callResponse);
+      }
+
+      @Override
+      public NextAction onSuccess(Packet packet, CallResponse<V1Secret> callResponse) {
+        packet.put(
+            SECRET_DATA_KEY, harvestAdminSecretData(callResponse.getResult(), loggingFilter));
+        return doNext(packet);
+      }
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -22,8 +22,6 @@ import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
@@ -40,6 +38,7 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_CREATED;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_EXISTS;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_REPLACED;
@@ -56,7 +55,6 @@ import static oracle.kubernetes.operator.logging.MessageKeys.MANAGED_SERVICE_REP
 public class ServiceHelper {
   public static final String CLUSTER_IP_TYPE = "ClusterIP";
   public static final String NODE_PORT_TYPE = "NodePort";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private ServiceHelper() {
   }
@@ -92,10 +90,6 @@ public class ServiceHelper {
 
   public static void updatePresenceFromEvent(DomainPresenceInfo info, V1Service service) {
     OperatorServiceType.getType(service).updateFromEvent(info, service);
-  }
-
-  public static V1Service[] getServerServices(DomainPresenceInfo info) {
-    return OperatorServiceType.SERVER.getServices(info);
   }
 
   public static boolean isServerService(V1Service service) {
@@ -428,11 +422,6 @@ public class ServiceHelper {
     abstract void addServicePortIfNeeded(String portName, Integer port);
 
     V1ServicePort createServicePort(String portName, Integer port) {
-      StringBuffer sb = new StringBuffer();
-      StackTraceElement[] stes = Thread.currentThread().getStackTrace();
-      for (StackTraceElement ste : stes) {
-        sb.append(ste.toString()).append("\r\n");
-      }
       return new V1ServicePort()
           .name(LegalNames.toDns1123LegalName(portName))
           .port(port)

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/LoggingFacade.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/LoggingFacade.java
@@ -12,10 +12,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** Centralized logging for the operator. */
+@SuppressWarnings({"unused", "WeakerAccess"})
 public class LoggingFacade {
 
-  public static final String TRACE = "OWLS-KO-TRACE: ";
-  protected static final String CLASS = LoggingFacade.class.getName();
+  public static final String RESOURCE_BUNDLE_NAME = "Operator";
+
+  private static final String LOGGER_NAME = "Operator";
+  public static final LoggingFacade LOGGER =
+      LoggingFactory.getLogger(LOGGER_NAME, RESOURCE_BUNDLE_NAME);
+
+  private static final String TRACE = "OWLS-KO-TRACE: ";
+  private static final String CLASS = LoggingFacade.class.getName();
   private final Logger logger;
 
   public LoggingFacade(Logger logger) {
@@ -51,7 +58,7 @@ public class LoggingFacade {
     if (value != null) {
       // Convert any object arrays such as String arrays.
       if (Object[].class.isAssignableFrom(value.getClass())) {
-        Object[] array = Object[].class.cast(value);
+        Object[] array = (Object[]) value;
         result = Arrays.toString(array);
       } else if (value.getClass().isArray()) {
         // Any other arrays are primitive arrays which must be cast to

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/AuthenticationFilter.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/AuthenticationFilter.java
@@ -4,7 +4,6 @@
 
 package oracle.kubernetes.operator.rest;
 
-import java.io.IOException;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.logging.Logger;
@@ -20,11 +19,11 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.rest.backend.RestBackend;
 import org.glassfish.jersey.server.ResourceConfig;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * AuthenticationFilter authenticates the request by extracting the access token from tha
@@ -43,8 +42,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 public class AuthenticationFilter extends BaseDebugLoggingFilter implements ContainerRequestFilter {
 
   public static final String REST_BACKEND_PROPERTY = "RestBackend";
-  public static final String ACCESS_TOKEN_PREFIX = "Bearer ";
-  private static LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+  static final String ACCESS_TOKEN_PREFIX = "Bearer ";
   @Context private Application application; // TBD - does this work?
 
   /** Construct an AuthenticationFilter. */
@@ -53,7 +51,7 @@ public class AuthenticationFilter extends BaseDebugLoggingFilter implements Cont
   }
 
   @Override
-  public void filter(ContainerRequestContext req) throws IOException {
+  public void filter(ContainerRequestContext req) {
     LOGGER.entering();
     try {
       ResourceConfig rc = (ResourceConfig) application;
@@ -85,6 +83,7 @@ public class AuthenticationFilter extends BaseDebugLoggingFilter implements Cont
     throw e;
   }
 
+  @SuppressWarnings("SameParameterValue")
   private String formatMessage(ContainerRequestContext req, String msgId) {
     return getResourceBundle(req.getLanguage()).getString(msgId);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/BaseDebugLoggingFilter.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/BaseDebugLoggingFilter.java
@@ -13,8 +13,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * BaseDebugLoggingFilter provides utilities shared by RequestDebugLoggingFilter and
@@ -22,18 +21,17 @@ import oracle.kubernetes.operator.logging.LoggingFactory;
  */
 public abstract class BaseDebugLoggingFilter {
 
-  protected static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-  protected static final String FILTER_REQUEST_START_TIME = "FILTER_REQUEST_START_TIME";
-  protected static final String FILTER_REQUEST_ENTITY = "FILTER_REQUEST_ENTITY";
+  static final String FILTER_REQUEST_START_TIME = "FILTER_REQUEST_START_TIME";
+  static final String FILTER_REQUEST_ENTITY = "FILTER_REQUEST_ENTITY";
   private static final String DATE_FORMAT =
       "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"; // ISO 8610, includes time zone
 
-  protected static String formatTime(long time) {
+  static String formatTime(long time) {
     // construct a new SimpleDataFormat each time since it is not thread safe:
     return new SimpleDateFormat(DATE_FORMAT).format(new Date(time));
   }
 
-  protected String formatEntity(MediaType type, String entityAsString) {
+  String formatEntity(MediaType type, String entityAsString) {
     String result = entityAsString;
     if (!MediaType.APPLICATION_JSON_TYPE.isCompatible(type)) {
       // TODO - convert to pretty printed json
@@ -41,12 +39,11 @@ public abstract class BaseDebugLoggingFilter {
     return result;
   }
 
-  protected String getLoggableHeaders(ContainerRequestContext req) {
+  String getLoggableHeaders(ContainerRequestContext req) {
     LOGGER.entering();
 
     // Make a copy of all of the request headers
-    MultivaluedHashMap<String, String> loggableHeaders =
-        new MultivaluedHashMap<String, String>(req.getHeaders());
+    MultivaluedHashMap<String, String> loggableHeaders = new MultivaluedHashMap<>(req.getHeaders());
 
     // Authorization headers contain credentials.  These credentials should not be
     // debug logged since they contain sensitive data.

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/ErrorFilter.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/ErrorFilter.java
@@ -12,9 +12,9 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.model.ErrorModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * ErrorFilter reformats string entities from non-success responses into arrays of message entities.
@@ -22,8 +22,6 @@ import oracle.kubernetes.operator.rest.model.ErrorModel;
 @Provider
 @Priority(FilterPriorities.ERROR_FILTER_PRIORITY)
 public class ErrorFilter implements ContainerResponseFilter {
-
-  private static LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   public ErrorFilter() {
     // nothing to do

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/ExceptionMapper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/ExceptionMapper.java
@@ -9,8 +9,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * ExceptionMapper converts non-WebApplicationExceptions into internal server errors and logs
@@ -18,8 +17,6 @@ import oracle.kubernetes.operator.logging.LoggingFactory;
  */
 @Provider
 public class ExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<Exception> {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /** Construct an ExceptionMapper. */
   public ExceptionMapper() {

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RequestDebugLoggingFilter.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RequestDebugLoggingFilter.java
@@ -14,17 +14,15 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import org.glassfish.jersey.message.MessageUtils;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** RequestDebugLoggingFilter debug logs all the REST Requests. */
 @Provider
 @Priority(FilterPriorities.REQUEST_DEBUG_LOGGING_FILTER_PRIORITY)
 public class RequestDebugLoggingFilter extends BaseDebugLoggingFilter
     implements ContainerRequestFilter {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /** Construct a RequestDebugLoggingFilter. */
   public RequestDebugLoggingFilter() {

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/ResponseDebugLoggingFilter.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/ResponseDebugLoggingFilter.java
@@ -12,16 +12,13 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /** ResponseDebugLoggingFilter debug logs all the REST responses. */
 @Provider
 @Priority(FilterPriorities.RESPONSE_DEBUG_LOGGING_FILTER_PRIORITY)
 public class ResponseDebugLoggingFilter extends BaseDebugLoggingFilter
     implements ContainerResponseFilter {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /** Construct a ResponseDebugLoggingFilter. */
   public ResponseDebugLoggingFilter() {

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RestBackendImpl.java
@@ -30,14 +30,14 @@ import oracle.kubernetes.operator.helpers.AuthorizationProxy.Operation;
 import oracle.kubernetes.operator.helpers.AuthorizationProxy.Resource;
 import oracle.kubernetes.operator.helpers.AuthorizationProxy.Scope;
 import oracle.kubernetes.operator.helpers.CallBuilder;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.rest.backend.RestBackend;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * RestBackendImpl implements the backend of the WebLogic operator REST api by making calls to
@@ -46,7 +46,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainList;
  */
 public class RestBackendImpl implements RestBackend {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final String NEW_CLUSTER =
       "{'clusterName':'%s','replicas':%d}".replaceAll("'", "\"");
   private static final TopologyRetriever INSTANCE =

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RestConfigImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RestConfigImpl.java
@@ -6,15 +6,13 @@ package oracle.kubernetes.operator.rest;
 
 import java.util.Collection;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.backend.RestBackend;
 import oracle.kubernetes.operator.utils.Certificates;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /** RestConfigImpl provides the WebLogic Operator REST api configuration. */
 public class RestConfigImpl implements RestConfig {
-
-  private static LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private final String principal;
   private final Collection<String> targetNamespaces;

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RestServer.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RestServer.java
@@ -17,8 +17,6 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 
 import io.kubernetes.client.util.SSLUtils;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.resource.VersionsResource;
 import oracle.kubernetes.operator.work.Container;
 import oracle.kubernetes.operator.work.ContainerResolver;
@@ -32,6 +30,8 @@ import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * The RestServer runs the WebLogic operator's REST api.
@@ -47,7 +47,6 @@ import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
  * </ul>
  */
 public class RestServer {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final int CORE_POOL_SIZE = 3;
   private static final String SSL_PROTOCOL = "TLSv1.2";
   private static final String[] SSL_PROTOCOLS = {
@@ -166,7 +165,7 @@ public class RestServer {
    *
    * @return the uri
    */
-  String getExternalHttpsUri() {
+  private String getExternalHttpsUri() {
     return baseExternalHttpsUri;
   }
 
@@ -175,7 +174,7 @@ public class RestServer {
    *
    * @return the uri
    */
-  String getInternalHttpsUri() {
+  private String getInternalHttpsUri() {
     return baseInternalHttpsUri;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ClusterResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ClusterResource.java
@@ -9,9 +9,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.model.ClusterModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * ClusterResource is a jaxrs resource that implements the REST api for the
@@ -20,15 +20,13 @@ import oracle.kubernetes.operator.rest.model.ClusterModel;
  */
 public class ClusterResource extends BaseResource {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a ClusterResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public ClusterResource(BaseResource parent, String pathSegment) {
+  ClusterResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ClustersResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ClustersResource.java
@@ -11,10 +11,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.model.ClusterModel;
 import oracle.kubernetes.operator.rest.model.CollectionModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * ClustersResource is a jaxrs resource that implements the REST api for the
@@ -23,15 +23,13 @@ import oracle.kubernetes.operator.rest.model.CollectionModel;
  */
 public class ClustersResource extends BaseResource {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a ClustersResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public ClustersResource(BaseResource parent, String pathSegment) {
+  ClustersResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/DomainResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/DomainResource.java
@@ -9,9 +9,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.model.DomainModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * DomainResource is a jaxrs resource that implements the REST api for the
@@ -20,15 +20,13 @@ import oracle.kubernetes.operator.rest.model.DomainModel;
  */
 public class DomainResource extends BaseResource {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a DomainResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public DomainResource(BaseResource parent, String pathSegment) {
+  DomainResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/DomainsResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/DomainsResource.java
@@ -11,10 +11,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.model.CollectionModel;
 import oracle.kubernetes.operator.rest.model.DomainModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * DomainsResource is a jaxrs resource that implements the REST api for the
@@ -23,15 +23,13 @@ import oracle.kubernetes.operator.rest.model.DomainModel;
  */
 public class DomainsResource extends BaseResource {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a DomainsResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public DomainsResource(BaseResource parent, String pathSegment) {
+  DomainsResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ScaleClusterResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ScaleClusterResource.java
@@ -8,9 +8,9 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.model.ScaleClusterParamsModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * ScaleResource is a jaxrs resource that implements the REST api for the
@@ -19,15 +19,13 @@ import oracle.kubernetes.operator.rest.model.ScaleClusterParamsModel;
  */
 public class ScaleClusterResource extends BaseResource {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a ScaleClusterResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public ScaleClusterResource(BaseResource parent, String pathSegment) {
+  ScaleClusterResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/SwaggerResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/SwaggerResource.java
@@ -9,8 +9,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * SwaggerResource is a jaxrs resource that implements the REST api for the
@@ -19,15 +18,13 @@ import oracle.kubernetes.operator.logging.LoggingFactory;
  */
 public class SwaggerResource extends BaseResource {
 
-  private static LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a SwaggerResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public SwaggerResource(BaseResource parent, String pathSegment) {
+  SwaggerResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/VersionResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/VersionResource.java
@@ -9,10 +9,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.backend.VersionUtils;
 import oracle.kubernetes.operator.rest.model.VersionModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * VersionResource is a jaxrs resource that implements the REST api for the /operator/{version}
@@ -21,15 +21,13 @@ import oracle.kubernetes.operator.rest.model.VersionModel;
  */
 public class VersionResource extends BaseResource {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   /**
    * Construct a VersionResource.
    *
    * @param parent - the jaxrs resource that parents this resource.
    * @param pathSegment - the last path segment in the url to this resource.
    */
-  public VersionResource(BaseResource parent, String pathSegment) {
+  VersionResource(BaseResource parent, String pathSegment) {
     super(parent, pathSegment);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/VersionsResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/VersionsResource.java
@@ -11,11 +11,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.backend.VersionUtils;
 import oracle.kubernetes.operator.rest.model.CollectionModel;
 import oracle.kubernetes.operator.rest.model.VersionModel;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * VersionsResource is a jaxrs resource that implements the REST api for the /operator path. It is
@@ -24,8 +24,6 @@ import oracle.kubernetes.operator.rest.model.VersionModel;
  */
 @Path("operator")
 public class VersionsResource extends BaseResource {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /** Construct a VersionsResource. */
   public VersionsResource() {
@@ -41,7 +39,7 @@ public class VersionsResource extends BaseResource {
   @Produces(MediaType.APPLICATION_JSON)
   public CollectionModel<VersionModel> get() {
     LOGGER.entering(href());
-    CollectionModel<VersionModel> collection = new CollectionModel<VersionModel>();
+    CollectionModel<VersionModel> collection = new CollectionModel<>();
     for (String version : VersionUtils.getVersions()) {
       VersionModel item =
           new VersionModel(

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpAfterStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpAfterStep.java
@@ -11,17 +11,16 @@ import java.util.Map;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.RollingHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
-public class ManagedServerUpAfterStep extends Step {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
-  public ManagedServerUpAfterStep(Step next) {
+public class ManagedServerUpAfterStep extends Step {
+
+  ManagedServerUpAfterStep(Step next) {
     super(next);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -15,19 +15,18 @@ import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo.ServerStartupInfo;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public class ManagedServerUpIteratorStep extends Step {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private final Collection<ServerStartupInfo> cols;
 
-  public ManagedServerUpIteratorStep(Collection<ServerStartupInfo> cols, Step next) {
+  ManagedServerUpIteratorStep(Collection<ServerStartupInfo> cols, Step next) {
     super(next);
     this.cols = cols;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -21,8 +21,6 @@ import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo.ServerStartupInfo;
 import oracle.kubernetes.operator.helpers.PodHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
@@ -33,10 +31,11 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 public class ManagedServersUpStep extends Step {
   static final String SERVERS_UP_MSG =
       "Running servers for domain with UID: {0}, running list: {1}";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static NextStepFactory NEXT_STEP_FACTORY =
       (info, config, servers, next) ->
           scaleDownIfNecessary(info, config, servers, new ClusterServicesStep(next));

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -22,8 +22,6 @@ import oracle.kubernetes.operator.WebLogicConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.http.HttpClient;
 import oracle.kubernetes.operator.http.Result;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.LoggingFilter;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.rest.Scan;
@@ -42,13 +40,13 @@ import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_STATE_MAP;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 public class ReadHealthStep extends Step {
 
-  public static final String OVERALL_HEALTH_NOT_AVAILABLE = "Not available";
-  public static final String OVERALL_HEALTH_FOR_SERVER_OVERLOADED =
+  static final String OVERALL_HEALTH_NOT_AVAILABLE = "Not available";
+  static final String OVERALL_HEALTH_FOR_SERVER_OVERLOADED =
       OVERALL_HEALTH_NOT_AVAILABLE + " (possibly overloaded)";
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private ReadHealthStep(Step next) {
     super(next);

--- a/operator/src/main/java/oracle/kubernetes/operator/utils/Certificates.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/utils/Certificates.java
@@ -10,8 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 public class Certificates {
   private static final String OPERATOR_DIR = "/operator/";
@@ -21,7 +20,6 @@ public class Certificates {
   private static final String INTERNAL_ID_DIR = OPERATOR_DIR + "internal-identity/";
   static final String INTERNAL_CERTIFICATE_KEY = INTERNAL_ID_DIR + "internalOperatorKey";
   static final String INTERNAL_CERTIFICATE = INTERNAL_ID_DIR + "internalOperatorCert";
-  private static LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static Function<String, Path> GET_PATH = p -> Paths.get(p);
 
   public static String getOperatorExternalKeyFile() {

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/UpdateDynamicClusterStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/UpdateDynamicClusterStep.java
@@ -7,17 +7,15 @@ package oracle.kubernetes.operator.wlsconfig;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.http.HttpClient;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /** Step for updating the cluster size of a WebLogic dynamic cluster. */
 public class UpdateDynamicClusterStep extends Step {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   final WlsClusterConfig wlsClusterConfig;
   final int targetClusterSize;

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
@@ -8,17 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.Step;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /** Contains configuration of a WLS cluster. */
 public class WlsClusterConfig {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private String name;
   private List<WlsServerConfig> servers = new ArrayList<>();
@@ -140,7 +139,7 @@ public class WlsClusterConfig {
    * @param serverName the name to look for
    * @return true or false
    */
-  public boolean hasNamedServer(String serverName) {
+  boolean hasNamedServer(String serverName) {
     return getServerConfigs().stream().anyMatch(c -> serverName.equals(c.getName()));
   }
 
@@ -195,16 +194,12 @@ public class WlsClusterConfig {
     return this.dynamicServersConfig;
   }
 
-  public void setDynamicServersConfig(WlsDynamicServersConfig dynamicServersConfig) {
-    this.dynamicServersConfig = dynamicServersConfig;
-  }
-
   /**
    * Returns the WlsDomainConfig object for the WLS domain that this cluster belongs to.
    *
    * @return the WlsDomainConfig object for the WLS domain that this cluster belongs to
    */
-  public WlsDomainConfig getWlsDomainConfig() {
+  WlsDomainConfig getWlsDomainConfig() {
     return wlsDomainConfig;
   }
 
@@ -215,7 +210,7 @@ public class WlsClusterConfig {
    * @param wlsDomainConfig the WlsDomainConfig object for the WLS domain that this cluster belongs
    *     to
    */
-  public void setWlsDomainConfig(WlsDomainConfig wlsDomainConfig) {
+  void setWlsDomainConfig(WlsDomainConfig wlsDomainConfig) {
     this.wlsDomainConfig = wlsDomainConfig;
   }
 
@@ -383,7 +378,7 @@ public class WlsClusterConfig {
    *
    * @return The REST URL path for updating cluster size of dynamic servers for this cluster
    */
-  public String getUpdateDynamicClusterSizeUrl() {
+  String getUpdateDynamicClusterSizeUrl() {
     return "/management/weblogic/latest/edit/clusters/" + name + "/dynamicServers";
   }
 
@@ -395,7 +390,7 @@ public class WlsClusterConfig {
    * @return A string containing the payload to be used in the REST request for updating the dynamic
    *     cluster size to the specified value.
    */
-  public String getUpdateDynamicClusterSizePayload(final int clusterSize) {
+  String getUpdateDynamicClusterSizePayload(final int clusterSize) {
     return "{ dynamicClusterSize: " + clusterSize + " }";
   }
 
@@ -438,8 +433,7 @@ public class WlsClusterConfig {
     final int targetClusterSize;
     final WlsClusterConfig wlsClusterConfig;
 
-    public DynamicClusterSizeConfigUpdate(
-        WlsClusterConfig wlsClusterConfig, int targetClusterSize) {
+    DynamicClusterSizeConfigUpdate(WlsClusterConfig wlsClusterConfig, int targetClusterSize) {
       this.targetClusterSize = targetClusterSize;
       this.wlsClusterConfig = wlsClusterConfig;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -12,8 +12,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.WlsDomain;
@@ -21,9 +19,10 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
+
 /** Contains a snapshot of configuration for a WebLogic Domain. */
 public class WlsDomainConfig implements WlsDomain {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   // Name of this WLS domain (This is NOT the domain UID in the weblogic domain kubernetes CRD)
   private String name;
@@ -77,10 +76,8 @@ public class WlsDomainConfig implements WlsDomain {
     this.name = name;
     this.adminServerName = adminServerName;
     // set domainConfig for each WlsClusterConfig
-    if (wlsClusterConfigs != null) {
-      for (WlsClusterConfig wlsClusterConfig : this.configuredClusters) {
-        wlsClusterConfig.setWlsDomainConfig(this);
-      }
+    for (WlsClusterConfig wlsClusterConfig : this.configuredClusters) {
+      wlsClusterConfig.setWlsDomainConfig(this);
     }
   }
 
@@ -156,10 +153,6 @@ public class WlsDomainConfig implements WlsDomain {
         wlsServerConfigs,
         wlsServerTemplates,
         wlsMachineConfigs);
-  }
-
-  public static String getRetrieveServersSearchUrl() {
-    return "/management/weblogic/latest/domainConfig/search";
   }
 
   public static String getRetrieveServersSearchPayload() {
@@ -275,6 +268,7 @@ public class WlsDomainConfig implements WlsDomain {
     return this.configuredClusters;
   }
 
+  @SuppressWarnings("unused")
   public void setConfiguredClusters(List<WlsClusterConfig> configuredClusters) {
     this.configuredClusters = configuredClusters;
   }
@@ -306,6 +300,7 @@ public class WlsDomainConfig implements WlsDomain {
     return this.serverTemplates;
   }
 
+  @SuppressWarnings("unused")
   public void setServerTemplates(List<WlsServerConfig> serverTemplates) {
     this.serverTemplates = serverTemplates;
   }
@@ -315,7 +310,7 @@ public class WlsDomainConfig implements WlsDomain {
    *
    * @return A Map of WlsMachineConfig, keyed by name, for each machine configured the WLS domain
    */
-  public synchronized Map<String, WlsMachineConfig> getMachineConfigs() {
+  synchronized Map<String, WlsMachineConfig> getMachineConfigs() {
     return wlsMachineConfigs;
   }
 
@@ -352,17 +347,10 @@ public class WlsDomainConfig implements WlsDomain {
    * @return The WlsServerConfig object containing configuration of the WLS server with the given
    *     name. This methods return null if no WLS configuration is found for the given server name.
    */
-  public synchronized WlsServerConfig getServerConfig(String serverName) {
-    WlsServerConfig result = null;
-    if (serverName != null && servers != null) {
-      for (WlsServerConfig serverConfig : servers) {
-        if (serverConfig.getName().equals(serverName)) {
-          result = serverConfig;
-          break;
-        }
-      }
-    }
-    return result;
+  public synchronized WlsServerConfig getServerConfig(@Nonnull String serverName) {
+    if (servers == null) return null;
+
+    return WlsServerConfig.getServerConfig(serverName, servers);
   }
 
   /**
@@ -372,7 +360,7 @@ public class WlsDomainConfig implements WlsDomain {
    * @return The WlsMachineConfig object containing configuration of the WLS machine with the given
    *     name. This methods return null if no WLS machine is configured with the given name.
    */
-  public synchronized WlsMachineConfig getMachineConfig(String machineName) {
+  synchronized WlsMachineConfig getMachineConfig(String machineName) {
     WlsMachineConfig result = null;
     if (machineName != null && wlsMachineConfigs != null) {
       result = wlsMachineConfigs.get(machineName);
@@ -397,7 +385,6 @@ public class WlsDomainConfig implements WlsDomain {
   public boolean validate(Domain domain, List<ConfigUpdate> suggestedConfigUpdates) {
     LOGGER.entering();
 
-    boolean updated = false;
     for (String clusterName : getClusterNames()) {
       WlsClusterConfig wlsClusterConfig = getClusterConfig(clusterName);
       if (wlsClusterConfig.getMaxClusterSize() > 0) {
@@ -423,8 +410,8 @@ public class WlsDomainConfig implements WlsDomain {
       }
     }
 
-    LOGGER.exiting(updated);
-    return updated;
+    LOGGER.exiting(false);
+    return false;
   }
 
   @Override
@@ -570,7 +557,7 @@ public class WlsDomainConfig implements WlsDomain {
     }
   }
 
-  WlsServerConfig getServerTemplate(String serverTemplateName) {
+  private WlsServerConfig getServerTemplate(String serverTemplateName) {
     for (WlsServerConfig serverTemplate : serverTemplates) {
       if (serverTemplate.getName().equals(serverTemplateName)) {
         return serverTemplate;

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServersConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServersConfig.java
@@ -7,32 +7,35 @@ package oracle.kubernetes.operator.wlsconfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * Contains values from a WLS dynamic servers configuration, which configures a WLS dynamic cluster.
  */
 public class WlsDynamicServersConfig {
 
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-
   String name;
-  String serverTemplateName;
-  Integer dynamicClusterSize;
-  Integer maxDynamicClusterSize;
-  String serverNamePrefix;
-  boolean calculatedListenPorts;
+  private String serverTemplateName;
+  private Integer dynamicClusterSize;
+  private Integer maxDynamicClusterSize;
+  private String serverNamePrefix;
+  private boolean calculatedListenPorts;
 
-  WlsServerConfig serverTemplate;
-  String machineNameMatchExpression;
-  List<WlsServerConfig> serverConfigs;
+  private WlsServerConfig serverTemplate;
 
+  /** The expression used in matching machine names assigned to dynamic servers. */
+  private String machineNameMatchExpression;
+
+  private List<WlsServerConfig> serverConfigs;
+
+  @SuppressWarnings("unused")
   public WlsDynamicServersConfig() {
   }
 
@@ -49,7 +52,7 @@ public class WlsDynamicServersConfig {
    * @param serverConfigs List of WlsServerConfig containing configurations of dynamic servers that
    *     corresponds to the current cluster size
    */
-  public WlsDynamicServersConfig(
+  WlsDynamicServersConfig(
       Integer dynamicClusterSize,
       Integer maxDynamicClusterSize,
       String serverNamePrefix,
@@ -208,6 +211,7 @@ public class WlsDynamicServersConfig {
     return dynamicClusterSize;
   }
 
+  @SuppressWarnings("unused")
   public void setDynamicClusterSize(Integer dynamicClusterSize) {
     this.dynamicClusterSize = dynamicClusterSize;
   }
@@ -221,19 +225,12 @@ public class WlsDynamicServersConfig {
     return maxDynamicClusterSize;
   }
 
+  @SuppressWarnings("unused")
   public void setMaxDynamicClusterSize(Integer maxDynamicClusterSize) {
     this.maxDynamicClusterSize = maxDynamicClusterSize;
   }
 
-  /**
-   * Return the expression used in matching machine names assigned to dynamic servers.
-   *
-   * @return the expression used in matching machine names assigned to dynamic servers
-   */
-  public String getMachineNameMatchExpression() {
-    return machineNameMatchExpression;
-  }
-
+  @SuppressWarnings("unused")
   public void setMachineNameMatchExpression(String machineNameMatchExpression) {
     this.machineNameMatchExpression = machineNameMatchExpression;
   }
@@ -249,6 +246,7 @@ public class WlsDynamicServersConfig {
     return serverConfigs;
   }
 
+  @SuppressWarnings("unused")
   public void setServerConfigs(List<WlsServerConfig> serverConfigs) {
     this.serverConfigs = serverConfigs;
   }
@@ -260,17 +258,10 @@ public class WlsDynamicServersConfig {
    * @return The WlsServerConfig object containing configuration of the WLS server with the given
    *     name. This methods return null if no WLS configuration is found for the given server name.
    */
-  public synchronized WlsServerConfig getServerConfig(String serverName) {
-    WlsServerConfig result = null;
-    if (serverName != null && serverConfigs != null) {
-      for (WlsServerConfig serverConfig : serverConfigs) {
-        if (serverConfig.getName().equals(serverName)) {
-          result = serverConfig;
-          break;
-        }
-      }
-    }
-    return result;
+  public synchronized WlsServerConfig getServerConfig(@Nonnull String serverName) {
+    if (serverConfigs == null) return null;
+
+    return WlsServerConfig.getServerConfig(serverName, serverConfigs);
   }
 
   /**
@@ -278,10 +269,11 @@ public class WlsDynamicServersConfig {
    *
    * @return The server template associated with this dynamic servers configuration
    */
-  public WlsServerConfig getServerTemplate() {
+  WlsServerConfig getServerTemplate() {
     return serverTemplate;
   }
 
+  @SuppressWarnings("unused")
   public void setServerTemplate(WlsServerConfig serverTemplate) {
     this.serverTemplate = serverTemplate;
   }
@@ -298,6 +290,7 @@ public class WlsDynamicServersConfig {
     return this.serverTemplateName;
   }
 
+  @SuppressWarnings("unused")
   public void setServerTemplateName(String serverTemplateName) {
     this.serverTemplateName = serverTemplateName;
   }
@@ -306,6 +299,7 @@ public class WlsDynamicServersConfig {
     return this.serverNamePrefix;
   }
 
+  @SuppressWarnings("unused")
   public void setServerNamePrefix(String serverNamePrefix) {
     this.serverNamePrefix = serverNamePrefix;
   }
@@ -314,11 +308,12 @@ public class WlsDynamicServersConfig {
     return this.calculatedListenPorts;
   }
 
+  @SuppressWarnings("unused")
   public void setCalculatedListenPorts(boolean calculatedListenPorts) {
     this.calculatedListenPorts = calculatedListenPorts;
   }
 
-  public void generateDynamicServerConfigs(
+  void generateDynamicServerConfigs(
       WlsServerConfig serverTemplate, String clusterName, String domainName) {
     List<String> dynamicServerNames = generateDynamicServerNames();
     serverConfigs =

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Fiber.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Fiber.java
@@ -20,10 +20,10 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.NextAction.Kind;
+
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 /**
  * User-level thread&#x2E; Represents the execution of one processing flow. The {@link Engine} is
@@ -47,16 +47,15 @@ import oracle.kubernetes.operator.work.NextAction.Kind;
  *
  * <h2>Debugging Aid</h2>
  *
- * <p>Setting the {@link #LOGGER} for FINE would give you basic start/stop/resume/suspend level
- * logging. Using FINER would cause more detailed logging, which includes what steps are executed in
- * what order and how they behaved.
+ * <p>Setting the logger to FINE would give you basic start/stop/resume/suspend level logging. Using
+ * FINER would cause more detailed logging, which includes what steps are executed in what order and
+ * how they behaved.
  */
 public final class Fiber implements Runnable, Future<Void>, ComponentRegistry {
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final int NOT_COMPLETE = 0;
   private static final int DONE = 1;
   private static final int CANCELLED = 2;
-  private static final ThreadLocal<Fiber> CURRENT_FIBER = new ThreadLocal<Fiber>();
+  private static final ThreadLocal<Fiber> CURRENT_FIBER = new ThreadLocal<>();
   /** Used to allocate unique number for each fiber. */
   private static final AtomicInteger iotaGen = new AtomicInteger();
   public final Engine owner;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
@@ -12,14 +12,16 @@ import java.util.ResourceBundle;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.models.V1VolumeMount;
+import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.utils.OperatorUtils;
 
 class DomainValidationMessages {
 
   /**
-   * Returns a validation message indicating that more than one managed server spec has the same effective name
-   * after DNS-1123 conversion.
+   * Returns a validation message indicating that more than one managed server spec has the same
+   * effective name after DNS-1123 conversion.
+   *
    * @param serverName the duplicate server name
    * @return the localized message
    */
@@ -28,8 +30,9 @@ class DomainValidationMessages {
   }
 
   /**
-   * Returns a validation message indicating that more than one cluster spec has the same effective name
-   * after DNS-1123 conversion.
+   * Returns a validation message indicating that more than one cluster spec has the same effective
+   * name after DNS-1123 conversion.
+   *
    * @param clusterName the duplicate cluster name
    * @return the localized message
    */
@@ -39,6 +42,7 @@ class DomainValidationMessages {
 
   /**
    * Returns a validation message indicating that a specified volume mount's path is not absolute.
+   *
    * @param mount the problematic volume mount
    * @return the localized message
    */
@@ -47,8 +51,9 @@ class DomainValidationMessages {
   }
 
   /**
-   * Returns a validation message indicating that none of the additional volume mounts contains a path which
-   * includes the log home.
+   * Returns a validation message indicating that none of the additional volume mounts contains a
+   * path which includes the log home.
+   *
    * @param logHome the log home to be used
    * @return the localized message
    */
@@ -63,28 +68,31 @@ class DomainValidationMessages {
   }
 
   private static String getBundleString(String key) {
-    return ResourceBundle.getBundle("Operator").getString(key);
+    return ResourceBundle.getBundle(LoggingFacade.RESOURCE_BUNDLE_NAME).getString(key);
   }
 
   static String reservedVariableNames(String prefix, List<String> reservedNames) {
     MessageFormat formatter = new MessageFormat("");
     formatter.applyPattern(getBundleString(MessageKeys.RESERVED_ENVIRONMENT_VARIABLES));
-    formatter.setFormats(new Format[]{getEnvNoun(), null, null, getToBe()});
-    return formatter.format(new Object[] {
-        reservedNames.size(),
-        OperatorUtils.joinListGrammatically(reservedNames),
-        prefix + ".serverPod.env",
-        reservedNames.size()});
+    formatter.setFormats(new Format[] {getEnvNoun(), null, null, getToBe()});
+    return formatter.format(
+        new Object[] {
+          reservedNames.size(),
+          OperatorUtils.joinListGrammatically(reservedNames),
+          prefix + ".serverPod.env",
+          reservedNames.size()
+        });
   }
 
   private static ChoiceFormat getEnvNoun() {
-    return new ChoiceFormat(new double[] {1, 2},
-                            new String[] {getBundleString("oneEnvVar"), getBundleString("multipleEnvVars")});
+    return new ChoiceFormat(
+        new double[] {1, 2},
+        new String[] {getBundleString("oneEnvVar"), getBundleString("multipleEnvVars")});
   }
 
   private static ChoiceFormat getToBe() {
-    return new ChoiceFormat(new double[] {1, 2},
-                            new String[] {getBundleString("singularToBe"), getBundleString("pluralToBe")});
+    return new ChoiceFormat(
+        new double[] {1, 2},
+        new String[] {getBundleString("singularToBe"), getBundleString("pluralToBe")});
   }
-
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -50,6 +50,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
 
   private static final String NS = "default";
   private static final String UID = "UID1";
+  private static final String OPERATOR_NAMESPACE = "operator";
 
   private List<Memento> mementos = new ArrayList<>();
   private KubernetesTestSupport testSupport = new KubernetesTestSupport();
@@ -100,7 +101,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   private void readExistingResources() {
-    testSupport.runStepsToCompletion(Main.readExistingResources("operator", NS));
+    testSupport.runStepsToCompletion(Main.readExistingResources(OPERATOR_NAMESPACE, NS));
   }
 
   private void addDomainResource(String uid, String namespace) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -227,8 +227,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
 
   @Test
   public void whenAdminPodCreatedWithNullAdminPort_adminServerPortSecureEnvVarIsNotSet() {
-    final Integer adminPort = null;
-    getServerTopology().setAdminPort(adminPort);
+    getServerTopology().setAdminPort(null);
     assertThat(getCreatedPodSpecContainer().getEnv(), not(hasEnvVar("ADMIN_SERVER_PORT_SECURE", "true")));
   }
 
@@ -241,8 +240,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
 
   @Test
   public void whenAdminPodCreatedWithAdminServerHasNullSslPort_adminServerPortSecureEnvVarIsNotSet() {
-    final Integer adminServerSslPort = null;
-    getServerTopology().setSslListenPort(adminServerSslPort);
+    getServerTopology().setSslListenPort(null);
     assertThat(getCreatedPodSpecContainer().getEnv(), not(hasEnvVar("ADMIN_SERVER_PORT_SECURE", "true")));
   }
 
@@ -290,7 +288,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getConfiguredDomainSpec().getAdminServer().getEnv();
     assertThat(
         getConfiguredDomainSpec().getAdminServer().getEnv(),
-        allOf(hasEnvVar("item1", itemRawValue)));
+        hasEnvVar("item1", itemRawValue));
   }
 
   @Test
@@ -381,7 +379,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getConfigurator().withServerStartState(ADMIN_STATE);
 
     assertThat(
-        getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("STARTUP_MODE", ADMIN_STATE)));
+        getCreatedPodSpecContainer().getEnv(), hasEnvVar("STARTUP_MODE", ADMIN_STATE));
   }
 
   @Test
@@ -389,7 +387,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getConfigurator().configureAdminServer().withServerStartState(ADMIN_STATE);
 
     assertThat(
-        getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("STARTUP_MODE", ADMIN_STATE)));
+        getCreatedPodSpecContainer().getEnv(), hasEnvVar("STARTUP_MODE", ADMIN_STATE));
   }
 
   @Test
@@ -400,7 +398,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
         .withServerStartState(ADMIN_STATE);
 
     assertThat(
-        getCreatedPodSpecContainer().getEnv(), allOf(hasEnvVar("STARTUP_MODE", ADMIN_STATE)));
+        getCreatedPodSpecContainer().getEnv(), hasEnvVar("STARTUP_MODE", ADMIN_STATE));
   }
 
   @Test
@@ -411,7 +409,7 @@ public class AdminPodHelperTest extends PodHelperTestBase {
         .withServerStartState(RUNNING_STATE);
 
     assertThat(
-        getCreatedPodSpecContainer().getEnv(), not(allOf(hasEnvVar("STARTUP_MODE", ADMIN_STATE))));
+        getCreatedPodSpecContainer().getEnv(), not(hasEnvVar("STARTUP_MODE", ADMIN_STATE)));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/work/StepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/StepTest.java
@@ -16,10 +16,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.Handler;
-import java.util.logging.Logger;
 
-import oracle.kubernetes.operator.logging.LoggingFactory;
+import com.meterware.simplestub.Memento;
 import oracle.kubernetes.operator.work.Fiber.CompletionCallback;
 import oracle.kubernetes.utils.TestUtils;
 import org.junit.After;
@@ -45,11 +43,9 @@ public class StepTest {
   private static final int ACQUIRE_SEMAPHORE = 6;
 
   private static final Command DEFAULT_COMMAND = new Command(INVOKE_NEXT);
-  private static final Logger UNDERLYING_LOGGER =
-      LoggingFactory.getLogger("Operator", "Operator").getUnderlyingLogger();
   private Engine engine = null;
-  private List<Handler> savedhandlers;
   private ScheduledExecutorService executorService;
+  private List<Memento> mementos = new ArrayList<>();
 
   /**
    * Simplifies creation of stepline. Steps will be connected following the list ordering of their
@@ -74,17 +70,9 @@ public class StepTest {
   }
 
   @Before
-  public void disableConsoleLogging() {
-    savedhandlers = TestUtils.removeConsoleHandlers(UNDERLYING_LOGGER);
-  }
-
-  @After
-  public void restoreConsoleLogging() {
-    TestUtils.restoreConsoleHandlers(UNDERLYING_LOGGER, savedhandlers);
-  }
-
-  @Before
   public void setup() {
+    mementos.add(
+        TestUtils.silenceOperatorLogger().ignoringLoggedExceptions(NullPointerException.class));
     executorService = Engine.wrappedExecutorService("StepTest", getDefaultContainer());
     engine = new Engine(executorService);
   }
@@ -95,6 +83,8 @@ public class StepTest {
 
   @After
   public void tearDown() throws Exception {
+    mementos.forEach(Memento::revert);
+
     executorService.shutdownNow();
     executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
   }
@@ -459,7 +449,7 @@ public class StepTest {
   }
 
   private abstract static class BaseStep extends Step {
-    public BaseStep(Step next) {
+    BaseStep(Step next) {
       super(next);
     }
 
@@ -486,10 +476,7 @@ public class StepTest {
           case INVOKE_NEXT:
             return doNext(packet);
           case SUSPEND_AND_RESUME:
-            return doSuspend(
-                (fiber) -> {
-                  fiber.resume(packet);
-                });
+            return doSuspend((fiber) -> fiber.resume(packet));
           case SUSPEND_AND_THROW:
             return doSuspend(
                 (fiber) -> {
@@ -532,12 +519,13 @@ public class StepTest {
     private int[] kind;
     private int count;
 
-    public Command(int... kind) {
+    Command(int... kind) {
       this.kind = kind;
       this.count = 0;
     }
 
-    public void setCount(int count) {
+    @SuppressWarnings("SameParameterValue")
+    void setCount(int count) {
       this.count = count;
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
@@ -17,10 +17,10 @@ import java.util.logging.SimpleFormatter;
 
 import ch.qos.logback.classic.LoggerContext;
 import com.meterware.simplestub.Memento;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import org.slf4j.LoggerFactory;
 
 import static com.meterware.simplestub.Stub.createStub;
+import static oracle.kubernetes.operator.logging.LoggingFacade.LOGGER;
 
 public class TestUtils {
   /**
@@ -29,7 +29,7 @@ public class TestUtils {
    * @return a collection of the removed handlers
    */
   public static ConsoleHandlerMemento silenceOperatorLogger() {
-    Logger logger = LoggingFactory.getLogger("Operator", "Operator").getUnderlyingLogger();
+    Logger logger = LOGGER.getUnderlyingLogger();
     List<Handler> savedHandlers = new ArrayList<>();
     for (Handler handler : logger.getHandlers()) {
       if (handler instanceof ConsoleHandler) {
@@ -46,29 +46,12 @@ public class TestUtils {
   }
 
   /**
-   * Removes the console handlers from the specified logger, in order to silence them during a test.
-   *
-   * @param logger a logger to silence
-   * @return a collection of the removed handlers
-   */
-  public static List<Handler> removeConsoleHandlers(Logger logger) {
-    List<Handler> savedHandlers = new ArrayList<>();
-    for (Handler handler : logger.getHandlers()) {
-      if (handler instanceof ConsoleHandler) {
-        savedHandlers.add(handler);
-      }
-    }
-    for (Handler handler : savedHandlers) logger.removeHandler(handler);
-    return savedHandlers;
-  }
-
-  /**
    * Restores the silenced logger handlers.
    *
    * @param logger a logger to restore
    * @param savedHandlers the handlers to restore
    */
-  public static void restoreConsoleHandlers(Logger logger, List<Handler> savedHandlers) {
+  private static void restoreConsoleHandlers(Logger logger, List<Handler> savedHandlers) {
     for (Handler handler : savedHandlers) {
       logger.addHandler(handler);
     }
@@ -218,10 +201,6 @@ public class TestUtils {
       log = logContext.getLogger("com.jayway.jsonpath.internal.path.CompiledPath");
       originalLogLevel = log.getLevel();
       log.setLevel(ch.qos.logback.classic.Level.INFO);
-    }
-
-    static Memento silenceLogger() {
-      return new JsonPathLoggerMemento();
     }
 
     @Override


### PR DESCRIPTION
The motivator for this cleanup was my mistaken use of "operator" rather than "Operator" as a bundle name. That's not something that should need to be specified separately every time the bundle is referenced; I have accordingly made it a constant. It then became apparently that we are writing independent and duplicate code to retrieve the logger in dozens of place, so I replaced them all with a simple import.