### PR TITLE
Owls 76524: implement DBPing for JRF domain integ test

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -78,6 +78,7 @@ public class BaseTest {
   private static String weblogicImageName;
   private static String weblogicImageServer;
   private static String domainApiVersion;
+  private static String dburl;
 
   // Set QUICKTEST env var to true to run a small subset of tests.
   // Set SMOKETEST env var to true to run an even smaller subset of tests
@@ -129,6 +130,10 @@ public class BaseTest {
         System.getenv("OCR_SERVER") != null
             ? System.getenv("OCR_SERVER")
             : appProps.getProperty("OCR_SERVER");
+    dburl =
+        System.getenv("DB_URL") != null
+            ? System.getenv("DB_URL")
+            : appProps.getProperty("DB_URL");        
     domainApiVersion =
         System.getenv("DOMAIN_API_VERSION") != null
             ? System.getenv("DOMAIN_API_VERSION")
@@ -294,6 +299,10 @@ public class BaseTest {
 
   public static String getDomainApiVersion() {
     return domainApiVersion;
+  }
+  
+  public static String getDbUrl() {
+    return dburl;
   }
 
   public static ExecResult cleanup() throws Exception {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorAdvancedTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorAdvancedTest.java
@@ -62,8 +62,11 @@ public class JrfInOperatorAdvancedTest extends BaseTest {
 
     // TODO: reconsider the logic to check the db readiness
     // The jrfdomain can not find the db pod even the db pod shows ready, sleep more time
-    logger.info("waiting for the db to be visible to rcu script ...");
-    Thread.sleep(20000);
+    // logger.info("waiting for the db to be visible to rcu script ...");
+    //Thread.sleep(20000);
+    
+    logger.info("DB_URL is: " + getDbUrl());
+    DbUtils.checkDb(new String[] {getDbUrl()}, rcuPodName);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorTest.java
@@ -644,8 +644,10 @@ public class JrfInOperatorTest extends BaseTest {
     if (!SMOKETEST) {
       testClusterScaling(operator, domain);
       int port = (Integer) domain.getDomainMap().get("managedServerPort");
-      testDomainLifecyle(operator, domain, port);
-      testOperatorLifecycle(operator, domain);
+      if (!QUICKTEST) {
+        testDomainLifecyle(operator, domain, port);
+        testOperatorLifecycle(operator, domain);
+      }
     }
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/JrfInOperatorTest.java
@@ -63,8 +63,11 @@ public class JrfInOperatorTest extends BaseTest {
 
     // TODO: reconsider the logic to check the db readiness
     // The jrfdomain can not find the db pod even the db pod shows ready, sleep more time
-    logger.info("waiting for the db to be visible to rcu script ...");
-    Thread.sleep(20000);
+    //logger.info("waiting for the db to be visible to rcu script ...");
+    //Thread.sleep(20000);
+    
+    logger.info("DB_URL is: " + getDbUrl());
+    DbUtils.checkDb(new String[] {getDbUrl()}, rcuPodName);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/DbUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/DbUtils.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.utils;
 
 import java.util.Map;
 import java.util.logging.Logger;
+import oracle.kubernetes.operator.BaseTest;
 
 public class DbUtils {
   public static final String DEFAULT_FMWINFRA_DOCKER_IMAGENAME =
@@ -17,7 +18,7 @@ public class DbUtils {
   public static final String DEFAULT_RCU_SYS_PASSWORD = "Oradoc_db1";
   public static final String DEFAULT_RCU_NAMESPACE = "rcu";
   private static final Logger logger = Logger.getLogger("OperatorIT", "OperatorIT");
-
+  
   /**
    * create oracle db pod in the k8s cluster.
    *
@@ -165,5 +166,17 @@ public class DbUtils {
       logger.info("Running " + command);
       TestUtils.exec(command);
     }
+  }
+  
+  public static void checkDb(String[] dburl, String rcuPod) throws Exception {
+  	String scriptsLocInPod = "/u01/oracle";
+  	TestUtils.copyFileViaCat(
+        BaseTest.getProjectRoot() + "/integration-tests/src/test/resources/jrf/checkDb.sh",
+        scriptsLocInPod + "/checkDb.sh",
+        rcuPod,
+        DEFAULT_RCU_NAMESPACE);
+    TestUtils.callShellScriptInsidePod(
+        rcuPod, DEFAULT_RCU_NAMESPACE, scriptsLocInPod, "checkDb.sh", dburl);
+  	
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -1109,6 +1109,40 @@ public class TestUtils {
     logger.info("Command to call kubectl sh file " + cmdKubectlSh);
     TestUtils.exec(cmdKubectlSh.toString());
   }
+  
+  /**
+   * exec into the pod and call the shell script with given arguments.
+   *
+   * @param podName pod name
+   * @param domainNS namespace
+   * @param scriptsLocInPod script location
+   * @param shScriptName script name
+   * @param args script arguments
+   * @throws Exception exception
+   */
+  public static void callShellScriptInsidePod(
+      String podName, String domainNS, String scriptsLocInPod, String shScriptName, String[] args)
+      throws Exception {
+    StringBuffer cmdKubectlSh = new StringBuffer("kubectl -n ");
+    cmdKubectlSh
+        .append(domainNS)
+        .append(" exec -it ")
+        .append(podName)
+        .append(" -- bash -c 'chmod +x ")
+        .append(scriptsLocInPod)
+        .append("/")
+        .append(shScriptName)
+        .append("  && ")
+        .append(scriptsLocInPod)
+        .append("/")
+        .append(shScriptName)
+        .append(" ")
+        .append(String.join(" ", args).toString())
+        .append("'");
+
+    logger.info("Command to call kubectl sh file " + cmdKubectlSh);
+    TestUtils.exec(cmdKubectlSh.toString(), true);
+  }
 
   /**
    * Build a jar archive.  The archive will only include the directory structure below the srcDir.

--- a/integration-tests/src/test/resources/OperatorIT.properties
+++ b/integration-tests/src/test/resources/OperatorIT.properties
@@ -11,4 +11,5 @@ weblogicImageTag = 12.2.1.3
 weblogicImageDevTag = 12.2.1.3-dev
 weblogicImageName = container-registry.oracle.com/middleware/weblogic
 OCR_SERVER=container-registry.oracle.com
+DB_URL=infradb.db.svc.cluster.local:1521/InfraPDB1.us.oracle.com
 DOMAIN_API_VERSION = weblogic.oracle/v5

--- a/integration-tests/src/test/resources/jrf/checkDb.sh
+++ b/integration-tests/src/test/resources/jrf/checkDb.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2018, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+#
+. /u01/oracle/wlserver/server/bin/setWLSEnv.sh
+
+echo "Check if the DB Service is Ready to accept Connection"
+connectString=${1:-infradb.db.svc.cluster.local:1521/InfraPDB1.us.oracle.com}
+echo "The DB Connection URL [$connectString]"
+
+max=20
+counter=0
+while [ $counter -le ${max} ]
+do
+ #java utils.dbping ORACLE_THIN "sys as sysdba" Oradoc_db1 ${connectString} 
+ java utils.dbping ORACLE_THIN scott tiger ${connectString} > dbping.err 2>&1 
+ [[ $? == 0 ]] && break;
+ ((counter++))
+ echo "[$counter/${max}] Retrying the DB Connection. Sleep for 10s more ..."
+ sleep 10
+done
+
+if [ $counter -gt ${max} ]; then 
+ echo "[ERRORR] Oracle DB Service is not ready after [${max}] iterations ..."
+ exit -1
+else 
+ java utils.dbping ORACLE_THIN scott tiger ${connectString} 
+fi 


### PR DESCRIPTION
Implement DBPing for JRF domain integ test during test class prepare phase.
Internal Jenkins run: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2473/consoleFull
There are 2 DBPing (searching "DB Service is Ready to accept Connection" ) happened for 2 JRF test classes. 