### PR TITLE
Ignore unknown properties during REST processing

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/rest/model/ScaleClusterParamsModel.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/model/ScaleClusterParamsModel.java
@@ -4,9 +4,12 @@
 
 package oracle.kubernetes.operator.rest.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * ScaleClusterParamsModel describes the input parameters to the WebLogic cluster scaling operation.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ScaleClusterParamsModel extends BaseModel {
 
   private int managedServerCount;


### PR DESCRIPTION
This change resolves an insecure binder configuration issue reported from code scanning such that the ScaleClusterResource POST parameter handling will now only use properties defined in the model.

For more context on the annotation, see https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations#property-inclusion