### PR TITLE
Simplify WaitForReadyStep

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -6,10 +6,14 @@ package oracle.kubernetes.operator;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.models.V1ObjectMeta;
@@ -18,41 +22,38 @@ import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.builders.WatchI;
-import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.CallBuilder;
-import oracle.kubernetes.operator.helpers.CallBuilderFactory;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.watcher.WatchListener;
-import oracle.kubernetes.operator.work.ContainerResolver;
-import oracle.kubernetes.operator.work.NextAction;
-import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
-/** Watches for Pods to become Ready or leave Ready state. */
-public class PodWatcher extends Watcher<V1Pod>
-    implements WatchListener<V1Pod>, PodAwaiterStepFactory {
+/**
+ * Watches for changes to pods.
+ */
+public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, PodAwaiterStepFactory {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
-  private final String ns;
+  private final String namespace;
   private final WatchListener<V1Pod> listener;
 
-  // Map of Pod name to callback
-  private final Map<String, Collection<Runnable>> readyCallbackRegistrations = new HashMap<>();
-  private final Map<String, Collection<Runnable>> deletedCallbackRegistrations = new HashMap<>();
+  // Map of Pod name to callback. Note that since each pod name can be mapped to multiple callback registrations,
+  // a concurrent map will not suffice; we therefore use an ordinary map and synchronous accesses.
+  private final Map<String, Collection<Consumer<V1Pod>>> modifiedCallbackRegistrations = new HashMap<>();
+  private final Map<String, Collection<Consumer<V1Pod>>> deletedCallbackRegistrations = new HashMap<>();
 
   private PodWatcher(
-      String ns,
+      String namespace,
       String initialResourceVersion,
       WatchTuning tuning,
       WatchListener<V1Pod> listener,
       AtomicBoolean isStopping) {
     super(initialResourceVersion, tuning, isStopping);
     setListener(this);
-    this.ns = ns;
+    this.namespace = namespace;
     this.listener = listener;
   }
 
@@ -79,55 +80,39 @@ public class PodWatcher extends Watcher<V1Pod>
     return watcher;
   }
 
-  private void registerOnReady(String podName, Runnable onReady) {
-    synchronized (readyCallbackRegistrations) {
-      Collection<Runnable> col = readyCallbackRegistrations.get(podName);
-      if (col == null) {
-        col = new ArrayList<>();
-        readyCallbackRegistrations.put(podName, col);
-      }
-      col.add(onReady);
+  private void addOnModifiedCallback(String podName, Consumer<V1Pod> callback) {
+    synchronized (modifiedCallbackRegistrations) {
+      modifiedCallbackRegistrations.computeIfAbsent(podName, k -> new ArrayList<>()).add(callback);
     }
   }
 
-  private Collection<Runnable> retrieveOnReady(String podName) {
-    synchronized (readyCallbackRegistrations) {
-      return readyCallbackRegistrations.remove(podName);
+  private @Nonnull Collection<Consumer<V1Pod>> getOnModifiedCallbacks(String podName) {
+    synchronized (modifiedCallbackRegistrations) {
+      return Optional.ofNullable(modifiedCallbackRegistrations.remove(podName)).orElse(Collections.emptyList());
     }
   }
 
-  private void unregisterOnReady(String podName, Runnable onReady) {
-    synchronized (readyCallbackRegistrations) {
-      Collection<Runnable> col = readyCallbackRegistrations.get(podName);
-      if (col != null) {
-        col.remove(onReady);
-      }
+  private void removeOnModifiedCallback(String podName, Consumer<V1Pod> callback) {
+    synchronized (modifiedCallbackRegistrations) {
+      Optional.ofNullable(modifiedCallbackRegistrations.get(podName)).ifPresent(c -> c.remove(callback));
     }
   }
 
-  private void registerOnDelete(String podName, Runnable onReady) {
+  private void addOnDeleteCallback(String podName, Consumer<V1Pod> callback) {
     synchronized (deletedCallbackRegistrations) {
-      Collection<Runnable> col = deletedCallbackRegistrations.get(podName);
-      if (col == null) {
-        col = new ArrayList<>();
-        deletedCallbackRegistrations.put(podName, col);
-      }
-      col.add(onReady);
+      deletedCallbackRegistrations.computeIfAbsent(podName, k -> new ArrayList<>()).add(callback);
     }
   }
 
-  private Collection<Runnable> retrieveOnDelete(String podName) {
+  private @Nonnull Collection<Consumer<V1Pod>> getOnDeleteCallbacks(String podName) {
     synchronized (deletedCallbackRegistrations) {
-      return deletedCallbackRegistrations.remove(podName);
+      return Optional.ofNullable(deletedCallbackRegistrations.remove(podName)).orElse(Collections.emptyList());
     }
   }
 
-  private void unregisterOnDelete(String podName, Runnable onReady) {
+  private void removeOnDeleteCallback(String podName, Consumer<V1Pod> callback) {
     synchronized (deletedCallbackRegistrations) {
-      Collection<Runnable> col = deletedCallbackRegistrations.get(podName);
-      if (col != null) {
-        col.remove(onReady);
-      }
+      Optional.ofNullable(deletedCallbackRegistrations.get(podName)).ifPresent(c -> c.remove(callback));
     }
   }
 
@@ -135,7 +120,7 @@ public class PodWatcher extends Watcher<V1Pod>
   public WatchI<V1Pod> initiateWatch(WatchBuilder watchBuilder) throws ApiException {
     return watchBuilder
         .withLabelSelectors(LabelConstants.DOMAINUID_LABEL, LabelConstants.CREATEDBYOPERATOR_LABEL)
-        .createPodWatch(ns);
+        .createPodWatch(namespace);
   }
 
   public void receivedResponse(Watch.Response<V1Pod> item) {
@@ -143,33 +128,15 @@ public class PodWatcher extends Watcher<V1Pod>
 
     listener.receivedResponse(item);
 
-    V1Pod pod;
-    Boolean isReady;
-    String podName;
+    V1Pod pod = item.object;
+    String podName = pod.getMetadata().getName();
     switch (item.type) {
       case "ADDED":
       case "MODIFIED":
-        pod = item.object;
-        isReady = !PodHelper.isDeleting(pod) && PodHelper.isReady(pod);
-        podName = pod.getMetadata().getName();
-        if (isReady) {
-          Collection<Runnable> col = retrieveOnReady(podName);
-          if (col != null) {
-            for (Runnable ready : col) {
-              ready.run();
-            }
-          }
-        }
+        getOnModifiedCallbacks(podName).forEach(c -> c.accept(pod));
         break;
       case "DELETED":
-        pod = item.object;
-        podName = pod.getMetadata().getName();
-        Collection<Runnable> col = retrieveOnDelete(podName);
-        if (col != null) {
-          for (Runnable delete : col) {
-            delete.run();
-          }
-        }
+        getOnDeleteCallbacks(podName).forEach(c -> c.accept(pod));
         break;
       case "ERROR":
       default:
@@ -200,107 +167,54 @@ public class PodWatcher extends Watcher<V1Pod>
     return new WaitForPodDeleteStep(pod, next);
   }
 
-  private abstract class WaitForPodStatusStep extends Step {
-    private final V1Pod pod;
+  private abstract class WaitForPodStatusStep extends WaitForReadyStep<V1Pod> {
 
     private WaitForPodStatusStep(V1Pod pod, Step next) {
-      super(next);
-      this.pod = pod;
-    }
-
-    @Override
-    public NextAction apply(Packet packet) {
-      if (!PodHelper.isDeleting(pod) && PodHelper.getReadyStatus(pod)) {
-        return doNext(packet);
-      }
-
-      V1ObjectMeta metadata = pod.getMetadata();
-
-      log(metadata);
-
-      AtomicBoolean didResume = new AtomicBoolean(false);
-      return doSuspend(
-          (fiber) -> {
-            Runnable ready =
-                () -> {
-                  if (didResume.compareAndSet(false, true)) {
-                    fiber.resume(packet);
-                  }
-                };
-            register(metadata, ready);
-
-            // Timing window -- pod may have come ready before registration for callback
-            CallBuilderFactory factory =
-                ContainerResolver.getInstance().getContainer().getSpi(CallBuilderFactory.class);
-            fiber
-                .createChildFiber()
-                .start(
-                    factory
-                        .create()
-                        .readPodAsync(
-                            metadata.getName(),
-                            metadata.getNamespace(),
-                            new ResponseStep<V1Pod>(null) {
-                              @Override
-                              public NextAction onFailure(
-                                  Packet packet,
-                                  CallResponse<V1Pod> callResponse) {
-                                if (callResponse.getStatusCode() == CallBuilder.NOT_FOUND) {
-                                  return onSuccess(packet, callResponse);
-                                }
-                                return super.onFailure(packet, callResponse);
-                              }
-
-                              @Override
-                              public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
-                                if (testPod(callResponse.getResult())) {
-                                  if (didResume.compareAndSet(false, true)) {
-                                    unregister(metadata, ready);
-                                    fiber.resume(packet);
-                                  }
-                                }
-                                return doNext(packet);
-                              }
-                            }),
-                    packet.clone(),
-                    null);
-          });
-    }
-
-    protected void log(V1ObjectMeta metadata) {
-      // no-op
-    }
-
-    protected abstract boolean testPod(V1Pod result);
-
-    protected abstract void register(V1ObjectMeta metadata, Runnable callback);
-
-    protected abstract void unregister(V1ObjectMeta metadata, Runnable callback);
-  }
-
-  private class WaitForPodReadyStep extends WaitForPodStatusStep {
-    private WaitForPodReadyStep(V1Pod pod, Step next) {
       super(pod, next);
     }
 
     @Override
-    protected void log(V1ObjectMeta metadata) {
-      LOGGER.info(MessageKeys.WAITING_FOR_POD_READY, metadata.getName());
+    V1ObjectMeta getMetadata(V1Pod pod) {
+      return pod.getMetadata();
+    }
+    
+    @Override
+    Step createReadAsyncStep(String name, String namespace, ResponseStep<V1Pod> responseStep) {
+      return new CallBuilder().readPodAsync(name, namespace, responseStep);
+    }
+  }
+
+  private class WaitForPodReadyStep extends WaitForPodStatusStep {
+
+    private WaitForPodReadyStep(V1Pod pod, Step next) {
+      super(pod, next);
+    }
+
+    // A pod is ready if it is not being deleted and has the ready status.
+    @Override
+    protected boolean isReady(V1Pod result) {
+      return result != null && !PodHelper.isDeleting(result) && PodHelper.isReady(result);
+    }
+
+    // Pods should be processed if ready.
+    @Override
+    boolean shouldProcessCallback(V1Pod resource) {
+      return isReady(resource);
     }
 
     @Override
-    protected boolean testPod(V1Pod result) {
-      return result != null && !PodHelper.isDeleting(result) && PodHelper.getReadyStatus(result);
+    protected void addCallback(String podName, Consumer<V1Pod> callback) {
+      addOnModifiedCallback(podName, callback);
     }
 
     @Override
-    protected void register(V1ObjectMeta metadata, Runnable callback) {
-      registerOnReady(metadata.getName(), callback);
+    protected void removeCallback(String podName, Consumer<V1Pod> callback) {
+      removeOnModifiedCallback(podName, callback);
     }
 
     @Override
-    protected void unregister(V1ObjectMeta metadata, Runnable callback) {
-      unregisterOnReady(metadata.getName(), callback);
+    protected void logWaiting(String name) {
+      LOGGER.info(MessageKeys.WAITING_FOR_POD_READY, name);
     }
   }
 
@@ -309,19 +223,20 @@ public class PodWatcher extends Watcher<V1Pod>
       super(pod, next);
     }
 
+    // A pod is considered deleted when reading its value from Kubernetes returns null.
     @Override
-    protected boolean testPod(V1Pod result) {
+    protected boolean isReady(V1Pod result) {
       return result == null;
     }
 
     @Override
-    protected void register(V1ObjectMeta metadata, Runnable callback) {
-      registerOnDelete(metadata.getName(), callback);
+    protected void addCallback(String podName, Consumer<V1Pod> callback) {
+      addOnDeleteCallback(podName, callback);
     }
 
     @Override
-    protected void unregister(V1ObjectMeta metadata, Runnable callback) {
-      unregisterOnDelete(metadata.getName(), callback);
+    protected void removeCallback(String podName, Consumer<V1Pod> callback) {
+      removeOnDeleteCallback(podName, callback);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -1,0 +1,214 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import io.kubernetes.client.models.V1ObjectMeta;
+import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.helpers.ResponseStep;
+import oracle.kubernetes.operator.steps.DefaultResponseStep;
+import oracle.kubernetes.operator.work.Fiber;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+
+/**
+ * This class is the base for steps that must suspend while waiting for a resource to become ready. It is typically
+ * implemented as a part of a {@link Watcher} and relies on callbacks from that watcher to proceed.
+ * @param <T> the type of resource handled by this step
+ */
+abstract class WaitForReadyStep<T> extends Step {
+  private T initialResource;
+
+  /**
+   * Creates a step which will only proceed once the specified resource is ready.
+   * @param resource the resource to watch
+   * @param next the step to run once it the resource is ready
+   */
+  WaitForReadyStep(T resource, Step next) {
+    super(next);
+    this.initialResource = resource;
+  }
+
+  /**
+   * Returns true if the specified resource is deemed "ready." Different steps may define readiness in different ways.
+   * @param resource the resource to check
+   * @return true if processing can proceed
+   */
+  abstract boolean isReady(T resource);
+
+  /**
+   * Returns true if the callback for this resource should be processed. This is typically used to exclude
+   * resources which have changed but are not yet ready, or else different instances with the same name.
+   * This default implementation processes all callbacks.
+   * 
+   * @param resource the resource to check
+   * @return true if the resource is expected
+   */
+  boolean shouldProcessCallback(T resource) {
+    return true;
+  }
+
+  /**
+   * Returns the metadata associated with the resource.
+   * @param resource the resource to check
+   * @return a Kubernetes metadata object containing the namespace and name
+   */
+  abstract V1ObjectMeta getMetadata(T resource);
+
+  /**
+   * Registers a callback for changes to the resource.
+   * @param name the name of the resource to watch
+   * @param callback the callback to invoke when a change is reported
+   */
+  abstract void addCallback(String name, Consumer<T> callback);
+
+  /**
+   * Unregisters a callback for the specified resource name.
+   * @param name the name of the resource to stop watching
+   * @param callback the previously registered callback
+   */
+  abstract void removeCallback(String name, Consumer<T> callback);
+
+  /**
+   * Creates a {@link Step} that reads the specified resource asynchronously and then invokes the specified response.
+   * @param name the name of the resource
+   * @param namespace the namespace containing the resource
+   * @param responseStep the step which should be invoked once the resource has been read
+   * @return the created step
+   */
+  abstract Step createReadAsyncStep(String name, String namespace, ResponseStep<T> responseStep);
+
+  /**
+   * Updates the packet when the resource is declared ready. The default implementation does nothing.
+   * @param packet the packet to update
+   * @param resource the now-ready resource
+   */
+  void updatePacket(Packet packet, T resource) {
+  }
+
+  /**
+   * Determines whether the state of the resource requires the fiber to be terminated.
+   * This default implementation always returns false; if it returns true, {@link #createTerminationException(Object)}
+   * must return a non-null result
+   * @param resource the resource to check
+   * @return true if the fiber should be terminated
+   */
+  boolean shouldTerminateFiber(T resource) {
+    return false;
+  }
+
+  /**
+   * Creates an exception to report as the fiber completion if the fiber is being terminated.
+   * @param resource the resource from which the exception should be created
+   * @return an exception. Must not return null if
+   */
+  Throwable createTerminationException(T resource) {
+    return null;
+  }
+
+  /**
+   * Log a message to indicate that we have started waiting for the resource to become ready.
+   * This default implementation does nothing.
+   * @param name the name of the resource
+   */
+  void logWaiting(String name) {
+    // no-op
+  }
+
+  @Override
+  public final NextAction apply(Packet packet) {
+    if (shouldTerminateFiber(initialResource))
+      return doTerminate(createTerminationException(initialResource), packet);
+    else if (isReady(initialResource)) {
+      return doNext(packet);
+    }
+
+    logWaiting(getName());
+    return doSuspend((fiber) -> resumeWhenReady(packet, fiber));
+  }
+
+  // Registers a callback for updates to the specified resource and
+  // verifies that we haven't already missed the update.
+  private void resumeWhenReady(Packet packet, Fiber fiber) {
+    Callback callback = new Callback(fiber, packet);
+    addCallback(getName(), callback);
+    checkUpdatedResource(packet, fiber, callback);
+  }
+
+  // It is possible that the watch event was received between the time the step was created, and the time the callback
+  // was registered. Just in case, we will check the latest resource value in Kubernetes and process the resource
+  // if it is now ready
+  private void checkUpdatedResource(Packet packet, Fiber fiber, Callback callback) {
+    fiber
+        .createChildFiber()
+        .start(
+            createReadAsyncStep(getName(), getNamespace(), resumeIfReady(callback)),
+            packet.clone(),
+            null);
+  }
+
+  private String getNamespace() {
+    return getMetadata(initialResource).getNamespace();
+  }
+
+  private String getName() {
+    return getMetadata(initialResource).getName();
+  }
+
+  private DefaultResponseStep<T> resumeIfReady(Callback callback) {
+    return new DefaultResponseStep<>(null) {
+      @Override
+      public NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
+        if (isReady(callResponse.getResult()))
+          callback.proceedFromWait(callResponse.getResult());
+        return doNext(packet);
+      }
+    };
+  }
+
+  private class Callback implements Consumer<T> {
+    private Fiber fiber;
+    private Packet packet;
+    private final AtomicBoolean didResume = new AtomicBoolean(false);
+
+    Callback(Fiber fiber, Packet packet) {
+      this.fiber = fiber;
+      this.packet = packet;
+    }
+
+    @Override
+    public void accept(T resource) {
+      if (shouldProcessCallback(resource)) {
+        proceedFromWait(resource);
+      }
+    }
+
+    // The resource has now either completed or failed, so we can continue processing.
+    private void proceedFromWait(T resource) {
+      removeCallback(getName(), this);
+
+      if (mayResumeFiber()) {
+        handleResourceReady(fiber, packet, resource);
+        fiber.resume(packet);
+      }
+    }
+
+    // Returns true if it is now time to resume the fiber.
+    // This method will return true only the first time it is called.
+    private boolean mayResumeFiber() {
+      return didResume.compareAndSet(false, true);
+    }
+  }
+
+  private void handleResourceReady(Fiber fiber, Packet packet, T resource) {
+    updatePacket(packet, resource);
+    if (shouldTerminateFiber(resource)) {
+      fiber.terminate(createTerminationException(resource), packet);
+    }
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -5,9 +5,8 @@
 package oracle.kubernetes.operator;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.kubernetes.client.models.V1Job;
 import io.kubernetes.client.models.V1JobCondition;
@@ -15,20 +14,20 @@ import io.kubernetes.client.models.V1JobStatus;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
+import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.watcher.WatchListener;
-import oracle.kubernetes.operator.work.FiberTestSupport;
-import oracle.kubernetes.operator.work.NextAction;
-import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Test;
 
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -41,13 +40,32 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   private static final int INITIAL_RESOURCE_VERSION = 234;
   private static final String NS = "ns1";
   private static final String VERSION = "123";
-  private Packet packet;
-  private V1Job job = new V1Job().metadata(new V1ObjectMeta().name("test").creationTimestamp(new DateTime()));
-  private FiberTestSupport fiberTestSupport = new FiberTestSupport();
+  private V1Job cachedJob = createJob();
+  private long clock;
 
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final TerminalStep terminalStep = new TerminalStep();
+
+  @Override
   public void setUp() throws Exception {
     super.setUp();
-    packet = new Packet();
+    addMemento(testSupport.install());
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+
+    testSupport.throwOnCompletionFailure();
+  }
+
+  private V1Job createJob() {
+    return new V1Job().metadata(new V1ObjectMeta().name("test").creationTimestamp(getCurrentTime()));
+  }
+
+  private DateTime getCurrentTime() {
+    return new DateTime(clock);
   }
 
   @Override
@@ -82,153 +100,261 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
 
   @Test
   public void whenJobHasNoStatus_reportNotComplete() {
-    assertThat(JobWatcher.isComplete(job), is(false));
+    assertThat(JobWatcher.isComplete(cachedJob), is(false));
   }
 
   @Test
   public void whenJobHasNoCondition_reportNotComplete() {
-    job.status(new V1JobStatus());
+    cachedJob.status(new V1JobStatus());
 
-    assertThat(JobWatcher.isComplete(job), is(false));
+    assertThat(JobWatcher.isComplete(cachedJob), is(false));
   }
 
   @Test
   public void whenJobConditionTypeFailed_reportNotComplete() {
-    job.status(new V1JobStatus().addConditionsItem(new V1JobCondition().type("Failed")));
+    cachedJob.status(new V1JobStatus().addConditionsItem(new V1JobCondition().type("Failed")));
 
-    assertThat(JobWatcher.isComplete(job), is(false));
+    assertThat(JobWatcher.isComplete(cachedJob), is(false));
   }
 
   @Test
   public void whenJobConditionStatusFalse_reportNotComplete() {
-    job.status(
+    cachedJob.status(
         new V1JobStatus().addConditionsItem(new V1JobCondition().type("Complete").status("False")));
 
-    assertThat(JobWatcher.isComplete(job), is(false));
+    assertThat(JobWatcher.isComplete(cachedJob), is(false));
   }
 
   @Test
   public void whenJobRunningAndReadyConditionIsTrue_reportComplete() {
-    makeJobReady(job);
+    markJobCompleted(cachedJob);
 
-    assertThat(JobWatcher.isComplete(job), is(true));
+    assertThat(JobWatcher.isComplete(cachedJob), is(true));
   }
 
-  private void makeJobReady(V1Job job) {
-    List<V1JobCondition> conditions =
-        Collections.singletonList(new V1JobCondition().type("Complete").status("True"));
-    job.status(new V1JobStatus().conditions(conditions));
+  private V1Job dontChangeJob(V1Job job) {
+    return job;
   }
 
-  private void makeJobFailed(V1Job job, String reason) {
-    List<V1JobCondition> conditions =
-        Collections.singletonList(new V1JobCondition().type("Failed").status("True").reason(reason));
-    job.status(new V1JobStatus().failed(1).conditions(conditions));
+  private V1Job markJobCompleted(V1Job job) {
+    return job.status(new V1JobStatus().addConditionsItem(createCondition("Complete")));
+  }
+
+  private V1JobCondition createCondition(String type) {
+    return new V1JobCondition().type(type).status("True");
+  }
+
+  private V1Job markJobFailed(V1Job job) {
+    return setFailedWithReason(job, null);
+  }
+
+  private V1Job markJobTimedOut(V1Job job) {
+    return setFailedWithReason(job, "DeadlineExceeded");
+  }
+
+  private V1Job setFailedWithReason(V1Job job, String reason) {
+    return job.status(new V1JobStatus().failed(1).addConditionsItem(createCondition("Failed").reason(reason)));
   }
 
   @Test
   public void whenJobHasNoStatus_reportNotFailed() {
-    assertThat(JobWatcher.isFailed(job), is(false));
+    assertThat(JobWatcher.isFailed(cachedJob), is(false));
   }
 
   @Test
   public void whenJobHasFailedCount_reportFailed() {
-    job.status(new V1JobStatus().failed(1));
+    cachedJob.status(new V1JobStatus().failed(1));
 
-    assertThat(JobWatcher.isFailed(job), is(true));
+    assertThat(JobWatcher.isFailed(cachedJob), is(true));
   }
 
   @Test
   public void whenJobHasFailedReason_getFailedReasonReturnsIt() {
-    makeJobFailed(job, "DeadlineExceeded");
+    setFailedWithReason(cachedJob, "AReason");
 
-    assertThat(JobWatcher.getFailedReason(job), is("DeadlineExceeded"));
+    assertThat(JobWatcher.getFailedReason(cachedJob), is("AReason"));
   }
 
   @Test
   public void whenJobHasNoFailedReason_getFailedReasonReturnsNull() {
-    makeJobFailed(job, null);
+    setFailedWithReason(cachedJob, null);
 
-    assertThat(JobWatcher.getFailedReason(job), nullValue());
+    assertThat(JobWatcher.getFailedReason(cachedJob), nullValue());
   }
 
   @Test
   public void whenJobHasNoFailedCondition_getFailedReasonReturnsNull() {
-    job.status(new V1JobStatus().addConditionsItem(new V1JobCondition().type("Complete").status("True")));
+    cachedJob.status(new V1JobStatus().addConditionsItem(createCondition("Complete")));
 
-    assertThat(JobWatcher.getFailedReason(job), nullValue());
+    assertThat(JobWatcher.getFailedReason(cachedJob), nullValue());
   }
 
   @Test
   public void whenJobHasNoJobCondition_getFailedReasonReturnsNull() {
-    job.status(new V1JobStatus().conditions(Collections.EMPTY_LIST));
+    cachedJob.status(new V1JobStatus().conditions(Collections.emptyList()));
 
-    assertThat(JobWatcher.getFailedReason(job), nullValue());
+    assertThat(JobWatcher.getFailedReason(cachedJob), nullValue());
   }
 
   @Test
   public void waitForReady_returnsAStep() {
-    AtomicBoolean stopping = new AtomicBoolean(true);
-    JobWatcher watcher =
-        JobWatcher.create(this, "ns", Integer.toString(INITIAL_RESOURCE_VERSION), tuning, stopping);
+    JobWatcher watcher = createWatcher(new AtomicBoolean(true));
 
-    assertThat(watcher.waitForReady(job, null), Matchers.instanceOf(Step.class));
+    assertThat(watcher.waitForReady(cachedJob, null), instanceOf(Step.class));
+  }
+
+  private JobWatcher createWatcher(AtomicBoolean stopping) {
+    return JobWatcher.create(this, "ns", Integer.toString(INITIAL_RESOURCE_VERSION), tuning, stopping);
   }
 
   @Test
   public void whenWaitForReadyAppliedToReadyJob_performNextStep() {
-    AtomicBoolean stopping = new AtomicBoolean(false);
-    JobWatcher watcher =
-        JobWatcher.create(this, "ns", Integer.toString(INITIAL_RESOURCE_VERSION), tuning, stopping);
+    startWaitForReady(this::markJobCompleted);
 
-    makeJobReady(job);
-
-    ListeningTerminalStep listeningStep = new ListeningTerminalStep(stopping);
-    Step step = watcher.waitForReady(job, listeningStep);
-    NextAction nextAction = step.apply(packet);
-    nextAction.getNext().apply(packet);
-
-    assertThat(listeningStep.wasPerformed, is(true));
+    assertThat(terminalStep.wasRun(), is(true));
   }
 
   @Test
-  public void whenReceivedDeadlineExceededResponse_doNotPerformNextStep() {
-    doReceivedResponseTest((j) -> makeJobFailed(j, "DeadlineExceeded"), false);
+  public void whenWaitForReadyAppliedToIncompleteJob_dontPerformNextStep() {
+    startWaitForReady(this::dontChangeJob);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  @Test
+  public void whenWaitForReadyAppliedToTimedOutJob_terminateWithException() {
+    startWaitForReady(this::markJobTimedOut);
+
+    assertThat(terminalStep.wasRun(), is(false));
+    testSupport.verifyCompletionThrowable(JobWatcher.DeadlineExceededException.class);
+  }
+
+  @Test
+  public void whenWaitForReadyAppliedToFailedJob_performNextStep() {
+    startWaitForReady(this::markJobFailed);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  // Starts the waitForReady step with job modified as needed
+  private void startWaitForReady(Function<V1Job,V1Job> jobFunction) {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    JobWatcher watcher = createWatcher(stopping);
+
+    V1Job cachedJob = jobFunction.apply(createJob());
+
+    try {
+      testSupport.runSteps(watcher.waitForReady(cachedJob, terminalStep));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  public void whenJobCompletedOnFirstRead_performNextStep() {
+    startWaitForReadyThenReadJob(this::markJobCompleted);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @Test
+  public void whenJobInProcessOnFirstRead_dontPerformNextStep() {
+    startWaitForReadyThenReadJob(this::dontChangeJob);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  @Test
+  public void whenJobTimedOutOnFirstRead_terminateWithException() {
+    startWaitForReadyThenReadJob(this::markJobTimedOut);
+
+    assertThat(terminalStep.wasRun(), is(false));
+    testSupport.verifyCompletionThrowable(JobWatcher.DeadlineExceededException.class);
+  }
+
+  @Test
+  public void whenJobFailedOnFirstRead_performNextStep() {
+    startWaitForReadyThenReadJob(this::markJobFailed);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  // Starts the waitForReady step with an incomplete job cached, but a modified one in kubernetes
+  private void startWaitForReadyThenReadJob(Function<V1Job,V1Job> jobFunction) {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    JobWatcher watcher = createWatcher(stopping);
+
+    V1Job persistedJob = jobFunction.apply(createJob());
+    testSupport.defineResources(persistedJob);
+
+    try {
+      testSupport.runSteps(watcher.waitForReady(cachedJob, terminalStep));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  public void whenReceivedDeadlineExceededResponse_terminateWithException() {
+    sendJobModifiedWatchAfterWaitForReady(this::markJobTimedOut);
+
+    assertThat(terminalStep.wasRun(), is(false));
+    testSupport.verifyCompletionThrowable(JobWatcher.DeadlineExceededException.class);
   }
 
   @Test
   public void whenReceivedFailedWithNoReasonResponse_performNextStep() {
-    doReceivedResponseTest((j) -> makeJobFailed(j, null), true);
+    sendJobModifiedWatchAfterWaitForReady(this::markJobFailed);
+
+    assertThat(terminalStep.wasRun(), is(true));
   }
 
   @Test
   public void whenReceivedCompleteResponse_performNextStep() {
-    doReceivedResponseTest((j) -> makeJobReady(j), true);
+    sendJobModifiedWatchAfterWaitForReady(this::markJobCompleted);
+
+    assertThat(terminalStep.wasRun(), is(true));
   }
 
-  private void doReceivedResponseTest(Consumer<V1Job> jobStatusUpdater, final boolean expectedResult) {
+  @Test
+  public void whenReceivedCallbackForDifferentCompletedJob_ignoreIt() {
+    sendJobModifiedWatchAfterWaitForReady(this::createCompletedJobWithDifferentTimestamp);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  @Test
+  public void whenReceivedCallbackForIncompleteJob_ignoreIt() {
+    sendJobModifiedWatchAfterWaitForReady(this::dontChangeJob);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  @SuppressWarnings("unused")
+  private V1Job createCompletedJobWithDifferentTimestamp(V1Job job) {
+    clock++;
+    return markJobCompleted(createJob());
+  }
+
+  // Starts the waitForReady step with an incomplete job and sends a watch indicating that the job has changed
+  private void sendJobModifiedWatchAfterWaitForReady(Function<V1Job,V1Job> modifier) {
     AtomicBoolean stopping = new AtomicBoolean(false);
-    JobWatcher watcher =
-        JobWatcher.create(this, "ns", Integer.toString(INITIAL_RESOURCE_VERSION), tuning, stopping);
+    JobWatcher watcher = createWatcher(stopping);
+    testSupport.defineResources(cachedJob);
 
-    ListeningTerminalStep listeningStep = new ListeningTerminalStep(stopping);
-    Step step = watcher.waitForReady(job, listeningStep);
-
-    // run WaitForReadyStep.apply() and the doSuspend() inside apply() to set up Complete callback
-    fiberTestSupport.runSteps(step);
-
-    jobStatusUpdater.accept(job);
-
-    watcher.receivedResponse(new Watch.Response<>("MODIFIED", job));
-    assertThat(listeningStep.wasPerformed, is(expectedResult));
+    try {
+      testSupport.runSteps(watcher.waitForReady(cachedJob, terminalStep));
+      watcher.receivedResponse(new Watch.Response<>("MODIFIED", modifier.apply(createJob())));
+    } finally {
+      stopping.set(true);
+    }
   }
 
   @Test
   public void afterFactoryDefined_createWatcherForDomain() {
     AtomicBoolean stopping = new AtomicBoolean(true);
-    JobWatcher.defineFactory(this, tuning, ns -> stopping);
-    Domain domain =
-        new Domain().withMetadata(new V1ObjectMeta().namespace(NS).resourceVersion(VERSION));
+    JobWatcher.defineFactory(this, tuning, s -> stopping);
+    Domain domain = new Domain().withMetadata(new V1ObjectMeta().namespace(NS).resourceVersion(VERSION));
 
     assertThat(JobWatcher.getOrCreateFor(domain), notNullValue());
   }
@@ -249,18 +375,4 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
     // Override as JobWatcher doesn't currently implement listener for callback
   }
 
-  static class ListeningTerminalStep extends Step {
-    private boolean wasPerformed = false;
-
-    ListeningTerminalStep(AtomicBoolean stopping) {
-      super(null);
-      stopping.set(true);
-    }
-
-    @Override
-    public NextAction apply(Packet packet) {
-      wasPerformed = true;
-      return doEnd(packet);
-    }
-  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -4,9 +4,8 @@
 
 package oracle.kubernetes.operator;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
@@ -14,11 +13,13 @@ import io.kubernetes.client.models.V1PodCondition;
 import io.kubernetes.client.models.V1PodStatus;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
+import oracle.kubernetes.operator.builders.WatchEvent;
+import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.watcher.WatchListener;
-import oracle.kubernetes.operator.work.NextAction;
-import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.operator.work.TerminalStep;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
@@ -32,12 +33,16 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 public class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
 
   private static final int INITIAL_RESOURCE_VERSION = 234;
-  private Packet packet;
-  private V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name("test"));
+  private static final String NS = "ns";
+  private static final String NAME = "test";
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final TerminalStep terminalStep = new TerminalStep();
 
+  @Override
+  @Before
   public void setUp() throws Exception {
     super.setUp();
-    packet = new Packet();
+    addMemento(testSupport.install());
   }
 
   @Override
@@ -73,48 +78,181 @@ public class PodWatcherTest extends WatcherTestBase implements WatchListener<V1P
   @Test
   public void waitForReady_returnsAStep() {
     AtomicBoolean stopping = new AtomicBoolean(true);
-    PodWatcher watcher =
-        PodWatcher.create(
-            this, "ns", Integer.toString(INITIAL_RESOURCE_VERSION), tuning, this, stopping);
+    PodWatcher watcher = createWatcher(stopping);
 
-    assertThat(watcher.waitForReady(pod, null), Matchers.instanceOf(Step.class));
+    assertThat(watcher.waitForReady(createPod(), null), Matchers.instanceOf(Step.class));
+  }
+
+  private PodWatcher createWatcher(AtomicBoolean stopping) {
+    return PodWatcher.create(this, NS, Integer.toString(INITIAL_RESOURCE_VERSION), tuning, this, stopping);
+  }
+
+  private V1Pod createPod() {
+    return new V1Pod().metadata(new V1ObjectMeta().namespace(NS).name(NAME));
   }
 
   @Test
-  public void whenWaitForReadyAppliedToReadyPod_performNextStep() {
+  public void whenPodInitiallyReady_waitForReadyProceedsImmediately() {
     AtomicBoolean stopping = new AtomicBoolean(false);
-    PodWatcher watcher =
-        PodWatcher.create(
-            this, "ns", Integer.toString(INITIAL_RESOURCE_VERSION), tuning, this, stopping);
+    PodWatcher watcher = createWatcher(stopping);
 
-    makePodReady(pod);
+    V1Pod pod = createPod();
+    markPodReady(pod);
 
-    ListeningTerminalStep listeningStep = new ListeningTerminalStep(stopping);
-    Step step = watcher.waitForReady(pod, listeningStep);
-    NextAction nextAction = step.apply(packet);
-    nextAction.getNext().apply(packet);
+    try {
+      testSupport.runSteps(watcher.waitForReady(pod, terminalStep));
 
-    assertThat(listeningStep.wasPerformed, is(true));
-  }
-
-  private void makePodReady(V1Pod pod) {
-    List<V1PodCondition> conditions =
-        Collections.singletonList(new V1PodCondition().type("Ready").status("True"));
-    pod.status(new V1PodStatus().phase("Running").conditions(conditions));
-  }
-
-  static class ListeningTerminalStep extends Step {
-    private boolean wasPerformed = false;
-
-    ListeningTerminalStep(AtomicBoolean stopping) {
-      super(null);
+      assertThat(terminalStep.wasRun(), is(true));
+    } finally {
       stopping.set(true);
     }
+  }
 
-    @Override
-    public NextAction apply(Packet packet) {
-      wasPerformed = true;
-      return doEnd(packet);
+  private V1Pod dontChangePod(V1Pod pod) {
+    return pod;
+  }
+
+  private V1Pod markPodReady(V1Pod pod) {
+    return pod.status(new V1PodStatus().phase("Running").addConditionsItem(createCondition("Ready")));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1PodCondition createCondition(String type) {
+    return new V1PodCondition().type(type).status("True");
+  }
+
+  @Test
+  public void whenPodReadyWhenWaitCreated_performNextStep() {
+    startWaitForReady(this::markPodReady);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @Test
+  public void whenPodNotReadyWhenWaitCreated_dontPerformNextStep() {
+    startWaitForReady(this::dontChangePod);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  private void startWaitForReady(Function<V1Pod, V1Pod> modifier) {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+
+    testSupport.defineResources(modifier.apply(createPod()));
+
+    try {
+      testSupport.runSteps(watcher.waitForReady(createPod(), terminalStep));
+
+    } finally {
+      stopping.set(true);
     }
   }
+
+  @Test
+  public void whenPodReadyOnFirstRead_runNextStep() {
+    startWaitForReadyThenReadPod(this::markPodReady);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @Test
+  public void whenPodNotReadyOnFirstRead_dontRunNextStep() {
+    startWaitForReadyThenReadPod(this::dontChangePod);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  private void startWaitForReadyThenReadPod(Function<V1Pod,V1Pod> modifier) {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+
+    V1Pod persistedPod = modifier.apply(createPod());
+    testSupport.defineResources(persistedPod);
+
+    try {
+      testSupport.runSteps(watcher.waitForReady(createPod(), terminalStep));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  public void whenPodReadyLater_runNextStep() {
+    sendPodModifiedWatchAfterWaitForReady(this::markPodReady);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @Test
+  public void whenPodNotReadyLater_dontRunNextStep() {
+    sendPodModifiedWatchAfterWaitForReady(this::dontChangePod);
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  // Starts the waitForReady step with an incomplete pod and sends a watch indicating that the pod has changed
+  private void sendPodModifiedWatchAfterWaitForReady(Function<V1Pod,V1Pod> modifier) {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+    testSupport.defineResources(createPod());
+
+    try {
+      testSupport.runSteps(watcher.waitForReady(createPod(), terminalStep));
+      watcher.receivedResponse(new Watch.Response<>("MODIFIED", modifier.apply(createPod())));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  public void whenPodDeletedOnFirstRead_runNextStep() {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+
+    try {
+      testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
+
+      assertThat(terminalStep.wasRun(), is(true));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  public void whenPodNotDeletedOnFirstRead_dontRunNextStep() {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+
+    testSupport.defineResources(createPod());
+    try {
+      testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
+
+      assertThat(terminalStep.wasRun(), is(false));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  public void whenPodDeletedLater_runNextStep() {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+
+    testSupport.defineResources(createPod());
+
+    try {
+      testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
+      watcher.receivedResponse(new Watch.Response<>("DELETED", createPod()));
+
+      assertThat(terminalStep.wasRun(), is(true));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  private Runnable reportPodIsNowDeleted(PodWatcher watcher) {
+    return () -> watcher.receivedResponse(WatchEvent.createDeleteEvent(createPod()).toWatchResponse());
+  }
+
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
@@ -29,14 +29,12 @@ import static org.hamcrest.Matchers.hasEntry;
 
 /** Tests behavior of the Watcher class. */
 @SuppressWarnings("SameParameterValue")
-public abstract class WatcherTestBase extends ThreadFactoryTestBase
-    implements StubWatchFactory.AllWatchesClosedListener {
+public abstract class WatcherTestBase extends ThreadFactoryTestBase implements StubWatchFactory.AllWatchesClosedListener {
   private static final int NEXT_RESOURCE_VERSION = 123456;
   private static final int INITIAL_RESOURCE_VERSION = 123;
   private static final String NAMESPACE = "testspace";
-  private final RuntimeException hasNextException =
-      new RuntimeException(Watcher.HAS_NEXT_EXCEPTION_MESSAGE);
-  protected WatchTuning tuning = new WatchTuning(30, 0);
+  private final RuntimeException hasNextException = new RuntimeException(Watcher.HAS_NEXT_EXCEPTION_MESSAGE);
+          WatchTuning tuning = new WatchTuning(30, 0);
   private List<Memento> mementos = new ArrayList<>();
   private List<Watch.Response<?>> callBacks = new ArrayList<>();
   private int resourceVersion = INITIAL_RESOURCE_VERSION;
@@ -70,13 +68,16 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
     StubWatchFactory.setListener(this);
   }
 
+  final void addMemento(Memento memento) {
+    mementos.add(memento);
+  }
+
   @After
-  public void tearDown() {
+  public void tearDown() throws Exception {
     shutDownThreads();
     for (Memento memento : mementos) memento.revert();
   }
 
-  @SuppressWarnings("unchecked")
   void sendInitialRequest(int initialResourceVersion) {
     scheduleAddResponse(createObjectWithMetaData());
 
@@ -120,7 +121,6 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
     return WatchEvent.createErrorEventWithoutStatus().toWatchResponse();
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void receivedEvents_areSentToListeners() {
     Object object1 = createObjectWithMetaData();
@@ -148,7 +148,6 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
         hasEntry("resourceVersion", String.valueOf(resourceVersion - 2)));
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void afterHttpGoneError_nextRequestSendsIncludedResourceVersion() {
     StubWatchFactory.addCallResponses(createHttpGoneErrorResponse(NEXT_RESOURCE_VERSION));
@@ -161,7 +160,6 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
         hasEntry("resourceVersion", Integer.toString(NEXT_RESOURCE_VERSION)));
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void afterHttpGoneErrorWithoutResourceVersion_nextRequestSendsResourceVersionZero() {
     StubWatchFactory.addCallResponses(createHttpGoneErrorWithoutResourceVersionResponse());
@@ -172,7 +170,6 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
     assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
   public void afterErrorWithoutStatus_nextRequestSendsResourceVersionZero() {
     StubWatchFactory.addCallResponses(createErrorWithoutStatusResponse());
@@ -183,7 +180,7 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
     assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings({"rawtypes"})
   @Test
   public void afterDelete_nextRequestSendsIncrementedResourceVersion() {
     scheduleDeleteResponse(createObjectWithMetaData());
@@ -196,7 +193,6 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
         hasEntry("resourceVersion", Integer.toString(INITIAL_RESOURCE_VERSION + 1)));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void afterExceptionDuringNext_closeWatchAndTryAgain() {
     StubWatchFactory.throwExceptionOnNext(hasNextException);
@@ -207,15 +203,11 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase
     assertThat(StubWatchFactory.getNumCloseCalls(), equalTo(2));
   }
 
-  protected void scheduleAddResponse(Object object) {
+  void scheduleAddResponse(Object object) {
     StubWatchFactory.addCallResponses(createAddResponse(object));
   }
 
-  protected void scheduleModifyResponse(Object object) {
-    StubWatchFactory.addCallResponses(createModifyResponse(object));
-  }
-
-  protected void scheduleDeleteResponse(Object object) {
+  private void scheduleDeleteResponse(Object object) {
     StubWatchFactory.addCallResponses(createDeleteResponse(object));
   }
 


### PR DESCRIPTION
Massive refactoring of the WaitForReadyStep functionality in the Domain and Pod watchers, expanding test coverage, simplifying the code, and extracting some common functionality. This will create a firmer foundation for the next change, which will actually monitor certain introspection job failures not currently being detected.

Kudos to @alai for getting better code coverage in the JobWatcher than I originally had in the PodWatcher.

The main test and functionality changes are related to the fact that the steps have to consider three cases in which the resource is found to be ready:

1. It is ready when the step is created
2. It is detected as a ready on a callback, and
3. It became ready between the time we created the step and the time we registered the callback

All "isReady" functionality must operate in all three scenarios.