### PR TITLE
OWLS-73891 part2 - clean up stale states about introspector jobs and domain presence infos

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -97,6 +97,9 @@ public class DomainProcessorImpl implements DomainProcessor {
     Map<String, DomainPresenceInfo> map = DOMAINS.get(ns);
     if (map != null) {
       map.remove(domainUid);
+      if (map.isEmpty()) {
+        DOMAINS.remove(ns);
+      }
     }
   }
 
@@ -195,7 +198,7 @@ public class DomainProcessorImpl implements DomainProcessor {
   }
 
   public void stopNamespace(String ns) {
-    Map<String, DomainPresenceInfo> map = DOMAINS.get(ns);
+    Map<String, DomainPresenceInfo> map = DOMAINS.remove(ns);
     if (map != null) {
       for (DomainPresenceInfo dpi : map.values()) {
         Domain dom = dpi.getDomain();

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -97,9 +97,6 @@ public class DomainProcessorImpl implements DomainProcessor {
     Map<String, DomainPresenceInfo> map = DOMAINS.get(ns);
     if (map != null) {
       map.remove(domainUid);
-      if (map.isEmpty()) {
-        DOMAINS.remove(ns);
-      }
     }
   }
 
@@ -198,7 +195,7 @@ public class DomainProcessorImpl implements DomainProcessor {
   }
 
   public void stopNamespace(String ns) {
-    Map<String, DomainPresenceInfo> map = DOMAINS.remove(ns);
+    Map<String, DomainPresenceInfo> map = DOMAINS.get(ns);
     if (map != null) {
       for (DomainPresenceInfo dpi : map.values()) {
         Domain dom = dpi.getDomain();

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -67,6 +67,10 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
     return JOB_WATCHERS.computeIfAbsent(getNamespace(domain), n -> factory.createFor(domain));
   }
 
+  public static void removeNamespace(String ns) {
+    JOB_WATCHERS.remove(ns);
+  }
+
   private static String getNamespace(Domain domain) {
     return domain.getMetadata().getNamespace();
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -225,6 +225,7 @@ public class Main {
       eventWatchers.remove(ns);
       podWatchers.remove(ns);
       serviceWatchers.remove(ns);
+      JobWatcher.removeNamespace(ns);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -246,7 +246,7 @@ public class Main {
     return new NullCompletionCallback(completionAction);
   }
 
-  private static Runnable recheckDomains() {
+  static Runnable recheckDomains() {
     return () -> {
       Collection<String> targetNamespaces = getTargetNamespaces();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -1,0 +1,91 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import com.meterware.simplestub.SystemPropertySupport;
+import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.weblogic.domain.model.Domain;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.function.Function.identity;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class NamespaceTest {
+  private static final String NAMESPACES_PROPERTY = "OPERATOR_TARGET_NAMESPACES";
+  private static final String ADDITIONAL_NAMESPACE = "NS3";
+
+  private Domain domain = DomainProcessorTestSetup.createTestDomain();
+  private final TuningParameters.WatchTuning tuning = new TuningParameters.WatchTuning(30, 0);
+  private List<Memento> mementos = new ArrayList<>();
+  private Set<String> currentNamespaces = new HashSet<>();
+
+  @Before
+  public void setUp() throws Exception {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(SystemPropertySupport.preserve(NAMESPACES_PROPERTY));
+    mementos.add(StaticStubSupport.install(Main.class, "isNamespaceStopping", currentNamespaces));
+
+    AtomicBoolean stopping = new AtomicBoolean(true);
+    JobWatcher.defineFactory(r -> createDaemonThread(), tuning, ns -> stopping);
+  }
+
+  private Thread createDaemonThread() {
+    Thread thread = new Thread();
+    thread.setDaemon(true);
+    return thread;
+  }
+
+  @After
+  public void tearDown() {
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  public void givenJobWatcherForNamespace_afterNamespaceDeletedAndRecreatedHaveDifferentWatcher() throws NoSuchFieldException {
+    addTargetNamespace(NS);
+    addTargetNamespace(ADDITIONAL_NAMESPACE);
+    cacheTargetNamespaces();
+    JobWatcher oldWatcher = JobWatcher.getOrCreateFor(domain);
+
+    deleteTargetNamespace(NS);
+    Main.recheckDomains().run();
+
+    assertThat(JobWatcher.getOrCreateFor(domain), not(sameInstance(oldWatcher)));
+  }
+
+  private void addTargetNamespace(String namespace) {
+    currentNamespaces.add(namespace);
+    System.setProperty(NAMESPACES_PROPERTY, String.join(",", currentNamespaces));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private void deleteTargetNamespace(String namespace) {
+    currentNamespaces.remove(namespace);
+    System.setProperty(NAMESPACES_PROPERTY, String.join(",", currentNamespaces));
+  }
+
+  private void cacheTargetNamespaces() throws NoSuchFieldException {
+    mementos.add(StaticStubSupport.install(Main.class, "isNamespaceStopping", createNamespaceFlags()));
+  }
+
+  private Map<String, AtomicBoolean> createNamespaceFlags() {
+    return currentNamespaces.stream().collect(Collectors.toMap(identity(), a-> new AtomicBoolean()));
+  }
+}


### PR DESCRIPTION
More clean up of stale objects (domain presence infos and introspector jobs) for a deleted and recreated namespace. 
This helps a previously existing domain to be successfully recreated after its namespace is deleted/recreated, and deleted from and then added back to operator's domainNamespaces list.