### PR TITLE
OWLS-76806 (Resolves #1231) - scripts such as livenessProbe.sh should use JAVA_HOME if set

### DIFF
--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -25,6 +25,7 @@ DH=${DOMAIN_HOME?}
 STATEFILE=${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
 if [ "${MOCK_WLS}" != 'true' ]; then
+  # Adjust PATH if necessary before calling jps
   adjustPath
 
   if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -25,6 +25,8 @@ DH=${DOMAIN_HOME?}
 STATEFILE=${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
 if [ "${MOCK_WLS}" != 'true' ]; then
+  adjustPath
+
   if [ `jps -l | grep -c " weblogic.NodeManager"` -eq 0 ]; then
     trace SEVERE "WebLogic NodeManager process not found."
     exit $RETVAL

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -20,6 +20,8 @@ DH=${DOMAIN_HOME?}
 
 STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
+adjustPath
+
 if [ `jps -v | grep -c " -Dweblogic.Name=${SERVER_NAME} "` -eq 0 ]; then
   trace "WebLogic server process not found"
   exit 1

--- a/operator/src/main/resources/scripts/readState.sh
+++ b/operator/src/main/resources/scripts/readState.sh
@@ -20,6 +20,7 @@ DH=${DOMAIN_HOME?}
 
 STATEFILE=/${DH}/servers/${SN}/data/nodemanager/${SN}.state
 
+# Adjust PATH if necessary before calling jps
 adjustPath
 
 if [ `jps -v | grep -c " -Dweblogic.Name=${SERVER_NAME} "` -eq 0 ]; then

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -76,6 +76,7 @@ trace "After stop-server.py" &>> ${STOP_OUT_FILE}
 # but let's try looking for the server process and
 # kill the server if the process still exists,
 # just in case we failed to stop it via wlst
+adjustPath
 pid=$(jps -v | grep " -Dweblogic.Name=${SERVER_NAME} " | awk '{print $1}')
 if [ ! -z $pid ]; then
   echo "Killing the server process $pid" &>> ${STOP_OUT_FILE}

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -76,7 +76,10 @@ trace "After stop-server.py" &>> ${STOP_OUT_FILE}
 # but let's try looking for the server process and
 # kill the server if the process still exists,
 # just in case we failed to stop it via wlst
+
+# Adjust PATH if necessary before calling jps
 adjustPath
+
 pid=$(jps -v | grep " -Dweblogic.Name=${SERVER_NAME} " | awk '{print $1}')
 if [ ! -z $pid ]; then
   echo "Killing the server process $pid" &>> ${STOP_OUT_FILE}

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -418,3 +418,14 @@ function getAdminServerUrl() {
   fi
   echo ${admin_protocol}://${AS_SERVICE_NAME}:${ADMIN_PORT}
 }
+
+#
+# adjustPath
+#   purpose: Prepend $PATH with $JAVA_HOME/bin if $JAVA_HOME is set
+#
+function adjustPath() {
+  if [ ! -z ${JAVA_HOME} ]; then
+    export PATH="${JAVA_HOME}/bin:$PATH"
+  fi
+}
+

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -422,10 +422,13 @@ function getAdminServerUrl() {
 #
 # adjustPath
 #   purpose: Prepend $PATH with $JAVA_HOME/bin if $JAVA_HOME is set
+#            and if $JAVA_HOME/bin is not already in $PATH
 #
 function adjustPath() {
   if [ ! -z ${JAVA_HOME} ]; then
-    export PATH="${JAVA_HOME}/bin:$PATH"
+    if [[ ":$PATH:" != *":${JAVA_HOME}/bin:"* ]]; then
+      export PATH="${JAVA_HOME}/bin:$PATH"
+    fi
   fi
 }
 


### PR DESCRIPTION
Append PATH with $JAVA_HOME/bin if $JAVA_HOME is set before calling jps

Tested on modified WebLogic image where java binaries are not found in PATH env var, but only in $JAVA_HOME/bin, and pods are started and remained in ready state.

Passed jenkins http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/2605/testReport/