### PR TITLE
 Add note to advise against using console for starting/stopping servers

### DIFF
--- a/docs-source/content/quickstart/create-domain.md
+++ b/docs-source/content/quickstart/create-domain.md
@@ -99,3 +99,6 @@ Depending on where your Kubernetes cluster is running, you may need to open fire
     a. Edit the `my-inputs.yaml` file (assuming that you named your copy `my-inputs.yaml`) to set `exposedAdminNodePort: true`.
 
     b. Open a browser to `http://localhost:30701`.
+
+    {{% notice note %}} Do not use the WebLogic Server Administration Console to start or stop servers. See [Starting and Stopping Servers]({{< relref "/userguide/managing-domains/domain-lifecycle/startup.md#starting_and_stopping_servers" >}}).
+    {{% /notice %}}

--- a/docs-source/content/userguide/managing-domains/domain-lifecycle/startup.md
+++ b/docs-source/content/userguide/managing-domains/domain-lifecycle/startup.md
@@ -27,6 +27,9 @@ will be graceful, the timeout, and if in-flight sessions are given the opportuni
 The `serverStartPolicy` property on the domain resource controls which servers should be running.
 The operator runtime monitors this property and creates or deletes the corresponding server pods.
 
+{{% notice note %}} Do not use the WebLogic Server Administration Console to start or stop servers.
+{{% /notice %}}
+
 #### `serverStartPolicy` rules
 
 You can specify the `serverStartPolicy` property at the domain, cluster, and server levels. Each level supports a different set of values.
@@ -165,12 +168,12 @@ The server will count toward the cluster's `replicas` count.  Also, if you confi
 
 ### Shutdown options
 
-The domain resource includes the element `serverPod` that is available under `spec`, `adminServer` and each entry of 
+The domain resource includes the element `serverPod` that is available under `spec`, `adminServer` and each entry of
 `clusters` and `managedServers`. The `serverPod` element controls many details of how pods are created for server instances.
 
 The `shutdown` element of `serverPod` controls how servers will be shutdown.  This element has three properties:
-`shutdownType`, `timeoutSeconds`, and `ignoreSessions`.  The `shutdownType` property can be set to either `Graceful`, the default, 
-or `Forced` specifying the type of shutdown.  The `timeoutSeconds` property configures how long the server is given to 
+`shutdownType`, `timeoutSeconds`, and `ignoreSessions`.  The `shutdownType` property can be set to either `Graceful`, the default,
+or `Forced` specifying the type of shutdown.  The `timeoutSeconds` property configures how long the server is given to
 complete shutdown before the server is killed.  The `ignoreSessions` property, which is only applicable for graceful shutdown, when `false`,
 the default, allows the shutdown process to take longer to give time for any active sessions to complete up to the configured timeout.
 The operator runtime monitors this property but will not restart any server pods solely to adjust the shutdown options.
@@ -220,7 +223,7 @@ For instance, given the following domain resource:
     ...
 ```
 
-Graceful shutdown is used for all servers in the domain because this is specified at the domain level and is not overridden at 
+Graceful shutdown is used for all servers in the domain because this is specified at the domain level and is not overridden at
 any cluster or server level.  The "cluster1" cluster defaults to ignoring sessions; however, the "cluster1_server1" server
 instance will not ignore sessions and will have a longer timeout.
 
@@ -261,7 +264,7 @@ such a label or annotation by modifying the `restartVersion`.
 {{% /notice %}}
 
 {{% notice note %}}
-Prior to version 2.2, the operator incorrectly restarted servers when the `serverStartState` property was changed.  Now, 
+Prior to version 2.2, the operator incorrectly restarted servers when the `serverStartState` property was changed.  Now,
 this property has no affect on already running servers.
 {{% /notice %}}
 


### PR DESCRIPTION
Added to the Startup and Shutdown doc and to the Quick Start Guide.