### PR TITLE
PR: owls-77057 fix nightly full test failure for changing image test of ItPodsRestart

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodsRestart.java
@@ -52,6 +52,7 @@ public class ItPodsRestart extends BaseTest {
   public static void staticPrepare() throws Exception {
     // initialize test properties and create the directories
     if (QUICKTEST) {
+      setMaxIterationsPod(40);
       initialize(APP_PROPS_FILE);
 
       logger.info("Checking if operator1 and domain are running, if not creating");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodsRestart.java
@@ -52,8 +52,8 @@ public class ItPodsRestart extends BaseTest {
   public static void staticPrepare() throws Exception {
     // initialize test properties and create the directories
     if (QUICKTEST) {
-      setMaxIterationsPod(40);
       initialize(APP_PROPS_FILE);
+      setMaxIterationsPod(40);
 
       logger.info("Checking if operator1 and domain are running, if not creating");
       if (operator1 == null) {


### PR DESCRIPTION
ItPodsRestart test passed more than 6 hrs nightly full test at: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2766/testReport/

10-03-2019 02:52:11 INFO  
                                    oracle.kubernetes.operator.ItPodsRestart testServerPodsRestartByChangingZImage SUCCESS - testServerPodsRestartByChangingZImage