### PR TITLE
Modified rcu script to support both SOA and FMWInfra Domain

### DIFF
--- a/kubernetes/samples/scripts/create-rcu-schema/common/createRepository.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/createRepository.sh
@@ -7,7 +7,9 @@
 echo "Check if the DB Service is ready to accept request "
 connectString=${1:-oracle-db.default.svc.cluster.local:1521/devpdb.k8s}
 schemaPrefix=${2:-domain1}
-echo "DB Connection URL [$connectString] and schemaPrefix is [${schemaPrefix}]"
+rcuType=${3:-fmw}
+
+echo "DB Connection String [$connectString], schemaPrefix [${schemaPrefix}] rcuType [${rcuType}]"
 
 max=20
 counter=0
@@ -27,10 +29,25 @@ else
  java utils.dbping ORACLE_THIN scott tiger ${connectString}
 fi
 
+# SOA need extra component(s) SOAINFRA and ESS
+# SOA need variables param(s) SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO
+
+extComponents=""
+extVariables=""
+if [ "x$rcuType" == "xsoa" ]; then
+  extComponents="-component SOAINFRA -component ESS"
+  extVariables="-variables SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO"
+  echo "Creating RCU Schema for SOA Infra .."
+fi
+
+#Debug 
+#export DISPLAY=0.0
+#/u01/oracle/oracle_common/bin/rcu -listComponents
+
 /u01/oracle/oracle_common/bin/rcu -silent -createRepository \
  -databaseType ORACLE -connectString ${connectString} \
  -dbUser sys  -dbRole sysdba -useSamePasswordForAllSchemaUsers true \
  -selectDependentsForComponents true \
- -schemaPrefix ${schemaPrefix} \
+ -schemaPrefix ${schemaPrefix} ${extComponents} ${extVariables} \
  -component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER \
- -component OPSS  -component WLS -component STB < /u01/oracle/pwd.txt
+ -component OPSS -component WLS -component STB  < /u01/oracle/pwd.txt

--- a/kubernetes/samples/scripts/create-rcu-schema/common/createRepository.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/createRepository.sh
@@ -29,8 +29,8 @@ else
  java utils.dbping ORACLE_THIN scott tiger ${connectString}
 fi
 
-# SOA need extra component(s) SOAINFRA and ESS
-# SOA need variables param(s) SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO
+# SOA needs extra component(s) SOAINFRA and ESS
+# SOA needs variables param(s) SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO
 
 extComponents=""
 extVariables=""

--- a/kubernetes/samples/scripts/create-rcu-schema/common/dropRepository.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/dropRepository.sh
@@ -7,7 +7,9 @@
 echo "Check if the DB Service is ready to accept request "
 connectString=${1:-oracle-db.default.svc.cluster.local:1521/devpdb.k8s}
 schemaPrefix=${2:-domain1}
-echo "DB Connection URL [$connectString] and schemaPrefix is [${schemaPrefix}]"
+rcuType=${3:-fmw}
+
+echo "DB Connection String [$connectString] schemaPrefix [${schemaPrefix}] rcuType[${rcuType}]"
 
 max=20
 counter=0
@@ -27,10 +29,21 @@ else
  java utils.dbping ORACLE_THIN scott tiger ${connectString} 
 fi 
 
+# SOA need extra component(s) SOAINFRA and ESS
+# SOA need variables param(s) SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO
+
+extComponents=""
+extVariables=""
+if [ "x$rcuType" == "xsoa" ]; then
+  extComponents="-component SOAINFRA -component ESS"
+  extVariables="-variables SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO"
+  echo "Dropping RCU Schema for SOA Infra .."
+fi
+
 /u01/oracle/oracle_common/bin/rcu -silent -dropRepository \
  -databaseType ORACLE -connectString ${connectString} \
  -dbUser sys  -dbRole sysdba \
  -selectDependentsForComponents true \
- -schemaPrefix ${schemaPrefix} \
+ -schemaPrefix ${schemaPrefix} ${extComponents} ${extVariables}  \
  -component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER \
  -component OPSS  -component WLS -component STB < /u01/oracle/pwd.txt

--- a/kubernetes/samples/scripts/create-rcu-schema/common/dropRepository.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/common/dropRepository.sh
@@ -29,8 +29,8 @@ else
  java utils.dbping ORACLE_THIN scott tiger ${connectString} 
 fi 
 
-# SOA need extra component(s) SOAINFRA and ESS
-# SOA need variables param(s) SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO
+# SOA needs extra component(s) SOAINFRA and ESS
+# SOA needs variables param(s) SOA_PROFILE_TYPE=SMALL,HEALTHCARE_INTEGRATION=NO
 
 extComponents=""
 extVariables=""

--- a/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
@@ -46,6 +46,11 @@ if [ -z ${rcupod} ]; then
   exit -2
 fi
 
+fmwimage=`kubectl get pod/rcu  -o jsonpath="{..image}"`
+rcuType=""
+[[ $fmwimage =~ .*soasuite.* ]] && rcuType=soa
+[[ $fmwimage =~ .*fmw-infr.* ]] && rcuType=fmw
+
 echo "Oradoc_db1" > pwd.txt
 echo "Oradoc_db1" >> pwd.txt
 
@@ -53,7 +58,7 @@ kubectl cp ${scriptDir}/common/dropRepository.sh  rcu:/u01/oracle
 kubectl cp pwd.txt rcu:/u01/oracle
 rm -rf dropRepository.sh pwd.txt
 
-kubectl exec -it rcu /bin/bash /u01/oracle/dropRepository.sh ${dburl} ${schemaPrefix}
+kubectl exec -it rcu /bin/bash /u01/oracle/dropRepository.sh ${dburl} ${schemaPrefix} ${rcuType}
 if [ $? != 0  ]; then
  echo "######################";
  echo "[ERROR] Could not drop the RCU Repository based on dburl[${dburl}] schemaPrefix[${schemaPrefix}]  ";


### PR DESCRIPTION
Updated the sample rcu creation scripts to work for both FMW and SOA Infra domain.  
Following modification were made to the scripts create-rcu-schema.sh/drop-rcu-schema.sh 
in the directory kubernetes/samples/scripts/create-rcu-schema
 
No change to the script interface. Based on the image String, the script will add the extra components and variables while creating the rcu for  FMW and SOA Infra  using the following logic

======= create-rcu-schema.sh ====
[[ $fmwimage =~ .*soasuite.* ]] && rcuType=soa
[[ $fmwimage =~ .*fmw-infr.* ]] && rcuType=fmw
=========
Starting of oracle DB Service remains same using the script start(stop)-db-service.sh

I run QUICK test on my branch to see any Regression on sample
http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/2784/console
All Tests Clean