### PR TITLE
Add OpenShift security section for anyuid security context

### DIFF
--- a/docs-source/content/security/certificates.md
+++ b/docs-source/content/security/certificates.md
@@ -2,7 +2,7 @@
 title: "Certificates"
 date: 2019-03-06T21:14:18-05:00
 weight: 1
-description: "SSL/TLS certificate handling for the WebLogic operator."
+description: "SSL/TLS certificate handling for the WebLogic Kubernetes Operator"
 ---
 
 #### Updating operator external certificate

--- a/docs-source/content/security/openshift.md
+++ b/docs-source/content/security/openshift.md
@@ -23,7 +23,7 @@ For example, to update the OpenShift policy, use:
 $ oc adm policy add-scc-to-user anyuid -z default
 ```
 
-and to annotate the WebLogic cotnainers, update the WebLogic `Domain` resource
+and to annotate the WebLogic containers, update the WebLogic `Domain` resource
 to include `annotations` for the `serverPod`. For example:
 
 ``` yaml

--- a/docs-source/content/security/openshift.md
+++ b/docs-source/content/security/openshift.md
@@ -2,22 +2,22 @@
 title: "OpenShift"
 date: 2019-10-04T08:08:08-05:00
 weight: 7
-description: "OpenShift information for the WebLogic operator"
+description: "OpenShift information for the WebLogic Kubernetes Operator"
 ---
 
 #### OpenShift `anyuid` security context
 
-The Docker images that Oracle publishes default the container user
-as `oracle` which is UID `1000` and GID `1000`. When running the
+The Docker images that Oracle publishes default to the container user
+as `oracle`, which is UID `1000` and GID `1000`. When running the
 Oracle images or layered images that retain the default user as
 `oracle` with OpenShift, the `anyuid` security context constraint
-is required to ensure proper access to file system within the
+is required to ensure proper access to the file system within the
 Docker image. This means that the administrator must:
 
 1. Ensure the `anyuid` security content is granted
 2. Ensure that WebLogic containers are annotated with `openshift.io/scc: anyuid`
 
-For example, to update the OpenShift policy use:
+For example, to update the OpenShift policy, use:
 
 ```bash
 $ oc adm policy add-scc-to-user anyuid -z default
@@ -41,6 +41,6 @@ spec:
 ```
 
 {{% notice note %}}
-For additional information about OpenShift requirements and the WebLogic operator,
+For additional information about OpenShift requirements and the operator,
 see the [OpenShift]({{<relref  "/userguide/introduction/introduction.md#openshift">}}) section in the User Guide.
 {{% /notice %}}

--- a/docs-source/content/security/openshift.md
+++ b/docs-source/content/security/openshift.md
@@ -1,0 +1,46 @@
+---
+title: "OpenShift"
+date: 2019-10-04T08:08:08-05:00
+weight: 7
+description: "OpenShift information for the WebLogic operator"
+---
+
+#### OpenShift `anyuid` security context
+
+The Docker images that Oracle publishes default the container user
+as `oracle` which is UID `1000` and GID `1000`. When running the
+Oracle images or layered images that retain the default user as
+`oracle` with OpenShift, the `anyuid` security context constraint
+is required to ensure proper access to file system within the
+Docker image. This means that the administrator must:
+
+1. Ensure the `anyuid` security content is granted
+2. Ensure that WebLogic containers are annotated with `openshift.io/scc: anyuid`
+
+For example, to update the OpenShift policy use:
+
+```bash
+$ oc adm policy add-scc-to-user anyuid -z default
+```
+
+and to annotate the WebLogic cotnainers, update the WebLogic `Domain` resource
+to include `annotations` for the `serverPod`. For example:
+
+``` yaml
+kind: Domain
+metadata:
+  name: domain1
+spec:
+  domainUID: domain1
+  serverPod:
+    env:
+      - name: var1
+        value: value1
+    annotations: 
+      openshift.io/scc: anyuid
+```
+
+{{% notice note %}}
+For additional information about OpenShift requirements and the WebLogic operator,
+see the [OpenShift]({{<relref  "/userguide/introduction/introduction.md#openshift">}}) section in the User Guide.
+{{% /notice %}}

--- a/docs-source/content/security/rbac.md
+++ b/docs-source/content/security/rbac.md
@@ -2,7 +2,7 @@
 title: "RBAC"
 date: 2019-02-23T17:15:36-05:00
 weight: 5
-description: "Role based authorization for the WebLogic operator"
+description: "Role based authorization for the WebLogic Kubernetes Operator"
 ---
 
 #### Contents

--- a/docs-source/content/security/secrets.md
+++ b/docs-source/content/security/secrets.md
@@ -2,7 +2,7 @@
 title: "Secrets"
 date: 2019-02-23T17:36:33-05:00
 weight: 6
-description: "Kubernetes secrets for the WebLogic operator"
+description: "Kubernetes secrets for the WebLogic Kubernetes Operator"
 ---
 
 #### Contents

--- a/docs-source/content/security/service-accounts.md
+++ b/docs-source/content/security/service-accounts.md
@@ -2,7 +2,7 @@
 title: "Service accounts"
 date: 2019-02-23T17:36:12-05:00
 weight: 4
-description: "Kubernetes service accounts for the WebLogic operator"
+description: "Kubernetes service accounts for the WebLogic Kubernetes Operator"
 ---
 
 

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -32,7 +32,8 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
 
 Operator 2.0.1+ is certified for use on OpenShift 3.11.43+, with Kubernetes 1.11.5+.  OpenShift 4 certification is currently in progress.
 
-When using the operator in OpenShift, the anyuid security context constraint is required to ensure that WebLogic containers run with a UNIX UID that has the correct permissions on the domain filesystem.
+When using the operator in OpenShift, the `anyuid` security context constraint is required to ensure that WebLogic containers run with a UNIX UID that has the correct permissions on the domain filesystem.
+For more information, see [OpenShift]({{<relref "/security/openshift.md">}}) in the Security section.
 
 ### Operator Docker image
 


### PR DESCRIPTION
Update the published documentation with more details of the requirement with OpenShift to use the `anyuid` security context.