### PR TITLE
Update prereq information in docs

### DIFF
--- a/docs-source/content/_index.md
+++ b/docs-source/content/_index.md
@@ -21,6 +21,10 @@ The [current release of the operator](https://github.com/oracle/weblogic-kuberne
 This release was published on August 27th, 2019.
 ***
 
+{{% notice note %}}
+Please review the prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction" >}}).
+{{% /notice %}}
+
 #### Operator earlier versions
 
 Documentation for prior releases of the operator is available [here](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/site/README.md).

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -49,6 +49,9 @@ present some extra challenges in areas like:
 As such, we *do not* recommend using these distributions to run the operator and/or WebLogic, and we do not 
 provide support for WebLogic or the operator running in these distributions.
 
+We have found that Docker for Desktop does not seem to suffer the same limitations, and we do support that as a
+dev/test option. 
+
 ### Operator Docker image
 
 You can find the operator image in

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -40,7 +40,7 @@ The official document that defines the [supported configurations is here](https:
 
 In accordance with these policies, the operator and WebLogic Server are supported on Oracle Cloud
 Infrastructure using *Oracle Container Engine for Kubernetes*, or in a cluster running *Oracle Linux
-Container Servies for use with Kubernetes* on OCI Compute; and on "authorized cloud platforms".
+Container Servies for use with Kubernetes* on OCI Compute; and on "authorized cloud environments".
 
 ### OpenShift
 

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -23,10 +23,10 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
 * Oracle WebLogic Server 12.2.1.3.0 with patch 29135930.
    * The existing WebLogic Docker image, `container-registry.oracle.com/middleware/weblogic:12.2.1.3 `,
    has all the necessary patches applied.
-   * A `docker pull` is required if you pulled the image prior to that date.
    * Check the WLS version with `docker run container-registry.oracle.com/middleware/weblogic:12.2.1.3 sh -c` `'source $ORACLE_HOME/wlserver/server/bin/setWLSEnv.sh > /dev/null 2>&1 && java weblogic.version'`.
    * Check the WLS patches with `docker run container-registry.oracle.com/middleware/weblogic:12.2.1.3 sh -c` `'$ORACLE_HOME/OPatch/opatch lspatches'`.
 * You must have the `cluster-admin` role to install the operator.
+* We do not currently support running WebLogic in non-Linux containers. 
 
 ### OpenShift
 
@@ -34,6 +34,20 @@ Operator 2.0.1+ is certified for use on OpenShift 3.11.43+, with Kubernetes 1.11
 
 When using the operator in OpenShift, the `anyuid` security context constraint is required to ensure that WebLogic containers run with a UNIX UID that has the correct permissions on the domain filesystem.
 For more information, see [OpenShift]({{<relref "/security/openshift.md">}}) in the Security section.
+
+### Important note about development-focused Kubernetes distributions
+
+There are a number of development-focused distributions of Kubernetes, like kind, Minikube, Minishift and so on.
+Often these run Kubernetes in a virtual machine on you development machine.  We have found that these distributions
+present some extra challenges in areas like:
+
+* Separate Docker image stores, making it necessary to save/load images to move them between Docker file systems,
+* Default virtual machine file sizes and resource limits that are too small to run WebLogic or hold the necessary images,
+* Storage providers that do not always support the features that the operator and/or WebLogic rely on, 
+* Load balancing implementations that do not always support the features that the operator and/or WebLogic rely on.
+
+As such, we *do not* recommend using these distributions to run the operator and/or WebLogic, and we do not 
+provide support for WebLogic or the operator running in these distributions.
 
 ### Operator Docker image
 

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -38,10 +38,6 @@ WebLogic Server and the operator are supported on "Authorized Cloud Environments
 
 The official document that defines the [supported configurations is here](https://www.oracle.com/middleware/technologies/ias/oracleas-supported-virtualization.html).
 
-In accordance with these policies, the operator and WebLogic Server are supported on Oracle Cloud
-Infrastructure using *Oracle Container Engine for Kubernetes*, or in a cluster running *Oracle Linux
-Container Servies for use with Kubernetes* on OCI Compute; and on Microsoft Azure using *Azure Kubernetes Service*.
-
 ### OpenShift
 
 Operator 2.0.1+ is certified for use on OpenShift Container Platform 3.11.43+, with Kubernetes 1.11.5+.  OpenShift 4 certification is currently in progress.

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -36,6 +36,8 @@ WebLogic Server and the operator are supported on "Authorized Cloud Environments
 [this Oracle licensing policy](https://www.oracle.com/assets/cloud-licensing-070579.pdf) and 
 [this list of eligible products](http://www.oracle.com/us/corporate/pricing/authorized-cloud-environments-3493562.pdf).
 
+The official document that defines the [supported configurations is here](https://www.oracle.com/middleware/technologies/ias/oracleas-supported-virtualization.html).
+
 In accordance with these policies, the operator and WebLogic Server are supported on Oracle Cloud
 Infrastructure using *Oracle Container Engine for Kubernetes*, or in a cluster running *Oracle Linux
 Container Servies for use with Kubernetes* on OCI Compute; and on Microsoft Azure using *Azure Kubernetes Service*.

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -38,6 +38,10 @@ WebLogic Server and the operator are supported on "Authorized Cloud Environments
 
 The official document that defines the [supported configurations is here](https://www.oracle.com/middleware/technologies/ias/oracleas-supported-virtualization.html).
 
+In accordance with these policies, the operator and WebLogic Server are supported on Oracle Cloud
+Infrastructure using *Oracle Container Engine for Kubernetes*, or in a cluster running *Oracle Linux
+Container Servies for use with Kubernetes* on OCI Compute; and on "authorized cloud platforms".
+
 ### OpenShift
 
 Operator 2.0.1+ is certified for use on OpenShift Container Platform 3.11.43+, with Kubernetes 1.11.5+.  OpenShift 4 certification is currently in progress.

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -38,7 +38,7 @@ For more information, see [OpenShift]({{<relref "/security/openshift.md">}}) in 
 ### Important note about development-focused Kubernetes distributions
 
 There are a number of development-focused distributions of Kubernetes, like kind, Minikube, Minishift and so on.
-Often these run Kubernetes in a virtual machine on you development machine.  We have found that these distributions
+Often these run Kubernetes in a virtual machine on your development machine.  We have found that these distributions
 present some extra challenges in areas like:
 
 * Separate Docker image stores, making it necessary to save/load images to move them between Docker file systems,

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -28,9 +28,21 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
 * You must have the `cluster-admin` role to install the operator.
 * We do not currently support running WebLogic in non-Linux containers. 
 
+### Cloud providers
+
+The Oracle [Global Pricing and Licensing site](https://www.oracle.com/corporate/pricing/specialty-topics.html)
+provides details about licensing practices and policies. 
+WebLogic Server and the operator are supported on "Authorized Cloud Environments" as defined in
+[this Oracle licensing policy](https://www.oracle.com/assets/cloud-licensing-070579.pdf) and 
+[this list of eligible products](http://www.oracle.com/us/corporate/pricing/authorized-cloud-environments-3493562.pdf).
+
+In accordance with these policies, the operator and WebLogic Server are supported on Oracle Cloud
+Infrastructure using *Oracle Container Engine for Kubernetes*, or in a cluster running *Oracle Linux
+Container Servies for use with Kubernetes* on OCI Compute; and on Microsoft Azure using *Azure Kubernetes Service*.
+
 ### OpenShift
 
-Operator 2.0.1+ is certified for use on OpenShift 3.11.43+, with Kubernetes 1.11.5+.  OpenShift 4 certification is currently in progress.
+Operator 2.0.1+ is certified for use on OpenShift Container Platform 3.11.43+, with Kubernetes 1.11.5+.  OpenShift 4 certification is currently in progress.
 
 When using the operator in OpenShift, the `anyuid` security context constraint is required to ensure that WebLogic containers run with a UNIX UID that has the correct permissions on the domain filesystem.
 For more information, see [OpenShift]({{<relref "/security/openshift.md">}}) in the Security section.

--- a/docs-source/content/userguide/overview/k8s-setup.md
+++ b/docs-source/content/userguide/overview/k8s-setup.md
@@ -17,7 +17,7 @@ If you need some help setting up a Kubernetes environment to experiment with the
 "Development/test" options:
 
 * Install [Docker for Mac](https://docs.docker.com/docker-for-mac/#kubernetes) and enable its embedded Kubernetes cluster (or register for the [Docker for Windows](https://beta.docker.com/form) beta and wait until Kubernetes is available there).
-* Install [Minikube](https://github.com/kubernetes/minikube) on your Windows/Linux/Mac computer.
+* We *do not* recommend or support other development/test options like Minikube, Minishift, kind, and so on.
 
 We have provided our hints and tips for several of these options in the sections below.
 


### PR DESCRIPTION
This PR updates the documentation to make our prereqs and supported platforms clearer.
Specifically, it calls out that we do not support dev/test options like kind, minikube,minishift.