### PR TITLE
OWLS-77092: Fix ItPodsRestart failure during parallel run in same k8s cluster

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1135,7 +1135,7 @@ public class Domain {
     }
     LoggerHelper.getLocal().log(Level.INFO, "Done - testDomainServerPodRestart");
   }
-
+   
   /**
    * Verify domain server pods get restarted after the property change by kubectl apply -f new
    * domain yaml file with added/changed property.
@@ -1152,20 +1152,26 @@ public class Domain {
         BaseTest.getUserProjectsDir() + "/weblogic-domains/" + domainUid + "/domain_new.yaml";
     String domainYamlFile =
         BaseTest.getUserProjectsDir() + "/weblogic-domains/" + domainUid + "/domain.yaml";
+    String changedDomainYamlFile =
+        BaseTest.getUserProjectsDir() + "/weblogic-domains/" + domainUid + "/domain_change.yaml";
     String fileWithChangedProperty =
         BaseTest.getProjectRoot()
             + "/integration-tests/src/test/resources/"
             + fileNameWithChangedProperty;
 
-    // copy the original domain.yaml to domain_new.yaml
-    TestUtils.copyFile(domainYamlFile, newDomainYamlFile);
+    // copy the original domain.yaml to domain_change.yaml
+    TestUtils.copyFile(domainYamlFile, changedDomainYamlFile);
 
-    // append the file with changed property to the end of domain_new.yaml
+    // append the file with changed property to the end of domain_change.yaml
     Files.write(
-        Paths.get(newDomainYamlFile),
+        Paths.get(changedDomainYamlFile),
         Files.readAllBytes(Paths.get(fileWithChangedProperty)),
         StandardOpenOption.APPEND);
-
+    
+    String oldPvc = "domainpodsrestart-weblogic-sample-pvc";
+    String newPvc = domainUid + "-" + pvMap.get("baseName") + "-pvc";
+    LoggerHelper.getLocal().log(Level.INFO, "newPvc in verifyDomainServerPodRestart: " + newPvc);
+    modifyPropertyInYaml(oldPvc, newPvc, changedDomainYamlFile, newDomainYamlFile);
     // kubectl apply the new constructed domain_new.yaml
     StringBuffer command = new StringBuffer();
     command.append("kubectl apply  -f ").append(newDomainYamlFile);
@@ -1182,7 +1188,44 @@ public class Domain {
     LoggerHelper.getLocal().log(
         Level.INFO, "Done - testDomainServerPodRestart with domainYamlWithChangedProperty");
   }
+   
+  /**
+   * Modify the property in the domain yaml file.
+   *
+   * @param oldString - the old property value
+   * @param newString - the new property value
+   * @param oldFileName - the file name that has the oldString 
+   * @param newFileName - the file name that has the newString changed from the old one
+   * @throws Exception - IOException or errors occurred during the call
+   */
+  public void modifyPropertyInYaml(String oldString, String newString, String oldFileName, String newFileName)
+      throws Exception {
+    LoggerHelper.getLocal().log(Level.INFO, "modifyDomainPvcInYaml");
+    String content =
+        new String(
+        Files.readAllBytes(
+            Paths.get(oldFileName)));
+    boolean result = content.indexOf(oldString) >= 0;
+    LoggerHelper.getLocal().log(Level.INFO,
+        "The search result for " + oldString + " is: " + result);
+    if (result) {
+      TestUtils.createNewYamlFile(
+          oldFileName,
+          newFileName,
+          oldString,
+          newString);
+      LoggerHelper.getLocal().log(Level.INFO,
+          "Done - generate new domain.yaml for "
+              + domainUid
+              + " oldPVC: "
+              + oldString
+              + " newPVC: "
+              + newString);
 
+    }
+    LoggerHelper.getLocal().log(Level.INFO, "Done - modifyPropertyInYaml");
+  }
+  
   /**
    * Get runtime server yaml file and verify the changed property is in that file.
    *


### PR DESCRIPTION
ItPodsRestart passed in the full test suite run: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2874/testReport/oracle.kubernetes.operator/
Both ItPodsRestart and ItOperator passed at:http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/2859/testReport/oracle.kubernetes.operator/
