### PR TITLE
Testsinparallel opupgrade

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1449,7 +1449,8 @@ public class Domain {
     // for remote k8s cluster and domain in image case, push the domain image to OCIR
     if (domainMap.containsKey("domainHomeImageBase") && BaseTest.SHARED_CLUSTER) {
       String image =
-          System.getenv("REPO_REGISTRY") + "/weblogick8s/domain-home-in-image:" + imageTag;
+          System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image") + ":" 
+                 + (String)domainMap.get("imageTag");
       TestUtils.loginAndPushImageToOcir(image);
 
       // create ocir registry secret in the same ns as domain which is used while pulling the domain
@@ -1726,7 +1727,8 @@ public class Domain {
       if (BaseTest.SHARED_CLUSTER) {
         domainMap.put(
             "image",
-            System.getenv("REPO_REGISTRY") + "/weblogick8s/domain-home-in-image:" + imageTag);
+            System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image") + ":" 
+                       + (String)domainMap.get("imageTag"));
         domainMap.put("imagePullSecretName", "ocir-domain");
         domainMap.put("imagePullPolicy", "Always");
       }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1449,8 +1449,7 @@ public class Domain {
     // for remote k8s cluster and domain in image case, push the domain image to OCIR
     if (domainMap.containsKey("domainHomeImageBase") && BaseTest.SHARED_CLUSTER) {
       String image =
-          System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image") + ":" 
-                 + (String)domainMap.get("imageTag");
+          System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image");
       TestUtils.loginAndPushImageToOcir(image);
 
       // create ocir registry secret in the same ns as domain which is used while pulling the domain
@@ -1727,8 +1726,7 @@ public class Domain {
       if (BaseTest.SHARED_CLUSTER) {
         domainMap.put(
             "image",
-            System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image") + ":" 
-                       + (String)domainMap.get("imageTag"));
+            System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image"));
         domainMap.put("imagePullSecretName", "ocir-domain");
         domainMap.put("imagePullPolicy", "Always");
       }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1445,11 +1445,10 @@ public class Domain {
     }
     String outputStr = result.stdout().trim();
     LoggerHelper.getLocal().log(Level.INFO, "Command returned " + outputStr);
-
+  
     // for remote k8s cluster and domain in image case, push the domain image to OCIR
     if (domainMap.containsKey("domainHomeImageBase") && BaseTest.SHARED_CLUSTER) {
-      String image =
-          System.getenv("REPO_REGISTRY") + "/weblogick8s/" + (String)domainMap.get("image");
+      String image = (String)domainMap.get("image");
       TestUtils.loginAndPushImageToOcir(image);
 
       // create ocir registry secret in the same ns as domain which is used while pulling the domain


### PR DESCRIPTION
operator upgrade test fix. fixed the image name when tests run in external jenkins so that each of the test uses its own image.