### PR TITLE
WIP:Fixed Voyager issue when running StickySession test

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItStickySession.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItStickySession.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -15,6 +16,7 @@ import oracle.kubernetes.operator.utils.LoggerHelper;
 import oracle.kubernetes.operator.utils.Operator;
 import oracle.kubernetes.operator.utils.TestUtils;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -39,6 +41,7 @@ public class ItStickySession extends BaseTest {
 
   private static Operator operator;
   private static Domain domain;
+  private static String domainNS;
   private static String testClassName;
 
   /**
@@ -56,22 +59,29 @@ public class ItStickySession extends BaseTest {
       }.getClass().getEnclosingClass().getSimpleName();
       // initialize test properties and create the directories
       initialize(APP_PROPS_FILE, testClassName);
-
+      testClassName = "itstickysesn";
+      
       // Create operator1
       if (operator == null) {
         LoggerHelper.getLocal().log(Level.INFO,
             "Creating Operator & waiting for the script to complete execution");
-        operator = TestUtils.createOperator(OPERATOR1_YAML);
+        Map<String, Object> operatorMap = TestUtils.createOperatorMap(getNewSuffixCount(), true, testClassName);
+        //operator = TestUtils.createOperator(OPERATOR1_YAML);
+        operator = TestUtils.createOperator(operatorMap, Operator.RestCertType.SELF_SIGNED);
+        Assert.assertNotNull(operator);
+        domainNS = ((ArrayList<String>) operatorMap.get("domainNamespaces")).get(0);
       }
-
+      
       // create domain
       if (domain == null) {
-        LoggerHelper.getLocal().log(Level.INFO,
-            "Creating WLS Domain & waiting for the script to complete execution");
-        Map<String, Object> domainMap = TestUtils.loadYaml(DOMAINONPV_WLST_YAML);
+        LoggerHelper.getLocal().log(Level.INFO, "Creating WLS Domain & waiting for the script to complete execution");
+        int number = getNewSuffixCount();
+        Map<String, Object> domainMap = TestUtils.createDomainMap(number, testClassName);
+        domainMap.put("namespace", domainNS);
         // Treafik doesn't work due to the bug 28050300. Use Voyager instead
         domainMap.put("loadBalancer", "VOYAGER");
-        domainMap.put("voyagerWebPort", new Integer("30355"));
+        domainMap.put("voyagerWebPort", 30944 + number);
+        LoggerHelper.getLocal().log(Level.INFO, "For this domain voyagerWebPort is set to: 30944 + " + number);
         domain = TestUtils.createDomain(domainMap);
         domain.verifyDomainCreated();
       }
@@ -91,7 +101,6 @@ public class ItStickySession extends BaseTest {
       // Wait some time for deployment gets ready
       Thread.sleep(10 * 1000);
     }
-
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -213,7 +213,7 @@ public class LoadBalancer {
     executeHelmCommand(cmd2);
 
     String cmd3 =
-        "helm install appscode/voyager --name voyager-operator --version 7.4.0 --namespace voyage "
+        "helm install appscode/voyager --name voyager-operator --version 7.4.0 --namespace voyager "
             + "--set cloudProvider=baremetal --set apiserver.enableValidatingWebhook=false";
     LoggerHelper.getLocal().log(Level.INFO, "Executing Install voyager operator cmd " + cmd3);
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -222,8 +222,8 @@ public class LoadBalancer {
 
   private void createVoyagerIngressPerDomain() throws Exception {
     upgradeVoyagerNamespace();
-    LoggerHelper.getLocal().log(Level.INFO, "Sleeping for 20 seconds after upgradeVoyagerNamespace ");
-    Thread.sleep(20 * 1000);
+    LoggerHelper.getLocal().log(Level.INFO, "Sleeping for 60 seconds after upgradeVoyagerNamespace ");
+    Thread.sleep(60 * 1000);
     createVoyagerIngress();
     LoggerHelper.getLocal().log(Level.INFO, "Sleeping for 20 seconds after createVoyagerIngress ");
     Thread.sleep(20 * 1000);
@@ -247,6 +247,21 @@ public class LoadBalancer {
 
     LoggerHelper.getLocal().log(Level.INFO, " upgradeVoyagerNamespace() Running " + cmd.toString());
     executeHelmCommand(cmd.toString());
+    
+    //Print out Voyager pod log
+    StringBuffer cmd0 = new StringBuffer("kubectl get pod -n voyager |grep voyager-| awk '{print $1}'");
+    LoggerHelper.getLocal().log(Level.INFO, "===== get voyager op pod name command: " + cmd0.toString());
+    ExecResult result = TestUtils.exec(cmd0.toString());
+    String podName = result.stdout();
+    LoggerHelper.getLocal().log(Level.INFO, "===== podName: " + podName);
+    
+    cmd0 = new StringBuffer("kubectl log ");
+    cmd0.append(podName)
+        .append(" --namespace voyager");
+
+    LoggerHelper.getLocal().log(Level.INFO, "===== voyager op pod log command: " + cmd0.toString());
+    result = TestUtils.exec(cmd0.toString());
+    LoggerHelper.getLocal().log(Level.INFO, "===== voyager op pod log: " + result.stdout());
   }
 
   private void createVoyagerIngress() throws Exception {


### PR DESCRIPTION
I found the cause why creating Voyager ingress failed with the error

Error: apiVersion "voyager.appscode.com/v1beta1" in ingress-per-domain/templates/voyager-ingress.yaml is not available

it's a timing issue. I found that after I added print-out of logs from Voyager pod to further debug, % of passed tests increased. So I then increased the waiting time between upgradeVoyagerNamespace and createVoyagerIngress from 20 sec to 60 sec. Now the tests passed three times in a row

http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/3022/consoleFull
http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/3023/consoleFull
http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/3025/console

below is msg from passed test:

oracle.kubernetes.operator.utils.LoadBalancer createVoyagerIngress createVoyagerIngress() Running cd /scratch/****/workspace/weblogic-kubernetes-operator-javatest/weblogic-operator/integration-tests/../integration-tests/src/test/resources/charts && helm install ingress-per-domain  --name voyager-ingress-itstickysesn-domain-31 --namespace itstickysesn-domainns-13 --set type=VOYAGER --set ****Domain.domainUID=itstickysesn-domain-31 --set ****Domain.clusterName=cluster-1 --set voyager.webPort=30975
10-26-2019 18:51:01 INFO  
                                    oracle.kubernetes.operator.utils.LoadBalancer executeHelmCommand Command returned NAME:   voyager-ingress-itstickysesn-domain-31

I also fixed a typo of Voyager namespace definition in our LoadBalance.java file