### PR TITLE
PR: Fix Jrf quicktest suite issue

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -286,7 +286,7 @@
             <id>jrf-integration-tests</id>
             <properties>
                 <skipITs>false</skipITs>
-                <includes-failsafe>**/JrfInOperator*Test.java</includes-failsafe>
+                <includes-failsafe>**/JrfDomain*</includes-failsafe>
                 <jrf_enabled>true</jrf_enabled>
             </properties>
         </profile>
@@ -306,7 +306,8 @@
             <id>wls-jrf-integration-tests</id>
             <properties>
                 <skipITs>false</skipITs>
-                <includes-failsafe>**/*.java</includes-failsafe>
+                <includes-failsafe>**/It*</includes-failsafe>
+                <includes-failsafe>**/JrfDomain*</includes-failsafe>
                 <jrf_enabled>true</jrf_enabled>
             </properties>
         </profile>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -306,8 +306,7 @@
             <id>wls-jrf-integration-tests</id>
             <properties>
                 <skipITs>false</skipITs>
-                <includes-failsafe>**/It*</includes-failsafe>
-                <includes-failsafe>**/JrfDomain*</includes-failsafe>
+                <includes-failsafe>**/It*,**/JrfDomain*</includes-failsafe>
                 <jrf_enabled>true</jrf_enabled>
             </properties>
         </profile>


### PR DESCRIPTION
After the change, 
Internal Jenkins:
JRF domain test is picked up by quicktest of  wls-jrf-integration-tests 
http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/3026/testReport/oracle.kubernetes.operator/

external Jenkins:
http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/667/testReport/



