### PR TITLE
Add a note to the quickstart about variations between k8s versions

### DIFF
--- a/docs-source/content/quickstart/introduction.md
+++ b/docs-source/content/quickstart/introduction.md
@@ -9,6 +9,12 @@ Use this Quick Start guide to create a WebLogic deployment in a Kubernetes clust
 These instructions assume that you are already familiar with Kubernetes.  If you need more detailed instructions, please
 refer to the [User guide]({{< relref "/userguide/_index.md" >}}).
 
+{{% notice note %}}
+All Kubernetes distributions and managed services have small differences.  In particular,
+the way that persistent storage and load balancers are managed varies significantly.  
+You may need to adjust the instructions in this guide to suit your particular flavor of Kubernetes.
+{{% /notice %}}
+
 **Important note for users of operator releases before 2.0**
 {{% expand "Click here to expand" %}}
 


### PR DESCRIPTION
Based on Paul's feedback about the quickstart - in particular the load balancing examples not working *as written* on new OKE clusters with no public IPs - I am adding a notice to the quickstart to make it clearer that you may need to adjust the instructions for different versions of k8s