### PR TITLE
OWLS-76689 - SOA:ADMINSERVER TAKING TIME TO RESTART USING SERVERSTARTPOLICY(NEVER TO IF_NEEDED) ON OKE CLUSTER 

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -156,7 +156,7 @@ public class ManagedServersUpStep extends Step {
         servers.add(serverName);
         addStartupInfo(new ServerStartupInfo(serverConfig, clusterName, server));
         addToCluster(clusterName);
-      } else if (server.isPrecreateServerService()) {
+      } else if ((!domain.isShuttingDown() || server.shouldStart(0)) && server.isPrecreateServerService()) {
         servers.add(serverName);
         addStartupInfo(new ServerStartupInfo(serverConfig, clusterName, server, true));
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -143,6 +143,21 @@ public class ManagedServersUpStep extends Step {
       this.domain = domain;
     }
 
+    /**
+     * Checks whether we should pre-create server service for the given server.
+     *
+     * @param server ServerSpec for the managed server
+     * @return True if we should pre-create server service for the given managed server, false
+     *         otherwise.
+     */
+    boolean shouldPrecreateServerService(ServerSpec server) {
+      if (server.isPrecreateServerService()) {
+        // skip pre-create if admin server and managed server are both shutting down
+        return ! (domain.getAdminServerSpec().isShuttingDown() && server.isShuttingDown());
+      }
+      return false;
+    }
+
     void addServerIfNeeded(@Nonnull WlsServerConfig serverConfig, WlsClusterConfig clusterConfig) {
       String serverName = serverConfig.getName();
       if (servers.contains(serverName) || serverName.equals(domainTopology.getAdminServerName())) {
@@ -156,7 +171,7 @@ public class ManagedServersUpStep extends Step {
         servers.add(serverName);
         addStartupInfo(new ServerStartupInfo(serverConfig, clusterName, server));
         addToCluster(clusterName);
-      } else if ((!domain.isShuttingDown() || server.shouldStart(0)) && server.isPrecreateServerService()) {
+      } else if (shouldPrecreateServerService(server)) {
         servers.add(serverName);
         addStartupInfo(new ServerStartupInfo(serverConfig, clusterName, server, true));
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -32,7 +32,7 @@ public class ServerDownStep extends Step {
     V1Pod oldPod = info.getServerPod(serverName);
 
     Step next;
-    if (isPreserveServices) {
+    if (isPreserveServices && !info.getDomain().isShuttingDown()) {
       next = getNext();
     } else {
       next = ServiceHelper.deleteServicesStep(serverName, getNext());

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -32,7 +32,7 @@ public class ServerDownStep extends Step {
     V1Pod oldPod = info.getServerPod(serverName);
 
     Step next;
-    if (isPreserveServices && !info.getDomain().isShuttingDown()) {
+    if (isPreserveServices) {
       next = getNext();
     } else {
       next = ServiceHelper.deleteServicesStep(serverName, getNext());

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -126,4 +126,6 @@ public interface ClusterConfigurator extends ServiceConfigurator {
   ClusterConfigurator withPriorityClassName(String priorityClassName);
 
   ClusterConfigurator withToleration(V1Toleration toleration);
+
+  ClusterConfigurator withPrecreateServerService(boolean precreateServerService);
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
@@ -312,6 +312,10 @@ public abstract class BaseConfiguration {
     return serverService.isPrecreateService();
   }
 
+  void setPrecreateServerService(boolean value) {
+    serverService.setIsPrecreateService(value);
+  }
+
   public Map<String, String> getServiceLabels() {
     return serverService.getLabels();
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
@@ -657,5 +657,11 @@ public class DomainCommonConfigurator extends DomainConfigurator {
       getDomainSpec().addToleration(toleration);
       return this;
     }
+
+    @Override
+    public ClusterConfigurator withPrecreateServerService(boolean precreateServerService) {
+      getDomainSpec().setPrecreateServerService(precreateServerService);
+      return this;
+    }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -733,7 +733,7 @@ public class DomainSpec extends BaseConfiguration {
 
     @Override
     public boolean isShuttingDown() {
-      return !getAdminServerSpec().shouldStart(0);
+      return getAdminServerSpec().isShuttingDown();
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpec.java
@@ -68,6 +68,13 @@ public interface ServerSpec {
   boolean shouldStart(int currentReplicas);
 
   /**
+   * Returns true if the server is shutting down, or not configured to be started.
+   *
+   * @return whether the server is shutting down, or not configured to be started.
+   */
+  boolean isShuttingDown();
+
+  /**
    * Returns the volume mounts to be defined for this server.
    *
    * @return a list of environment volume mounts

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpecCommonImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpecCommonImpl.java
@@ -127,6 +127,11 @@ public abstract class ServerSpecCommonImpl extends ServerSpecBase {
     }
   }
 
+  @Override
+  public boolean isShuttingDown() {
+    return !shouldStart(0);
+  }
+
   boolean isStartAdminServerOnly() {
     return domainSpec.isStartAdminServerOnly();
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -134,6 +134,20 @@ public class DomainProcessorTest {
   }
 
   @Test
+  public void whenDomainScaledDown_withPreCreateServerService_doesNotRemoveServices() {
+    defineServerResources(ADMIN_NAME);
+    Arrays.stream(MANAGED_SERVER_NAMES).forEach(this::defineServerResources);
+
+    domainConfigurator.configureCluster(CLUSTER).withReplicas(MIN_REPLICAS).withPrecreateServerService(true);
+
+    DomainPresenceInfo info = new DomainPresenceInfo(domain);
+    processor.makeRightDomainPresence(info, true, false, false);
+
+    assertThat((int) getServerServices().count(), equalTo(MAX_SERVERS + NUM_ADMIN_SERVERS));
+    assertThat(getRunningPods().size(), equalTo(MIN_REPLICAS + NUM_ADMIN_SERVERS + NUM_JOB_PODS));
+  }
+
+  @Test
   public void whenDomainShutDown_removeAllPodsAndServices() {
     defineServerResources(ADMIN_NAME);
     Arrays.stream(MANAGED_SERVER_NAMES).forEach(this::defineServerResources);

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -321,7 +321,7 @@ public class ManagedServersUpStepTest {
   }
 
   @Test
-  public void whenClusterStartupDefinedForServerNotRunning_addToServerss() {
+  public void whenClusterStartupDefinedForServerNotRunning_addToServers() {
     configureServerToStart("ms1");
     configureCluster("cluster1");
     addWlsCluster("cluster1", "ms1");

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -496,6 +496,17 @@ public class ManagedServersUpStepTest {
 
     invokeStep();
 
+    assertThat(getServers(), allOf(hasItem("ms1"), hasItem("ms2")));
+  }
+
+  @Test
+  public void whenClusterStartupDefinedWithPreCreateServerService_adminServerDown_addAllToServers() {
+    configureCluster("cluster1").withPrecreateServerService(true);
+    addWlsCluster("cluster1", "ms1", "ms2");
+    configureAdminServer().withServerStartPolicy(START_NEVER);
+
+    invokeStep();
+
     assertThat(getServers(),
         allOf(
             hasItem("ms1"),
@@ -504,10 +515,9 @@ public class ManagedServersUpStepTest {
   }
 
   @Test
-  public void whenClusterStartupDefinedWithPreCreateServerService_adminServerDown_addAllToServers() {
-    configureCluster("cluster1").withPrecreateServerService(true);
+  public void whenClusterStartupDefinedWithPreCreateServerService_managedServerDown_addAllToServers() {
+    configureCluster("cluster1").withPrecreateServerService(true).withServerStartPolicy(START_NEVER);
     addWlsCluster("cluster1", "ms1", "ms2");
-    configureAdminServer().withServerStartPolicy(START_NEVER);
 
     invokeStep();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -507,11 +507,7 @@ public class ManagedServersUpStepTest {
 
     invokeStep();
 
-    assertThat(getServers(),
-        allOf(
-            hasItem("ms1"),
-            hasItem("ms2"))
-    );
+    assertThat(getServers(), allOf(hasItem("ms1"), hasItem("ms2")));
   }
 
   @Test
@@ -521,11 +517,7 @@ public class ManagedServersUpStepTest {
 
     invokeStep();
 
-    assertThat(getServers(),
-        allOf(
-            hasItem("ms1"),
-            hasItem("ms2"))
-    );
+    assertThat(getServers(), allOf(hasItem("ms1"), hasItem("ms2")));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -28,6 +28,7 @@ import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
 import oracle.kubernetes.weblogic.domain.ClusterConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
@@ -46,6 +47,7 @@ import static oracle.kubernetes.utils.LogMatcher.containsFine;
 import static oracle.kubernetes.weblogic.domain.model.ConfigurationConstants.START_ALWAYS;
 import static oracle.kubernetes.weblogic.domain.model.ConfigurationConstants.START_IF_NEEDED;
 import static oracle.kubernetes.weblogic.domain.model.ConfigurationConstants.START_NEVER;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -319,7 +321,7 @@ public class ManagedServersUpStepTest {
   }
 
   @Test
-  public void whenClusterStartupDefinedForServerNotRunning_addToServers() {
+  public void whenClusterStartupDefinedForServerNotRunning_addToServerss() {
     configureServerToStart("ms1");
     configureCluster("cluster1");
     addWlsCluster("cluster1", "ms1");
@@ -327,6 +329,16 @@ public class ManagedServersUpStepTest {
     invokeStep();
 
     assertThat(getServers(), hasItem("ms1"));
+  }
+
+  @Test
+  public void whenClusterStartupDefinedWithZeroReplicas_addNothingToServers() {
+    configureCluster("cluster1").withReplicas(0);
+    addWlsCluster("cluster1", "ms1", "ms2");
+
+    invokeStep();
+
+    assertThat(getServers(), empty());
   }
 
   @Test
@@ -477,6 +489,46 @@ public class ManagedServersUpStepTest {
     assertStoppingServers(createNextStepWithout("server2"), "server1", "server3", ADMIN);
   }
 
+  @Test
+  public void whenClusterStartupDefinedWithPreCreateServerService_addAllToServers() {
+    configureCluster("cluster1").withPrecreateServerService(true);
+    addWlsCluster("cluster1", "ms1", "ms2");
+
+    invokeStep();
+
+    assertThat(getServers(),
+        allOf(
+            hasItem("ms1"),
+            hasItem("ms2"))
+    );
+  }
+
+  @Test
+  public void whenClusterStartupDefinedWithPreCreateServerService_adminServerDown_addAllToServers() {
+    configureCluster("cluster1").withPrecreateServerService(true);
+    addWlsCluster("cluster1", "ms1", "ms2");
+    configureAdminServer().withServerStartPolicy(START_NEVER);
+
+    invokeStep();
+
+    assertThat(getServers(),
+        allOf(
+            hasItem("ms1"),
+            hasItem("ms2"))
+    );
+  }
+
+  @Test
+  public void whenClusterStartupDefinedWithPreCreateServerService_allServersDown_addNothingToServers() {
+    configureCluster("cluster1").withPrecreateServerService(true).withServerStartPolicy(START_NEVER);
+    addWlsCluster("cluster1", "ms1", "ms2");
+    configureAdminServer().withServerStartPolicy(START_NEVER);
+
+    invokeStep();
+
+    assertThat(getServers(), empty());
+  }
+
   private void assertStoppingServers(Step step, String... servers) {
     assertThat(((ServerDownIteratorStep) step).getServersToStop(), containsInAnyOrder(servers));
   }
@@ -534,6 +586,10 @@ public class ManagedServersUpStepTest {
 
   private void configureServer(String serverName) {
     configurator.configureServer(serverName);
+  }
+
+  private AdminServerConfigurator configureAdminServer() {
+    return configurator.configureAdminServer();
   }
 
   private ServerConfigurator configureServerToStart(String serverName) {


### PR DESCRIPTION
Minor changes to preCreateServerServices behavior by removing precreated services for managed servers when both admin server and all managed servers in the cluster are being brought down.                      

Issue fixed (OWLS-76689):
In SOA domains, the startup of admin server involves JNDI lookup of managed servers, restarting the admin server was found to be very slow, when the preCreateServerServices feature was enabled. This is due to each managed server host name was able to resolve due to the existence of precreated server services, so the JNDI lookup will attempt to connect to each managed server until the configured timeout value in the JNDI lookup, since the managed servers are not running. With this change, each lookup of the managed server will result in a UnknownHostException, and failed fast, which was the same behavior as when the admin server was started up the first time when the domain was first started.

Filer verified that the change reduced the admin server startup time from 22 minutes to around 2 minutes in the restart scenario. Filer also verified that the
issue in OWLS-75155, which was why the preCreateServerService feature was introduced, did not regress with this change.

jenkins http://wls-jenkins.us.oracle.com/job/weblogic-kubernetes-operator-javatest/2990/
