### PR TITLE
Prepare file permissions on persistent volume using an init container

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -18,6 +18,20 @@ spec:
         app: %DOMAIN_UID%-create-weblogic-sample-domain-job
     spec:
       restartPolicy: Never
+        initContainers:
+        - name: fix-pvc-owner
+          image: %WEBLOGIC_IMAGE%
+          command: ["sh", "-c", "chown -R 1000:1000 %DOMAIN_ROOT_DIR%"]
+          volumeMounts:
+          - name: weblogic-sample-domain-storage-volume
+            mountPath: %DOMAIN_ROOT_DIR%
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+        volumes:
+        - name: weblogic-sample-domain-storage-volume
+          persistentVolumeClaim:
+            claimName: %DOMAIN_PVC_NAME%
       containers:
         - name: create-weblogic-sample-domain-job
           image: %WEBLOGIC_IMAGE%

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -18,7 +18,7 @@ spec:
         app: %DOMAIN_UID%-create-weblogic-sample-domain-job
     spec:
       restartPolicy: Never
-        initContainers:
+      initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
           command: ["sh", "-c", "chown -R 1000:1000 %DOMAIN_ROOT_DIR%"]
@@ -28,10 +28,6 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-        volumes:
-        - name: weblogic-sample-domain-storage-volume
-          persistentVolumeClaim:
-            claimName: %DOMAIN_PVC_NAME%
       containers:
         - name: create-weblogic-sample-domain-job
           image: %WEBLOGIC_IMAGE%


### PR DESCRIPTION
Several customers have reported difficulty creating a domain on a persistent volume because default file permissions on the volume are set to only give permission to the root user.  This change uses an initContainer to give permission to the "oracle" (1000) user.