### PR TITLE
add file ownership tracing to introspect-job/server-pod, and to sample pv create-domain-job scripts

### DIFF
--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/common/utility.sh
@@ -39,7 +39,32 @@ function checkDomainSecret {
   fi
 }
 
+#
+# traceDirs before|after
+#   Trace contents and owner of DOMAIN_HOME/LOG_HOME/DATA_HOME directories
+#
+function traceDirs() {
+  echo "id = '`id`'"
+  local indir
+  for indir in DOMAIN_HOME_DIR DOMAIN_ROOT_DIR DOMAIN_LOGS_DIR; do
+    [ -z "${!indir}" ] && continue
+    echo "Directory trace for $indir=${!indir} ($1)"
+    local cnt=0
+    local odir=""
+    local cdir="${!indir}/*"
+    while [ ${cnt} -lt 30 ] && [ ! "$cdir" = "$odir" ]; do
+      echo "  ls -ld $cdir:"
+      ls -ld $cdir 2>&1 | sed 's/^/    /'
+      odir="$cdir"
+      cdir="`dirname "$cdir"`"
+      cnt=$((cnt + 1))
+    done
+  done
+}
+
 function prepareDomainHomeDir { 
+  traceDirs before
+
   # Do not proceed if the domain already exists
   local domainFolder=${DOMAIN_HOME_DIR}
   if [ -d ${domainFolder} ]; then
@@ -51,5 +76,6 @@ function prepareDomainHomeDir {
   createFolder ${DOMAIN_LOGS_DIR}
   createFolder ${DOMAIN_ROOT_DIR}/applications
   createFolder ${DOMAIN_ROOT_DIR}/stores
-}
 
+  traceDirs after
+}

--- a/kubernetes/samples/scripts/create-soa-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-soa-domain/domain-home-on-pv/common/utility.sh
@@ -39,7 +39,32 @@ function checkDomainSecret {
   fi
 }
 
+#
+# traceDirs before|after
+#   Trace contents and owner of DOMAIN_HOME/LOG_HOME/DATA_HOME directories
+#
+function traceDirs() {
+  echo "id = '`id`'"
+  local indir
+  for indir in DOMAIN_HOME_DIR DOMAIN_ROOT_DIR DOMAIN_LOGS_DIR; do
+    [ -z "${!indir}" ] && continue
+    echo "Directory trace for $indir=${!indir} ($1)"
+    local cnt=0
+    local odir=""
+    local cdir="${!indir}/*"
+    while [ ${cnt} -lt 30 ] && [ ! "$cdir" = "$odir" ]; do
+      echo "  ls -ld $cdir:"
+      ls -ld $cdir 2>&1 | sed 's/^/    /'
+      odir="$cdir"
+      cdir="`dirname "$cdir"`"
+      cnt=$((cnt + 1))
+    done
+  done
+}
+
 function prepareDomainHomeDir { 
+  traceDirs before
+
   # Do not proceed if the domain already exists
   local domainFolder=${DOMAIN_HOME_DIR}
   if [ -d ${domainFolder} ]; then
@@ -51,5 +76,6 @@ function prepareDomainHomeDir {
   createFolder ${DOMAIN_LOGS_DIR}
   createFolder ${DOMAIN_ROOT_DIR}/applications
   createFolder ${DOMAIN_ROOT_DIR}/stores
-}
 
+  traceDirs after
+}

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/common/utility.sh
@@ -39,7 +39,32 @@ function checkDomainSecret {
   fi
 }
 
+#
+# traceDirs before|after
+#   Trace contents and owner of DOMAIN_HOME/LOG_HOME/DATA_HOME directories
+#
+function traceDirs() {
+  echo "id = '`id`'"
+  local indir
+  for indir in DOMAIN_HOME_DIR DOMAIN_ROOT_DIR DOMAIN_LOGS_DIR; do
+    [ -z "${!indir}" ] && continue
+    echo "Directory trace for $indir=${!indir} ($1)"
+    local cnt=0
+    local odir=""
+    local cdir="${!indir}/*"
+    while [ ${cnt} -lt 30 ] && [ ! "$cdir" = "$odir" ]; do
+      echo "  ls -ld $cdir:"
+      ls -ld $cdir 2>&1 | sed 's/^/    /'
+      odir="$cdir"
+      cdir="`dirname "$cdir"`"
+      cnt=$((cnt + 1))
+    done
+  done
+}
+
 function prepareDomainHomeDir { 
+  traceDirs before
+
   # Do not proceed if the domain already exists
   local domainFolder=${DOMAIN_HOME_DIR}
   if [ -d ${domainFolder} ]; then
@@ -51,5 +76,6 @@ function prepareDomainHomeDir {
   createFolder ${DOMAIN_LOGS_DIR}
   createFolder ${DOMAIN_ROOT_DIR}/applications
   createFolder ${DOMAIN_ROOT_DIR}/stores
-}
 
+  traceDirs after
+}

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -56,9 +56,10 @@ function createFolder {
 
 trace "Introspecting the domain"
 
-# list potentially interesting env-vars before they're updated by export.*Homes
+# list potentially interesting env-vars and dirs before they're updated by export.*Homes
 
 traceEnv before
+traceDirs before
 
 # set defaults
 # set ORACLE_HOME/WL_HOME/MW_HOME to defaults if needed
@@ -101,9 +102,10 @@ fi
 
 exportEffectiveDomainHome || exit 1
 
-# list potentially interesting env-vars after they're updated by export.*Homes
+# list potentially interesting env-vars and dirs after they're updated by export.*Homes
 
 traceEnv after
+traceDirs after
 
 # check if we're using a supported WebLogic version
 # (the check  will log a message if it fails)

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -120,9 +120,10 @@ function copySitCfg() {
   fi
 }
 
-# trace env vars before export.*Home calls
+# trace env vars and dirs before export.*Home calls
 
 traceEnv before
+traceDirs before
 
 #
 # Configure startup mode
@@ -180,9 +181,10 @@ fi
 
 exportEffectiveDomainHome || exitOrLoop
 
-# trace env vars after export.*Home calls
+# trace env vars and dirs after export.*Home calls
 
 traceEnv after
+traceDirs after
 
 #
 # Check if introspector actually ran.  This should never fail since

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -273,6 +273,29 @@ function traceEnv() {
   done
 }
 
+#
+# traceDirs before|after
+#   Trace contents and owner of DOMAIN_HOME/LOG_HOME/DATA_HOME directories
+#
+function traceDirs() {
+  trace "id = '`id`'"
+  local indir
+  for indir in DOMAIN_HOME LOG_HOME DATA_HOME; do
+    [ -z "${!indir}" ] && continue
+    trace "Directory trace for $indir=${!indir} ($1)"
+    local cnt=0
+    local odir=""
+    local cdir="${!indir}/*"
+    while [ ${cnt} -lt 30 ] && [ ! "$cdir" = "$odir" ]; do
+      echo "  ls -ld $cdir:"
+      ls -ld $cdir 2>&1 | sed 's/^/    /'
+      odir="$cdir"
+      cdir="`dirname "$cdir"`"
+      cnt=$((cnt + 1))
+    done
+  done
+}
+
 
 #
 # exportEffectiveDomainHome

--- a/src/integration-tests/introspector/util_subst.sh
+++ b/src/integration-tests/introspector/util_subst.sh
@@ -83,6 +83,7 @@ cp $sfilename $tfilename || exit 1
 
 env | awk -F= '{ print $1 }' | sort -r | while read ii; do
   [ "$ii" = "KHELP" ] && continue
+  [ "$ii" = "LS_COLORS" ] && continue
   varstr1="\${$ii:-[^}]*}"
   varstr2="\${$ii}"
   newstr="${!ii}"


### PR DESCRIPTION
Implements JIRA `(OWLS-77081) add file security tracing - show user & file permissions`

Adds runtime tracing to introspector & start-server.  
Adds tracing to the three pv samples 'create domain job' path.

Sample output:

```
@[2019-11-18T20:07:55.755 UTC][introspectDomain.sh:281][FINE] id = 'uid=1000(oracle) gid=1000(oracle) groups=1000(oracle)'
@[2019-11-18T20:07:55.772 UTC][introspectDomain.sh:285][FINE] Directory trace for DOMAIN_HOME=/shared/domains/domain1 (before)
  ls -ld /shared/domains/domain1/*:
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/autodeploy
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/backup_config
    drwxr-x--- 6 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/bin
    drwxr-x--- 8 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/config
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/console-ext
    -rw-r----- 1 oracle oracle  327 Jul 19  2017 /shared/domains/domain1/fileRealm.properties
    drwxr-x--- 3 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/init-info
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/lib
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/nodemanager
    drwxr-x--- 2 oracle oracle 4096 Jul 19  2017 /shared/domains/domain1/resources
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/security
    drwxr-x--- 3 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1/servers
    -rw-r----- 1 oracle oracle  776 Nov 18 20:07 /shared/domains/domain1/startManagedWebLogic_readme.txt
    -rwxr-x--- 1 oracle oracle  239 Nov 18 20:07 /shared/domains/domain1/startWebLogic.sh
  ls -ld /shared/domains/domain1:
    drwxr-x--- 13 oracle oracle 4096 Nov 18 20:07 /shared/domains/domain1
  ls -ld /shared/domains:
    drwxr-xr-x 3 oracle oracle 4096 Nov 18 20:07 /shared/domains
  ls -ld /shared:
    drwxrwxrwx 5 oracle oracle 4096 Nov 18 20:07 /shared
  ls -ld /:
    drwxr-xr-x 1 root root 4096 Nov 18 20:07 /
@[2019-11-18T20:07:55.803 UTC][introspectDomain.sh:285][FINE] Directory trace for LOG_HOME=/shared/logs (before)
  ls -ld /shared/logs/*:
    ls: cannot access /shared/logs/*: No such file or directory
  ls -ld /shared/logs:
    drwxr-xr-x 2 oracle oracle 4096 Nov 18 20:07 /shared/logs
  ls -ld /shared:
    drwxrwxrwx 5 oracle oracle 4096 Nov 18 20:07 /shared
  ls -ld /:
    drwxr-xr-x 1 root root 4096 Nov 18 20:07 /
@[2019-11-18T20:07:55.831 UTC][introspectDomain.sh:285][FINE] Directory trace for DATA_HOME=/shared/data (before)
  ls -ld /shared/data/*:
    ls: cannot access /shared/data/*: No such file or directory
  ls -ld /shared/data:
    drwxr-x--- 2 oracle oracle 4096 Nov 18 20:07 /shared/data
  ls -ld /shared:
    drwxrwxrwx 5 oracle oracle 4096 Nov 18 20:07 /shared
  ls -ld /:
    drwxr-xr-x 1 root root 4096 Nov 18 20:07 /
```