### PR TITLE
Handle forbidden status from Async call

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/calls/FailureStatusSource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/FailureStatusSource.java
@@ -1,0 +1,11 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.calls;
+
+public interface FailureStatusSource {
+
+  String getMessage();
+
+  String getReason();
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/ForbiddenErrorBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/ForbiddenErrorBuilder.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.calls;
+
+import java.net.HttpURLConnection;
+
+import io.kubernetes.client.ApiException;
+
+/**
+ * A builder for 'forbidden' async results.
+ */
+public class ForbiddenErrorBuilder implements FailureStatusSource {
+  private static final String FORBIDDEN_REASON = "Forbidden";
+
+  private String message;
+
+  private ForbiddenErrorBuilder(ApiException e) {
+    this.message = e.getMessage();
+  }
+
+  public static boolean isForbiddenOperation(ApiException e) {
+    return e.getCode() == HttpURLConnection.HTTP_FORBIDDEN;
+  }
+
+  public static ForbiddenErrorBuilder fromException(ApiException exception) {
+    if (!isForbiddenOperation(exception))
+      throw new IllegalArgumentException("Is not forbidden exception");
+
+    return new ForbiddenErrorBuilder(exception);
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String getReason() {
+    return FORBIDDEN_REASON;
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/UnrecoverableErrorBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/UnrecoverableErrorBuilder.java
@@ -1,0 +1,30 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.calls;
+
+import io.kubernetes.client.ApiException;
+import oracle.kubernetes.operator.calls.unprocessable.UnprocessableEntityBuilder;
+
+public class UnrecoverableErrorBuilder {
+
+  /**
+   * Returns true if the specified call response indicates an unprocessable entity response from Kubernetes.
+   * @param callResponse the response from a Kubernetes call
+   * @return true if an unprocessable entity failure has been reported
+   */
+  public static <T> boolean isAsyncCallFailure(CallResponse<T> callResponse) {
+    return callResponse.isFailure() && isUnrecoverable(callResponse.getE());
+  }
+
+  private static boolean isUnrecoverable(ApiException e) {
+    return ForbiddenErrorBuilder.isForbiddenOperation(e) || UnprocessableEntityBuilder.isUnprocessableEntity(e);
+  }
+
+  public static FailureStatusSource fromException(ApiException apiException) {
+    if (UnprocessableEntityBuilder.isUnprocessableEntity(apiException))
+      return UnprocessableEntityBuilder.fromException(apiException);
+    else
+      return ForbiddenErrorBuilder.fromException(apiException);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/unprocessable/UnprocessableEntityBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/unprocessable/UnprocessableEntityBuilder.java
@@ -7,8 +7,9 @@ import java.util.Collections;
 
 import com.google.gson.Gson;
 import io.kubernetes.client.ApiException;
+import oracle.kubernetes.operator.calls.FailureStatusSource;
 
-public class UnprocessableEntityBuilder {
+public class UnprocessableEntityBuilder implements FailureStatusSource {
   static final int HTTP_UNPROCESSABLE_ENTITY = 422;
   private ErrorBody errorBody;
 
@@ -31,10 +32,12 @@ public class UnprocessableEntityBuilder {
     errorBody = new ErrorBody();
   }
 
+  @Override
   public String getMessage() {
     return errorBody.getMessage();
   }
 
+  @Override
   public String getReason() {
     return errorBody.getDetails().getCauses()[0].getReason();
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
@@ -10,7 +10,8 @@ import javax.json.JsonValue;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.custom.V1Patch;
 import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.calls.unprocessable.UnprocessableEntityBuilder;
+import oracle.kubernetes.operator.calls.FailureStatusSource;
+import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
@@ -23,15 +24,6 @@ public class DomainStatusPatch extends Step {
   private final String name;
   private final String namespace;
   private JsonPatchBuilder patchBuilder;
-
-  /**
-   * Returns true if the specified call response indicates an unprocessable entity response from Kubernetes.
-   * @param callResponse the response from a Kubernetes call
-   * @return true if an unprocessable entity failure has been reported
-   */
-  static <T> boolean isUnprocessableEntityFailure(CallResponse<T> callResponse) {
-    return callResponse.isFailure() && UnprocessableEntityBuilder.isUnprocessableEntity(callResponse.getE());
-  }
 
   /**
    * Update the domain status. This may involve either replacing the current status or adding to it.
@@ -50,8 +42,8 @@ public class DomainStatusPatch extends Step {
    * @param apiException the exception reporting an unprocessable entity
    */
   static Step createStep(Domain domain, ApiException apiException) {
-    UnprocessableEntityBuilder builder = UnprocessableEntityBuilder.fromException(apiException);
-    return createStep(domain, builder.getReason(), builder.getMessage());
+    FailureStatusSource failure = UnrecoverableErrorBuilder.fromException(apiException);
+    return createStep(domain, failure.getReason(), failure.getMessage());
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -26,6 +26,7 @@ import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.NextAction;
@@ -320,7 +321,7 @@ public abstract class JobStepContext extends BasePodStepContext {
 
     @Override
     public NextAction onFailure(Packet packet, CallResponse<V1Job> callResponse) {
-      if (DomainStatusPatch.isUnprocessableEntityFailure(callResponse))
+      if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse))
         return updateDomainStatus(packet, callResponse);
       else
         return super.onFailure(packet, callResponse);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -38,6 +38,7 @@ import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.WebLogicConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
@@ -784,7 +785,7 @@ public abstract class PodStepContext extends BasePodStepContext {
 
     @Override
     public NextAction onFailure(Packet packet, CallResponse<V1Pod> callResponse) {
-      if (DomainStatusPatch.isUnprocessableEntityFailure(callResponse))
+      if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse))
         return updateDomainStatus(packet, callResponse);
       else
         return onFailure(getConflictStep(), packet, callResponse);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -21,6 +21,7 @@ import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.VersionConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
@@ -610,7 +611,7 @@ public class ServiceHelper {
 
       @Override
       public NextAction onFailure(Packet packet, CallResponse<V1Service> callResponse) {
-        if (DomainStatusPatch.isUnprocessableEntityFailure(callResponse))
+        if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse))
           return updateDomainStatus(packet, callResponse);
         else
           return onFailure(getConflictStep(), packet, callResponse);


### PR DESCRIPTION
When an update to a pod, service or job fails with 403 (forbidden), abort and record the result in the domain status