### PR TITLE
Correct issue with CRD not generating structural schema

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -173,6 +173,7 @@ public class CrdHelper {
       V1beta1JSONSchemaProps status =
           gson.fromJson(jsonElementStatus, V1beta1JSONSchemaProps.class);
       return new V1beta1JSONSchemaProps()
+          .type("object")
           .putPropertiesItem("spec", spec)
           .putPropertiesItem("status", status);
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -245,6 +245,11 @@ public class CrdHelperTest {
       V1beta1JSONSchemaProps openApiV3Schema = validation.getOpenAPIV3Schema();
       if (openApiV3Schema == null || openApiV3Schema.getProperties().size() != 2) return false;
 
+      // check for structural schema condition 1 -- top level type value
+      // https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/
+      //     custom-resource-definitions/#specifying-a-structural-schema
+      if (openApiV3Schema == null || !openApiV3Schema.getType().equals("object")) return false;
+
       V1beta1JSONSchemaProps spec = openApiV3Schema.getProperties().get("spec");
       if (spec == null || spec.getProperties().isEmpty()) return false;
 


### PR DESCRIPTION
Without this change, Kubernetes was reporting a warning in the status of the CRD.