### PR TITLE
use patch to update status

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -384,7 +384,7 @@ public class DomainProcessorImpl implements DomainProcessor {
                         Component.createFor(info, delegate.getVersion()));
                 packet.put(LoggingFilter.LOGGING_FILTER_PACKET_KEY, loggingFilter);
                 Step strategy =
-                    DomainStatusUpdater.createStatusStep(main.statusUpdateTimeoutSeconds, null);
+                    ServerStatusReader.createStatusStep(main.statusUpdateTimeoutSeconds, null);
                 FiberGate gate = getStatusFiberGate(info.getNamespace());
 
                 Fiber f =

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -63,6 +63,7 @@ import oracle.kubernetes.weblogic.domain.model.Channel;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_COMPONENT_NAME;
 import static oracle.kubernetes.operator.helpers.LegalNames.toJobIntrospectorName;
 
 public class DomainProcessorImpl implements DomainProcessor {
@@ -472,13 +473,15 @@ public class DomainProcessorImpl implements DomainProcessor {
           new StartPlanStep(
               info, isDeleting ? createDomainDownPlan(info) : createDomainUpPlan(info));
       if (!isDeleting && dom != null)
-        strategy = new DomainValidationStep(dom, strategy);
+        strategy = new DomainValidationStep(strategy);
 
+      Packet packet = new Packet();
+      packet.getComponents().put(DOMAIN_COMPONENT_NAME, Component.createFor(info));
       runDomainPlan(
           dom,
           domainUid,
           ns,
-          new StepAndPacket(strategy, new Packet()),
+          new StepAndPacket(strategy, packet),
           isDeleting,
           isWillInterrupt);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -10,18 +10,23 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.json.Json;
+import javax.json.JsonPatchBuilder;
 
+import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.models.V1ObjectMeta;
 import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.calls.FailureStatusSource;
+import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo.ServerStartupInfo;
 import oracle.kubernetes.operator.helpers.PodHelper;
+import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
@@ -55,8 +60,9 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Progre
  * listening to events from {@link PodWatcher} and 2) Factory for {@link Step}s that the main
  * processing flow can use to explicitly set the condition to Progressing or Failed.
  */
+@SuppressWarnings("WeakerAccess")
 public class DomainStatusUpdater {
-  public static final String INSPECTING_DOMAIN_PROGRESS_REASON = "InspectingDomainPrescence";
+  public static final String INSPECTING_DOMAIN_PROGRESS_REASON = "InspectingDomainPresence";
   public static final String MANAGED_SERVERS_STARTING_PROGRESS_REASON = "ManagedServersStarting";
   public static final String SERVERS_READY_REASON = "ServersReady";
   public static final String ALL_STOPPED_AVAILABLE_REASON = "AllServersStopped";
@@ -68,15 +74,12 @@ public class DomainStatusUpdater {
   }
 
   /**
-   * Asynchronous step to set Domain status to indicate WebLogic server status.
-   *
-   * @param timeoutSeconds Timeout in seconds
-   * @param next Next step
-   * @return Step
+   * Creates an asynchronous step to update domain status from the topology in the current packet.
+   * @param next the next step
+   * @return the new step
    */
-  @SuppressWarnings("SameParameterValue")
-  static Step createStatusStep(int timeoutSeconds, Step next) {
-    return new StatusUpdateHookStep(timeoutSeconds, next);
+  static Step createStatusUpdateStep(Step next) {
+    return new StatusUpdateStep(next);
   }
 
   /**
@@ -112,59 +115,16 @@ public class DomainStatusUpdater {
     return new AvailableStep(reason, next);
   }
 
-  private static NextAction doDomainUpdate(
-      Domain dom, DomainPresenceInfo info, Packet packet, Step conflictStep, Step next) {
-    V1ObjectMeta meta = dom.getMetadata();
-    NextAction na = new NextAction();
-
-    // *NOTE* See the note in KubernetesVersion
-    // If we update the CrdHelper to include the status subresource, then this code
-    // needs to be modified to use replaceDomainStatusAsync.  Then, validate if onSuccess
-    // should update info.
-
-    na.invoke(
-        new CallBuilder()
-            .replaceDomainAsync(
-                meta.getName(),
-                meta.getNamespace(),
-                dom,
-                new DefaultResponseStep<Domain>(next) {
-                  @Override
-                  public NextAction onFailure(Packet packet, CallResponse<Domain> callResponse) {
-                    if (callResponse.getStatusCode() == CallBuilder.NOT_FOUND) {
-                      return doNext(packet); // Just ignore update
-                    }
-                    return super.onFailure(
-                        getRereadDomainConflictStep(info, meta, conflictStep),
-                        packet,
-                        callResponse);
-                  }
-
-                  @Override
-                  public NextAction onSuccess(Packet packet, CallResponse<Domain> callResponse) {
-                    // Update info only if using replaceDomain
-                    // Skip, if we switch to using replaceDomainStatus
-                    info.setDomain(callResponse.getResult());
-                    return doNext(packet);
-                  }
-                }),
-        packet);
-    return na;
-  }
-
-  private static Step getRereadDomainConflictStep(
-      DomainPresenceInfo info, V1ObjectMeta meta, Step next) {
-    return new CallBuilder()
-        .readDomainAsync(
-            meta.getName(),
-            meta.getNamespace(),
-            new DefaultResponseStep<Domain>(next) {
-              @Override
-              public NextAction onSuccess(Packet packet, CallResponse<Domain> callResponse) {
-                info.setDomain(callResponse.getResult());
-                return doNext(packet);
-              }
-            });
+  /**
+   * Asynchronous step to set Domain condition to Failed after an asynchronous call failure.
+   *
+   * @param callResponse the response from an unrecoverable call
+   * @param next Next step
+   * @return Step
+   */
+  public static Step createFailedStep(CallResponse<?> callResponse, Step next) {
+    FailureStatusSource failure = UnrecoverableErrorBuilder.fromException(callResponse.getE());
+    return createFailedStep(failure.getReason(), failure.getMessage(), next);
   }
 
   /**
@@ -175,14 +135,92 @@ public class DomainStatusUpdater {
    * @return Step
    */
   static Step createFailedStep(Throwable throwable, Step next) {
-    return new FailedStep(throwable, next);
+    return createFailedStep("Exception", throwable.getMessage(), next);
   }
 
-  static class DomainConditionStepContext {
-    private final DomainPresenceInfo info;
+  /**
+   * Asynchronous step to set Domain condition to Failed.
+   *
+   * @param reason the reason for the failure
+   * @param message a fuller description of the problem
+   * @param next Next step
+   * @return Step
+   */
+  private static Step createFailedStep(String reason, String message, Step next) {
+    return new FailedStep(reason, message, next);
+  }
 
-    DomainConditionStepContext(Packet packet) {
+  abstract static class DomainStatusUpdaterStep extends Step {
+
+    DomainStatusUpdaterStep(Step next) {
+      super(next);
+    }
+
+    DomainStatusUpdaterContext createContext(Packet packet) {
+      return new DomainStatusUpdaterContext(packet, this);
+    }
+
+    void modifyStatus(DomainStatus domainStatus) {
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      DomainStatusUpdaterContext context = createContext(packet);
+
+      DomainStatus newStatus = context.getNewStatus();
+      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomainUid(), newStatus);
+
+      return context.isStatusChanged(newStatus)
+            ? doNext(packet)
+            : doNext(createDomainStatusPatchStep(context, newStatus), packet);
+    }
+
+    private Step createDomainStatusPatchStep(DomainStatusUpdaterContext context, DomainStatus newStatus) {
+      JsonPatchBuilder builder = Json.createPatchBuilder();
+      newStatus.createPatchFrom(builder, context.getStatus());
+
+      return new CallBuilder().patchDomainAsync(
+            context.getDomainName(),
+            context.getNamespace(),
+            new V1Patch(builder.build().toString()),
+            createResponseStep());
+    }
+
+    private ResponseStep<Domain> createResponseStep() {
+      return new DefaultResponseStep<>(getNext());
+    }
+
+  }
+
+  static class DomainStatusUpdaterContext {
+    private final DomainPresenceInfo info;
+    private DomainStatusUpdaterStep domainStatusUpdaterStep;
+
+    DomainStatusUpdaterContext(Packet packet, DomainStatusUpdaterStep domainStatusUpdaterStep) {
       info = packet.getSpi(DomainPresenceInfo.class);
+      this.domainStatusUpdaterStep = domainStatusUpdaterStep;
+    }
+
+    DomainStatus getNewStatus() {
+      DomainStatus newStatus = cloneStatus();
+      modifyStatus(newStatus);
+      return newStatus;
+    }
+
+    String getDomainUid() {
+      return getDomain().getDomainUid();
+    }
+
+    boolean isStatusChanged(DomainStatus newStatus) {
+      return newStatus.equals(getStatus());
+    }
+
+    private String getNamespace() {
+      return getMetadata().getNamespace();
+    }
+
+    private V1ObjectMeta getMetadata() {
+      return getDomain().getMetadata();
     }
 
     DomainPresenceInfo getInfo() {
@@ -190,95 +228,69 @@ public class DomainStatusUpdater {
     }
 
     DomainStatus getStatus() {
-      return getDomain().getOrCreateStatus();
+      return getDomain().getStatus();
     }
 
     Domain getDomain() {
       return info.getDomain();
     }
-  }
 
-  private static class StatusUpdateHookStep extends Step {
-    private final int timeoutSeconds;
-
-    StatusUpdateHookStep(int timeoutSeconds, Step next) {
-      super(next);
-      this.timeoutSeconds = timeoutSeconds;
+    void modifyStatus(DomainStatus status) {
+      domainStatusUpdaterStep.modifyStatus(status);
     }
 
-    @Override
-    public NextAction apply(Packet packet) {
-      DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
-      return doNext(
-          ServerStatusReader.createDomainStatusReaderStep(
-              info, timeoutSeconds, new StatusUpdateStep(getNext())),
-          packet);
+    private String getDomainName() {
+      return getMetadata().getName();
+    }
+
+    DomainStatus cloneStatus() {
+      return Optional.ofNullable(getStatus()).map(DomainStatus::new).orElse(new DomainStatus());
     }
   }
 
-  static class StatusUpdateStep extends Step {
+  /**
+   * A step which updates the domain status from the domain topology in the current packet.
+   */
+  private static class StatusUpdateStep extends DomainStatusUpdaterStep {
     StatusUpdateStep(Step next) {
       super(next);
     }
 
     @Override
-    public NextAction apply(Packet packet) {
-      LOGGER.entering();
-
-      final StatusUpdateContext context = new StatusUpdateContext(packet);
-
-      DomainStatus status = context.getStatus();
-
-      boolean isStatusModified =
-          modifyDomainStatus(
-              status,
-              s -> {
-                if (context.getDomain() != null) {
-                  if (context.getDomainConfig().isPresent()) {
-                    s.setServers(new ArrayList<>(context.getServerStatuses().values()));
-                    s.setClusters(new ArrayList<>(context.getClusterStatuses().values()));
-                    s.setReplicas(context.getReplicaSetting());
-                  }
-
-                  if (context.isHasFailedPod()) {
-                    s.removeConditionIf(c -> c.getType() == Available);
-                    s.removeConditionIf(c -> c.getType() == Progressing);
-                    s.addCondition(
-                        new DomainCondition(Failed).withStatus(TRUE).withReason("PodFailed"));
-                  } else {
-                    s.removeConditionIf(c -> c.getType() == Failed);
-                    if (context.allIntendedServersRunning()) {
-                      s.removeConditionIf(c -> c.getType() == Progressing);
-                      s.addCondition(
-                          new DomainCondition(Available)
-                              .withStatus(TRUE)
-                              .withReason(SERVERS_READY_REASON));
-                    }
-                  }
-                }
-              });
-
-      if (isStatusModified) {
-        LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getInfo().getDomainUid(), status);
-      }
-      LOGGER.exiting();
-
-      return isStatusModified
-          ? doDomainUpdate(
-              context.getDomain(), context.getInfo(), packet, StatusUpdateStep.this, getNext())
-          : doNext(packet);
+    DomainStatusUpdaterContext createContext(Packet packet) {
+      return new StatusUpdateContext(packet, this);
     }
 
-    static class StatusUpdateContext extends DomainConditionStepContext {
+    static class StatusUpdateContext extends DomainStatusUpdaterContext {
       private final WlsDomainConfig config;
       private final Map<String, String> serverState;
       private final Map<String, ServerHealth> serverHealth;
 
-      StatusUpdateContext(Packet packet) {
-        super(packet);
+      StatusUpdateContext(Packet packet, StatusUpdateStep statusUpdateStep) {
+        super(packet, statusUpdateStep);
         config = packet.getValue(DOMAIN_TOPOLOGY);
         serverState = packet.getValue(SERVER_STATE_MAP);
         serverHealth = packet.getValue(SERVER_HEALTH_MAP);
+      }
+
+      @Override
+      void modifyStatus(DomainStatus status) {
+        if (getDomain() == null) return;
+        
+        if (getDomainConfig().isPresent()) {
+          status.setServers(new ArrayList<>(getServerStatuses().values()));
+          status.setClusters(new ArrayList<>(getClusterStatuses().values()));
+          status.setReplicas(getReplicaSetting());
+        }
+
+        if (isHasFailedPod()) {
+          status.addCondition(new DomainCondition(Failed).withStatus(TRUE).withReason("PodFailed"));
+        } else if (allIntendedServersRunning()) {
+          status.addCondition(new DomainCondition(Available).withStatus(TRUE).withReason(SERVERS_READY_REASON));
+        } else if (!status.hasConditionWith(c -> c.hasType(Progressing))) {
+          status.addCondition(new DomainCondition(Progressing).withStatus(TRUE)
+                .withReason(MANAGED_SERVERS_STARTING_PROGRESS_REASON));
+        }
       }
 
       private boolean allIntendedServersRunning() {
@@ -289,9 +301,7 @@ public class DomainStatusUpdater {
       }
 
       private Stream<ServerStartupInfo> getServerStartupInfos() {
-        return Optional.ofNullable(getInfo().getServerStartupInfo())
-            .map(Collection::stream)
-            .orElse(Stream.empty());
+        return Optional.ofNullable(getInfo().getServerStartupInfo()).stream().flatMap(Collection::stream);
       }
 
       private Optional<WlsDomainConfig> getDomainConfig() {
@@ -301,7 +311,7 @@ public class DomainStatusUpdater {
       private Optional<WlsDomainConfig> getScanCacheDomainConfig() {
         DomainPresenceInfo info = getInfo();
         Scan scan = ScanCache.INSTANCE.lookupScan(info.getNamespace(), info.getDomainUid());
-        return Optional.ofNullable(scan).map(s -> s.getWlsDomainConfig());
+        return Optional.ofNullable(scan).map(Scan::getWlsDomainConfig);
       }
 
       private boolean shouldBeRunning(ServerStartupInfo startupInfo) {
@@ -402,12 +412,12 @@ public class DomainStatusUpdater {
 
       private Collection<String> getServerNames() {
         Set<String> result = new HashSet<>();
-        getDomainConfig().stream().forEach(config -> {
+        getDomainConfig().ifPresent(config -> {
           result.addAll(config.getServerConfigs().keySet());
           for (WlsClusterConfig cluster : config.getConfiguredClusters()) {
             Optional.ofNullable(cluster.getDynamicServersConfig())
                 .ifPresent(dynamicConfig -> Optional.ofNullable(dynamicConfig.getServerConfigs())
-                    .ifPresent(servers -> servers.stream().forEach(item -> result.add(item.getName()))));
+                    .ifPresent(servers -> servers.forEach(item -> result.add(item.getName()))));
           }
         });
         return result;
@@ -415,18 +425,18 @@ public class DomainStatusUpdater {
 
       private Collection<String> getClusterNames() {
         Set<String> result = new HashSet<>();
-        getDomainConfig().stream().forEach(config -> result.addAll(config.getClusterConfigs().keySet()));
+        getDomainConfig().ifPresent(config -> result.addAll(config.getClusterConfigs().keySet()));
         return result;
       }
 
       private Integer getClusterMaximumSize(String clusterName) {
         return getDomainConfig().map(config -> Optional.ofNullable(config.getClusterConfig(clusterName)))
-            .map(cluster -> cluster.map(c -> c.getMaxClusterSize()).orElse(0)).get();
+            .map(cluster -> cluster.map(WlsClusterConfig::getMaxClusterSize).orElse(0)).get();
       }
     }
   }
 
-  private static class ProgressingStep extends Step {
+  private static class ProgressingStep extends DomainStatusUpdaterStep {
     private final String reason;
     private final boolean isPreserveAvailable;
 
@@ -437,65 +447,26 @@ public class DomainStatusUpdater {
     }
 
     @Override
-    public NextAction apply(Packet packet) {
-      LOGGER.entering();
-
-      DomainConditionStepContext context = new DomainConditionStepContext(packet);
-      DomainStatus status = context.getStatus();
-
-      boolean isStatusModified =
-          modifyDomainStatus(
-              status,
-              s -> {
-                s.addCondition(
-                    new DomainCondition(Progressing).withStatus(TRUE).withReason(reason));
-                s.removeConditionIf(c -> c.getType() == Failed);
-                if (!isPreserveAvailable) {
-                  s.removeConditionIf(c -> c.getType() == Available);
-                }
-              });
-
-      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomain().getDomainUid(), status);
-      LOGGER.exiting();
-
-      return isStatusModified
-          ? doDomainUpdate(
-              context.getDomain(), context.getInfo(), packet, ProgressingStep.this, getNext())
-          : doNext(packet);
+    void modifyStatus(DomainStatus status) {
+      status.addCondition(new DomainCondition(Progressing).withStatus(TRUE).withReason(reason));
+      if (!isPreserveAvailable) status.removeConditionIf(c -> c.getType() == Available);
     }
   }
 
-  private static class EndProgressingStep extends Step {
+  private static class EndProgressingStep extends DomainStatusUpdaterStep {
 
     EndProgressingStep(Step next) {
       super(next);
     }
 
     @Override
-    public NextAction apply(Packet packet) {
-      LOGGER.entering();
-
-      DomainConditionStepContext context = new DomainConditionStepContext(packet);
-      DomainStatus status = context.getStatus();
-
-      boolean isStatusModified =
-          modifyDomainStatus(
-              status,
-              s ->
-                  s.removeConditionIf(
-                      c -> c.getType() == Progressing && TRUE.equals(c.getStatus())));
-
-      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomain().getDomainUid(), status);
-      LOGGER.exiting();
-
-      return isStatusModified
-          ? doDomainUpdate(
-              context.getDomain(), context.getInfo(), packet, EndProgressingStep.this, getNext())
-          : doNext(packet);
+    void modifyStatus(DomainStatus status) {
+      status.removeConditionIf(
+          c -> c.getType() == Progressing && TRUE.equals(c.getStatus()));
     }
   }
 
-  private static class AvailableStep extends Step {
+  private static class AvailableStep extends DomainStatusUpdaterStep {
     private final String reason;
 
     private AvailableStep(String reason, Step next) {
@@ -504,75 +475,29 @@ public class DomainStatusUpdater {
     }
 
     @Override
-    public NextAction apply(Packet packet) {
-      LOGGER.entering();
-
-      DomainConditionStepContext context = new DomainConditionStepContext(packet);
-      DomainStatus status = context.getStatus();
-
-      boolean isStatusModified =
-          modifyDomainStatus(
-              status,
-              s -> {
-                s.addCondition(new DomainCondition(Available).withStatus(TRUE).withReason(reason));
-                s.removeConditionIf(c -> c.getType() == Failed);
-              });
-
-      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomain().getDomainUid(), status);
-      LOGGER.exiting();
-
-      return isStatusModified
-          ? doDomainUpdate(
-              context.getDomain(), context.getInfo(), packet, AvailableStep.this, getNext())
-          : doNext(packet);
+    void modifyStatus(DomainStatus status) {
+      status.addCondition(new DomainCondition(Available).withStatus(TRUE).withReason(reason));
     }
   }
 
-  private static boolean modifyDomainStatus(DomainStatus domainStatus, Consumer<DomainStatus> statusUpdateConsumer) {
-    final DomainStatus currentStatus = new DomainStatus(domainStatus);
-    synchronized (domainStatus) {
-      statusUpdateConsumer.accept(domainStatus);
-      return !domainStatus.equals(currentStatus);
-    }
-  }
+  private static class FailedStep extends DomainStatusUpdaterStep {
+    private final String reason;
+    private final String message;
 
-  private static class FailedStep extends Step {
-    private final Throwable throwable;
-
-    private FailedStep(Throwable throwable, Step next) {
+    private FailedStep(String reason, String message, Step next) {
       super(next);
-      this.throwable = throwable;
+      this.reason = reason;
+      this.message = message;
     }
 
     @Override
-    public NextAction apply(Packet packet) {
-      LOGGER.entering();
-
-      DomainConditionStepContext context = new DomainConditionStepContext(packet);
-      final DomainStatus status = context.getStatus();
-
-      boolean isStatusModified =
-          modifyDomainStatus(
-              status,
-              s -> {
-                s.addCondition(
-                    new DomainCondition(Failed)
-                        .withStatus(TRUE)
-                        .withReason("Exception")
-                        .withMessage(throwable.getMessage()));
-                if (s.hasConditionWith(c -> c.hasType(Progressing))) {
-                  s.addCondition(new DomainCondition(Progressing).withStatus(FALSE));
-                }
-              });
-
-
-      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomain().getDomainUid(), status);
-      LOGGER.exiting();
-
-      return isStatusModified
-          ? doDomainUpdate(
-              context.getDomain(), context.getInfo(), packet, FailedStep.this, getNext())
-          : doNext(packet);
+    void modifyStatus(DomainStatus s) {
+      s.setReason(reason);
+      s.setMessage(message);
+      s.addCondition(new DomainCondition(Failed).withStatus(TRUE).withReason(reason).withMessage(message));
+      if (s.hasConditionWith(c -> c.hasType(Progressing))) {
+        s.addCondition(new DomainCondition(Progressing).withStatus(FALSE));
+      }
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -146,7 +146,7 @@ public class DomainStatusUpdater {
    * @param next Next step
    * @return Step
    */
-  private static Step createFailedStep(String reason, String message, Step next) {
+  public static Step createFailedStep(String reason, String message, Step next) {
     return new FailedStep(reason, message, next);
   }
 
@@ -492,8 +492,6 @@ public class DomainStatusUpdater {
 
     @Override
     void modifyStatus(DomainStatus s) {
-      s.setReason(reason);
-      s.setMessage(message);
       s.addCondition(new DomainCondition(Failed).withStatus(TRUE).withReason(reason).withMessage(message));
       if (s.hasConditionWith(c -> c.hasType(Progressing))) {
         s.addCondition(new DomainCondition(Progressing).withStatus(FALSE));

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
@@ -9,29 +9,15 @@ import javax.json.JsonValue;
 
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.custom.V1Patch;
-import oracle.kubernetes.operator.steps.DefaultResponseStep;
-import oracle.kubernetes.operator.work.NextAction;
-import oracle.kubernetes.operator.work.Packet;
-import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
-public class DomainStatusPatch extends Step {
+public class DomainStatusPatch {
   static final String BAD_DOMAIN = "ErrBadDomain";
   static final String ERR_INTROSPECTOR = "ErrIntrospector";
 
   private final String name;
   private final String namespace;
   private JsonPatchBuilder patchBuilder;
-
-  /**
-   * Update the domain status. This may involve either replacing the current status or adding to it.
-   * @param domain the domain to update
-   * @param reason the reason, a camel-cased string with no spaces
-   * @param message a text description of the new status; may include multiple lines
-   */
-  static Step createStep(Domain domain, String reason, String message) {
-    return new DomainStatusPatch(domain, reason, message);
-  }
 
   /**
    * Update the domain status synchronously. This may involve either replacing the current status or adding to it.
@@ -47,16 +33,6 @@ public class DomainStatusPatch extends Step {
     name = domain.getMetadata().getName();
     namespace = domain.getMetadata().getNamespace();
     patchBuilder = getPatchBuilder(domain, reason, message);
-  }
-
-  @Override
-  public NextAction apply(Packet packet) {
-    Step step = new CallBuilder().patchDomainAsync(name, namespace, getPatchBody(), createResponseStep());
-    return doNext(step, packet);
-  }
-
-  private DefaultResponseStep<Domain> createResponseStep() {
-    return new DefaultResponseStep<>(getNext());
   }
 
   private static JsonPatchBuilder getPatchBuilder(Domain domain, String reason, String message) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainStatusPatch.java
@@ -9,9 +9,6 @@ import javax.json.JsonValue;
 
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.custom.V1Patch;
-import oracle.kubernetes.operator.calls.CallResponse;
-import oracle.kubernetes.operator.calls.FailureStatusSource;
-import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
@@ -21,6 +18,7 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 public class DomainStatusPatch extends Step {
   static final String BAD_DOMAIN = "ErrBadDomain";
   static final String ERR_INTROSPECTOR = "ErrIntrospector";
+
   private final String name;
   private final String namespace;
   private JsonPatchBuilder patchBuilder;
@@ -33,17 +31,6 @@ public class DomainStatusPatch extends Step {
    */
   static Step createStep(Domain domain, String reason, String message) {
     return new DomainStatusPatch(domain, reason, message);
-  }
-
-  /**
-   * Update the domain status in response to an unprocessable entity error. This may involve either replacing
-   * the current status or adding to it.
-   * @param domain the domain to update
-   * @param apiException the exception reporting an unprocessable entity
-   */
-  static Step createStep(Domain domain, ApiException apiException) {
-    FailureStatusSource failure = UnrecoverableErrorBuilder.fromException(apiException);
-    return createStep(domain, failure.getReason(), failure.getMessage());
   }
 
   /**
@@ -103,4 +90,5 @@ public class DomainStatusPatch extends Step {
   private V1Patch getPatchBody() {
     return new V1Patch(patchBuilder.build().toString());
   }
+
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationStep.java
@@ -5,6 +5,9 @@ package oracle.kubernetes.operator.helpers;
 
 import java.util.List;
 
+import oracle.kubernetes.operator.DomainStatusUpdater;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
@@ -12,22 +15,26 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 
 import static java.lang.System.lineSeparator;
 import static oracle.kubernetes.operator.helpers.DomainStatusPatch.BAD_DOMAIN;
+import static oracle.kubernetes.operator.logging.MessageKeys.DOMAIN_VALIDATION_FAILED;
 
 public class DomainValidationStep extends Step {
-  private Domain domain;
 
-  public DomainValidationStep(Domain domain, Step next) {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  public DomainValidationStep(Step next) {
     super(next);
-    this.domain = domain;
   }
 
   @Override
   public NextAction apply(Packet packet) {
+    DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
+    Domain domain = info.getDomain();
     List<String> validationFailures = domain.getValidationFailures();
 
     if (validationFailures.isEmpty()) return doNext(packet);
 
-    Step step = DomainStatusPatch.createStep(domain, BAD_DOMAIN, perLine(validationFailures));
+    LOGGER.severe(DOMAIN_VALIDATION_FAILED, domain.getDomainUid(), perLine(validationFailures));
+    Step step = DomainStatusUpdater.createFailedStep(BAD_DOMAIN, perLine(validationFailures), null);
     return doNext(step, packet);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -4,7 +4,6 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.io.File;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,6 +19,7 @@ import io.kubernetes.client.models.V1PodTemplateSpec;
 import io.kubernetes.client.models.V1SecretVolumeSource;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
+import oracle.kubernetes.operator.DomainStatusUpdater;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
@@ -328,7 +328,7 @@ public abstract class JobStepContext extends BasePodStepContext {
     }
 
     private NextAction updateDomainStatus(Packet packet, CallResponse<V1Job> callResponse) {
-      return doNext(DomainStatusPatch.createStep(getDomain(), callResponse.getE()), packet);
+      return doNext(DomainStatusUpdater.createFailedStep(callResponse, null), packet);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -31,6 +31,7 @@ import io.kubernetes.client.models.V1Probe;
 import io.kubernetes.client.models.V1Status;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
+import oracle.kubernetes.operator.DomainStatusUpdater;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.PodAwaiterStepFactory;
@@ -792,7 +793,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     }
 
     private NextAction updateDomainStatus(Packet packet, CallResponse<V1Pod> callResponse) {
-      return doNext(DomainStatusPatch.createStep(getDomain(), callResponse.getE()), packet);
+      return doNext(DomainStatusUpdater.createFailedStep(callResponse, null), packet);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -17,6 +17,7 @@ import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServicePort;
 import io.kubernetes.client.models.V1ServiceSpec;
 import io.kubernetes.client.models.V1Status;
+import oracle.kubernetes.operator.DomainStatusUpdater;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.VersionConstants;
@@ -618,7 +619,7 @@ public class ServiceHelper {
       }
 
       private NextAction updateDomainStatus(Packet packet, CallResponse<V1Service> callResponse) {
-        return doNext(DomainStatusPatch.createStep(getDomain(), callResponse.getE()), packet);
+        return doNext(DomainStatusUpdater.createFailedStep(callResponse, null), packet);
       }
 
       @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -156,6 +156,7 @@ public class MessageKeys {
   public static final String JOB_DEADLINE_EXCEEDED_MESSAGE = "WLSKO-0154";
   public static final String JOB_LOG_PARSE_FAILURE = "WLSKO-0155";
   public static final String VERIFY_ACCESS_DENIED_WITH_NS = "WLSKO-0156";
+  public static final String DOMAIN_VALIDATION_FAILED = "WLSKO-0157";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/ScanCacheImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/ScanCacheImpl.java
@@ -3,15 +3,12 @@
 
 package oracle.kubernetes.operator.rest;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 class ScanCacheImpl implements ScanCache {
   static final ScanCache INSTANCE = new ScanCacheImpl();
-  private final ConcurrentMap<String, ConcurrentMap<String, Scan>> map = new ConcurrentHashMap<>();
-
-  private ScanCacheImpl() {
-  }
+  private final Map<String, Map<String, Scan>> map = new ConcurrentHashMap<>();
 
   @Override
   public void registerScan(String ns, String domainUid, Scan domainScan) {
@@ -21,7 +18,7 @@ class ScanCacheImpl implements ScanCache {
 
   @Override
   public Scan lookupScan(String ns, String domainUid) {
-    ConcurrentMap<String, Scan> m = map.get(ns);
+    Map<String, Scan> m = map.get(ns);
     return m != null ? m.get(domainUid) : null;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
@@ -3,6 +3,8 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import javax.annotation.Nonnull;
+
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import oracle.kubernetes.json.Description;
@@ -11,8 +13,10 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
+
 /** ServerStatus describes the current status of a specific WebLogic Server. */
-public class ClusterStatus implements Comparable<ClusterStatus> {
+public class ClusterStatus implements Comparable<ClusterStatus>, PatchableComponent<ClusterStatus> {
 
   @Description("WebLogic cluster name. Required.")
   @SerializedName("clusterName")
@@ -33,6 +37,16 @@ public class ClusterStatus implements Comparable<ClusterStatus> {
   @Description("The maximum number of cluster members. Required.")
   @Range(minimum = 0)
   private Integer maximumReplicas;
+
+  public ClusterStatus() {
+  }
+
+  ClusterStatus(ClusterStatus other) {
+    this.clusterName = other.clusterName;
+    this.replicas = other.replicas;
+    this.readyReplicas = other.readyReplicas;
+    this.maximumReplicas = other.maximumReplicas;
+  }
 
   /**
    * WebLogic cluster name. Required.
@@ -76,12 +90,8 @@ public class ClusterStatus implements Comparable<ClusterStatus> {
     return this;
   }
 
-  public Integer getReadyReplicas() {
+  Integer getReadyReplicas() {
     return readyReplicas;
-  }
-
-  public void setReadyReplicas(Integer readyReplicas) {
-    this.readyReplicas = readyReplicas;
   }
 
   public ClusterStatus withReadyReplicas(Integer readyReplicas) {
@@ -89,12 +99,8 @@ public class ClusterStatus implements Comparable<ClusterStatus> {
     return this;
   }
 
-  public Integer getMaximumReplicas() {
+  Integer getMaximumReplicas() {
     return maximumReplicas;
-  }
-
-  public void setMaximumReplicas(Integer maximumReplicas) {
-    this.maximumReplicas = maximumReplicas;
   }
 
   public ClusterStatus withMaximumReplicas(Integer maximumReplicas) {
@@ -140,7 +146,22 @@ public class ClusterStatus implements Comparable<ClusterStatus> {
   }
 
   @Override
-  public int compareTo(ClusterStatus o) {
+  public int compareTo(@Nonnull ClusterStatus o) {
     return clusterName.compareTo(o.clusterName);
+  }
+
+  @Override
+  public boolean isPatchableFrom(ClusterStatus other) {
+    return other.getClusterName() != null && other.getClusterName().equals(clusterName);
+  }
+
+  private static ObjectPatch<ClusterStatus> clusterPatch = createObjectPatch(ClusterStatus.class)
+        .withStringField("clusterName", ClusterStatus::getClusterName)
+        .withIntegerField("maximumReplicas", ClusterStatus::getMaximumReplicas)
+        .withIntegerField("readyReplicas", ClusterStatus::getReadyReplicas)
+        .withIntegerField("replicas", ClusterStatus::getReplicas);
+
+  static ObjectPatch<ClusterStatus> getObjectPatch() {
+    return clusterPatch;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -331,19 +331,6 @@ public class Domain {
   }
 
   /**
-   * DomainStatus represents information about the status of a domain. Status may trail the actual
-   * state of a system.
-   *
-   * @return Status
-   */
-  public DomainStatus getOrCreateStatus() {
-    if (status == null) {
-      status = new DomainStatus();
-    }
-    return status;
-  }
-
-  /**
    * Reference to secret containing WebLogic startup credentials username and password.
    *
    * @return credentials secret

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
@@ -14,8 +14,10 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.joda.time.DateTime;
 
+import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
+
 /** DomainCondition contains details for the current condition of this domain. */
-public class DomainCondition implements Comparable<DomainCondition> {
+public class DomainCondition implements Comparable<DomainCondition>, PatchableComponent<DomainCondition> {
 
   @Description(
       "The type of the condition. Valid types are Progressing, "
@@ -52,6 +54,15 @@ public class DomainCondition implements Comparable<DomainCondition> {
   public DomainCondition(DomainConditionType conditionType) {
     lastTransitionTime = SystemClock.now();
     type = conditionType;
+  }
+
+  DomainCondition(DomainCondition other) {
+    this.type = other.type;
+    this.lastProbeTime = other.lastProbeTime;
+    this.lastTransitionTime = other.lastTransitionTime;
+    this.message = other.message;
+    this.reason = other.reason;
+    this.status = other.status;
   }
 
   /**
@@ -170,6 +181,11 @@ public class DomainCondition implements Comparable<DomainCondition> {
   }
 
   @Override
+  public boolean isPatchableFrom(DomainCondition other) {
+    return false; // domain conditions are never patched
+  }
+
+  @Override
   public String toString() {
     return new ToStringBuilder(this)
         .append("lastProbeTime", lastProbeTime)
@@ -212,4 +228,15 @@ public class DomainCondition implements Comparable<DomainCondition> {
   public int compareTo(DomainCondition o) {
     return type.compareTo(o.type);
   }
+
+  private static ObjectPatch<DomainCondition> conditionPatch = createObjectPatch(DomainCondition.class)
+        .withStringField("message", DomainCondition::getMessage)
+        .withStringField("reason", DomainCondition::getReason)
+        .withStringField("status", DomainCondition::getStatus)
+        .withEnumField("type", DomainCondition::getType);
+
+  static ObjectPatch<DomainCondition> getObjectPatch() {
+    return conditionPatch;
+  }
+
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
@@ -66,6 +66,22 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
   }
 
   /**
+   * Returns the reason to set on the domain status when this condition is added.
+   * @return a reason or null
+   */
+  String getStatusReason() {
+    return getType().getStatusReason(this);
+  }
+
+  /**
+   * Returns the message to set on the domain status when this condition is added.
+   * @return a message or null
+   */
+  String getStatusMessage() {
+    return getType().getStatusMessage(this);
+  }
+
+  /**
    * Last time we probed the condition.
    *
    * @return time

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainConditionType.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainConditionType.java
@@ -4,7 +4,16 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 public enum DomainConditionType {
-  Progressing,
+  Progressing {
+    @Override
+    DomainConditionType[] typesToRemove() {
+      return new DomainConditionType[] {Progressing, Failed};
+    }
+  },
   Available,
-  Failed
+  Failed;
+
+  DomainConditionType[] typesToRemove() {
+    return new DomainConditionType[] {Progressing, Available, Failed};
+  }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainConditionType.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainConditionType.java
@@ -11,9 +11,27 @@ public enum DomainConditionType {
     }
   },
   Available,
-  Failed;
+  Failed {
+    @Override
+    String getStatusMessage(DomainCondition condition) {
+      return condition.getMessage();
+    }
+
+    @Override
+    String getStatusReason(DomainCondition condition) {
+      return condition.getReason();
+    }
+  };
 
   DomainConditionType[] typesToRemove() {
     return new DomainConditionType[] {Progressing, Available, Failed};
+  }
+
+  String getStatusMessage(DomainCondition condition) {
+    return null;
+  }
+
+  String getStatusReason(DomainCondition condition) {
+    return null;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -6,9 +6,13 @@ package oracle.kubernetes.weblogic.domain.model;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.json.JsonPatchBuilder;
 import javax.validation.Valid;
 
 import oracle.kubernetes.json.Description;
@@ -18,6 +22,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.joda.time.DateTime;
+
+import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
 
 /**
  * DomainStatus represents information about the status of a domain. Status may trail the actual
@@ -64,12 +70,16 @@ public class DomainStatus {
   public DomainStatus() {
   }
 
+  /**
+   * A copy constructor that creates a deep copy.
+   * @param that the object to copy
+   */
   public DomainStatus(DomainStatus that) {
-    conditions.addAll(that.conditions);
     message = that.message;
     reason = that.reason;
-    servers.addAll(that.servers);
-    clusters.addAll(that.clusters);
+    conditions = that.conditions.stream().map(DomainCondition::new).collect(Collectors.toList());
+    servers = that.servers.stream().map(ServerStatus::new).collect(Collectors.toList());
+    clusters = that.clusters.stream().map(ClusterStatus::new).collect(Collectors.toList());
     startTime = that.startTime;
     replicas = that.replicas;
   }
@@ -84,18 +94,24 @@ public class DomainStatus {
   }
 
   /**
-   * Adds a condition to the status, replacing any existing conditions with the same type.
+   * Adds a condition to the status, replacing any existing conditions with the same type, and removing other
+   * conditions according to the domain rules.
    *
-   * @param condition the condition to add.
+   * @param newCondition the condition to add.
    * @return this object.
    */
-  public DomainStatus addCondition(DomainCondition condition) {
-    if (!isNewCondition(condition)) {
-      return this;
-    }
+  public DomainStatus addCondition(DomainCondition newCondition) {
+    conditions = conditions.stream().filter(c -> preserve(c, newCondition.getType())).collect(Collectors.toList());
 
-    conditions.add(condition);
+    conditions.add(newCondition);
     return this;
+  }
+
+  private boolean preserve(DomainCondition condition, DomainConditionType newType) {
+    for (DomainConditionType type : newType.typesToRemove())
+      if (condition.getType() == type) return false;
+
+    return true;
   }
 
   /**
@@ -283,6 +299,19 @@ public class DomainStatus {
     return this;
   }
 
+  /**
+   * Add the status for a server.
+   * @param server the status for one server
+   * @return this object
+   */
+  public DomainStatus addServer(ServerStatus server) {
+    for (ListIterator<ServerStatus> it = servers.listIterator(); it.hasNext(); )
+      if (Objects.equals(it.next().getServerName(), server.getServerName())) it.remove();
+
+    servers.add(server);
+    return this;
+  }
+
   public List<ClusterStatus> getClusters() {
     return clusters;
   }
@@ -299,8 +328,16 @@ public class DomainStatus {
     return new HashSet<>(clusters1).equals(new HashSet<>(clusters2));
   }
 
-  public DomainStatus withClusters(List<ClusterStatus> clusters) {
-    this.clusters = clusters;
+  /**
+   * Add the status for a cluster.
+   * @param cluster the status for one cluster
+   * @return this object
+   */
+  public DomainStatus addCluster(ClusterStatus cluster) {
+    for (ListIterator<ClusterStatus> it = clusters.listIterator(); it.hasNext(); )
+      if (Objects.equals(it.next().getClusterName(), cluster.getClusterName())) it.remove();
+
+    clusters.add(cluster);
     return this;
   }
 
@@ -356,4 +393,18 @@ public class DomainStatus {
         .append(message, rhs.message)
         .isEquals();
   }
+
+  private static ObjectPatch<DomainStatus> statusPatch = createObjectPatch(DomainStatus.class)
+        .withConstructor(DomainStatus::new)
+        .withStringField("message", DomainStatus::getMessage)
+        .withStringField("reason", DomainStatus::getReason)
+        .withIntegerField("replicas", DomainStatus::getReplicas)
+        .withListField("conditions", DomainCondition.getObjectPatch(), DomainStatus::getConditions)
+        .withListField("clusters", ClusterStatus.getObjectPatch(), DomainStatus::getClusters)
+        .withListField("servers", ServerStatus.getObjectPatch(), DomainStatus::getServers);
+
+  public void createPatchFrom(JsonPatchBuilder builder, @Nullable DomainStatus oldStatus) {
+    statusPatch.createPatch(builder, "/status", oldStatus, this);
+  }
+
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -104,6 +104,8 @@ public class DomainStatus {
     conditions = conditions.stream().filter(c -> preserve(c, newCondition.getType())).collect(Collectors.toList());
 
     conditions.add(newCondition);
+    reason = newCondition.getStatusReason();
+    message = newCondition.getStatusMessage();
     return this;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
@@ -1,0 +1,402 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonPatchBuilder;
+import javax.json.JsonValue;
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+/**
+ * A class which can create JSON patches from the difference of two objects.
+ * @param <T> the class of the object to patch
+ */
+@SuppressWarnings("SameParameterValue")
+class ObjectPatch<T> {
+  private List<FieldPatch<T>> fields = new ArrayList<>();
+  private Supplier<T> constructor;
+
+  @SuppressWarnings("unused")
+  static <S> ObjectPatch<S> createObjectPatch(Class<S> forClass) {
+    return new ObjectPatch<>();
+  }
+
+  /**
+   * Supplies a constructor for the case where a source object is allowed to be null.
+   * @param constructor a constructor for a default object of the appropriate type
+   * @return this object
+   */
+  ObjectPatch<T> withConstructor(Supplier<T> constructor) {
+    this.constructor = constructor;
+    return this;
+  }
+
+  ObjectPatch<T> withIntegerField(String fieldName, Function<T,Integer> getter) {
+    fields.add(new IntegerField<>(fieldName, getter));
+    return this;
+  }
+
+  ObjectPatch<T> withStringField(String fieldName, Function<T,String> getter) {
+    fields.add(new StringField<>(fieldName, getter));
+    return this;
+  }
+
+  ObjectPatch<T> withDateTimeField(String fieldName, Function<T,DateTime> getter) {
+    fields.add(new DateTimeField<>(fieldName, getter));
+    return this;
+  }
+
+  <E> ObjectPatch<T> withEnumField(String fieldName, Function<T,E> getter) {
+    fields.add(new EnumField<>(fieldName, getter));
+    return this;
+  }
+
+  <O> ObjectPatch<T> withObjectField(String fieldName, Function<T,O> getter, ObjectPatch<O> objectPatch) {
+    fields.add(new ObjectField<>(fieldName, getter, objectPatch));
+    return this;
+  }
+
+  ObjectPatch<T> withListField(String fieldName, Function<T,List<String>> getter) {
+    fields.add(new StringListField<>(fieldName, getter));
+    return this;
+  }
+
+  <P extends PatchableComponent<P>> ObjectPatch<T> withListField(
+        String fieldName, ObjectPatch<P> objectPatch, Function<T,List<P>> getter) {
+    fields.add(new ObjectListField<>(fieldName, objectPatch, getter));
+    return this;
+  }
+
+  void createPatch(JsonPatchBuilder builder, String parentPath, @Nullable T oldValue, T newValue) {
+    T startValue = getStartValue(builder, parentPath, oldValue);
+
+    for (FieldPatch<T> field : fields) field.patchField(builder, parentPath, startValue, newValue);
+  }
+
+  private T getStartValue(JsonPatchBuilder builder, String parentPath, @Nullable T oldValue) {
+    if (oldValue != null) return oldValue;
+
+    if (constructor == null) throw new RuntimeException("No constructor supplied for null object");
+    builder.add(parentPath, JsonValue.EMPTY_JSON_OBJECT);
+    return constructor.get();
+  }
+
+  private void replaceItem(JsonPatchBuilder builder, String parent, T oldItem, T newItem) {
+    for (FieldPatch<T> field : fields) {
+      field.patchField(builder, parent, oldItem, newItem);
+    }
+  }
+
+  private void addItem(JsonPatchBuilder builder, String parent, T newItem) {
+    builder.add(parent + "/-", createObjectBuilder(newItem).build());
+  }
+
+  private JsonObjectBuilder createObjectBuilder(T newItem) {
+    JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+    for (FieldPatch<T> field : fields) {
+      field.addToObject(objectBuilder, newItem);
+    }
+    return objectBuilder;
+  }
+
+  abstract static class FieldPatch<T> {
+    private String fieldName;
+
+    FieldPatch(String fieldName) {
+      this.fieldName = fieldName;
+    }
+
+    abstract void addToObject(JsonObjectBuilder builder, T instance);
+
+    abstract void patchField(JsonPatchBuilder builder, String parent, T oldItem, T newItem);
+
+    String getPath(String parent) {
+      return parent + "/" + fieldName;
+    }
+  }
+
+  abstract static class ScalarFieldPatch<T, S> extends FieldPatch<T> {
+
+    private String name;
+    private Function<T, S> getter;
+
+    ScalarFieldPatch(String name, Function<T, S> getter) {
+      super(name);
+      this.name = name;
+      this.getter = getter;
+    }
+
+    @Override
+    public void addToObject(JsonObjectBuilder builder, T instance) {
+      Optional.ofNullable(getter.apply(instance)).ifPresent(c -> addToObject(builder, name, c));
+    }
+
+    abstract void addToObject(JsonObjectBuilder builder, String name, S value);
+
+    @Override
+    public void patchField(JsonPatchBuilder builder, String parent, T oldItem, T newItem) {
+      patchFieldValue(builder, getPath(parent), getter.apply(oldItem), getter.apply(newItem));
+    }
+
+    private void patchFieldValue(JsonPatchBuilder builder, String path, S oldValue, S newValue) {
+      if (Objects.equals(oldValue, newValue)) return;
+
+      if (oldValue == null)
+        addField(builder, path, newValue);
+      else if (newValue == null)
+        builder.remove(path);
+      else
+        replaceField(builder, path, oldValue, newValue);
+    }
+
+    abstract void replaceField(JsonPatchBuilder builder, String path, S oldValue, S newValue);
+
+    abstract void addField(JsonPatchBuilder builder, String path, S newValue);
+  }
+
+  static class IntegerField<T> extends ScalarFieldPatch<T,Integer> {
+
+    IntegerField(String name, Function<T, Integer> getter) {
+      super(name, getter);
+    }
+
+    @Override
+    void addToObject(JsonObjectBuilder builder, String name, Integer value) {
+      builder.add(name, value);
+    }
+
+    @Override
+    void replaceField(JsonPatchBuilder builder, String path, Integer oldValue, Integer newValue) {
+      builder.replace(path, newValue);
+    }
+
+    @Override
+    void addField(JsonPatchBuilder builder, String path, Integer newValue) {
+      builder.add(path, newValue);
+    }
+  }
+
+  static class StringField<T> extends ScalarFieldPatch<T,String> {
+
+    StringField(String name, Function<T, String> getter) {
+      super(name, getter);
+    }
+
+    @Override
+    void addToObject(JsonObjectBuilder builder, String name, String value) {
+      builder.add(name, value);
+    }
+
+    @Override
+    void replaceField(JsonPatchBuilder builder, String path, String oldValue, String newValue) {
+      builder.replace(path, newValue);
+    }
+
+    @Override
+    void addField(JsonPatchBuilder builder, String path, String newValue) {
+      builder.add(path, newValue);
+    }
+  }
+
+  static class DateTimeField<T> extends StringField<T> {
+    private static final DateTimeFormatter DATE_FORMAT = ISODateTimeFormat.dateTime();
+
+
+    DateTimeField(String name, Function<T, DateTime> getter) {
+      super(name, a -> toString(getter.apply(a)));
+    }
+
+    private static String toString(DateTime dateTime) {
+      return Optional.ofNullable(dateTime).map(DATE_FORMAT::print).orElse(null);
+    }
+  }
+
+  static class EnumField<T,E> extends StringField<T> {
+    EnumField(String name, Function<T, E> getter) {
+      super(name, a -> getter.apply(a).toString());
+    }
+  }
+
+  static class ObjectField<T, O> extends ScalarFieldPatch<T,O> {
+
+    private final ObjectPatch<O> objectPatch;
+
+    ObjectField(String fieldName, Function<T, O> getter, ObjectPatch<O> objectPatch) {
+      super(fieldName, getter);
+      this.objectPatch = objectPatch;
+    }
+
+    @Override
+    public void addToObject(JsonObjectBuilder builder, String name, O value) {
+      builder.add(name, objectPatch.createObjectBuilder(value));
+    }
+
+    @Override
+    void replaceField(JsonPatchBuilder builder, String path, O oldValue, O newValue) {
+      objectPatch.replaceItem(builder, path, oldValue, newValue);
+    }
+
+    @Override
+    void addField(JsonPatchBuilder builder, String path, O newValue) {
+      builder.add(path, objectPatch.createObjectBuilder(newValue).build());
+    }
+  }
+
+  static class ObjectListField<T, P extends PatchableComponent<P>> extends FieldPatch<T> {
+
+    private final ObjectPatch<P> objectPatch;
+    private Function<T,List<P>> getter;
+    private String fieldName;
+
+    ObjectListField(String fieldName, ObjectPatch<P> objectPatch, Function<T, List<P>> getter) {
+      super(fieldName);
+      this.fieldName = fieldName;
+      this.objectPatch = objectPatch;
+      this.getter = getter;
+    }
+
+    @Override
+    public void addToObject(JsonObjectBuilder builder, T newItem) {
+      List<P> contents = getter.apply(newItem);
+      if (contents.isEmpty()) return;
+      
+      JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+      contents.stream().map(objectPatch::createObjectBuilder).forEach(arrayBuilder::add);
+      builder.add(fieldName, arrayBuilder.build());
+    }
+
+    @Override
+    public void patchField(JsonPatchBuilder builder, String parent, T oldItem, T newItem) {
+      P[] oldItems = getListField(oldItem);
+      P[] newItems = getListField(newItem);
+      List<Disposition> disposition
+            = Arrays.stream(oldItems).map(c -> getDisposition(c, newItems)).collect(Collectors.toList());
+
+      for (int i = 0; i < oldItems.length; i++)
+        if (disposition.get(i).type == DispositionType.UPDATE)
+          objectPatch.replaceItem(
+                builder, getPath(parent) + "/" + i, oldItems[i], newItems[disposition.get(i).newIndex]);
+
+      for (int i = disposition.size() - 1; i >= 0; i--)
+        if (disposition.get(i).type == DispositionType.REMOVE)
+          removePatch(builder, getPath(parent), i);
+
+      if (oldItems.length == 0 && newItems.length != 0)
+        builder.add(getPath(parent), JsonValue.EMPTY_JSON_ARRAY);
+      
+      for (int j = 0; j < newItems.length; j++)
+        if (Disposition.shouldAdd(disposition, j)) objectPatch.addItem(builder, getPath(parent), newItems[j]);
+    }
+
+    @SuppressWarnings({"unchecked", "SuspiciousToArrayCall"})
+    private P[] getListField(T item) {
+      return (P[]) getter.apply(item).toArray(new PatchableComponent[0]);
+    }
+
+    Disposition getDisposition(P oldItem, P[] newItems) {
+      for (int i = 0; i < newItems.length; i++)
+        if (oldItem.equals(newItems[i]))
+          return Disposition.retain(i);
+        else if (newItems[i].isPatchableFrom(oldItem))
+          return Disposition.update(i);
+
+      return Disposition.remove();
+    }
+
+    void removePatch(JsonPatchBuilder builder, String parent, int index) {
+      builder.remove(parent + "/" + index);
+    }
+
+  }
+
+  enum DispositionType { REMOVE, UPDATE, EXISTS }
+
+  static class Disposition {
+    private DispositionType type;
+    private int newIndex;
+
+    Disposition(DispositionType type, int newIndex) {
+      this.type = type;
+      this.newIndex = newIndex;
+    }
+
+    static Disposition remove() {
+      return new Disposition(DispositionType.REMOVE, Integer.MIN_VALUE);
+    }
+
+    static Disposition update(int newIndex) {
+      return new Disposition(DispositionType.UPDATE, newIndex);
+    }
+
+    static Disposition retain(int newIndex) {
+      return new Disposition(DispositionType.EXISTS, newIndex);
+    }
+
+    static boolean shouldAdd(List<Disposition> dispositions, int newIndex) {
+      return dispositions.stream().noneMatch(d -> d.newIndex == newIndex);
+    }
+  }
+
+  static class StringListField<T> extends FieldPatch<T> {
+
+    private Function<T,List<String>> getter;
+    private String fieldName;
+
+    StringListField(String fieldName, Function<T, List<String>> getter) {
+      super(fieldName);
+      this.fieldName = fieldName;
+      this.getter = getter;
+    }
+
+    @Override
+    public void addToObject(JsonObjectBuilder builder, T newItem) {
+      List<String> contents = getter.apply(newItem);
+      if (contents.isEmpty()) return;
+
+      JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+      contents.forEach(arrayBuilder::add);
+      builder.add(fieldName, arrayBuilder.build());
+    }
+
+    @Override
+    public void patchField(JsonPatchBuilder builder, String parent, T oldItem, T newItem) {
+      List<String> oldItems = getter.apply(oldItem);
+      List<String> newItems = getter.apply(newItem);
+      List<String> addedItems = getDifference(newItems, oldItems);
+      List<String> removedItems = getDifference(oldItems, newItems);
+
+      removedItems.forEach(e -> removeFromList(builder, parent, oldItems.indexOf(e)));
+      addedItems.forEach(e -> addToList(builder, parent, e));
+    }
+
+    List<String> getDifference(List<String> start, List<String> toRemove) {
+      ArrayList<String> difference = new ArrayList<>(start);
+      difference.removeAll(toRemove);
+      return difference;
+    }
+
+    private void removeFromList(JsonPatchBuilder builder, String parent, int index) {
+      builder.remove(getPath(parent) + "/" + index);
+    }
+
+    private void addToList(JsonPatchBuilder builder, String parent, String entry) {
+      builder.add(getPath(parent) + "/-", entry);
+    }
+
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/PatchableComponent.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/PatchableComponent.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+public interface PatchableComponent<T> {
+
+  /**
+   * Returns true if it is possible to patch the specified component to create this one.
+   * @param other the component to compare
+   * @return false if the component are not patch-compatible
+   */
+  boolean isPatchableFrom(T other);
+
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerHealth.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerHealth.java
@@ -5,21 +5,22 @@ package oracle.kubernetes.weblogic.domain.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import oracle.kubernetes.json.Description;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.joda.time.DateTime;
 
+import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
+
 /** ServerHealth describes the current status and health of a specific WebLogic Server. */
 public class ServerHealth {
 
   @Description("RFC 3339 date and time at which the server started.")
-  @SerializedName("activationTime")
   @Expose
   private DateTime activationTime;
 
@@ -28,32 +29,34 @@ public class ServerHealth {
           + "failed to read the health. If the value is \"Not available (possibly overloaded)\", the "
           + "operator has failed to read the health of the server possibly due to the server is "
           + "in overloaded state.")
-  @SerializedName("overallHealth")
   @Expose
   private String overallHealth;
 
   @Description("Status of unhealthy subsystems, if any.")
-  @SerializedName("subsystems")
   @Expose
   @Valid
   private List<SubsystemHealth> subsystems = new ArrayList<>();
+
+  public ServerHealth() {
+  }
+
+  /**
+   * Copy constructor.
+   * @param other the object to deep-copy
+   */
+  ServerHealth(ServerHealth other) {
+    this.activationTime = other.activationTime;
+    this.overallHealth = other.overallHealth;
+    this.subsystems = other.subsystems.stream().map(SubsystemHealth::new).collect(Collectors.toList());
+  }
 
   /**
    * RFC 3339 date and time at which the server started.
    *
    * @return activation time
    */
-  public DateTime getActivationTime() {
+  private DateTime getActivationTime() {
     return activationTime;
-  }
-
-  /**
-   * RFC 3339 date and time at which the server started.
-   *
-   * @param activationTime activation time
-   */
-  public void setActivationTime(DateTime activationTime) {
-    this.activationTime = activationTime;
   }
 
   /**
@@ -80,15 +83,6 @@ public class ServerHealth {
    * Server health of this WebLogic server.
    *
    * @param overallHealth overall health
-   */
-  public void setOverallHealth(String overallHealth) {
-    this.overallHealth = overallHealth;
-  }
-
-  /**
-   * Server health of this WebLogic server.
-   *
-   * @param overallHealth overall health
    * @return this
    */
   public ServerHealth withOverallHealth(String overallHealth) {
@@ -106,22 +100,13 @@ public class ServerHealth {
   }
 
   /**
-   * Status of unhealthy subsystems, if any.
+   * Add the status of an unhealthy subsystem.
    *
-   * @param subsystems subsystems
-   */
-  public void setSubsystems(List<SubsystemHealth> subsystems) {
-    this.subsystems = subsystems;
-  }
-
-  /**
-   * Status of unhealthy subsystems, if any.
-   *
-   * @param subsystems subsystems
+   * @param subsystem the unhealthy subsystem
    * @return this
    */
-  public ServerHealth withSubsystems(List<SubsystemHealth> subsystems) {
-    this.subsystems = subsystems;
+  public ServerHealth addSubsystem(SubsystemHealth subsystem) {
+    subsystems.add(subsystem);
     return this;
   }
 
@@ -157,5 +142,14 @@ public class ServerHealth {
         .append(activationTime, rhs.activationTime)
         .append(Domain.sortOrNull(subsystems), Domain.sortOrNull(rhs.subsystems))
         .isEquals();
+  }
+
+  private static ObjectPatch<ServerHealth> healthPatch = createObjectPatch(ServerHealth.class)
+        .withDateTimeField("activationTime", ServerHealth::getActivationTime)
+        .withStringField("overallHealth", ServerHealth::getOverallHealth)
+        .withListField("subsystems", SubsystemHealth.getObjectPatch(), ServerHealth::getSubsystems);
+
+  static ObjectPatch<ServerHealth> getObjectPatch() {
+    return healthPatch;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -3,46 +3,59 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import java.util.Optional;
+import javax.annotation.Nonnull;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import oracle.kubernetes.json.Description;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
+
 /** ServerStatus describes the current status of a specific WebLogic Server. */
-public class ServerStatus implements Comparable<ServerStatus> {
+public class ServerStatus implements Comparable<ServerStatus>, PatchableComponent<ServerStatus> {
 
   @Description("WebLogic Server name. Required.")
-  @SerializedName("serverName")
   @Expose
   @NotNull
   private String serverName;
 
   @Description("Current state of this WebLogic Server. Required.")
-  @SerializedName("state")
   @Expose
   @NotNull
   private String state;
 
   @Description("WebLogic cluster name, if the server is part of a cluster.")
-  @SerializedName("clusterName")
   @Expose
   private String clusterName;
 
   @Description("Name of node that is hosting the Pod containing this WebLogic Server.")
-  @SerializedName("nodeName")
   @Expose
   private String nodeName;
 
   @Description("Current status and health of a specific WebLogic Server.")
-  @SerializedName("health")
   @Expose
   @Valid
   private ServerHealth health;
+
+  public ServerStatus() {
+  }
+
+  /**
+   * Copy constructor for a deep copy.
+   * @param other the object to copy
+   */
+  ServerStatus(ServerStatus other) {
+    this.serverName = other.serverName;
+    this.state = other.state;
+    this.clusterName = other.clusterName;
+    this.nodeName = other.nodeName;
+    this.health = Optional.ofNullable(other.health).map(ServerHealth::new).orElse(null);
+  }
 
   /**
    * WebLogic Server name. Required.
@@ -144,15 +157,6 @@ public class ServerStatus implements Comparable<ServerStatus> {
    * Name of node that is hosting the Pod containing this WebLogic Server.
    *
    * @param nodeName node name
-   */
-  public void setNodeName(String nodeName) {
-    this.nodeName = nodeName;
-  }
-
-  /**
-   * Name of node that is hosting the Pod containing this WebLogic Server.
-   *
-   * @param nodeName node name
    * @return this
    */
   public ServerStatus withNodeName(String nodeName) {
@@ -165,17 +169,8 @@ public class ServerStatus implements Comparable<ServerStatus> {
    *
    * @return health
    */
-  public ServerHealth getHealth() {
+  private ServerHealth getHealth() {
     return health;
-  }
-
-  /**
-   * ServerHealth describes the current status and health of a specific WebLogic Server.
-   *
-   * @param health health
-   */
-  public void setHealth(ServerHealth health) {
-    this.health = health;
   }
 
   /**
@@ -230,7 +225,23 @@ public class ServerStatus implements Comparable<ServerStatus> {
   }
 
   @Override
-  public int compareTo(ServerStatus o) {
+  public int compareTo(@Nonnull ServerStatus o) {
     return serverName.compareTo(o.serverName);
+  }
+
+  @Override
+  public boolean isPatchableFrom(ServerStatus other) {
+    return other.getServerName() != null && other.getServerName().equals(serverName);
+  }
+
+  private static ObjectPatch<ServerStatus> serverPatch = createObjectPatch(ServerStatus.class)
+        .withStringField("serverName", ServerStatus::getServerName)
+        .withStringField("clusterName", ServerStatus::getClusterName)
+        .withStringField("state", ServerStatus::getState)
+        .withStringField("nodeName", ServerStatus::getNodeName)
+        .withObjectField("health", ServerStatus::getHealth, ServerHealth.getObjectPatch());
+
+  static ObjectPatch<ServerStatus> getObjectPatch() {
+    return serverPatch;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/SubsystemHealth.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/SubsystemHealth.java
@@ -4,54 +4,58 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import oracle.kubernetes.json.Description;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
+
 /** SubsystemHealth describes the current health of a specific subsystem. */
-public class SubsystemHealth implements Comparable<SubsystemHealth> {
+public class SubsystemHealth implements Comparable<SubsystemHealth>, PatchableComponent<SubsystemHealth> {
 
   @Description("Server health of this WebLogic Server. Required.")
-  @SerializedName("health")
   @Expose
   @NotNull
   private String health;
 
   @Description("Name of subsystem providing symptom information. Required.")
-  @SerializedName("subsystemName")
   @Expose
   @NotNull
   private String subsystemName;
 
   @Description("Symptoms provided by the reporting subsystem.")
-  @SerializedName("symptoms")
   @Expose
   @Valid
   private List<String> symptoms = new ArrayList<>();
+
+  public SubsystemHealth() {
+  }
+
+  /**
+   * Copy constructor.
+   * @param other the object to copy
+   */
+  SubsystemHealth(SubsystemHealth other) {
+    this.health = other.health;
+    this.subsystemName = other.subsystemName;
+    this.symptoms = new ArrayList<>(other.symptoms);
+  }
 
   /**
    * Server health of this WebLogic Server. Required.
    *
    * @return health
    */
-  public String getHealth() {
+  private String getHealth() {
     return health;
-  }
-
-  /**
-   * Server health of this WebLogic Server. Required.
-   *
-   * @param health health
-   */
-  public void setHealth(String health) {
-    this.health = health;
   }
 
   /**
@@ -70,17 +74,8 @@ public class SubsystemHealth implements Comparable<SubsystemHealth> {
    *
    * @return subsystem name
    */
-  public String getSubsystemName() {
+  private String getSubsystemName() {
     return subsystemName;
-  }
-
-  /**
-   * Name of subsystem providing symptom information. Required.
-   *
-   * @param subsystemName subsystem name
-   */
-  public void setSubsystemName(String subsystemName) {
-    this.subsystemName = subsystemName;
   }
 
   /**
@@ -99,17 +94,8 @@ public class SubsystemHealth implements Comparable<SubsystemHealth> {
    *
    * @return symptoms
    */
-  public List<String> getSymptoms() {
+  private List<String> getSymptoms() {
     return symptoms;
-  }
-
-  /**
-   * Symptoms provided by the reporting subsystem.
-   *
-   * @param symptoms symptoms
-   */
-  public void setSymptoms(List<String> symptoms) {
-    this.symptoms = symptoms;
   }
 
   /**
@@ -120,6 +106,17 @@ public class SubsystemHealth implements Comparable<SubsystemHealth> {
    */
   public SubsystemHealth withSymptoms(List<String> symptoms) {
     this.symptoms = symptoms;
+    return this;
+  }
+
+  /**
+   * Symptoms provided by the reporting subsystem.
+   *
+   * @param symptoms symptoms
+   * @return this
+   */
+  public SubsystemHealth withSymptoms(String... symptoms) {
+    this.symptoms = Arrays.asList(symptoms);
     return this;
   }
 
@@ -158,7 +155,21 @@ public class SubsystemHealth implements Comparable<SubsystemHealth> {
   }
 
   @Override
-  public int compareTo(SubsystemHealth o) {
+  public int compareTo(@Nonnull SubsystemHealth o) {
     return subsystemName.compareTo(o.subsystemName);
+  }
+
+  @Override
+  public boolean isPatchableFrom(SubsystemHealth other) {
+    return other.subsystemName != null && other.subsystemName.equals(subsystemName);
+  }
+
+  private static ObjectPatch<SubsystemHealth> healthPatch = createObjectPatch(SubsystemHealth.class)
+        .withStringField("health", SubsystemHealth::getHealth)
+        .withStringField("subsystemName", SubsystemHealth::getSubsystemName)
+        .withListField("symptoms", SubsystemHealth::getSymptoms);
+
+  static ObjectPatch<SubsystemHealth> getObjectPatch() {
+    return healthPatch;
   }
 }

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -162,6 +162,7 @@ WLSKO-0154=Job {0} failed due to reason: DeadlineExceeded. \
   Use tuning parameter 'domainPresenceFailureRetryMaxCount' to configure max retries.
 WLSKO-0155=Unexpected exception, {0}, while parsing introspect job log [{1}].
 WLSKO-0156=Access denied for operator service account for operation {0} on resource {1} in namespace {2}
+WLSKO-0157=Domain {0} is not valid: {1}
 
 
 # Domain status messages

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -28,6 +28,7 @@ import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.operator.helpers.UnitTestHash;
+import oracle.kubernetes.operator.rest.ScanCacheStub;
 import oracle.kubernetes.operator.utils.InMemoryCertificates;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
@@ -95,6 +96,7 @@ public class DomainProcessorTest {
     mementos.add(TuningParametersStub.install());
     mementos.add(InMemoryCertificates.install());
     mementos.add(UnitTestHash.install());
+    mementos.add(ScanCacheStub.install());
 
     domainConfigurator = DomainConfiguratorFactory.forDomain(domain);
     testSupport.defineResources(domain);

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
@@ -13,9 +13,8 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodSpec;
 import io.kubernetes.client.models.V1PodStatus;
-import oracle.kubernetes.operator.helpers.AsyncCallTestSupport;
-import oracle.kubernetes.operator.helpers.BodyMatcher;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.utils.RandomStringGenerator;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
@@ -26,7 +25,6 @@ import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.ServerConfigurator;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
-import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
@@ -35,6 +33,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static oracle.kubernetes.operator.DomainConditionMatcher.hasCondition;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainStatusUpdater.SERVERS_READY_REASON;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
@@ -52,18 +52,13 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class DomainStatusUpdaterTest {
-  private static final String NS = "namespace";
-  private static final String NAME = "name";
+  private static final String NAME = UID;
   private final TerminalStep endStep = new TerminalStep();
   private final WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("mydomain");
-  private AsyncCallTestSupport testSupport = new AsyncCallTestSupport();
+  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private List<Memento> mementos = new ArrayList<>();
-  private Domain domain =
-      new Domain()
-          .withMetadata(new V1ObjectMeta().namespace(NS).name(NAME))
-          .withSpec(new DomainSpec());
+  private Domain domain = DomainProcessorTestSetup.createTestDomain();
   private DomainPresenceInfo info = new DomainPresenceInfo(domain);
-  private Domain recordedDomain;
   private RandomStringGenerator generator = new RandomStringGenerator();
   private final String message = generator.getUniqueString();
   private String reason = generator.getUniqueString();
@@ -72,28 +67,16 @@ public class DomainStatusUpdaterTest {
   @Before
   public void setUp() throws NoSuchFieldException {
     mementos.add(TestUtils.silenceOperatorLogger());
-    mementos.add(testSupport.installRequestStepFactory());
+    mementos.add(testSupport.install());
 
     domain.setStatus(new DomainStatus());
 
     defineServerPod("server1");
     defineServerPod("server2");
     testSupport.addDomainPresenceInfo(info);
-    testSupport
-        .createCannedResponse("replaceDomain")
-        .withNamespace(NS)
-        .withName(NAME)
-        .withBody(new RecordBody())
-        .returning(domain);
+    testSupport.defineResources(domain);
     testSupport.addToPacket(SERVER_STATE_MAP, Collections.emptyMap());
     testSupport.addToPacket(SERVER_HEALTH_MAP, Collections.emptyMap());
-  }
-
-  private boolean recordBody(Object domain) {
-    if (!(domain instanceof Domain)) return false;
-
-    this.recordedDomain = (Domain) domain;
-    return true;
   }
 
   private V1ObjectMeta createPodMetadata(String serverName) {
@@ -124,10 +107,10 @@ public class DomainStatusUpdaterTest {
     configSupport.addWlsCluster("clusterB", "server2");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        getServerStatus(recordedDomain, "server1"),
+        getServerStatus(getRecordedDomain(), "server1"),
         equalTo(
             new ServerStatus()
                 .withState(RUNNING_STATE)
@@ -136,7 +119,7 @@ public class DomainStatusUpdaterTest {
                 .withServerName("server1")
                 .withHealth(overallHealth("health1"))));
     assertThat(
-        getServerStatus(recordedDomain, "server2"),
+        getServerStatus(getRecordedDomain(), "server2"),
         equalTo(
             new ServerStatus()
                 .withState(SHUTDOWN_STATE)
@@ -177,10 +160,10 @@ public class DomainStatusUpdaterTest {
     configSupport.addWlsCluster("clusterC", "server3", "server4");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        getServerStatus(recordedDomain, "server3"),
+        getServerStatus(getRecordedDomain(), "server3"),
         equalTo(
             new ServerStatus()
                 .withState(RUNNING_STATE)
@@ -188,7 +171,7 @@ public class DomainStatusUpdaterTest {
                 .withServerName("server3")
                 .withHealth(overallHealth("health3"))));
     assertThat(
-        getServerStatus(recordedDomain, "server4"),
+        getServerStatus(getRecordedDomain(), "server4"),
         equalTo(
             new ServerStatus()
                 .withState(SHUTDOWN_STATE)
@@ -208,10 +191,10 @@ public class DomainStatusUpdaterTest {
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
     setClusterAndNodeName(getPod("server2"), "clusterB", "node2");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        getServerStatus(recordedDomain, "server2"),
+        getServerStatus(getRecordedDomain(), "server2"),
         equalTo(
             new ServerStatus()
                 .withState(STANDBY_STATE)
@@ -223,7 +206,6 @@ public class DomainStatusUpdaterTest {
 
   @Test
   public void statusStep_updatesDomainWhenHadNoStatus() {
-    domain.setStatus(null);
     testSupport.addToPacket(SERVER_STATE_MAP, ImmutableMap.of("server1", RUNNING_STATE));
     testSupport.addToPacket(
         SERVER_HEALTH_MAP, ImmutableMap.of("server1", overallHealth("health1")));
@@ -232,12 +214,13 @@ public class DomainStatusUpdaterTest {
     WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("mydomain");
     configSupport.addWlsServer("server1");
     configSupport.addWlsCluster("clusterA", "server1");
+    domain.setStatus(null);
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        getServerStatus(recordedDomain, "server1"),
+        getServerStatus(getRecordedDomain(), "server1"),
         equalTo(
             new ServerStatus()
                 .withState(RUNNING_STATE)
@@ -252,7 +235,6 @@ public class DomainStatusUpdaterTest {
     info = new DomainPresenceInfo(domain);
     testSupport.addDomainPresenceInfo(info);
     defineServerPod("server1");
-
     domain.setStatus(
         new DomainStatus()
             .withServers(
@@ -272,16 +254,17 @@ public class DomainStatusUpdaterTest {
         SERVER_HEALTH_MAP, ImmutableMap.of("server1", overallHealth("health1")));
     setClusterAndNodeName(getPod("server1"), "clusterA", "node1");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.clearNumCalls();
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, nullValue());
+    assertThat(testSupport.getNumCalls(), equalTo(0));
   }
 
   @Test
   public void whenDomainHasNoClusters_statusLacksReplicaCount() {
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain.getStatus().getReplicas(), nullValue());
+    assertThat(getRecordedDomain().getStatus().getReplicas(), nullValue());
   }
 
   @Test
@@ -295,9 +278,9 @@ public class DomainStatusUpdaterTest {
     configSupport.addWlsCluster("cluster1", "server1", "server2", "server3");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain.getStatus().getReplicas(), equalTo(3));
+    assertThat(getRecordedDomain().getStatus().getReplicas(), equalTo(3));
   }
 
   @Test
@@ -321,19 +304,19 @@ public class DomainStatusUpdaterTest {
     configSupport.addWlsCluster("cluster3", "server8", "server9");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain.getStatus().getReplicas(), nullValue());
+    assertThat(getRecordedDomain().getStatus().getReplicas(), nullValue());
   }
 
   @Test
   public void whenAllDesiredServersRunning_establishAvailableCondition() {
     setAllDesiredServersRunning();
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        recordedDomain,
+        getRecordedDomain(),
         hasCondition(Available).withStatus("True").withReason(SERVERS_READY_REASON));
   }
 
@@ -360,10 +343,10 @@ public class DomainStatusUpdaterTest {
     configSupport.addWlsCluster("clusterB", "server2");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        recordedDomain,
+        getRecordedDomain(),
         hasCondition(Available).withStatus("True").withReason(SERVERS_READY_REASON));
   }
 
@@ -372,10 +355,10 @@ public class DomainStatusUpdaterTest {
     domain.getStatus().addCondition(new DomainCondition(Available).withStatus("True"));
     setAllDesiredServersRunning();
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        recordedDomain,
+        getRecordedDomain(),
         hasCondition(Available).withStatus("True").withReason(SERVERS_READY_REASON));
   }
 
@@ -386,30 +369,30 @@ public class DomainStatusUpdaterTest {
         .addCondition(new DomainCondition(Available).withReason(SERVERS_READY_REASON));
     setAllDesiredServersRunning();
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
     assertThat(
-        recordedDomain,
+        getRecordedDomain(),
         hasCondition(Available).withStatus("True").withReason(SERVERS_READY_REASON));
   }
 
   @Test
-  public void whenAllDesiredServersRunningAndProgessingConditionFound_removeIt() {
+  public void whenAllDesiredServersRunningAndProgressingConditionFound_removeIt() {
     domain.getStatus().addCondition(new DomainCondition(Progressing));
     setAllDesiredServersRunning();
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Progressing)));
+    assertThat(getRecordedDomain(), not(hasCondition(Progressing)));
   }
 
   @Test
   public void whenNotAllDesiredServersRunning_dontEstablishAvailableCondition() {
     setDesiredServerNotRunning();
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Available)));
+    assertThat(getRecordedDomain(), not(hasCondition(Available)));
   }
 
   private void setDesiredServerNotRunning() {
@@ -431,9 +414,24 @@ public class DomainStatusUpdaterTest {
     configSupport.addWlsCluster("clusterA", "server1", "server2");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, hasCondition(Progressing));
+    assertThat(getRecordedDomain(), hasCondition(Progressing));
+  }
+
+  @Test
+  public void whenNotAllDesiredServersRunningAndProgressingConditionNotFound_addOne() {
+    setDesiredServerNotRunning();
+
+    WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("mydomain");
+    configSupport.addWlsServer("server1");
+    configSupport.addWlsServer("server2");
+    configSupport.addWlsCluster("clusterA", "server1", "server2");
+    testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
+
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
+
+    assertThat(getRecordedDomain(), hasCondition(Progressing));
   }
 
   @Test
@@ -442,34 +440,34 @@ public class DomainStatusUpdaterTest {
     setDesiredServerNotRunning();
     failPod("server1");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Progressing)));
+    assertThat(getRecordedDomain(), not(hasCondition(Progressing)));
   }
 
   @Test
   public void whenNoPodsFailed_dontEstablishFailedCondition() {
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Failed)));
+    assertThat(getRecordedDomain(), not(hasCondition(Failed)));
   }
 
   @Test
   public void whenNoPodsFailedAndFailedConditionFound_removeIt() {
     domain.getStatus().addCondition(new DomainCondition(Failed));
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Failed)));
+    assertThat(getRecordedDomain(), not(hasCondition(Failed)));
   }
 
   @Test
   public void whenAtLeastOnePodFailed_establishFailedCondition() {
     failPod("server1");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, hasCondition(Failed));
+    assertThat(getRecordedDomain(), hasCondition(Failed));
   }
 
   @Test
@@ -477,9 +475,9 @@ public class DomainStatusUpdaterTest {
     domain.getStatus().addCondition(new DomainCondition(Failed).withStatus("True"));
     failPod("server2");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, hasCondition(Failed).withStatus("True"));
+    assertThat(getRecordedDomain(), hasCondition(Failed).withStatus("True"));
   }
 
   @Test
@@ -487,9 +485,9 @@ public class DomainStatusUpdaterTest {
     domain.getStatus().addCondition(new DomainCondition(Failed).withStatus("False "));
     failPod("server2");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, hasCondition(Failed).withStatus("True"));
+    assertThat(getRecordedDomain(), hasCondition(Failed).withStatus("True"));
   }
 
   @Test
@@ -497,9 +495,9 @@ public class DomainStatusUpdaterTest {
     domain.getStatus().addCondition(new DomainCondition(Failed).withStatus("False "));
     failPod("server2");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Available)));
+    assertThat(getRecordedDomain(), not(hasCondition(Available)));
   }
 
   @Test
@@ -507,9 +505,9 @@ public class DomainStatusUpdaterTest {
     domain.getStatus().addCondition(new DomainCondition(Available));
     failPod("server2");
 
-    testSupport.runSteps(new DomainStatusUpdater.StatusUpdateStep(endStep));
+    testSupport.runSteps(DomainStatusUpdater.createStatusUpdateStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Available)));
+    assertThat(getRecordedDomain(), not(hasCondition(Available)));
   }
 
   private void failPod(String serverName) {
@@ -566,7 +564,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, hasCondition(Progressing).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain(), hasCondition(Progressing).withStatus("True").withReason(reason));
   }
 
   @Test
@@ -574,7 +572,7 @@ public class DomainStatusUpdaterTest {
       whenDomainHasNoProgressingCondition_progressingStepUpdatesItWithProgressingTrueAndReason() {
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, hasCondition(Progressing).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain(), hasCondition(Progressing).withStatus("True").withReason(reason));
   }
 
   @Test
@@ -584,13 +582,12 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, hasCondition(Progressing).withStatus("True").withReason(reason));
-    assertThat(recordedDomain.getStatus().getConditions(), hasSize(1));
+    assertThat(getRecordedDomain(), hasCondition(Progressing).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain().getStatus().getConditions(), hasSize(1));
   }
 
   @Test
-  public void
-      whenDomainHasProgressingTrueConditionWithDifferentReason_progressingStepUpdatesReason() {
+  public void whenDomainHasProgressingTrueConditionWithDifferentReason_progressingStepUpdatesReason() {
     domain
         .getStatus()
         .addCondition(
@@ -600,8 +597,9 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, hasCondition(Progressing).withStatus("True").withReason(reason));
-    assertThat(recordedDomain.getStatus().getConditions(), hasSize(1));
+    assertThat(getRecordedDomain(), hasCondition(Progressing).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain().getStatus().getConditions(), hasSize(1));
+    assertThat(testSupport.getNumCalls(), equalTo(1));
   }
 
   @Test
@@ -612,7 +610,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, nullValue());
+    assertThat(testSupport.getNumCalls(), equalTo(0));
   }
 
   @Test
@@ -621,7 +619,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Failed)));
+    assertThat(getRecordedDomain(), not(hasCondition(Failed)));
   }
 
   @Test
@@ -630,7 +628,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, false, endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Available)));
+    assertThat(getRecordedDomain(), not(hasCondition(Available)));
   }
 
   @Test
@@ -639,14 +637,14 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createProgressingStep(reason, true, endStep));
 
-    assertThat(recordedDomain, hasCondition(Available));
+    assertThat(getRecordedDomain(), hasCondition(Available));
   }
 
   @Test
   public void whenDomainHasNoConditions_endProgressingStepDoesNothing() {
     testSupport.runSteps(DomainStatusUpdater.createEndProgressingStep(endStep));
 
-    assertThat(recordedDomain, nullValue());
+    assertThat(testSupport.getNumCalls(), equalTo(0));
   }
 
   @Test
@@ -655,7 +653,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createEndProgressingStep(endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Progressing)));
+    assertThat(getRecordedDomain(), not(hasCondition(Progressing)));
   }
 
   @Test
@@ -664,7 +662,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createEndProgressingStep(endStep));
 
-    assertThat(recordedDomain, nullValue());
+    assertThat(testSupport.getNumCalls(), equalTo(0));
   }
 
   @Test
@@ -673,7 +671,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createEndProgressingStep(endStep));
 
-    assertThat(recordedDomain, nullValue());
+    assertThat(testSupport.getNumCalls(), equalTo(0));
   }
 
   @Test
@@ -682,7 +680,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createEndProgressingStep(endStep));
 
-    assertThat(recordedDomain, nullValue());
+    assertThat(testSupport.getNumCalls(), equalTo(0));
   }
 
   @Test
@@ -691,7 +689,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createAvailableStep(reason, endStep));
 
-    assertThat(recordedDomain, hasCondition(Available).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain(), hasCondition(Available).withStatus("True").withReason(reason));
   }
 
   @Test
@@ -699,7 +697,7 @@ public class DomainStatusUpdaterTest {
       whenDomainLacksAvailableCondition_availableStepUpdatesDomainWithAvailableTrueAndReason() {
     testSupport.runSteps(DomainStatusUpdater.createAvailableStep(reason, endStep));
 
-    assertThat(recordedDomain, hasCondition(Available).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain(), hasCondition(Available).withStatus("True").withReason(reason));
   }
 
   @Test
@@ -708,18 +706,18 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createAvailableStep(reason, endStep));
 
-    assertThat(recordedDomain, hasCondition(Available).withStatus("True").withReason(reason));
-    assertThat(recordedDomain.getStatus().getConditions(), hasSize(1));
+    assertThat(getRecordedDomain(), hasCondition(Available).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain().getStatus().getConditions(), hasSize(1));
   }
 
   @Test
-  public void whenDomainHasProgressingCondition_availableStepIgnoresIt() {
+  public void whenDomainHasProgressingCondition_availableStepRemovesIt() {
     domain.getStatus().addCondition(new DomainCondition(Progressing));
 
     testSupport.runSteps(DomainStatusUpdater.createAvailableStep(reason, endStep));
 
-    assertThat(recordedDomain, hasCondition(Available).withStatus("True").withReason(reason));
-    assertThat(recordedDomain, hasCondition(Progressing));
+    assertThat(getRecordedDomain(), hasCondition(Available).withStatus("True").withReason(reason));
+    assertThat(getRecordedDomain(), not(hasCondition(Progressing)));
   }
 
   @Test
@@ -728,7 +726,7 @@ public class DomainStatusUpdaterTest {
 
     testSupport.runSteps(DomainStatusUpdater.createAvailableStep(reason, endStep));
 
-    assertThat(recordedDomain, not(hasCondition(Failed)));
+    assertThat(getRecordedDomain(), not(hasCondition(Failed)));
   }
 
   @Test
@@ -738,7 +736,7 @@ public class DomainStatusUpdaterTest {
     testSupport.runSteps(DomainStatusUpdater.createFailedStep(failure, endStep));
 
     assertThat(
-        recordedDomain,
+          getRecordedDomain(),
         hasCondition(Failed).withStatus("True").withReason("Exception").withMessage(message));
   }
 
@@ -749,7 +747,7 @@ public class DomainStatusUpdaterTest {
     testSupport.runSteps(DomainStatusUpdater.createFailedStep(failure, endStep));
 
     assertThat(
-        recordedDomain,
+          getRecordedDomain(),
         hasCondition(Failed).withStatus("True").withReason("Exception").withMessage(message));
   }
 
@@ -760,33 +758,30 @@ public class DomainStatusUpdaterTest {
     testSupport.runSteps(DomainStatusUpdater.createFailedStep(failure, endStep));
 
     assertThat(
-        recordedDomain,
+          getRecordedDomain(),
         hasCondition(Failed).withStatus("True").withReason("Exception").withMessage(message));
-    assertThat(recordedDomain.getStatus().getConditions(), hasSize(1));
+    assertThat(getRecordedDomain().getStatus().getConditions(), hasSize(1));
   }
 
   @Test
-  public void whenDomainHasProgressingTrueCondition_failedStepUpdatesItToFalse() {
+  public void whenDomainHasProgressingTrueCondition_failedStepRemovesIt() {
     domain.getStatus().addCondition(new DomainCondition(Progressing).withStatus("True"));
 
     testSupport.runSteps(DomainStatusUpdater.createFailedStep(failure, endStep));
 
-    assertThat(recordedDomain, hasCondition(Progressing).withStatus("False"));
+    assertThat(getRecordedDomain(), not(hasCondition(Progressing)));
   }
 
   @Test
-  public void whenDomainHasAvailableCondition_failedStepIgnoresIt() {
+  public void whenDomainHasAvailableCondition_failedStepRemovesIt() {
     domain.getStatus().addCondition(new DomainCondition(Available));
 
     testSupport.runSteps(DomainStatusUpdater.createFailedStep(failure, endStep));
 
-    assertThat(recordedDomain, hasCondition(Available));
+    assertThat(getRecordedDomain(), not(hasCondition(Available)));
   }
 
-  class RecordBody implements BodyMatcher {
-    @Override
-    public boolean matches(Object actualBody) {
-      return recordBody(actualBody);
-    }
+  private Domain getRecordedDomain() {
+    return testSupport.getResourceWithName(KubernetesTestSupport.DOMAIN, NAME);
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1SecretReference;
 import oracle.kubernetes.operator.DomainProcessorTestSetup;
 import oracle.kubernetes.operator.calls.unprocessable.UnprocessableEntityBuilder;
+import oracle.kubernetes.operator.rest.ScanCacheStub;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
@@ -86,6 +87,7 @@ public class DomainIntrospectorJobTest {
             .withLogLevel(Level.INFO));
     mementos.add(TuningParametersStub.install());
     mementos.add(testSupport.install());
+    mementos.add(ScanCacheStub.install());
     testSupport.addDomainPresenceInfo(domainPresenceInfo);
     testSupport.defineResources(domain);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -1,0 +1,579 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonPatchBuilder;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
+import oracle.kubernetes.weblogic.domain.model.DomainCondition;
+import oracle.kubernetes.weblogic.domain.model.DomainConditionType;
+import oracle.kubernetes.weblogic.domain.model.DomainStatus;
+import oracle.kubernetes.weblogic.domain.model.ServerHealth;
+import oracle.kubernetes.weblogic.domain.model.ServerStatus;
+import oracle.kubernetes.weblogic.domain.model.SubsystemHealth;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static com.meterware.simplestub.Stub.createStrictStub;
+import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
+import static oracle.kubernetes.operator.WebLogicConstants.STARTING_STATE;
+import static oracle.kubernetes.operator.helpers.DomainStatusPatchTest.OrderedArrayMatcher.hasItemsInOrder;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class DomainStatusPatchTest {
+  private PatchBuilderStub builder = createStrictStub(PatchBuilderStub.class);
+
+  @Test      // todo have ADD full status definition as json object - then remove constructor item
+  public void whenExistingStatusNull_addStatus() {
+    DomainStatus status2 = new DomainStatus().withReplicas(2);
+
+    computePatch(null, status2);
+
+    assertThat(builder.getPatches(), hasItemInArray("ADD /status"));
+  }
+
+  @Test
+  public void whenExistingStatusNotNull_dontAddStatus() {
+    DomainStatus status1 = new DomainStatus().withReplicas(3);
+    DomainStatus status2 = new DomainStatus().withReplicas(2);
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), not(hasItemInArray("ADD /status")));
+  }
+
+  @Test
+  public void whenOnlyNewStatusHasReplicas_addIt() {
+    DomainStatus status2 = new DomainStatus().withReplicas(2);
+
+    computePatch(null, status2);
+
+    assertThat(builder.getPatches(), hasItemsInOrder("ADD /status", "ADD /status/replicas 2"));
+  }
+
+  @Test
+  public void whenOnlyExistingNewStatusHasReplicas_addIt() {
+    DomainStatus status1 = new DomainStatus();
+    DomainStatus status2 = new DomainStatus().withReplicas(2);
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemsInOrder("ADD /status/replicas 2"));
+  }
+
+  private void computePatch(DomainStatus status1, DomainStatus status2) {
+    status2.createPatchFrom(builder, status1);
+  }
+
+  @Test
+  public void whenOnlyOldStatusHasReplicas_removeIt() {
+    DomainStatus status1 = new DomainStatus().withReplicas(2);
+    DomainStatus status2 = new DomainStatus();
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemInArray("REMOVE /status/replicas"));
+  }
+
+  @Test
+  public void whenBothHaveSameReplicas_ignoreIt() {
+    DomainStatus status1 = new DomainStatus().withReplicas(2);
+    DomainStatus status2 = new DomainStatus().withReplicas(2);
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), arrayWithSize(0));
+  }
+
+  @Test
+  public void whenBothHaveDifferentReplicas_replaceIt() {
+    DomainStatus status1 = new DomainStatus().withReplicas(2);
+    DomainStatus status2 = new DomainStatus().withReplicas(3);
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemInArray("REPLACE /status/replicas 3"));
+  }
+
+  @Test
+  public void whenOnlyNewHasMessage_addIt() {
+    DomainStatus status1 = new DomainStatus();
+    DomainStatus status2 = new DomainStatus().withMessage("new and hot");
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemInArray("ADD /status/message 'new and hot'"));
+  }
+
+  @Test
+  public void whenBothHaveDifferentMessages_replaceIt() {
+    DomainStatus status1 = new DomainStatus().withMessage("old and broken");
+    DomainStatus status2 = new DomainStatus().withMessage("new and hot");
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemInArray("REPLACE /status/message 'new and hot'"));
+  }
+
+  @Test
+  public void whenOnlyOldHasReason_deleteIt() {
+    DomainStatus status1 = new DomainStatus().withReason("just because");
+    DomainStatus status2 = new DomainStatus();
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemInArray("REMOVE /status/reason"));
+  }
+
+  @Test
+  public void whenOnlyNewStatusHasConditions_addNewConditions() {
+    DomainStatus status1 = new DomainStatus();
+    DomainStatus status2 = new DomainStatus()
+          .addCondition(new DomainCondition(DomainConditionType.Available)
+                .withReason("because").withMessage("hello").withStatus("true"))
+          .addCondition(new DomainCondition(DomainConditionType.Progressing)
+                .withReason("ok now").withStatus("true"));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "ADD /status/conditions []",
+                "ADD /status/conditions/- {'message':'hello','reason':'because','status':'true','type':'Available'}",
+                "ADD /status/conditions/- {'reason':'ok now','status':'true','type':'Progressing'}"
+                ));
+  }
+
+  @Test
+  public void whenOnlyOldStatusHasConditions_removeThem() {
+    DomainStatus status1 = new DomainStatus()
+          .addCondition(new DomainCondition(DomainConditionType.Available)
+                .withReason("because").withMessage("hello").withStatus("true"))
+          .addCondition(new DomainCondition(DomainConditionType.Progressing)
+                .withReason("drat").withStatus("true"));
+    DomainStatus status2 = new DomainStatus();
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemsInOrder("REMOVE /status/conditions/1", "REMOVE /status/conditions/0"));
+  }
+
+  @Test
+  public void whenBothStatusesHaveConditions_replaceMismatches() {  // time to rethink this
+    DomainStatus status1 = new DomainStatus()
+          .addCondition(new DomainCondition(DomainConditionType.Available)
+                .withReason("ok now").withMessage("hello").withStatus("true"))
+          .addCondition(new DomainCondition(DomainConditionType.Progressing)
+                .withReason("because").withStatus("true"));
+    DomainStatus status2 = new DomainStatus()
+          .addCondition(new DomainCondition(DomainConditionType.Available)
+                .withReason("ok now").withMessage("hello").withStatus("true"))
+          .addCondition(new DomainCondition(DomainConditionType.Progressing)
+                .withReason("trying").withMessage("Almost"));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder("REMOVE /status/conditions/1",
+                          "ADD /status/conditions/- {'message':'Almost','reason':'trying','type':'Progressing'}"));
+  }
+
+  @Test
+  public void whenBothStatusesHaveSameConditionTypeWithMismatch_replaceIt() {  // time to rethink this
+    DomainStatus status1 = new DomainStatus()
+          .addCondition(new DomainCondition(DomainConditionType.Progressing)
+                .withReason("because").withMessage("Not There"));
+    DomainStatus status2 = new DomainStatus()
+          .addCondition(new DomainCondition(DomainConditionType.Progressing)
+                .withReason("trying").withMessage("Almost"));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder("REMOVE /status/conditions/0",
+                          "ADD /status/conditions/- {'message':'Almost','reason':'trying','type':'Progressing'}"));
+  }
+
+  @Test
+  public void whenOnlyNewStatusHasClusters_addNewClusters() {
+    DomainStatus status1 = new DomainStatus();
+    DomainStatus status2 = new DomainStatus()
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster1").withReplicas(2).withReadyReplicas(4).withMaximumReplicas(10))
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster2").withReplicas(4).withMaximumReplicas(8));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "ADD /status/clusters/- {'clusterName':'cluster1','maximumReplicas':10,'readyReplicas':4,'replicas':2}",
+                "ADD /status/clusters/- {'clusterName':'cluster2','maximumReplicas':8,'replicas':4}"
+                ));
+  }
+
+  @Test
+  public void whenOnlyOldStatusHasClusters_removeThem() {
+    DomainStatus status1 = new DomainStatus()
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster1").withReplicas(2).withReadyReplicas(4).withMaximumReplicas(10))
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster2").withReplicas(4).withMaximumReplicas(8));
+    DomainStatus status2 = new DomainStatus();
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemsInOrder("REMOVE /status/clusters/1", "REMOVE /status/clusters/0"));
+  }
+
+  @Test
+  public void whenBothStatusesHaveClusters_replaceChangedFieldsInMatchingOnes() {
+    DomainStatus status1 = new DomainStatus()
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster1").withReplicas(2).withReadyReplicas(4).withMaximumReplicas(10))
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster2").withReplicas(5).withReadyReplicas(6).withMaximumReplicas(8))
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster3").withReplicas(3).withMaximumReplicas(6));
+    DomainStatus status2 = new DomainStatus()
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster1").withReplicas(2).withReadyReplicas(4).withMaximumReplicas(10))
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster2").withReplicas(2).withMaximumReplicas(8))
+          .addCluster(new ClusterStatus()
+              .withClusterName("cluster4").withReplicas(4).withMaximumReplicas(8));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "REMOVE /status/clusters/1/readyReplicas",
+                "REPLACE /status/clusters/1/replicas 2",
+                "REMOVE /status/clusters/2",
+                "ADD /status/clusters/- {'clusterName':'cluster4','maximumReplicas':8,'replicas':4}"
+                ));
+  }
+
+  @Test
+  public void excludingHealthWhenOnlyNewStatusHasServers_addThem() {
+    DomainStatus status1 = new DomainStatus();
+    DomainStatus status2 = new DomainStatus()
+          .addServer(new ServerStatus()
+                .withServerName("ms1").withClusterName("cluster1").withState(RUNNING_STATE).withNodeName("node1"))
+          .addServer(new ServerStatus()
+                .withServerName("ms2").withClusterName("cluster1").withState(STARTING_STATE));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+             "ADD /status/servers/- {'clusterName':'cluster1','nodeName':'node1','serverName':'ms1','state':'RUNNING'}",
+             "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
+             ));
+  }
+
+  @Test
+  public void excludingHealthWhenOnlyOldStatusHasServers_removeThem() {
+    DomainStatus status1 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1").withClusterName("cluster1"))
+          .addServer(new ServerStatus().withServerName("ms2").withClusterName("cluster1"));
+    DomainStatus status2 = new DomainStatus();
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(), hasItemsInOrder("REMOVE /status/servers/1", "REMOVE /status/servers/0"));
+  }
+
+  @Test
+  public void withHealthScalarsWhenOnlyNewStatusHasServers_addThem() {
+    DateTime activationTime = new DateTime();
+    DomainStatus status1 = new DomainStatus();
+    DomainStatus status2 = new DomainStatus()
+          .addServer(new ServerStatus()
+                .withServerName("ms1").withClusterName("cluster1")
+                .withHealth(new ServerHealth().withOverallHealth("AOK").withActivationTime(activationTime)))
+          .addServer(new ServerStatus()
+                .withServerName("ms2").withClusterName("cluster1").withState(STARTING_STATE));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "ADD /status/servers/- {'clusterName':'cluster1',"
+                      + "'health':{'activationTime':'" + activationTime + "','overallHealth':'AOK'},"
+                      + "'serverName':'ms1'}",
+                "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
+                ));
+  }
+
+  @Test
+  public void withHealthScalarsWhenBothStatusesHasServers_modifyThem() {
+    DateTime activationTime = new DateTime();
+    DomainStatus status1 = new DomainStatus()
+          .addServer(new ServerStatus()
+                .withServerName("ms1").withClusterName("cluster1")
+                .withHealth(new ServerHealth().withOverallHealth("AOK")))
+          .addServer(new ServerStatus()
+                .withServerName("ms2").withClusterName("cluster1")
+                .withHealth(new ServerHealth().withOverallHealth("starting").withActivationTime(activationTime)));
+    DomainStatus status2 = new DomainStatus()
+          .addServer(new ServerStatus()
+                .withServerName("ms2").withClusterName("cluster1")
+                .withHealth(new ServerHealth().withOverallHealth("AOK").withActivationTime(activationTime)))
+          .addServer(new ServerStatus()
+                .withServerName("ms3").withClusterName("cluster1").withState(STARTING_STATE));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "REPLACE /status/servers/1/health/overallHealth 'AOK'",
+                "REMOVE /status/servers/0",
+                "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms3','state':'STARTING'}"
+                ));
+  }
+
+  @Test
+  public void withSubsystemHealthWhenOnlyNewStatusHasSubsystemValues_addThem() {
+    DateTime activationTime = new DateTime();
+    DomainStatus status1 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1"))
+          .addServer(new ServerStatus().withServerName("ms2")
+                .withHealth(new ServerHealth().withOverallHealth("OK")));
+    DomainStatus status2 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1")
+                .withHealth(new ServerHealth().withOverallHealth("Confused").withActivationTime(activationTime)
+                .addSubsystem(new SubsystemHealth().withSubsystemName("ejb").withHealth("confused"))))
+          .addServer(new ServerStatus().withServerName("ms2")
+                .withHealth(new ServerHealth().withOverallHealth("Lagging")
+                .addSubsystem(new SubsystemHealth().withSubsystemName("web").withHealth("slow"))))
+          .addServer(new ServerStatus().withServerName("ms3")
+                .withHealth(new ServerHealth().withOverallHealth("Broken").withActivationTime(activationTime)
+                .addSubsystem(new SubsystemHealth().withSubsystemName("jmx").withHealth("obsolete"))
+                .addSubsystem(new SubsystemHealth().withSubsystemName("sockets").withHealth("uninitialized"))));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "ADD /status/servers/0/health "
+                      + "{'activationTime':'" + activationTime
+                      + "','overallHealth':'Confused','subsystems':[{'health':'confused','subsystemName':'ejb'}]}",
+                "REPLACE /status/servers/1/health/overallHealth 'Lagging'",
+                "ADD /status/servers/1/health/subsystems/- {'health':'slow','subsystemName':'web'}",
+                "ADD /status/servers/- "
+                      + "{'health':"
+                      +     "{'activationTime':'" + activationTime + "','overallHealth':'Broken',"
+                      +      "'subsystems':["
+                      +         "{'health':'obsolete','subsystemName':'jmx'},"
+                      +         "{'health':'uninitialized','subsystemName':'sockets'}"
+                      +      "]},"
+                      + "'serverName':'ms3'}"
+                ));
+  }
+
+  @Test
+  public void whenSubsystemRemovedOrModified_patchAsNeeded() {
+    DateTime activationTime = new DateTime();
+    DomainStatus status1 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1")
+                .withHealth(new ServerHealth().withOverallHealth("Confused").withActivationTime(activationTime)
+                .addSubsystem(new SubsystemHealth().withSubsystemName("ejb").withHealth("confused"))))
+          .addServer(new ServerStatus().withServerName("ms2")
+                .withHealth(new ServerHealth().withOverallHealth("Lagging")
+                .addSubsystem(new SubsystemHealth().withSubsystemName("web").withHealth("slow"))
+                .addSubsystem(new SubsystemHealth().withSubsystemName("jmx").withHealth("obsolete"))))
+          .addServer(new ServerStatus().withServerName("ms3")
+                .withHealth(new ServerHealth().withOverallHealth("Broken").withActivationTime(activationTime)
+                .addSubsystem(new SubsystemHealth().withSubsystemName("web").withHealth("slow"))
+                .addSubsystem(new SubsystemHealth().withSubsystemName("sockets").withHealth("uninitialized"))));
+    DomainStatus status2 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1")
+                .withHealth(new ServerHealth().withOverallHealth("Confused").withActivationTime(activationTime)
+                .addSubsystem(new SubsystemHealth().withSubsystemName("ejb").withHealth("improving"))))
+          .addServer(new ServerStatus().withServerName("ms2")
+                .withHealth(new ServerHealth().withOverallHealth("Lagging")
+                .addSubsystem(new SubsystemHealth().withSubsystemName("web").withHealth("slow"))))
+          .addServer(new ServerStatus().withServerName("ms3")
+                .withHealth(new ServerHealth().withOverallHealth("Broken").withActivationTime(activationTime)));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "REPLACE /status/servers/0/health/subsystems/0/health 'improving'",
+                "REMOVE /status/servers/1/health/subsystems/1",
+                "REMOVE /status/servers/2/health/subsystems/1",
+                "REMOVE /status/servers/2/health/subsystems/0"
+                ));
+  }
+
+  @Test
+  public void whenSubsystemSymptomsAddedAndRemoved_addAndRemove() {
+    DomainStatus status1 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1")
+                .withHealth(new ServerHealth()
+                .addSubsystem(new SubsystemHealth().withSubsystemName("ejb").withSymptoms("s2","s4"))));
+    DomainStatus status2 = new DomainStatus()
+          .addServer(new ServerStatus().withServerName("ms1")
+                .withHealth(new ServerHealth()
+                .addSubsystem(new SubsystemHealth().withSubsystemName("ejb").withSymptoms("s1", "s2", "s3"))));
+
+    computePatch(status1, status2);
+
+    assertThat(builder.getPatches(),
+          hasItemsInOrder(
+                "REMOVE /status/servers/0/health/subsystems/0/symptoms/1",
+                "ADD /status/servers/0/health/subsystems/0/symptoms/- 's1'",
+                "ADD /status/servers/0/health/subsystems/0/symptoms/- 's3'"
+                ));
+  }
+
+  // todo status deep clone
+
+
+  abstract static class PatchBuilderStub implements JsonPatchBuilder {
+    private List<String> patches = new ArrayList<>();
+
+    String[] getPatches() {
+      return patches.toArray(new String[0]);
+    }
+
+    @Override
+    public JsonPatchBuilder add(String s, boolean b) {
+      patches.add("ADD " + s + " " + b);
+      return this;
+    }
+
+    @Override
+    public JsonPatchBuilder add(String s, JsonValue jsonValue) {
+      if (jsonValue == JsonValue.EMPTY_JSON_OBJECT)
+        patches.add("ADD " + s);
+      else
+        patches.add("ADD " + s + " " + toPatchString(jsonValue));
+      return this;     
+    }
+
+    @Override
+    public JsonPatchBuilder add(String s, String s1) {
+      patches.add("ADD " + s + " '" + s1 + "'");
+      return this;
+    }
+
+    @Override
+    public JsonPatchBuilder add(String s, int i) {
+      patches.add("ADD " + s + " " + i);
+      return this;
+    }
+
+    @Override
+    public JsonPatchBuilder remove(String s) {
+      patches.add("REMOVE " + s);
+      return this;
+    }
+
+    @Override
+    public JsonPatchBuilder replace(String s, int i) {
+      patches.add("REPLACE " + s + " " + i);
+      return this;
+    }
+
+    @Override
+    public JsonPatchBuilder replace(String s, String s1) {
+      patches.add("REPLACE " + s + " '" + s1 + "'");
+      return this;
+    }
+
+    private String toPatchString(JsonValue jsonValue) {
+      if (jsonValue.equals(JsonObject.FALSE))
+        return "'false'";
+      else if (jsonValue.equals(JsonValue.TRUE))
+        return "'true'";
+      else if (jsonValue instanceof JsonString)
+        return "'" + ((JsonString) jsonValue).getString() + "'";
+      else if (jsonValue instanceof JsonNumber)
+        return ((JsonNumber) jsonValue).numberValue().toString();
+      else if (jsonValue instanceof JsonObject)
+        return "{" + toPatchFieldStream(jsonValue.asJsonObject()).collect(Collectors.joining(",")) + "}";
+      else if (jsonValue instanceof JsonArray)
+        return "[" + toPatchFieldStream(jsonValue.asJsonArray()).collect(Collectors.joining(",")) + "]";
+      else
+        return "";
+    }
+
+    private Stream<String> toPatchFieldStream(JsonObject jsonObject) {
+      return jsonObject.entrySet().stream()
+            .sorted(Comparator.comparing(Map.Entry::getKey))
+            .map(this::toPatchField);
+    }
+
+    private Stream<String> toPatchFieldStream(JsonArray jsonArray) {
+      return jsonArray.stream().map(this::toPatchString);
+    }
+
+    private String toPatchField(Map.Entry<String,JsonValue> entry) {
+      return "'" + entry.getKey() + "':" + toPatchString(entry.getValue());
+    }
+  }
+
+
+  @SuppressWarnings("unused")
+  static class OrderedArrayMatcher extends TypeSafeDiagnosingMatcher<String[]> {
+    private String[] expectedItems;
+
+    private OrderedArrayMatcher(String[] expectedItems) {
+      this.expectedItems = expectedItems;
+    }
+
+    static OrderedArrayMatcher hasItemsInOrder(String... items) {
+      return new OrderedArrayMatcher(items);
+    }
+
+    @Override
+    protected boolean matchesSafely(String[] array, Description mismatchDescription) {
+      int j = 0;
+      for (String expectedItem : expectedItems) {
+        j = foundIndex(array, expectedItem, j);
+        if (j++ < 0) return itemNotFound(expectedItem, array, mismatchDescription);
+      }
+      return true;
+    }
+
+    private int foundIndex(String[] array, String expectedItem, int startIndex) {
+      for (int i = startIndex; i < array.length; i++)
+        if (Objects.equals(expectedItem, array[i])) return i;
+
+      return -1;
+    }
+
+    private boolean itemNotFound(String expectedItem, String[] array, Description mismatchDescription) {
+      mismatchDescription
+            .appendText("did not find ").appendValue(expectedItem)
+            .appendText(" in order in ").appendValueList("[", ",", "]", array);
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("expected array containing, in order, ").appendValueList("[", ",", "]", expectedItems);
+    }
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -22,17 +22,14 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.json.Json;
 import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
 import javax.json.JsonPatch;
 import javax.json.JsonStructure;
-import javax.json.JsonValue;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
@@ -71,6 +68,7 @@ import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
 import org.joda.time.DateTime;
@@ -96,10 +94,13 @@ public class KubernetesTestSupport extends FiberTestSupport {
   public static final String SERVICE = "Service";
   public static final String SUBJECT_ACCESS_REVIEW = "SubjectAccessReview";
   public static final String TOKEN_REVIEW = "TokenReview";
+
   private Map<String, DataRepository<?>> repositories = new HashMap<>();
   private Map<Class<?>, String> dataTypes = new HashMap<>();
   private Failure failure;
   private long resourceVersion;
+  private int numCalls;
+  private boolean addCreationTimestamp;
 
   /**
    * Installs a factory into CallBuilder to use canned responses.
@@ -182,6 +183,25 @@ public class KubernetesTestSupport extends FiberTestSupport {
       String resourceName, Class<T> resourceClass, Function<List<T>, Object> toList) {
     dataTypes.put(resourceClass, resourceName);
     repositories.put(resourceName, new NamespacedDataRepository<>(resourceClass, toList));
+  }
+
+  /**
+   * Clears the number of calls made to Kubernetes.
+   */
+  public void clearNumCalls() {
+    numCalls = 0;
+  }
+
+  /**
+   * Returns the number of calls made to Kubernetes.
+   * @return a non-negative integer
+   */
+  public int getNumCalls() {
+    return numCalls;
+  }
+
+  public void setAddCreationTimestamp(boolean addCreationTimestamp) {
+    this.addCreationTimestamp = addCreationTimestamp;
   }
 
   @SuppressWarnings("unchecked")
@@ -446,7 +466,9 @@ public class KubernetesTestSupport extends FiberTestSupport {
     public DateTime deserialize(
         final JsonElement je, final Type type, final JsonDeserializationContext jdc)
         throws JsonParseException {
-      return new DateTime(Long.parseLong(je.getAsJsonObject().get("iMillis").getAsString()));
+      return je.isJsonObject()
+            ? new DateTime(Long.parseLong(je.getAsJsonObject().get("iMillis").getAsString()))
+            : DateTime.parse(je.getAsString());
     }
 
     @Override
@@ -483,13 +505,19 @@ public class KubernetesTestSupport extends FiberTestSupport {
       onUpdateActions = ((DataRepository<T>) parent).onUpdateActions;
     }
 
-    void createResourceInNamespace(T resource) {
-      createResource(getMetadata(resource).getNamespace(), resource);
-    }
-
     @SuppressWarnings("unchecked")
     void createResourceInNamespace(String name, String namespace, Object resource) {
       data.put(name, (T) resource);
+    }
+
+    void createResourceInNamespace(T resource) {
+      createResource(getMetadata(resource).getNamespace(), withOptionalCreationTimeStamp(resource));
+    }
+
+    private T withOptionalCreationTimeStamp(T resource) {
+      if (addCreationTimestamp)
+        getMetadata(resource).setCreationTimestamp(SystemClock.now());
+      return resource;
     }
 
     T createResource(String namespace, T resource) {
@@ -557,7 +585,7 @@ public class KubernetesTestSupport extends FiberTestSupport {
     T replaceResource(String name, T resource) {
       setName(resource, name);
 
-      data.put(name, resource);
+      data.put(name, withOptionalCreationTimeStamp(resource));
       onUpdateActions.forEach(a -> a.accept(resource));
       return resource;
     }
@@ -611,16 +639,6 @@ public class KubernetesTestSupport extends FiberTestSupport {
       return Json.createReader(new StringReader(json)).read();
     }
 
-    JsonArray toJsonArray(List<JsonObject> patch) {
-      JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-      for (JsonObject jsonObject : patch) arrayBuilder.add(toJsonValue(jsonObject));
-      return arrayBuilder.build();
-    }
-
-    private JsonValue toJsonValue(JsonObject jsonObject) {
-      return Json.createReader(new StringReader(jsonObject.toString())).readValue();
-    }
-
     boolean hasElementWithName(String name) {
       return data.containsKey(name);
     }
@@ -629,7 +647,7 @@ public class KubernetesTestSupport extends FiberTestSupport {
       return Optional.ofNullable(getMetadata(resource)).map(V1ObjectMeta::getName).orElse(null);
     }
 
-    private V1ObjectMeta getMetadata(@Nonnull Object resource) {
+    V1ObjectMeta getMetadata(@Nonnull Object resource) {
       return KubernetesUtils.getResourceMetadata(resource);
     }
 
@@ -711,6 +729,11 @@ public class KubernetesTestSupport extends FiberTestSupport {
 
     private DataRepository<T> inNamespace(String namespace) {
       return repositories.computeIfAbsent(namespace, n -> new DataRepository<>(resourceType, this));
+    }
+
+    @Override
+    T replaceResource(String name, T resource) {
+      return inNamespace(getMetadata(resource).getNamespace()).replaceResource(name, resource);
     }
 
     @Override
@@ -811,11 +834,6 @@ public class KubernetesTestSupport extends FiberTestSupport {
       return dataRepository.deleteResource(requestParams.name, requestParams.namespace);
     }
 
-    @SuppressWarnings("unchecked")
-    private List<JsonObject> asJsonObject(Object body) {
-      return (List<JsonObject>) body;
-    }
-
     private Object patchResource(DataRepository dataRepository) {
       return dataRepository.patchResource(
           requestParams.name, requestParams.namespace, (V1Patch) requestParams.body);
@@ -846,6 +864,7 @@ public class KubernetesTestSupport extends FiberTestSupport {
 
     @Override
     public NextAction apply(Packet packet) {
+      numCalls++;
       try {
         Object callResult = callContext.execute();
         CallResponse callResponse = createResponse(callResult);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
@@ -31,15 +31,18 @@ import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClockTestSupport;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
+import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.CUSTOM_RESOURCE_DEFINITION;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.POD;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.SUBJECT_ACCESS_REVIEW;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.TOKEN_REVIEW;
@@ -47,10 +50,12 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class KubernetesTestSupportTest {
+
   private static final String NS = "namespace1";
   private static final String POD_LOG_CONTENTS = "asdfghjkl";
   List<Memento> mementos = new ArrayList<>();
@@ -60,11 +65,12 @@ public class KubernetesTestSupportTest {
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger());
     mementos.add(testSupport.install());
+    mementos.add(SystemClockTestSupport.installClock());
   }
 
   @After
   public void tearDown() throws Exception {
-    for (Memento memento : mementos) memento.revert();
+    mementos.forEach(Memento::revert);
 
     testSupport.throwOnCompletionFailure();
   }
@@ -79,6 +85,16 @@ public class KubernetesTestSupportTest {
     testSupport.runSteps(new CallBuilder().createCustomResourceDefinitionAsync(crd, responseStep));
 
     assertThat(testSupport.getResources(CUSTOM_RESOURCE_DEFINITION), contains(crd));
+  }
+
+  @Test
+  public void afterCreateCrd_incrementNumCalls() {
+    V1beta1CustomResourceDefinition crd = createCrd("mycrd");
+
+    TestResponseStep<V1beta1CustomResourceDefinition> responseStep = new TestResponseStep<>();
+    testSupport.runSteps(new CallBuilder().createCustomResourceDefinitionAsync(crd, responseStep));
+
+    assertThat(testSupport.getNumCalls(), equalTo(1));
   }
 
   @SuppressWarnings("SameParameterValue")
@@ -102,7 +118,7 @@ public class KubernetesTestSupportTest {
 
     TestResponseStep<V1beta1CustomResourceDefinition> responseStep = new TestResponseStep<>();
     Step steps =
-        new CallBuilder().createCustomResourceDefinitionAsync(createCrd("mycrd"), responseStep);
+          new CallBuilder().createCustomResourceDefinitionAsync(createCrd("mycrd"), responseStep);
     testSupport.runSteps(steps);
 
     testSupport.verifyCompletionThrowable(ApiException.class);
@@ -121,6 +137,53 @@ public class KubernetesTestSupportTest {
     testSupport.runSteps(steps);
 
     assertThat(testSupport.getResources(CUSTOM_RESOURCE_DEFINITION), contains(crd));
+  }
+
+  @Test
+  public void afterReplaceDomainWithTimeStampEnabled_timeStampIsChanged() {
+    Domain originalDomain = createDomain(NS, "domain1");
+    testSupport.defineResources(originalDomain);
+    testSupport.setAddCreationTimestamp(true);
+
+    SystemClockTestSupport.increment();
+    Step steps = new CallBuilder().replaceDomainAsync("domain1", NS, createDomain(NS, "domain1"), null);
+    testSupport.runSteps(steps);
+
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, "domain1");
+    assertThat(getCreationTimestamp(updatedDomain), not(equalTo(getCreationTimestamp(originalDomain))));
+  }
+
+  @Test
+  public void afterReplaceDomainWithTimeStampDisabled_timeStampIsNotChanged() {
+    Domain originalDomain = createDomain(NS, "domain1");
+    testSupport.defineResources(originalDomain);
+
+    SystemClockTestSupport.increment();
+    Step steps = new CallBuilder().replaceDomainAsync("domain1", NS, createDomain(NS, "domain1"), null);
+    testSupport.runSteps(steps);
+
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, "domain1");
+    assertThat(getCreationTimestamp(updatedDomain), equalTo(getCreationTimestamp(originalDomain)));
+  }
+
+  @Test
+  public void afterPatchDomainWithTimeStampEnabled_timeStampIsNotChanged() {
+    Domain originalDomain = createDomain(NS, "domain1");
+    testSupport.defineResources(originalDomain);
+    testSupport.setAddCreationTimestamp(true);
+    SystemClockTestSupport.increment();
+
+    JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
+    patchBuilder.add("/spec/replicas", 5);
+    Step steps = new CallBuilder().patchDomainAsync("domain1", NS, new V1Patch(patchBuilder.build().toString()), null);
+    testSupport.runSteps(steps);
+
+    Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, "domain1");
+    assertThat(getCreationTimestamp(updatedDomain), equalTo(getCreationTimestamp(originalDomain)));
+  }
+
+  private DateTime getCreationTimestamp(Domain domain) {
+    return domain.getMetadata().getCreationTimestamp();
   }
 
   @Test
@@ -227,7 +290,7 @@ public class KubernetesTestSupportTest {
 
     TestResponseStep<V1PodList> responseStep = new TestResponseStep<>();
     testSupport.runSteps(
-        new CallBuilder().withLabelSelectors("k1=v1").listPodAsync("ns1", responseStep));
+          new CallBuilder().withLabelSelectors("k1=v1").listPodAsync("ns1", responseStep));
 
     assertThat(responseStep.callResponse.getResult().getItems(), containsInAnyOrder(pod1, pod3));
   }
@@ -245,8 +308,8 @@ public class KubernetesTestSupportTest {
 
     TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
     testSupport.runSteps(
-        new CallBuilder().patchPodAsync("pod1", "ns1",
-            new V1Patch(patchBuilder.build().toString()), responseStep));
+          new CallBuilder().patchPodAsync("pod1", "ns1",
+                new V1Patch(patchBuilder.build().toString()), responseStep));
 
     V1Pod pod2 = (V1Pod) testSupport.getResources(POD).stream().findFirst().orElse(pod1);
     assertThat(pod2.getMetadata().getLabels(), hasEntry("k1", "v2"));
@@ -261,8 +324,8 @@ public class KubernetesTestSupportTest {
 
     TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
     testSupport.runSteps(
-        new CallBuilder().patchPodAsync("pod1", "ns1",
-            new V1Patch(patchBuilder.build().toString()), responseStep));
+          new CallBuilder().patchPodAsync("pod1", "ns1",
+                new V1Patch(patchBuilder.build().toString()), responseStep));
 
     V1Pod pod2 = (V1Pod) testSupport.getResources(POD).stream().findFirst().orElse(pod1);
     assertThat(pod2.getMetadata().getLabels(), hasEntry("k1", "v2"));
@@ -314,9 +377,9 @@ public class KubernetesTestSupportTest {
 
     TestResponseStep<V1EventList> responseStep = new TestResponseStep<>();
     testSupport.runSteps(
-        new CallBuilder()
-            .withFieldSelector("action=walk,involvedObject.kind=bird")
-            .listEventAsync("ns1", responseStep));
+          new CallBuilder()
+                .withFieldSelector("action=walk,involvedObject.kind=bird")
+                .listEventAsync("ns1", responseStep));
 
     assertThat(responseStep.callResponse.getResult().getItems(), containsInAnyOrder(s1, s3));
   }
@@ -349,6 +412,7 @@ public class KubernetesTestSupportTest {
   }
 
   static class TestResponseStep<T> extends DefaultResponseStep<T> {
+
     private CallResponse<T> callResponse;
 
     TestResponseStep() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -21,6 +21,7 @@ import oracle.kubernetes.operator.DomainProcessorDelegateStub;
 import oracle.kubernetes.operator.DomainProcessorImpl;
 import oracle.kubernetes.operator.DomainProcessorTestSetup;
 import oracle.kubernetes.operator.builders.WatchEvent;
+import oracle.kubernetes.operator.rest.ScanCacheStub;
 import oracle.kubernetes.operator.utils.InMemoryCertificates;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.work.Component;
@@ -81,6 +82,7 @@ public class PodPresenceTest {
     mementos.add(TuningParametersStub.install());
     mementos.add(InMemoryCertificates.install());
     mementos.add(UnitTestHash.install());
+    mementos.add(ScanCacheStub.install());
 
     domains.put(NS, new HashMap<>(ImmutableMap.of(UID, info)));
     disableDomainProcessing();

--- a/operator/src/test/java/oracle/kubernetes/operator/rest/ScanCacheStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/rest/ScanCacheStub.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.rest;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+
+/**
+ * Installs a per-test instance into ScanCache.INSTANCE to prevent state from spilling over from one test to another.
+ */
+public class ScanCacheStub {
+
+  public static Memento install() throws NoSuchFieldException {
+    return StaticStubSupport.install(ScanCache.class, "INSTANCE", new ScanCacheImpl());
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainConditionTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainConditionTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import com.meterware.simplestub.Memento;
 import oracle.kubernetes.utils.SystemClockTestSupport;
-import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,5 +49,14 @@ public class DomainConditionTest {
     SystemClockTestSupport.increment();
 
     assertThat(oldCondition.equals(new DomainCondition(Available).withStatus("True")), is(true));
+  }
+
+  @Test
+  public void mayNotPatchObjects() {
+    DomainCondition oldCondition = new DomainCondition(Available).withStatus("False");
+    DomainCondition newCondition = new DomainCondition(Available).withStatus("True");
+
+    assertThat(newCondition.isPatchableFrom(oldCondition), is(false));
+
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -8,13 +8,18 @@ import java.util.List;
 
 import com.meterware.simplestub.Memento;
 import oracle.kubernetes.utils.SystemClockTestSupport;
+import org.hamcrest.Description;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionMatcher.hasCondition;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Available;
+import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Progressing;
+import static oracle.kubernetes.weblogic.domain.model.DomainStatusTest.ClusterStatusMatcher.clusterStatus;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -42,7 +47,37 @@ public class DomainStatusTest {
   }
 
   @Test
-  public void whenAddedConditionIsSameTypeAsExisting_oldConditionIsReplaced() {
+  public void whenAddedConditionIsFailed_replaceOldFailedCondition() {
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("True"));
+
+    assertThat(domainStatus, hasCondition(Failed).withStatus("True"));
+    assertThat(domainStatus, not(hasCondition(Failed).withStatus("False")));
+  }
+
+  @Test
+  public void whenAddedConditionIsFailed_removeProgressingCondition() {
+    domainStatus.addCondition(new DomainCondition(Progressing).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("True"));
+
+    assertThat(domainStatus, not(hasCondition(Progressing)));
+    assertThat(domainStatus, hasCondition(Failed).withStatus("True"));
+  }
+
+  @Test
+  public void whenAddedConditionIsFailed_removeExistedAvailableCondition() {
+    domainStatus.addCondition(new DomainCondition(Available).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("True"));
+
+    assertThat(domainStatus, not(hasCondition(Available)));
+    assertThat(domainStatus, hasCondition(Failed).withStatus("True"));
+  }
+
+  @Test
+  public void whenAddedConditionIsAvailable_replaceOldAvailableCondition() {
     domainStatus.addCondition(new DomainCondition(Available).withStatus("False"));
 
     domainStatus.addCondition(new DomainCondition(Available).withStatus("True"));
@@ -52,13 +87,53 @@ public class DomainStatusTest {
   }
 
   @Test
-  public void whenAddedConditionIsDifferentTypeThenExisting_oldConditionIsNotReplaced() {
-    domainStatus.addCondition(new DomainCondition(Available).withStatus("True"));
-
+  public void whenAddedConditionIsAvailable_removeExistedProgressingCondition() {
     domainStatus.addCondition(new DomainCondition(Progressing).withStatus("False"));
 
+    domainStatus.addCondition(new DomainCondition(Available).withStatus("True"));
+
+    assertThat(domainStatus, not(hasCondition(Progressing)));
     assertThat(domainStatus, hasCondition(Available).withStatus("True"));
-    assertThat(domainStatus, hasCondition(Progressing).withStatus("False"));
+  }
+
+  @Test
+  public void whenAddedConditionIsAvailable_removeExistedFailedCondition() {
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Available).withStatus("True"));
+
+    assertThat(domainStatus, not(hasCondition(Failed)));
+    assertThat(domainStatus, hasCondition(Available).withStatus("True"));
+  }
+
+  @Test
+  public void whenAddedConditionIsProgressing_replaceOldProgressingCondition() {
+    domainStatus.addCondition(new DomainCondition(Progressing).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Progressing).withStatus("True"));
+
+    assertThat(domainStatus, hasCondition(Progressing).withStatus("True"));
+    assertThat(domainStatus, not(hasCondition(Progressing).withStatus("False")));
+  }
+
+  @Test
+  public void whenAddedConditionIsProgressing_leaveExistingAvailableCondition() {
+    domainStatus.addCondition(new DomainCondition(Available).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Progressing).withStatus("True"));
+
+    assertThat(domainStatus, hasCondition(Progressing).withStatus("True"));
+    assertThat(domainStatus, hasCondition(Available).withStatus("False"));
+  }
+
+  @Test
+  public void whenAddedConditionIsProgress_removeExistedFailedCondition() {
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("False"));
+
+    domainStatus.addCondition(new DomainCondition(Progressing).withStatus("True"));
+
+    assertThat(domainStatus, not(hasCondition(Failed)));
+    assertThat(domainStatus, hasCondition(Progressing).withStatus("True"));
   }
 
   @Test
@@ -72,4 +147,132 @@ public class DomainStatusTest {
 
     assertThat(domainStatus.hasConditionWith(c -> c.hasType(Available)), is(true));
   }
+
+  @Test
+  public void whenClusterStatusAdded_statusHasClusterStatus() {
+    domainStatus.addCluster(new ClusterStatus().withClusterName("cluster1").withReplicas(3));
+
+    assertThat(domainStatus.getClusters(), hasItem(clusterStatus("cluster1").withReplicas(3)));
+  }
+
+  @Test
+  public void whenClusterStatusAdded_remainingClusterStatusesUnaffected() {
+    domainStatus.addCluster(new ClusterStatus().withClusterName("cluster1").withReplicas(3));
+
+    domainStatus.addCluster(new ClusterStatus().withClusterName("cluster2").withMaximumReplicas(10));
+
+    assertThat(domainStatus.getClusters(), hasItem(clusterStatus("cluster1").withReplicas(3)));
+  }
+
+  @Test
+  public void whenClusterStatusAdded_matchingClusterStatusesReplaced() {
+    domainStatus.addCluster(new ClusterStatus().withClusterName("cluster1").withReplicas(3));
+
+    domainStatus.addCluster(new ClusterStatus().withClusterName("cluster1").withMaximumReplicas(10));
+
+    assertThat(domainStatus.getClusters(), hasItem(clusterStatus("cluster1").withMaximumReplicas(10)));
+    assertThat(domainStatus.getClusters(), not(hasItem(clusterStatus("cluster1").withReplicas(3))));
+  }
+
+  @Test
+  public void whenHasCondition_cloneIsEqual() {
+    domainStatus.addCondition(new DomainCondition(Progressing).withStatus("False"));
+
+    DomainStatus clone = new DomainStatus(this.domainStatus);
+
+    assertThat(clone, equalTo(domainStatus));
+  }
+
+  @Test
+  public void whenHasServerStatusWithHealth_cloneIsEqual() {
+    domainStatus.addServer(new ServerStatus().withHealth(new ServerHealth().withOverallHealth("peachy")));
+
+    DomainStatus clone = new DomainStatus(this.domainStatus);
+
+    assertThat(clone, equalTo(domainStatus));
+  }
+
+  @Test
+  public void whenHasServerStatusWithoutHealth_cloneIsEqual() {
+    domainStatus.addServer(new ServerStatus().withServerName("myserver"));
+
+    DomainStatus clone = new DomainStatus(this.domainStatus);
+
+    assertThat(clone, equalTo(domainStatus));
+  }
+
+  static class ClusterStatusMatcher extends org.hamcrest.TypeSafeDiagnosingMatcher<ClusterStatus> {
+    private String name;
+    private Integer replicas;
+    private Integer maximumReplicas;
+    private Integer readyReplicas;
+
+    private ClusterStatusMatcher(String name) {
+      this.name = name;
+    }
+
+    static ClusterStatusMatcher clusterStatus(String name) {
+      return new ClusterStatusMatcher(name);
+    }
+
+    ClusterStatusMatcher withReplicas(int replicas) {
+      this.replicas = replicas;
+      return this;
+    }
+
+    ClusterStatusMatcher withMaximumReplicas(int maximumReplicas) {
+      this.maximumReplicas = maximumReplicas;
+      return this;
+    }
+
+    ClusterStatusMatcher withReadyReplicas(int readyReplicas) {
+      this.readyReplicas = readyReplicas;
+      return this;
+    }
+
+    @Override
+    protected boolean matchesSafely(ClusterStatus clusterStatus, Description description) {
+      OptionalFieldMatcher matcher = new OptionalFieldMatcher(description);
+      matcher.check("clusterName", name, clusterStatus.getClusterName());
+      matcher.check("replicas", replicas, clusterStatus.getReplicas());
+      matcher.check("maximumReplicas", maximumReplicas, clusterStatus.getMaximumReplicas());
+      matcher.check("readyReplicas", readyReplicas, clusterStatus.getReadyReplicas());
+
+      return matcher.matches;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("cluster status for ").appendValue(name);
+      if (replicas != null) description.appendText(", with " + replicas + " replicas");
+      if (maximumReplicas != null) description.appendText(", with " + maximumReplicas + " maximum replicas");
+      if (readyReplicas != null) description.appendText(", with " + readyReplicas + " ready replicas");
+    }
+  }
+
+  static class OptionalFieldMatcher {
+    private Description description;
+    private boolean matches = true;
+
+    OptionalFieldMatcher(Description description) {
+      this.description = description;
+    }
+
+    void check(String fieldName, String expected, String actual) {
+      if (expected == null || expected.equals(actual)) return;
+
+      matches = false;
+      description.appendText(fieldName).appendValue(actual);
+    }
+
+    void check(String fieldName, Number expected, Number actual) {
+      if (expected == null || expected.equals(actual)) return;
+
+      matches = false;
+      description.appendText(fieldName).appendValue(actual);
+    }
+
+
+  }
+
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class DomainStatusTest {
@@ -146,6 +147,25 @@ public class DomainStatusTest {
     domainStatus.addCondition(new DomainCondition(Available));
 
     assertThat(domainStatus.hasConditionWith(c -> c.hasType(Available)), is(true));
+  }
+
+  @Test
+  public void afterFailedConditionAdded_copyMessageAndReasonToStatus() {
+    domainStatus.addCondition(new DomainCondition(Failed).withMessage("message").withReason("reason"));
+
+    assertThat(domainStatus.getMessage(), equalTo("message"));
+    assertThat(domainStatus.getReason(), equalTo("reason"));
+  }
+
+  @Test
+  public void afterNonFailedConditionAdded_clearStatusMessageAndReason() {
+    domainStatus.setMessage("old message");
+    domainStatus.setReason("old reason");
+
+    domainStatus.addCondition(new DomainCondition(Progressing).withMessage("message").withReason("reason"));
+
+    assertThat(domainStatus.getMessage(), nullValue());
+    assertThat(domainStatus.getReason(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
Moves status update logic into the DomainStatus object (effect of adding new conditions)
When a 'failed' condition is added, reflects the reason and message to the domain status
Uses patching to update domain status, thus avoiding update conflicts/