### PR TITLE
Remove unneeded image pull secret

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.jms.ConnectionFactory;
 import javax.jms.QueueConnection;
 import javax.jms.QueueConnectionFactory;
@@ -1725,8 +1724,6 @@ public class Domain {
       domainMap.put("image", imageName + ":" + imageTag);
       if (System.getenv("IMAGE_PULL_SECRET_WEBLOGIC") != null) {
         domainMap.put("imagePullSecretName", System.getenv("IMAGE_PULL_SECRET_WEBLOGIC"));
-      } else {
-        domainMap.put("imagePullSecretName", "docker-store");
       }
     } else {
       // use default image attibute value for JENKINS and standalone runs and for SHARED_CLUSTER use

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/JrfDomain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/JrfDomain.java
@@ -6,8 +6,6 @@ package oracle.kubernetes.operator.utils;
 import java.util.Map;
 import java.util.logging.Level;
 
-import oracle.kubernetes.operator.BaseTest;
-
 /**
  * JRF Domain class with all the utility methods.
  */
@@ -61,8 +59,6 @@ public class JrfDomain extends Domain {
 
     if (System.getenv("IMAGE_PULL_SECRET_FMWINFRA") != null) {
       domainMap.put("imagePullSecretName", System.getenv("IMAGE_PULL_SECRET_FMWINFRA"));
-    } else {
-      domainMap.put("imagePullSecretName", "docker-store");
     }
 
     // update create-domain-script.sh if adminPortEnabled is true


### PR DESCRIPTION
The functional tests are specifying an image pull secret in the domain CRD that is never used in the tests. This causes domain validation to be added in owls-76750 to fail.