### PR TITLE
OWLS 72829: Separate JVM arguments for NM and server instance

### DIFF
--- a/docs-source/content/userguide/managing-domains/_index.md
+++ b/docs-source/content/userguide/managing-domains/_index.md
@@ -65,14 +65,14 @@ Please be aware of the following important considerations for WebLogic domains r
 
 * _Security Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
 
-* _JVM Memory and Java Option Arguments:_ The following environment variables can be used to customize the JVM memory and Java options for both the WebLogic managed servers and node manager instances:
+* _JVM Memory and Java Option Arguments:_ The following environment variables can be used to customize the JVM memory and Java options for both the WebLogic Managed Servers and Node Manager instances:
  
-    * JAVA_OPTIONS - Java options for starting WL server
-    * USER_MEM_ARGS - JVM mem args for starting WL server
-    * NODEMGR_JAVA_OPTIONS - Java options for starting Node Manager instance
-    * NODEMGR_MEM_ARGS - JVM mem args for starting Node Manager instance
+    * `JAVA_OPTIONS` - Java options for starting WebLogic Server
+    * `USER_MEM_ARGS` - JVM mem args for starting WebLogic Server
+    * `NODEMGR_JAVA_OPTIONS` - Java options for starting Node Manager instance
+    * `NODEMGR_MEM_ARGS` - JVM mem args for starting Node Manager instance
     
-    See [Domain resource]({{< relref "/userguide/managing-domains/domain-resource/_index.md" >}}) for more information on `JVM Memory and Java Option Environment Variables`.
+    For more information, see [Domain resource]({{< relref "/userguide/managing-domains/domain-resource/_index.md" >}}).
 
 The following features are **not** certified or supported in this release:
 

--- a/docs-source/content/userguide/managing-domains/_index.md
+++ b/docs-source/content/userguide/managing-domains/_index.md
@@ -82,7 +82,7 @@ The following features are **not** certified or supported in this release:
 * Multicast
 * Multitenancy
 * Production redeployment
-.
+
 Please consult My Oracle Support Doc ID 2349228.1 for up-to-date information about the features of WebLogic Server that are supported in Kubernetes environments.
 
 

--- a/docs-source/content/userguide/managing-domains/_index.md
+++ b/docs-source/content/userguide/managing-domains/_index.md
@@ -65,6 +65,15 @@ Please be aware of the following important considerations for WebLogic domains r
 
 * _Security Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
 
+* _JVM Memory and Java Option Arguments:_ The following environment variables can be used to customize the JVM memory and Java options for both the WebLogic managed servers and node manager instances:
+ 
+    * JAVA_OPTIONS - Java options for starting WL server
+    * USER_MEM_ARGS - JVM mem args for starting WL server
+    * NODEMGR_JAVA_OPTIONS - Java options for starting Node Manager instance
+    * NODEMGR_MEM_ARGS - JVM mem args for starting Node Manager instance
+    
+    See [Domain resource]({{< relref "/userguide/managing-domains/domain-resource/_index.md" >}}) for more information on `JVM Memory and Java Option Environment Variables`.
+
 The following features are **not** certified or supported in this release:
 
 * Whole server migration
@@ -73,7 +82,7 @@ The following features are **not** certified or supported in this release:
 * Multicast
 * Multitenancy
 * Production redeployment
-
+.
 Please consult My Oracle Support Doc ID 2349228.1 for up-to-date information about the features of WebLogic Server that are supported in Kubernetes environments.
 
 

--- a/docs-source/content/userguide/managing-domains/domain-resource.md
+++ b/docs-source/content/userguide/managing-domains/domain-resource.md
@@ -111,7 +111,7 @@ You can use the following environment variables to specify JVM memory and JVM op
 * `NODEMGR_JAVA_OPTIONS` : Java options for starting Node Manager instance.
 * `NODEMGR_MEM_ARGS` : JVM memory arguments for starting Node Manager instance.
 
-Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
+Note: The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
 
 The following behavior occurs depending on whether or not `NODEMGR_JAVA_OPTIONS` and `NODEMGR_MEM_ARGS` are defined:
 

--- a/docs-source/content/userguide/managing-domains/domain-resource.md
+++ b/docs-source/content/userguide/managing-domains/domain-resource.md
@@ -102,6 +102,47 @@ Sub-sections related to the Administration Server, specific clusters, or specifi
 
 The elements `serverStartPolicy`, `serverStartState`, `serverPod` and `serverService` are repeated under `adminServer` and under each entry of `clusters` or `managedServers`.  The values directly under `spec` set the defaults for the entire domain.  The values under a specific entry under `clusters` set the defaults for cluster members of that cluster.  The values under `adminServer` or an entry under `managedServers` set the values for that specific server.  Values from the domain scope and values from the cluster (for cluster members) are merged with or overridden by the setting for the specific server depending on the element.  See the [startup and shutdown]({{< relref "/userguide/managing-domains/domain-lifecycle/startup.md" >}}) documentation for details about `serverStartPolicy` combination.
 
+### JVM Memory and Java Option Environment Variables
+
+The following environment variables can be used to specify JVM Memory and JVM Option arguments to WLS managed server and node manager instances:
+
+* JAVA_OPTIONS : Java options for starting WebLogic server.
+* USER_MEM_ARGS : JVM memory arguments for starting WebLogic server.
+* NODEMGR_JAVA_OPTIONS : Java options for starting Node Manager instance.
+* NODEMGR_MEM_ARGS : JVM memory arguments for starting Node Manager instance.
+
+The following behavior occurs depending on whether or not NODEMGR_JAVA_OPTIONS and NODEMGR_MEM_ARGS is defined:
+
+* If NODEMGR_JAVA_OPTIONS is not defined AND JAVA_OPTIONS is defined then the JAVA_OPTIONS value will be applied to the Node Manager instance.
+* If NODEMGR_MEM_ARGS is not defined then default (-Xms64m -Xmx100m) memory values will be applied to the Node Manager instance.
+
+This example snippet illustrates how to add the above environment variables using the `env` attribute under the `serverPod` configuration in your domain resource YAML file. 
+```
+# Copyright 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+apiVersion: "weblogic.oracle/v6"
+kind: Domain
+metadata:
+  name: domain1
+  namespace: domains23
+  labels:
+    weblogic.resourceVersion: domain-v2
+    weblogic.domainUID: domain1
+spec:
+  serverPod:
+    # an (optional) list of environment variable to be set on the servers
+    env:
+    - name: JAVA_OPTIONS
+      value: "-Dweblogic.StdoutDebugEnabled=false "
+    - name: USER_MEM_ARGS
+      value: "-XX:MaxRAMFraction=1 -Djava.security.egd=file:/dev/./urandom "
+    - name: NODEMGR_JAVA_OPTIONS
+      value: "-Dweblogic.StdoutDebugEnabled=false -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap "
+    - name: NODEMGR_MEM_ARGS
+      value: "-Xms64m -Xmx100m -Djava.security.egd=file:/dev/./urandom "
+```
+      
 ### Pod generation
 
 The operator creates a pod for each running WebLogic Server instance.  This pod will have a container based on the Docker image specified by the `image` field.  Additional pod or container content can be specified using the elements under `serverPod`.  This includes Kubernetes sidecar and init containers, labels, annotations, volumes, volume mounts, scheduling constraints, including anti-affinity, [resource requirements](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/), or [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).

--- a/docs-source/content/userguide/managing-domains/domain-resource.md
+++ b/docs-source/content/userguide/managing-domains/domain-resource.md
@@ -111,6 +111,8 @@ You can use the following environment variables to specify JVM memory and JVM op
 * `NODEMGR_JAVA_OPTIONS` : Java options for starting Node Manager instance.
 * `NODEMGR_MEM_ARGS` : JVM memory arguments for starting Node Manager instance.
 
+Note:_ The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
+
 The following behavior occurs depending on whether or not `NODEMGR_JAVA_OPTIONS` and `NODEMGR_MEM_ARGS` are defined:
 
 * If `NODEMGR_JAVA_OPTIONS` is not defined and `JAVA_OPTIONS` is defined, then the `JAVA_OPTIONS` value will be applied to the Node Manager instance.
@@ -136,9 +138,9 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false "
     - name: USER_MEM_ARGS
-      value: "-XX:MaxRAMFraction=1 -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom "
     - name: NODEMGR_JAVA_OPTIONS
-      value: "-Dweblogic.StdoutDebugEnabled=false -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap "
+      value: "-Dweblogic.StdoutDebugEnabled=false "
     - name: NODEMGR_MEM_ARGS
       value: "-Xms64m -Xmx100m -Djava.security.egd=file:/dev/./urandom "
 ```

--- a/docs-source/content/userguide/managing-domains/domain-resource.md
+++ b/docs-source/content/userguide/managing-domains/domain-resource.md
@@ -102,19 +102,19 @@ Sub-sections related to the Administration Server, specific clusters, or specifi
 
 The elements `serverStartPolicy`, `serverStartState`, `serverPod` and `serverService` are repeated under `adminServer` and under each entry of `clusters` or `managedServers`.  The values directly under `spec` set the defaults for the entire domain.  The values under a specific entry under `clusters` set the defaults for cluster members of that cluster.  The values under `adminServer` or an entry under `managedServers` set the values for that specific server.  Values from the domain scope and values from the cluster (for cluster members) are merged with or overridden by the setting for the specific server depending on the element.  See the [startup and shutdown]({{< relref "/userguide/managing-domains/domain-lifecycle/startup.md" >}}) documentation for details about `serverStartPolicy` combination.
 
-### JVM Memory and Java Option Environment Variables
+### JVM memory and Java option environment variables
 
-The following environment variables can be used to specify JVM Memory and JVM Option arguments to WLS managed server and node manager instances:
+You can use the following environment variables to specify JVM memory and JVM option arguments to WebLogic Server Managed Server and Node Manager instances:
 
-* JAVA_OPTIONS : Java options for starting WebLogic server.
-* USER_MEM_ARGS : JVM memory arguments for starting WebLogic server.
-* NODEMGR_JAVA_OPTIONS : Java options for starting Node Manager instance.
-* NODEMGR_MEM_ARGS : JVM memory arguments for starting Node Manager instance.
+* `JAVA_OPTIONS` : Java options for starting WebLogic Server.
+* `USER_MEM_ARGS` : JVM memory arguments for starting WebLogic Server.
+* `NODEMGR_JAVA_OPTIONS` : Java options for starting Node Manager instance.
+* `NODEMGR_MEM_ARGS` : JVM memory arguments for starting Node Manager instance.
 
-The following behavior occurs depending on whether or not NODEMGR_JAVA_OPTIONS and NODEMGR_MEM_ARGS is defined:
+The following behavior occurs depending on whether or not `NODEMGR_JAVA_OPTIONS` and `NODEMGR_MEM_ARGS` are defined:
 
-* If NODEMGR_JAVA_OPTIONS is not defined AND JAVA_OPTIONS is defined then the JAVA_OPTIONS value will be applied to the Node Manager instance.
-* If NODEMGR_MEM_ARGS is not defined then default (-Xms64m -Xmx100m) memory values will be applied to the Node Manager instance.
+* If `NODEMGR_JAVA_OPTIONS` is not defined and `JAVA_OPTIONS` is defined, then the `JAVA_OPTIONS` value will be applied to the Node Manager instance.
+* If `NODEMGR_MEM_ARGS` is not defined, then default memory values (-Xms64m -Xmx100m) will be applied to the Node Manager instance.
 
 This example snippet illustrates how to add the above environment variables using the `env` attribute under the `serverPod` configuration in your domain resource YAML file. 
 ```

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -32,6 +32,8 @@
 #   FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR = "true" if WebLogic server should fail to 
 #                       boot if situational configuration related errors are 
 #                       found. Default to "true" if unspecified.
+#   NODEMGR_MEM_ARGS  = JVM mem args for starting the Node Manager instance
+#   NODEMGR_JAVA_OPTIONS  = Java options for starting the Node Manager instance
 #
 # If SERVER_NAME is set, then this NM is for a WL Server and these must also be set:
 # 
@@ -297,12 +299,14 @@ if [ -z "${NODEMGR_MEM_ARGS}" ]; then
   NODEMGR_MEM_ARGS="-Xms64m -Xmx100m"
 fi
 
-# USER_MEM_ARGS is not applied to Node Manager.  Use NODEMGR_MEM_ARGS
-# (or NODEMGR_JAVA_OPTIONS) to specify JVM memory arguments for Node Manager.
-# Specifying a non-empty USER_MEM_ARGS environment variable prevents MEM_ARGS
-# from being specified in the common WebLogic environment scripts in the WebLogic
-# installation.  NOTE: Specifying USER_MEM_ARGS with ' ' (space, not empty string)
-# prevents WLS from calculating default values (see commBaseEnv.sh)
+# We prevent USER_MEM_ARGS from being applied to the NM here and only pass
+# USER_MEM_ARGS to WL Servers via the WL Server startup properties file above.
+# This is so that WL Servers and NM can have different tuning. Use NODEMGR_MEM_ARGS or
+# NODEMGR_JAVA_OPTIONS to specify JVM memory arguments for NMs.
+# NOTE: Specifying USER_MEM_ARGS with ' ' (space, not empty string)
+# prevents MEM_ARGS from being implicitly set by the WebLogic env
+# scripts in the WebLogic installation and WLS from inserting default
+# values for memory arguments. (See commBaseEnv.sh).
 USER_MEM_ARGS=" "
 export USER_MEM_ARGS
 

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -288,32 +288,27 @@ export NODEMGR_HOME="${NODEMGR_HOME?}"
 export DOMAIN_HOME="${DOMAIN_HOME?}"
 
 # Apply JAVA_OPTIONS to Node Manager if NODEMGR_JAVA_OPTIONS not specified
-trace "pre-NODEMGR_JAVA_OPTIONS='${NODEMGR_JAVA_OPTIONS}'"
 if [ -z ${NODEMGR_JAVA_OPTIONS} ]; then
   NODEMGR_JAVA_OPTIONS="${JAVA_OPTIONS}"
 fi
 
-trace "NODEMGR_MEM_ARGS='${NODEMGR_MEM_ARGS}'"
 if [ -z "${NODEMGR_MEM_ARGS}" ]; then
   # Default JVM memory arguments for Node Manager
   NODEMGR_MEM_ARGS="-Xms64m -Xmx100m"
 fi
 
 # USER_MEM_ARGS is not applied to Node Manager.  Use NODEMGR_MEM_ARGS
-# (or NODEMGR_JAVA_OPTIONS) to specify JVM memory arguments for Node Manager
+# (or NODEMGR_JAVA_OPTIONS) to specify JVM memory arguments for Node Manager.
 # Specifying a non-empty USER_MEM_ARGS environment variable prevents MEM_ARGS
 # from being specified in the common WebLogic environment scripts in the WebLogic
-# installation.  NOTE: Specifying USER_MEM_ARGS with ' ' (not empty string)
-# prevents WLS from caluculating default values (see commBaseEnv.sh)
-trace "startNodeManager.sh USER_MEM_ARGS='${USER_MEM_ARGS}'"
+# installation.  NOTE: Specifying USER_MEM_ARGS with ' ' (space, not empty string)
+# prevents WLS from calculating default values (see commBaseEnv.sh)
 USER_MEM_ARGS=" "
 export USER_MEM_ARGS
 
 # NODEMGR_MEM_ARGS and NODEMGR_JAVA_OPTIONS are exported to Node Manager as JAVA_OPTIONS
 # environment variable.
-trace "post startNodeManager.sh USER_MEM_ARGS='${USER_MEM_ARGS}'"
 export JAVA_OPTIONS="${NODEMGR_MEM_ARGS} ${NODEMGR_JAVA_OPTIONS} -Dweblogic.RootDirectory=${DOMAIN_HOME}"
-trace "post-startNodeManager.sh JAVA_OPTIONS='${JAVA_OPTIONS}'"
 
 ###############################################################################
 #

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -286,7 +286,34 @@ export VM_TYPE="HotSpot"
 #  Copied from ${DOMAIN_HOME}/bin/startNodeManager.sh 
 export NODEMGR_HOME="${NODEMGR_HOME?}"
 export DOMAIN_HOME="${DOMAIN_HOME?}"
-export JAVA_OPTIONS="${JAVA_OPTIONS} -Dweblogic.RootDirectory=${DOMAIN_HOME}"
+
+# Apply JAVA_OPTIONS to Node Manager if NODEMGR_JAVA_OPTIONS not specified
+trace "pre-NODEMGR_JAVA_OPTIONS='${NODEMGR_JAVA_OPTIONS}'"
+if [ -z ${NODEMGR_JAVA_OPTIONS} ]; then
+  NODEMGR_JAVA_OPTIONS="${JAVA_OPTIONS}"
+fi
+
+trace "NODEMGR_MEM_ARGS='${NODEMGR_MEM_ARGS}'"
+if [ -z "${NODEMGR_MEM_ARGS}" ]; then
+  # Default JVM memory arguments for Node Manager
+  NODEMGR_MEM_ARGS="-Xms64m -Xmx100m"
+fi
+
+# USER_MEM_ARGS is not applied to Node Manager.  Use NODEMGR_MEM_ARGS
+# (or NODEMGR_JAVA_OPTIONS) to specify JVM memory arguments for Node Manager
+# Specifying a non-empty USER_MEM_ARGS environment variable prevents MEM_ARGS
+# from being specified in the common WebLogic environment scripts in the WebLogic
+# installation.  NOTE: Specifying USER_MEM_ARGS with ' ' (not empty string)
+# prevents WLS from caluculating default values (see commBaseEnv.sh)
+trace "startNodeManager.sh USER_MEM_ARGS='${USER_MEM_ARGS}'"
+USER_MEM_ARGS=" "
+export USER_MEM_ARGS
+
+# NODEMGR_MEM_ARGS and NODEMGR_JAVA_OPTIONS are exported to Node Manager as JAVA_OPTIONS
+# environment variable.
+trace "post startNodeManager.sh USER_MEM_ARGS='${USER_MEM_ARGS}'"
+export JAVA_OPTIONS="${NODEMGR_MEM_ARGS} ${NODEMGR_JAVA_OPTIONS} -Dweblogic.RootDirectory=${DOMAIN_HOME}"
+trace "post-startNodeManager.sh JAVA_OPTIONS='${JAVA_OPTIONS}'"
 
 ###############################################################################
 #

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -750,13 +750,13 @@ function checkFileStores() {
 
 function checkNodeManagerMemArg() {
 
+  trace "Verifying node manager memory arguments"
+
   # Verify that NODEMGR_MEM_ARGS environment value was applied to the Node Manager command line
   linecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
        grep "\-Xms64m -Xmx100m" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
        | grep -v "NODEMGR_MEM_ARGS"  | wc -l`"
   logstatus=0
-
-  trace "linecount: $linecount"
 
   if [ "$linecount" != "1" ]; then
     trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 1 line that match ' grep '-Xms64m -Xmx100m' ', this probably means that it's reporting NODEMGR_MEM_ARGS not applied"
@@ -772,8 +772,6 @@ function checkNodeManagerMemArg() {
        grep "MaxRAMFraction=1" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
        | grep -v "JAVA_OPTIONS" | wc -l`"
   logstatus=0
-
-  trace "maxRamlinecount: $maxRamlinecount"
 
   if [ "$maxRamlinecount" != "0" ]; then
     trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 0 lines that match ' grep 'MaxRAMFraction=1' ', this probably means that it's reporting USER_MEM_ARGS was applied"
@@ -792,13 +790,13 @@ function checkNodeManagerMemArg() {
 #
 function checkManagedServer1MemArg() {
 
+  trace "Verifying managed server memory arguments"
+
   # Verify that USER_MEM_ARGS environment value was applied to the Managed Server 1 command line
   maxRamlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
        grep "MaxRAMFraction=1"  /shared/logs/${MANAGED_SERVER_NAME_BASE?}1.out \
        | grep -v "JAVA_OPTIONS" | wc -l`"
   logstatus=0
-
-  trace "maxRamlinecount: $maxRamlinecount"
 
   if [ "$maxRamlinecount" != "1" ]; then
     trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 1 line that match ' grep 'MaxRAMFraction=1' ', this probably means that it's reporting USER_MEM_ARGS not applied"
@@ -814,8 +812,6 @@ function checkManagedServer1MemArg() {
        grep "\-Xms64m -Xmx100m" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1.out \
        | grep -v "NODEMGR_MEM_ARGS"  | wc -l`"
   logstatus=0
-
-  trace "linecount: $linecount"
 
   if [ "$linecount" != "0" ]; then
     trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 0 lines that match ' grep '-Xms64m -Xmx100m' ', this probably means that it's reporting NODEMGR_MEM_ARGS was applied"
@@ -835,13 +831,13 @@ function checkManagedServer1MemArg() {
 
 function checkNodeManagerJavaOptions() {
 
+  trace "Verifying node manager java options"
+
   # Verify that NODEMGR_JAVA_OPTIONS environment value was applied to the Node Manager command line
   nodeMgrlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
        grep "\-Dnodemgr.java.options" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
        | grep -v "NODEMGR_JAVA_OPTIONS"  | wc -l`"
   logstatus=0
-
-  trace "nodeMgrlinecount: $nodeMgrlinecount"
 
   if [ "$nodeMgrlinecount" != "1" ]; then
     trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 1 line that match ' grep '-Dnodemgr.java.options' ', this probably means that it's reporting NODEMGR_JAVA_OPTIONS not applied"
@@ -857,8 +853,6 @@ function checkNodeManagerJavaOptions() {
        grep "\-Dnodemgr.java.options" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1.out \
        | grep -v "NODEMGR_JAVA_OPTIONS" | wc -l`"
   logstatus=0
-
-  trace "nmJavaOptlinecount: $nmJavaOptlinecount"
 
   if [ "$nmJavaOptlinecount" != "0" ]; then
     trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 0 lines that match ' grep 'M-Dnodemgr.java.options' ', this probably means that it's reporting NODEMGR_JAVA_OPTIONS was applied"

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -742,6 +742,134 @@ function checkFileStores() {
   fi
 }
 
+#############################################################################
+#
+# Validate NODEMGR_MEM_ARGS environment variable values (-Xms64m -Xmx100m)
+# applied to Node Manager command line.
+#
+
+function checkNodeManagerMemArg() {
+
+  # Verify that NODEMGR_MEM_ARGS environment value was applied to the Node Manager command line
+  linecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "\-Xms64m -Xmx100m" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
+       | grep -v "NODEMGR_MEM_ARGS"  | wc -l`"
+  logstatus=0
+
+  trace "linecount: $linecount"
+
+  if [ "$linecount" != "1" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 1 line that match ' grep '-Xms64m -Xmx100m' ', this probably means that it's reporting NODEMGR_MEM_ARGS not applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+
+  # Verify that USER_MEM_ARGS environment value did not get applied to the Node Manager command line
+  maxRamlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "MaxRAMFraction=1" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
+       | grep -v "JAVA_OPTIONS" | wc -l`"
+  logstatus=0
+
+  trace "maxRamlinecount: $maxRamlinecount"
+
+  if [ "$maxRamlinecount" != "0" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 0 lines that match ' grep 'MaxRAMFraction=1' ', this probably means that it's reporting USER_MEM_ARGS was applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+}
+
+#############################################################################
+#
+# Validate USER_MEM_ARGS environment variable values (-MaxRAMFraction)
+# applied to Managed Server command line.
+#
+function checkManagedServer1MemArg() {
+
+  # Verify that USER_MEM_ARGS environment value was applied to the Managed Server 1 command line
+  maxRamlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "MaxRAMFraction=1"  /shared/logs/${MANAGED_SERVER_NAME_BASE?}1.out \
+       | grep -v "JAVA_OPTIONS" | wc -l`"
+  logstatus=0
+
+  trace "maxRamlinecount: $maxRamlinecount"
+
+  if [ "$maxRamlinecount" != "1" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 1 line that match ' grep 'MaxRAMFraction=1' ', this probably means that it's reporting USER_MEM_ARGS not applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+
+  # Verify that USER_MEM_ARGS environment value did not get applied to the Node Manager command line
+  linecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "\-Xms64m -Xmx100m" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1.out \
+       | grep -v "NODEMGR_MEM_ARGS"  | wc -l`"
+  logstatus=0
+
+  trace "linecount: $linecount"
+
+  if [ "$linecount" != "0" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 0 lines that match ' grep '-Xms64m -Xmx100m' ', this probably means that it's reporting NODEMGR_MEM_ARGS was applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+}
+
+#############################################################################
+#
+# Validate NODEMGR_JAVA_OPTIONS environment variable values (-Dnodemgr.java.options)
+# applied to Node Manager command line.
+#
+
+function checkNodeManagerJavaOptions() {
+
+  # Verify that NODEMGR_JAVA_OPTIONS environment value was applied to the Node Manager command line
+  nodeMgrlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "\-Dnodemgr.java.options" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
+       | grep -v "NODEMGR_JAVA_OPTIONS"  | wc -l`"
+  logstatus=0
+
+  trace "nodeMgrlinecount: $nodeMgrlinecount"
+
+  if [ "$nodeMgrlinecount" != "1" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 1 line that match ' grep '-Dnodemgr.java.options' ', this probably means that it's reporting NODEMGR_JAVA_OPTIONS not applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+
+  # Verify that NODEMGR_JAVA_OPTIONS environment value did not get applied to the Managed Server command line
+  nmJavaOptlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "\-Dnodemgr.java.options" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1.out \
+       | grep -v "NODEMGR_JAVA_OPTIONS" | wc -l`"
+  logstatus=0
+
+  trace "nmJavaOptlinecount: $nmJavaOptlinecount"
+
+  if [ "$nmJavaOptlinecount" != "0" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1' does not contain exactly 0 lines that match ' grep 'M-Dnodemgr.java.options' ', this probably means that it's reporting NODEMGR_JAVA_OPTIONS was applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+}
+
 
 #############################################################################
 #
@@ -810,5 +938,14 @@ checkFileStores util_test_adminfilestores.sh ${ADMIN_NAME}
 
 # Verify default file store was created for managed-server1
 checkFileStores util_test_ms1filestores.sh ${MANAGED_SERVER_NAME_BASE?}1
+
+# Verify node manager memory args
+checkNodeManagerMemArg
+
+# Verify Managed Server memory args
+checkManagedServer1MemArg
+
+# Verify node manager java options
+checkNodeManagerJavaOptions
 
 trace "Info: Success!"

--- a/src/integration-tests/introspector/wl-introspect-pod.yamlt
+++ b/src/integration-tests/introspector/wl-introspect-pod.yamlt
@@ -17,6 +17,12 @@ spec:
     env:
     - name: JAVA_OPTIONS
       value: "-Djava.security.egd=file:/dev/./urandom "
+    - name: USER_MEM_ARGS
+      value: "-XX:MaxRAMFraction=1 -XX:+UseContainerSupport "
+    - name: NODEMGR_JAVA_OPTIONS
+      value: "-Dnodemgr.java.options -Djava.security.egd=file:/dev/./urandom "
+    - name: NODEMGR_MEM_ARGS
+      value: "-Xms64m -Xmx100m -XX:+UseContainerSupport "
     - name: NAMESPACE
       value: "${NAMESPACE}"
     - name: DOMAIN_UID

--- a/src/integration-tests/introspector/wl-introspect-pod.yamlt
+++ b/src/integration-tests/introspector/wl-introspect-pod.yamlt
@@ -17,12 +17,6 @@ spec:
     env:
     - name: JAVA_OPTIONS
       value: "-Djava.security.egd=file:/dev/./urandom "
-    - name: USER_MEM_ARGS
-      value: "-XX:MaxRAMFraction=1 -XX:+UseContainerSupport "
-    - name: NODEMGR_JAVA_OPTIONS
-      value: "-Dnodemgr.java.options -Djava.security.egd=file:/dev/./urandom "
-    - name: NODEMGR_MEM_ARGS
-      value: "-Xms64m -Xmx100m -XX:+UseContainerSupport "
     - name: NAMESPACE
       value: "${NAMESPACE}"
     - name: DOMAIN_UID

--- a/src/integration-tests/introspector/wl-pod.yamlt
+++ b/src/integration-tests/introspector/wl-pod.yamlt
@@ -20,11 +20,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Djava.security.egd=file:/dev/./urandom "
     - name: USER_MEM_ARGS
-      value: "-XX:MaxRAMFraction=1 -XX:+UseContainerSupport "
+      value: "-XX:MaxRAMFraction=1 "
     - name: NODEMGR_JAVA_OPTIONS
       value: "-Dnodemgr.java.options -Djava.security.egd=file:/dev/./urandom "
     - name: NODEMGR_MEM_ARGS
-      value: "-Xms64m -Xmx100m -XX:+UseContainerSupport "
+      value: "${NODEMGR_MEM_ARGS}"
     - name: DOMAIN_NAME
       value: "${DOMAIN_NAME}"
     - name: DOMAIN_HOME

--- a/src/integration-tests/introspector/wl-pod.yamlt
+++ b/src/integration-tests/introspector/wl-pod.yamlt
@@ -19,6 +19,12 @@ spec:
     env:
     - name: JAVA_OPTIONS
       value: "-Djava.security.egd=file:/dev/./urandom "
+    - name: USER_MEM_ARGS
+      value: "-XX:MaxRAMFraction=1 -XX:+UseContainerSupport "
+    - name: NODEMGR_JAVA_OPTIONS
+      value: "-Dnodemgr.java.options -Djava.security.egd=file:/dev/./urandom "
+    - name: NODEMGR_MEM_ARGS
+      value: "-Xms64m -Xmx100m -XX:+UseContainerSupport "
     - name: DOMAIN_NAME
       value: "${DOMAIN_NAME}"
     - name: DOMAIN_HOME


### PR DESCRIPTION
To separate JVM arguments (memory and java options) for WLS managed server instances and the node manager instance, the following environment variables can be used:

- JAVA_OPTIONS - Java options for starting WL server
- USER_MEM_ARGS - JVM mem args for starting WL server
- NODEMGR_JAVA_OPTIONS - Java options for starting Node Manager instance
- NODEMGR_MEM_ARGS - JVM mem args for starting Node Manager instance

The following behavior occurs depending on whether or not NODEMGR_JAVA_OPTIONS and NODEMGR_MEM_ARGS is defined:

- If NODEMGR_JAVA_OPTIONS is not defined then any values defined for JAVA_OPTIONS are applied to the Node Manager instance.  
- If NODEMGR_MEM_ARGS is not defined then default ("-Xms64m -Xmx100m") values are applied.

To apply the defined NODEMGR_MEM_ARGS to the node manager instance, the memory argument values are pre-prepended to the JAVA_OPTIONS environment variable that are used on the command line for starting the node manager.  The same process is used when applying the defined USER_MEM_ARGS to the WLS managed server instance.  USER_MEM_ARGS values are pre-prepended to the JAVA_OPTIONS environment variable that are used on the command line for starting the managed server instance.

For example, if the following environment variables are defined in the CRD:

env:
    - name: JAVA_OPTIONS
      value: "-Dweblogic.StdoutDebugEnabled=false "
    - name: USER_MEM_ARGS
      value: "-XX:MaxRAMFraction=1 -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
    - name: NODEMGR_JAVA_OPTIONS
      value: "-Dweblogic.StdoutDebugEnabled=false -Dnodemgr.java.options "
    - name: NODEMGR_MEM_ARGS
      value: "-Xms64m -Xmx100m -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "

The Node Manager will be started with the following command line:

/usr/java/default/bin/java -DLogFile=/shared/logs/sample-domain1/managed-server1_nodemanager.log -DNodeManagerHome=/u01/nodemanager/sample-domain1/managed-server1 -server -Djdk.tls.ephemeralDHKeySize=2048 -Dcoherence.home=/u01/oracle/wlserver/../coherence -Dbea.home=/u01/oracle/wlserver/.. -**Xms64m -Xmx100m -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -Dweblogic.StdoutDebugEnabled=false -Dnodemgr.java.options** -Dweblogic.RootDirectory=/shared/domains/sample-domain1 -Djava.system.class.loader=com.oracle.classloader.weblogic.LaunchClassLoader -Djava.security.policy=/u01/oracle/wlserver/server/lib/weblogic.policy -Dweblogic.nodemanager.JavaHome=/usr/java/default weblogic.NodeManager -v

The Managed server instance will be started the following command line:

Starting WLS with line:
/usr/java/jdk1.8.0_192/bin/java -server     -cp /u01/oracle/wlserver/server/lib/weblogic-launcher.jar -Dlaunch.use.env.classpath=true -Dweblogic.Name=managed-server1 -Djava.security.policy=/u01/oracle/wlserver/server/lib/weblogic.policy -Dweblogic.system.BootIdentityFile=/shared/domains/sample-domain1/servers/managed-server1/security/boot.properties -Dweblogic.nodemanager.ServiceEnabled=true -Dweblogic.nmservice.RotationEnabled=true **-XX:MaxRAMFraction=1 -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom**   -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dweblogic.SituationalConfig.failBootOnError=true -Dweblogic.Stdout=/shared/logs/sample-domain1/managed-server1.out -Dweblogic.StdoutDebugEnabled=false -Djava.system.class.loader=com.oracle.classloader.weblogic.LaunchClassLoader  -javaagent:/u01/oracle/wlserver/server/lib/debugpatch-agent.jar -da -Dwls.home=/u01/oracle/wlserver/server -Dweblogic.home=/u01/oracle/wlserver/server   -Dweblogic.management.server=http://sample-domain1-admin-server:7001   weblogic.Server

Tests for the above feature using environment variables were added to the introspector integration test.