### PR TITLE
add Traefik notice

### DIFF
--- a/docs-source/content/samples/simple/ingress/_index.md
+++ b/docs-source/content/samples/simple/ingress/_index.md
@@ -9,6 +9,8 @@ description: "Load balancer sample scripts."
 The Oracle WebLogic Server Kubernetes Operator supports three load balancers: Traefik, Voyager, and Apache. We provide samples that demonstrate how to install and configure each one. The samples are located in following folders:
 
 * [traefik](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/traefik/README.md)
+_Traefik is recommended for development and test environments only.  For production environments, we recommend Apache or Voyager Ingress controllers, or the load balancer provided by your cloud provider._
+
 * [voyager](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/voyager/README.md)
 * apache-samples/[custom-sample](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/apache-samples/custom-sample/README.md)
 * apache-samples/[default-sample](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/apache-samples/default-sample/README.md)

--- a/docs-source/content/userguide/managing-domains/ingress/_index.md
+++ b/docs-source/content/userguide/managing-domains/ingress/_index.md
@@ -70,6 +70,10 @@ Information about how to install and configure these to load balance WebLogic cl
  - [Traefik guide](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/traefik/README.md)
  - [Voyager guide](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/voyager/README.md)
 
+ {{% notice note %}}
+ Traefik is recommended for development and test environments only.  For production environments, we recommend Apache or Voyager Ingress controllers, or the load balancer provided by your cloud provider.
+ {{% /notice %}}
+
 Samples are also provided for these two Ingress controllers, showing how to manage multiple WebLogic clusters as the backends, using different routing rules, host-routing and path-routing; and TLS termination:
 
 - [Traefik samples](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/traefik/samples)


### PR DESCRIPTION
I did not put the Traefik notice in the Quick Start guide because it is a declared walk-through for demonstration purposes only. However, if you want me to put it there also, I will.