### PR TITLE
add FAQs for mapping PVC and ConfigMap to instances

### DIFF
--- a/docs-source/content/faq/configmaps.md
+++ b/docs-source/content/faq/configmaps.md
@@ -37,7 +37,7 @@ in your [domain resource](https://github.com/oracle/weblogic-kubernetes-operator
 
 ```
 This provides access to two files, found at paths `/weblogic-operator/my/first` and `/weblogic-operator/my/second`. 
-Both a volume and a volumeMount entry are required, and must have the same name. The name of the ConfigMap is 
+Both a `volume` and a `volumeMount` entry are required, and must have the same name. The name of the `ConfigMap` is 
 specified in the `name` field under the `configMap` entry. The `items` entry is an array,
-in which each entry maps a ConfigMap key to a file name under the directory specified as `mountPath` under a volumeMount.
+in which each entry maps a `ConfigMap` key to a file name under the directory specified as `mountPath` under a `volumeMount`.
 

--- a/docs-source/content/faq/configmaps.md
+++ b/docs-source/content/faq/configmaps.md
@@ -1,0 +1,33 @@
+> I need to provide an instance with access to a Config Map
+
+Configuration information in Kubernetes may be provided by a 
+[ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#create-a-configmap), 
+which consists of a set of key-value pairs. Each entry may be accessed by one or more operator-managed nodes
+as a read-only text file. Access can be provided across the domain, within a single cluster, or for a single server.
+In each case, the access is configured within the ``ServerPod`` element of the configuration. For example, given
+a ConfigMap named `my-map` with entries `key-1` and `key-2`, you can provide access to both values as separate files
+in the same directory within the `cluster-1` cluster with the following: 
+
+```
+  clusters:
+  - clusterName: cluster-1
+    serverPod:
+      volumes:
+      - name: my-volume-1
+        configMap:
+          name: my-map
+          items: 
+          - key: key-1
+            path: first
+          - key: key-2
+            path: second
+      volumeMounts:
+      - name: my-volume-1
+        mountPath: /weblogic-operator/my
+
+```
+This provides access to two files, found at paths `/weblogic-operator/my/first` and `/weblogic-operator/my/second`. 
+Both a volume and a volumeMount entry are required, and must have the same name. The name of the ConfigMap is 
+specified in the `name` field under the `configMap` entry. The `items` entry is an array,
+in which each entry maps a ConfigMap key to a file name under the directory specified as `mountPath` under a volumeMount.
+

--- a/docs-source/content/faq/configmaps.md
+++ b/docs-source/content/faq/configmaps.md
@@ -1,12 +1,22 @@
-> I need to provide an instance with access to a Config Map
+---
+title: "Providing access to a Config Map"
+date: 2020-01-07T15:02:28-05:00
+draft: false
+weight: 11
+---
+> I need to provide an instance with access to a Config Map.
 
-Configuration information in Kubernetes may be provided by a 
+Configuration files can be supplied to Kubernetes pods and jobs by a 
 [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#create-a-configmap), 
 which consists of a set of key-value pairs. Each entry may be accessed by one or more operator-managed nodes
 as a read-only text file. Access can be provided across the domain, within a single cluster, or for a single server.
-In each case, the access is configured within the ``ServerPod`` element of the configuration. For example, given
+In each case, the access is configured within the `serverPod` element of the desired scope. 
+
+For example, given
 a ConfigMap named `my-map` with entries `key-1` and `key-2`, you can provide access to both values as separate files
-in the same directory within the `cluster-1` cluster with the following: 
+in the same directory within the `cluster-1` cluster with the following
+in your [domain resource](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/docs/domains/Domain.md):
+ 
 
 ```
   clusters:

--- a/docs-source/content/faq/volumes.md
+++ b/docs-source/content/faq/volumes.md
@@ -1,11 +1,20 @@
-> I need to provide an instance with access to a Persistent Volume Claim
+---
+title: "Providing access to a Persistent Volume Claim"
+date: 2020-01-07T15:02:28-05:00
+draft: false
+weight: 10
+---
+> I need to provide an instance with access to a Persistent Volume Claim.
 
 Some applications need access to a file, either to read data or to provide additional logging beyond what is 
 built into the operator. One common way of doing that within Kubernetes is to create a 
 [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) (PVC) and map
 it to a file. The domain configuration can then be used to provide access to the claim across the domain, 
 within a single cluster, or for a single server.
-In each case, the access is configured within the ``ServerPod`` element of the configuration. For example, here is
+In each case, the access is configured within the ``serverPod`` element of the configuration of the
+desired scope. 
+
+For example, here is
 a read-only PersistentVolumeClaim specification. Note that its name is `myclaim`.
 
 ```
@@ -23,7 +32,8 @@ spec:
   storageClassName: slow
 ```
 
-To provide access to this claim within the `cluster-1` cluster, specify 
+To provide access to this claim to all managed servers in the `cluster-1` cluster, specify the following 
+in your [domain resource](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/docs/domains/Domain.md):
 
 ```
   clusters:
@@ -38,12 +48,9 @@ To provide access to this claim within the `cluster-1` cluster, specify
         mountPath: /weblogic-operator/my/volume1
 
 ``` 
-Note the use of the claim name in the `claimName` field of the `volume` entry. Both a volume and a 
-volumeMount entry are required, and must have the same name. The volume entry associates that name with the claim,
-while the volumeMount entry defines the path to it that the application can use to access the file.
+Note the use of the claim name in the `claimName` field of the `volume` entry. Both a `volume` and a 
+`volumeMount` entry are required, and must have the same name. The `volume` entry associates that name with the claim,
+while the `volumeMount` entry defines the path to it that the application can use to access the file.
 
-NOTE: if the PVC is mapped either across the domain or to a cluster, 
+NOTE: If the PVC is mapped either across the domain or to a cluster, 
 its access mode must be either `ReadOnlyMany` or `ReadWriteMany`.
-
-[ConfigMaps](https://kubernetes.io/docs/concepts/storage/volumes/#configmap). In both cases, all you need
-is the name of the corresponding Kubernetes resource.

--- a/docs-source/content/faq/volumes.md
+++ b/docs-source/content/faq/volumes.md
@@ -1,0 +1,49 @@
+> I need to provide an instance with access to a Persistent Volume Claim
+
+Some applications need access to a file, either to read data or to provide additional logging beyond what is 
+built into the operator. One common way of doing that within Kubernetes is to create a 
+[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) (PVC) and map
+it to a file. The domain configuration can then be used to provide access to the claim across the domain, 
+within a single cluster, or for a single server.
+In each case, the access is configured within the ``ServerPod`` element of the configuration. For example, here is
+a read-only PersistentVolumeClaim specification. Note that its name is `myclaim`.
+
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: myclaim
+spec:
+  accessModes:
+    - ReadOnlyMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: slow
+```
+
+To provide access to this claim within the `cluster-1` cluster, specify 
+
+```
+  clusters:
+  - clusterName: cluster-1
+    serverPod:
+      volumes:
+      - name: my-volume-1
+        persistentVolumeClaim:
+          claimName: myclaim
+      volumeMounts:
+      - name: my-volume-1
+        mountPath: /weblogic-operator/my/volume1
+
+``` 
+Note the use of the claim name in the `claimName` field of the `volume` entry. Both a volume and a 
+volumeMount entry are required, and must have the same name. The volume entry associates that name with the claim,
+while the volumeMount entry defines the path to it that the application can use to access the file.
+
+NOTE: if the PVC is mapped either across the domain or to a cluster, 
+its access mode must be either `ReadOnlyMany` or `ReadWriteMany`.
+
+[ConfigMaps](https://kubernetes.io/docs/concepts/storage/volumes/#configmap). In both cases, all you need
+is the name of the corresponding Kubernetes resource.

--- a/docs-source/content/faq/volumes.md
+++ b/docs-source/content/faq/volumes.md
@@ -15,7 +15,7 @@ In each case, the access is configured within the ``serverPod`` element of the c
 desired scope. 
 
 For example, here is
-a read-only PersistentVolumeClaim specification. Note that its name is `myclaim`.
+a read-only `PersistentVolumeClaim` specification. Note that its name is `myclaim`.
 
 ```
 apiVersion: v1


### PR DESCRIPTION
Added FAQ entries to explain how to add per-server persistent volume claims and config maps.

I could not find information on what is actually required to get the new entries added to the index page, or the reason for the headers on other such pages that include dates and weight. Is that documented somewhere?

Note: this requires creating both a volume and a volumeMount entry. If we aren't attempting to support the full range of persistent volumes, but only these two, we might consider simplifying to a single entry. As it is, we should add some validations, including the existing of a matching volume for every volume mount, and possibly also some validation that the specified resource (PVC or ConfigMap) actually exists.