### PR TITLE
Nm mem args

### DIFF
--- a/docs-source/content/userguide/managing-domains/domain-resource.md
+++ b/docs-source/content/userguide/managing-domains/domain-resource.md
@@ -116,8 +116,9 @@ Note: The `USER_MEM_ARGS` environment variable defaults to `-Djava.security.egd=
 The following behavior occurs depending on whether or not `NODEMGR_JAVA_OPTIONS` and `NODEMGR_MEM_ARGS` are defined:
 
 * If `NODEMGR_JAVA_OPTIONS` is not defined and `JAVA_OPTIONS` is defined, then the `JAVA_OPTIONS` value will be applied to the Node Manager instance.
-* If `NODEMGR_MEM_ARGS` is not defined, then default memory values (-Xms64m -Xmx100m) will be applied to the Node Manager instance.
-* If `NODEMGR_MEM_ARGS` environment variable does not define `-Djava.security.egd=file:/dev/./urandom` security property then it will be added in order to speed up Node Manager startup.
+* If `NODEMGR_MEM_ARGS` is not defined, then default memory and Java security property values (`-Xms64m -Xmx100m -Djava.security.egd=file:/dev/./urandom`) will be applied to the Node Manager instance. It can be explicitly set to another value in your domain resource YAML file using the `env` attribute under the `serverPod` configuration.
+
+Note: Defining `-Djava.security.egd=file:/dev/./urandom` in the `NODEMGR_MEM_ARGS` environment variable helps to speed up the Node Manager startup on systems with low entropy.
 
 This example snippet illustrates how to add the above environment variables using the `env` attribute under the `serverPod` configuration in your domain resource YAML file. 
 ```

--- a/docs-source/content/userguide/managing-domains/domain-resource.md
+++ b/docs-source/content/userguide/managing-domains/domain-resource.md
@@ -117,6 +117,7 @@ The following behavior occurs depending on whether or not `NODEMGR_JAVA_OPTIONS`
 
 * If `NODEMGR_JAVA_OPTIONS` is not defined and `JAVA_OPTIONS` is defined, then the `JAVA_OPTIONS` value will be applied to the Node Manager instance.
 * If `NODEMGR_MEM_ARGS` is not defined, then default memory values (-Xms64m -Xmx100m) will be applied to the Node Manager instance.
+* If `NODEMGR_MEM_ARGS` environment variable does not define `-Djava.security.egd=file:/dev/./urandom` security property then it will be added in order to speed up Node Manager startup.
 
 This example snippet illustrates how to add the above environment variables using the `env` attribute under the `serverPod` configuration in your domain resource YAML file. 
 ```

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -296,14 +296,7 @@ fi
 
 if [ -z "${NODEMGR_MEM_ARGS}" ]; then
   # Default JVM memory arguments for Node Manager
-  NODEMGR_MEM_ARGS="-Xms64m -Xmx100m"
-fi
-
-# If not already defined, set 'java.security.egd' option to /dev/urandom for
-# Node Manager JVM for low entropy.  Speeds up boot process of Node Manager.
-if [[ ! "${NODEMGR_MEM_ARGS}" =~ .*urandom* ]]
-then
-  NODEMGR_MEM_ARGS="${NODEMGR_MEM_ARGS} -Djava.security.egd=file:/dev/./urandom "
+  NODEMGR_MEM_ARGS="-Xms64m -Xmx100m -Djava.security.egd=file:/dev/./urandom "
 fi
 
 # We prevent USER_MEM_ARGS from being applied to the NM here and only pass

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -299,6 +299,13 @@ if [ -z "${NODEMGR_MEM_ARGS}" ]; then
   NODEMGR_MEM_ARGS="-Xms64m -Xmx100m"
 fi
 
+# If not already defined, set 'java.security.egd' option to /dev/urandom for
+# Node Manager JVM for low entropy.  Speeds up boot process of Node Manager.
+if [[ ! "${NODEMGR_MEM_ARGS}" =~ .*urandom* ]]
+then
+  NODEMGR_MEM_ARGS="${NODEMGR_MEM_ARGS} -Djava.security.egd=file:/dev/./urandom "
+fi
+
 # We prevent USER_MEM_ARGS from being applied to the NM here and only pass
 # USER_MEM_ARGS to WL Servers via the WL Server startup properties file above.
 # This is so that WL Servers and NM can have different tuning. Use NODEMGR_MEM_ARGS or

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -522,7 +522,7 @@ function deployPod() {
       export LOCAL_SERVER_DEFAULT_PORT=$ADMIN_PORT
       export KEEP_DEFAULT_DATA_HOME="true"
       export EXPERIMENTAL_LINK_SERVER_DEFAULT_DATA_DIR=""
-      export NODEMGR_MEM_ARGS="-Xms32m -Xmx200m "
+      export NODEMGR_MEM_ARGS="-Xms32m -Xmx200m -Djava.security.egd=file:/dev/./urandom"
     else
       export LOCAL_SERVER_DEFAULT_PORT=$MANAGED_SERVER_PORT
       export KEEP_DEFAULT_DATA_HOME=""
@@ -787,9 +787,9 @@ function checkNodeManagerMemArg() {
   fi
 
   # Verify that NODEMGR_MEM_ARGS environment value contains "-Djava.security.egd=file:/dev/./urandom" in the Node Manager
-  # command line of the Admin Server pod.
+  # command line of the Managed Server pod.
   adminLinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
-       grep "urandom" /shared/logs/${ADMIN_NAME?}_nodemanager.out \
+       grep "urandom" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \
        | grep -v "NODEMGR_MEM_ARGS"  |  grep -v "JAVA_OPTIONS" | wc -l`"
   logstatus=0
 

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -786,6 +786,22 @@ function checkNodeManagerMemArg() {
     exit 1
   fi
 
+  # Verify that NODEMGR_MEM_ARGS environment value contains "-Djava.security.egd=file:/dev/./urandom" in the Node Manager
+  # command line of the Admin Server pod.
+  adminLinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
+       grep "urandom" /shared/logs/${ADMIN_NAME?}_nodemanager.out \
+       | grep -v "NODEMGR_MEM_ARGS"  |  grep -v "JAVA_OPTIONS" | wc -l`"
+  logstatus=0
+
+  if [ "$adminLinecount" != "1" ]; then
+    trace "Error: The latest log from 'kubectl -n ${NAMESPACE} logs ${DOMAIN_UID}-${ADMIN-NAME?}' does not contain exactly 1 line that match ' grep '-Djava.security.egd=file:/dev/./urandom' ', this probably means that it's reporting NODEMGR_MEM_ARGS not applied"
+    logstatus=1
+  fi
+
+  if [ $logstatus -ne 0 ]; then
+    exit 1
+  fi
+
   # Verify that USER_MEM_ARGS environment value did not get applied to the Node Manager command line
   maxRamlinecount="`kubectl exec -it -n ${NAMESPACE} ${DOMAIN_UID}-${MANAGED_SERVER_NAME_BASE?}1 \
        grep "MaxRAMFraction=1" /shared/logs/${MANAGED_SERVER_NAME_BASE?}1_nodemanager.out \

--- a/src/integration-tests/introspector/wl-pod.yamlt
+++ b/src/integration-tests/introspector/wl-pod.yamlt
@@ -22,7 +22,7 @@ spec:
     - name: USER_MEM_ARGS
       value: "-XX:MaxRAMFraction=1 "
     - name: NODEMGR_JAVA_OPTIONS
-      value: "-Dnodemgr.java.options -Djava.security.egd=file:/dev/./urandom "
+      value: "-Dnodemgr.java.options"
     - name: NODEMGR_MEM_ARGS
       value: "${NODEMGR_MEM_ARGS}"
     - name: DOMAIN_NAME


### PR DESCRIPTION
NM_MEM_ARGS environment variable will, by default, include the java security property '-Djava.security.egd=file:/dev/./urandom', if not already defined.  This is to help speed up the Node Manager startup, especially when the system has low entropy.   Also updated 'Domain Resource' section of user guide documentation to include defaulting information about 'NODEMGR_MEM_ARGS' environment variable.

