### PR TITLE
Make getAdminService idempotent

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -166,9 +166,7 @@ public class DomainStatusUpdater {
     @Override
     public NextAction apply(Packet packet) {
       DomainStatusUpdaterContext context = createContext(packet);
-
       DomainStatus newStatus = context.getNewStatus();
-      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomainUid(), newStatus);
 
       return context.isStatusChanged(newStatus)
             ? doNext(packet)
@@ -178,6 +176,7 @@ public class DomainStatusUpdater {
     private Step createDomainStatusPatchStep(DomainStatusUpdaterContext context, DomainStatus newStatus) {
       JsonPatchBuilder builder = Json.createPatchBuilder();
       newStatus.createPatchFrom(builder, context.getStatus());
+      LOGGER.info(MessageKeys.DOMAIN_STATUS, context.getDomainUid(), newStatus);
 
       return new CallBuilder().patchDomainAsync(
             context.getDomainName(),

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -835,12 +835,12 @@ public class ServiceHelper {
 
     @Override
     Map<String, String> getServiceLabels() {
-      return getAdminService().map(AdminService::getLabels).orElse(Collections.emptyMap());
+      return getNullableAdminService().map(AdminService::getLabels).orElse(Collections.emptyMap());
     }
 
     @Override
     Map<String, String> getServiceAnnotations() {
-      return getAdminService().map(AdminService::getAnnotations).orElse(Collections.emptyMap());
+      return getNullableAdminService().map(AdminService::getAnnotations).orElse(Collections.emptyMap());
     }
 
     @Override
@@ -873,10 +873,10 @@ public class ServiceHelper {
     }
 
     private Channel getChannel(String channelName) {
-      return getAdminService().map(a -> a.getChannel(channelName)).orElse(null);
+      return getNullableAdminService().map(a -> a.getChannel(channelName)).orElse(null);
     }
 
-    private Optional<AdminService> getAdminService() {
+    private Optional<AdminService> getNullableAdminService() {
       return Optional.ofNullable(getDomain().getAdminServerSpec())
           .map(AdminServerSpec::getAdminService);
     }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/AdminServer.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/AdminServer.java
@@ -97,8 +97,12 @@ public class AdminServer extends Server {
         .toHashCode();
   }
 
-  public AdminService getAdminService() {
+  public AdminService createAdminService() {
     if (adminService == null) adminService = new AdminService();
+    return adminService;
+  }
+
+  public AdminService getAdminService() {
     return adminService;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
@@ -300,7 +300,7 @@ public class DomainCommonConfigurator extends DomainConfigurator {
 
     @Override
     public AdminService configureAdminService() {
-      return adminServer.getAdminService();
+      return adminServer.createAdminService();
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -101,6 +101,8 @@ public class DomainStatus {
    * @return this object.
    */
   public DomainStatus addCondition(DomainCondition newCondition) {
+    if (conditions.contains(newCondition)) return this;
+
     conditions = conditions.stream().filter(c -> preserve(c, newCondition.getType())).collect(Collectors.toList());
 
     conditions.add(newCondition);

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/AdminServerTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/AdminServerTest.java
@@ -106,16 +106,16 @@ public class AdminServerTest extends BaseConfigurationTestBase {
 
   @Test
   public void whenHaveSameAdminServiceChannels_objectsAreEqual() {
-    server1.getAdminService().withChannel(CHANNEL1, PORT1).withChannel(CHANNEL2, PORT2);
-    server2.getAdminService().withChannel(CHANNEL2, PORT2).withChannel(CHANNEL1, PORT1);
+    server1.createAdminService().withChannel(CHANNEL1, PORT1).withChannel(CHANNEL2, PORT2);
+    server2.createAdminService().withChannel(CHANNEL2, PORT2).withChannel(CHANNEL1, PORT1);
 
     assertThat(server1, equalTo(server2));
   }
 
   @Test
   public void whenHaveDifferentAdminServiceChannels_objectsAreNotEqual() {
-    server1.getAdminService().withChannel(CHANNEL1, PORT1).withChannel(CHANNEL2, PORT2);
-    server2.getAdminService().withChannel(CHANNEL1, PORT2).withChannel(CHANNEL2, PORT1);
+    server1.createAdminService().withChannel(CHANNEL1, PORT1).withChannel(CHANNEL2, PORT2);
+    server2.createAdminService().withChannel(CHANNEL1, PORT2).withChannel(CHANNEL2, PORT1);
 
     assertThat(server1, not(equalTo(server2)));
   }
@@ -134,16 +134,16 @@ public class AdminServerTest extends BaseConfigurationTestBase {
 
   @Test
   public void whenHaveSameAdminServiceLabels_objectsAreEqual() {
-    server1.getAdminService().withServiceLabel(NAME1, VALUE1).withServiceLabel(NAME2, VALUE2);
-    server2.getAdminService().withServiceLabel(NAME2, VALUE2).withServiceLabel(NAME1, VALUE1);
+    server1.createAdminService().withServiceLabel(NAME1, VALUE1).withServiceLabel(NAME2, VALUE2);
+    server2.createAdminService().withServiceLabel(NAME2, VALUE2).withServiceLabel(NAME1, VALUE1);
 
     assertThat(server1, equalTo(server2));
   }
 
   @Test
   public void whenHaveDifferentAdminServiceLabels_objectsAreNotEqual() {
-    server1.getAdminService().withServiceLabel(NAME1, VALUE1).withServiceLabel(NAME2, VALUE2);
-    server2.getAdminService().withServiceLabel(NAME1, VALUE2).withServiceLabel(NAME2, VALUE1);
+    server1.createAdminService().withServiceLabel(NAME1, VALUE1).withServiceLabel(NAME2, VALUE2);
+    server2.createAdminService().withServiceLabel(NAME1, VALUE2).withServiceLabel(NAME2, VALUE1);
 
     assertThat(server1, not(equalTo(server2)));
   }
@@ -163,11 +163,11 @@ public class AdminServerTest extends BaseConfigurationTestBase {
   @Test
   public void whenHaveSameAdminServiceAnnotations_objectsAreEqual() {
     server1
-        .getAdminService()
+        .createAdminService()
         .withServiceAnnotation(NAME1, VALUE1)
         .withServiceAnnotation(NAME2, VALUE2);
     server2
-        .getAdminService()
+        .createAdminService()
         .withServiceAnnotation(NAME2, VALUE2)
         .withServiceAnnotation(NAME1, VALUE1);
 
@@ -177,14 +177,21 @@ public class AdminServerTest extends BaseConfigurationTestBase {
   @Test
   public void whenHaveDifferentAdminServiceAnnotations_objectsAreNotEqual() {
     server1
-        .getAdminService()
+        .createAdminService()
         .withServiceAnnotation(NAME1, VALUE1)
         .withServiceAnnotation(NAME2, VALUE2);
     server2
-        .getAdminService()
+        .createAdminService()
         .withServiceAnnotation(NAME1, VALUE2)
         .withServiceAnnotation(NAME2, VALUE1);
 
     assertThat(server1, not(equalTo(server2)));
+  }
+
+  @Test
+  public void callingGetAdminService_doesNotChangeTheObject() {
+    server1.getAdminService();
+
+    assertThat(server1, equalTo(server2));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class DomainStatusTest {
@@ -48,6 +49,17 @@ public class DomainStatusTest {
   }
 
   @Test
+  public void whenAddedConditionEqualsPresentCondition_ignoreIt() {
+    DomainCondition originalCondition = new DomainCondition(Failed).withStatus("True");
+    domainStatus.addCondition(originalCondition);
+
+    SystemClockTestSupport.increment();
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("True"));
+
+    assertThat(domainStatus.getConditions().get(0), sameInstance(originalCondition));
+  }
+
+  @Test
   public void whenAddedConditionIsFailed_replaceOldFailedCondition() {
     domainStatus.addCondition(new DomainCondition(Failed).withStatus("False"));
 
@@ -68,7 +80,7 @@ public class DomainStatusTest {
   }
 
   @Test
-  public void whenAddedConditionIsFailed_removeExistedAvailableCondition() {
+  public void whenAddedConditionIsFailed_removeExistingAvailableCondition() {
     domainStatus.addCondition(new DomainCondition(Available).withStatus("False"));
 
     domainStatus.addCondition(new DomainCondition(Failed).withStatus("True"));


### PR DESCRIPTION
The getAdminService method was changing the AdminServer object in a way that changed the behavior of equals(), causing repeated domain updates. This corrects that.