### PR TITLE
Introspect Test Fix: integration test PV directory cleanup now expect…

### DIFF
--- a/src/integration-tests/introspector/createTestRoot.sh
+++ b/src/integration-tests/introspector/createTestRoot.sh
@@ -15,9 +15,9 @@
 
 DOMAIN_UID=${1?}
 
-mkdir -p /pv-root/acceptance_test_pv/domain-${DOMAIN_UID}-storage/domains || exit 1
-mkdir -p /pv-root/acceptance_test_pv/domain-${DOMAIN_UID}-storage/mysql || exit 1
-chmod 777 /pv-root/acceptance_test_pv || exit 1
-chmod 777 /pv-root/acceptance_test_pv/domain-${DOMAIN_UID}-storage || exit 1
-chmod 777 /pv-root/acceptance_test_pv/domain-${DOMAIN_UID}-storage/domains || exit 1
-chmod 777 /pv-root/acceptance_test_pv/domain-${DOMAIN_UID}-storage/mysql || exit 1
+mkdir -p /pv-root/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage/domains || exit 1
+mkdir -p /pv-root/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage/mysql || exit 1
+chmod 777 /pv-root/introspect/acceptance_test_pv || exit 1
+chmod 777 /pv-root/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage || exit 1
+chmod 777 /pv-root/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage/domains || exit 1
+chmod 777 /pv-root/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage/mysql || exit 1

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -326,7 +326,7 @@ function createTestRootPVDir() {
   mkdir -p ${PV_ROOT} || exit 1
   chmod 777 ${PV_ROOT} || exit 1
 
-  trace "Info: Creating k8s cluster physical directory 'PV_ROOT/acceptance_test_pv/domain-${DOMAIN_UID}-storage' via 'kubectl run'."
+  trace "Info: Creating k8s cluster physical directory 'PV_ROOT/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage' via 'kubectl run'."
   trace "Info: Test k8s resources use this physical directory via a PV/PVC '/shared' logical directory."
 
   ${SCRIPTPATH}/util_krun.sh -m ${PV_ROOT}:/pv-root \

--- a/src/integration-tests/introspector/mysql.yamlt
+++ b/src/integration-tests/introspector/mysql.yamlt
@@ -26,7 +26,7 @@ spec:
   capacity:
     storage: 10Gi
   hostPath:
-    path: ${PV_ROOT}/acceptance_test_pv/domain-${DOMAIN_UID}-storage/mysql
+    path: ${PV_ROOT}/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage/mysql
     type: ""
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ${DOMAIN_UID}-mysql-storage-class

--- a/src/integration-tests/introspector/wl-pv.yamlt
+++ b/src/integration-tests/introspector/wl-pv.yamlt
@@ -15,7 +15,7 @@ spec:
   capacity:
     storage: 10Gi
   hostPath:
-    path: ${PV_ROOT}/acceptance_test_pv/domain-${DOMAIN_UID}-storage/domains
+    path: ${PV_ROOT}/introspect/acceptance_test_pv/domain-${DOMAIN_UID}-storage/domains
     type: ""
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ${DOMAIN_UID}-weblogic-domain-storage-class


### PR DESCRIPTION
…s tests to be one directory deeper

This change puts this standalone test's PV directories one level deeper so that the new version of 'cleanup.sh' can find them.