### PR TITLE
[OWLS-79168] Run operator as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,20 +16,20 @@ RUN yum -y install openssl && yum clean all
 # ----------
 MAINTAINER Ryan Eberhard <ryan.eberhard@oracle.com>
 
-RUN mkdir /operator
-RUN mkdir /operator/lib
+# make the operator run with a non-root user id (1000 is the `oracle` user)
+RUN groupadd -g 1000 oracle && \
+    useradd -d /operator -M -s /bin/bash -g 1000 -u 1000 oracle && \
+    mkdir /operator && \
+    mkdir /operator/lib && \
+    chown -R 1000:1000 /operator
+USER 1000
+
 ENV PATH=$PATH:/operator
 
 ARG VERSION
 COPY src/scripts/* /operator/
 COPY operator/target/weblogic-kubernetes-operator-$VERSION.jar /operator/weblogic-kubernetes-operator.jar
 COPY operator/target/lib/*.jar /operator/lib/
-
-# make the operator run with a non-root user id (1000 is the `oracle` user)
-RUN groupadd -g 1000 oracle
-RUN useradd -d /operator -M -s /bin/bash -g 1000 -u 1000 oracle 
-RUN chown -R 1000:1000 /operator
-USER 1000
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD /operator/livenessProbe.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ COPY src/scripts/* /operator/
 COPY operator/target/weblogic-kubernetes-operator-$VERSION.jar /operator/weblogic-kubernetes-operator.jar
 COPY operator/target/lib/*.jar /operator/lib/
 
+# make the operator run with a non-root user id (1000 is the `oracle` user)
+RUN chown -R 1000:1000 /operator
+USER 1000
+
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD /operator/livenessProbe.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY operator/target/weblogic-kubernetes-operator-$VERSION.jar /operator/weblogi
 COPY operator/target/lib/*.jar /operator/lib/
 
 # make the operator run with a non-root user id (1000 is the `oracle` user)
+RUN groupadd -g 1000 oracle
+RUN useradd -d /operator -M -s /bin/bash -g 1000 -u 1000 oracle 
 RUN chown -R 1000:1000 /operator
 USER 1000
 


### PR DESCRIPTION
This PR changes the operator to run as a non-root user.  This is implemented in response to requests from specific users, plus general security hygiene improvement. 

Passed quicktest -> 
http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/880/testReport/oracle.kubernetes.operator/

output showing that operator is running as user 1000(oracle) and files are owned by that use and group

[root@mark weblogic-kubernetes-operator]# k get pods 
NAME READY STATUS RESTARTS AGE
weblogic-operator-759c44db4f-525h9 0/1 Running 0 5s
[root@mark weblogic-kubernetes-operator]# k exec -ti weblogic-operator-759c44db4f-525h9 /bin/bash
bash-4.2$ id
uid=1000(oracle) gid=1000(oracle) groups=1000(oracle)
bash-4.2$ ls -al
total 892
drwxr-xr-x. 1 oracle oracle 4096 Jan 22 14:44 .
drwxr-xr-x. 1 root root 44 Jan 22 14:44 ..
rw-rr-. 1 oracle oracle 0 Jan 22 14:46 .alive
drwxr-----. 3 oracle oracle 19 Jan 22 14:44 .pki
rw-rr-. 1 oracle oracle 0 Jan 22 14:44 .ready
drwxrwxrwx. 3 root root 4096 Jan 22 14:45 config
drwxrwxrwx. 3 root root 59 Jan 22 14:44 debug-config
drwxr-xr-x. 2 oracle oracle 6 Jan 22 14:44 external-identity
-rwxr-xr-x. 1 oracle oracle 2785 Jan 22 14:10 initialize-external-operator-identity.sh
-rwxr-xr-x. 1 oracle oracle 5226 Jan 22 14:10 initialize-internal-operator-identity.sh
drwxr-xr-x. 3 oracle oracle 4096 Jan 22 14:44 internal-identity
drwxr-xr-x. 1 oracle oracle 4096 Jan 22 14:44 lib
-rwxr-xr-x. 1 oracle oracle 469 Jan 22 14:10 livenessProbe.sh
rw-rr-. 1 oracle oracle 804 Feb 20 2019 logstash.conf
rw-rr-. 1 oracle oracle 435 Jan 22 14:44 logstash.properties
-rwxr-xr-x. 1 oracle oracle 2379 Jan 22 14:10 operator.sh
-rwxr-xr-x. 1 oracle oracle 260 Jan 22 14:10 readinessProbe.sh
-rwxr-xr-x. 1 oracle oracle 8924 Jan 22 14:10 scalingAction.sh
drwxrwxrwt. 3 root root 100 Jan 22 14:45 secrets
rw-rr-. 1 oracle oracle 846500 Jan 22 14:14 weblogic-kubernetes-operator.jar
bash-4.2$

ps -ef n output showing operator is running with uid 1000:

1000 30849 30832 0 14:20 ? Ss 0:00 bash /operator/operator.sh
1000 31057 30849 4 14:20 ? Sl 0:32 java -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=1 -XshowSettings:vm -Djava.util.logging.config.file=/operator/logstash.properties -jar /operator/weblogic-kubernetes-operator.jar