### PR TITLE
PR: Owls 79241 improve JRF domain cleanup logic

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
@@ -70,7 +70,11 @@ public class ItJrfPvWlst extends BaseTest {
           + "/kubernetes/samples/scripts " 
           + getResultDir(),
           true);
-   
+      
+      //To take care of leftover pods caused by test being aborted
+      DbUtils.deleteRcuPod(getResultDir());
+      DbUtils.stopOracleDB(getResultDir());
+      
       DbUtils.startOracleDB(getResultDir());
       DbUtils.createRcuSchema(getResultDir(),rcuSchemaPrefix);
     

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
@@ -70,11 +70,10 @@ public class ItJrfPvWlst extends BaseTest {
           + "/kubernetes/samples/scripts " 
           + getResultDir(),
           true);
-      
-      //To take care of leftover pods caused by test being aborted
+      //delete leftover pods caused by test being aborted
       DbUtils.deleteRcuPod(getResultDir());
       DbUtils.stopOracleDB(getResultDir());
-      
+       
       DbUtils.startOracleDB(getResultDir());
       DbUtils.createRcuSchema(getResultDir(),rcuSchemaPrefix);
     

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/DbUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/DbUtils.java
@@ -113,7 +113,7 @@ public class DbUtils {
   public static void deleteRcuPod(String scriptsDir) throws Exception {
     String cmd = "kubectl delete -f " 
         + scriptsDir
-        + "/scripts/create-rcu-schema/common/rcu.yaml";
+        + "/scripts/create-rcu-schema/common/rcu.yaml --ignore-not-found";
     TestUtils.exec(cmd, true);
   }
 


### PR DESCRIPTION
Internal Jenkins passed at: http://wls-jenkins.us.oracle.com/view/weblogic-operator/job/weblogic-kubernetes-operator-javatest/3975/testReport/
External Jenkins passed at: http://build.weblogick8s.org:8080/job/weblogic-kubernetes-operator-quicktest/890/testReport/

Locally I simulated "abort test" scenario to verify the fix.