### PR TITLE
Update Voyager sample for latest version and Voyager links

### DIFF
--- a/kubernetes/samples/charts/util/setup.sh
+++ b/kubernetes/samples/charts/util/setup.sh
@@ -6,6 +6,7 @@
 
 MYDIR="$(dirname "$(readlink -f "$0")")"
 VNAME=voyager-operator  # release name of Voyager
+VVERS=v12.0.0-rc.1      # release version of Voyager
 TNAME=traefik-operator  # release name of Traefik
 
 function createVoyager() {
@@ -24,7 +25,7 @@ function createVoyager() {
   if [ "$(helm list | grep $VNAME |  wc -l)" = 0 ]; then
     echo "Ihstall voyager operator."
     
-    helm install appscode/voyager --name $VNAME \
+    helm install appscode/voyager --name $VNAME --version $VVERS \
       --namespace voyager \
       --set cloudProvider=baremetal \
       --set apiserver.enableValidatingWebhook=false \

--- a/kubernetes/samples/charts/util/setup.sh
+++ b/kubernetes/samples/charts/util/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 #  This script is to create or delete Ingress controllers. We support two ingress controllers: traefik and voyager.
@@ -24,7 +24,7 @@ function createVoyager() {
   if [ "$(helm list | grep $VNAME |  wc -l)" = 0 ]; then
     echo "Ihstall voyager operator."
     
-    helm install appscode/voyager --name $VNAME --version 7.4.0 \
+    helm install appscode/voyager --name $VNAME \
       --namespace voyager \
       --set cloudProvider=baremetal \
       --set apiserver.enableValidatingWebhook=false \

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -1,9 +1,13 @@
 # Install and configure Voyager
 
 ## A step-by-step guide to install the Voyager operator
-AppsCode has provided a Helm chart to install Voyager. See the official installation document at https://appscode.com/products/voyager/7.4.0/setup/install/.
+AppsCode has provided a Helm chart and instructions to install Voyager. See the official installation document at:
+- https://appscode.com/products/voyager/latest/setup/install/
 
-As a demonstration, the following are the detailed steps to install the Voyager operator by using a Helm chart on a Linux OS.
+Also check the Kubernetes version support matrix based on your Kubernetes installation at:
+- https://github.com/appscode/voyager#supported-versions
+
+As a *demonstration*, the following are steps to install the Voyager operator by using Helm 2 on a Linux OS.
 
 ### 1. Add the AppsCode chart repository
 ```
@@ -13,15 +17,16 @@ $ helm repo update
 Verify that the chart repository has been added.
 ```
 $ helm search appscode/voyager
-NAME            	CHART VERSION	APP VERSION	DESCRIPTION                                       
-appscode/voyager	8.0.1        	8.0.1      	Voyager by AppsCode - Secure HAProxy Ingress Co...
+NAME                    CHART VERSION   APP VERSION     DESCRIPTION
+appscode/voyager        v12.0.0-rc.1    v12.0.0-rc.1    Voyager by AppsCode - Secure HAProxy Ingress Controller f...
 ```
+> **NOTE**: After updating the helm repository, the Voyager version listed maybe newer that the one appearing here, please check with the Voyager site for the lastest supported versions.
 
-### 2. Install the Voyager operator
+
+### 2. Install the Voyager operator with Helm 2 support
 ```
-# Kubernetes 1.9.x - 1.10.x
 $ kubectl create ns voyager
-$ helm install appscode/voyager --name voyager-operator --version 7.4.0 \
+$ helm install appscode/voyager --name voyager-operator \
   --namespace voyager \
   --set cloudProvider=baremetal \
   --set apiserver.enableValidatingWebhook=false
@@ -29,60 +34,59 @@ $ helm install appscode/voyager --name voyager-operator --version 7.4.0 \
 Wait until the Voyager Operator is running.
 ```
 $ kubectl -n voyager get all
-NAME                                            READY     STATUS    RESTARTS   AGE
-pod/voyager-voyager-operator-77cbfdcb86-gqwgt   1/1       Running   0          46m
+NAME                                    READY   STATUS    RESTARTS   AGE
+pod/voyager-operator-5686bc6556-9bs5z   1/1     Running   0          46m
 
-NAME                               TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
-service/voyager-voyager-operator   ClusterIP   10.105.254.144   <none>        443/TCP,56791/TCP   46m
+NAME                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+service/voyager-operator   ClusterIP   10.105.254.144   <none>        443/TCP,56791/TCP   46m
 
-NAME                                       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/voyager-voyager-operator   1         1         1            1           46m
+NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/voyager-operator   1/1     1            1           46m
 
-NAME                                                  DESIRED   CURRENT   READY     AGE
-replicaset.apps/voyager-voyager-operator-77cbfdcb86   1         1         1         46m
+NAME                                          DESIRED   CURRENT   READY   AGE
+replicaset.apps/voyager-operator-5686bc6556   1         1         1       46m
 ```
-> **NOTE**: All the generated Kubernetes resources of the Voyager operator have names with the pattern `voyager-<releaseName>XXX`. This logic is controlled by the Voyager Helm chart. In our case, we use `releaseName` `voyager-operator`, so all the generated resources have names like `voyager-voyager-operatorXXX`.
-
-## Optionally, download the Voyager Helm chart
-If you want, you can download the Voyager Helm chart and untar it into a local folder:
-```
-$ helm fetch appscode/voyager --untar --version 7.4.0
-```
+> **NOTE**: All the generated Kubernetes resources of the Voyager operator have names controlled by the Voyager Helm chart. In our case, we use `releaseName` of `voyager-operator`.
 
 ## Update the Voyager operator
-After the Voyager operator is installed and running, if you want to change some configurations of the operator, use `helm upgrade` to achieve this.
+After the Voyager operator is installed and running, to change some configuration of the Voyager operator, use `helm upgrade` to achieve this.
 ```
 $ helm upgrade voyager-operator appscode/voyager [flags]
 ```
 
-## Configure Voyager as a load balancer for WLS domains
-We'll demonstrate how to use Voyager to handle traffic to backend WLS domains.
+## Configure Voyager as a load balancer for WebLogic domains
+We'll demonstrate how to use Voyager to handle traffic to backend WebLogic domains.
 
-### 1. Install WLS domains
+### 1. Install WebLogic domains
 Now we need to prepare some domains for Voyager load balancing.
 
-Create two WLS domains:
+Create two WebLogic domains:
 - One domain with name `domain1` under namespace `default`.
 - One domain with name `domain2` under namespace `test1`.
 - Each domain has a web application installed with the URL context `testwebapp`.
+
 
 ### 2. Install the Voyager Ingress
 #### Install a host-routing Ingress
 ```
 $ kubectl create -f samples/host-routing.yaml
 ```
-Now you can send requests to different WLS domains with the unique entry point of Voyager with different hostnames.
+Now you can send requests to different WebLogic domains with the unique entry point of Voyager with different host names.
 ```
 $ curl -H 'host: domain1.org' http://${HOSTNAME}:30305/testwebapp/
 $ curl -H 'host: domain2.org' http://${HOSTNAME}:30305/testwebapp/
 ```
 To see the Voyager host-routing stats web page, access the URL `http://${HOSTNAME}:30315` in your web browser.
 
+> **NOTE**: When using a web browser with a `NodePort` for the Voyager load balancer, the `Host` header is set to the host name including the `NodePort` value.
+> For example, if you type into the address bar `http://app.myhost.com:30305/testwebapp` then the host name in `Ingress` YAML file would be `- host: app.myhost.com:30305`
+
+
 #### Install a path-routing Ingress
 ```
 $ kubectl create -f samples/path-routing.yaml
 ```
-Now you can send requests to different WLS domains with the unique entry point of Voyager with different paths.
+Now you can send requests to different WebLogic domains with the unique entry point of Voyager with different paths.
 ```
 $ curl http://${HOSTNAME}:30307/domain1/
 $ curl http://${HOSTNAME}:30307/domain2/
@@ -90,9 +94,9 @@ $ curl http://${HOSTNAME}:30307/domain2/
 To see the Voyager path-routing stats web page, access URL `http://${HOSTNAME}:30317` in your web browser.
 
 #### Install a TLS-enabled Ingress
-This sample demonstrates accessing the two WLS domains using an HTTPS endpoint and the WLS domains are protected by different TLS certificates.
+This sample demonstrates accessing the two WebLogic domains using an HTTPS endpoint and the WebLogic domains are protected by different TLS certificates.
 
-First, you need to create two secrets with TLS certificates, one with the common name `domain1.org`, the other with the common name `domain2.org`. We use `openssl` to generate self-signed certificates for demonstration purposes. Note that the TLS secret needs to be in the same namespace as the WLS domain.
+First, you need to create two secrets with TLS certificates, one with the common name `domain1.org`, the other with the common name `domain2.org`. We use `openssl` to generate self-signed certificates for demonstration purposes. Note that the TLS secret needs to be in the same namespace as the WebLogic domain.
 ```
 # create a TLS secret for domain1
 $ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls1.key -out /tmp/tls1.crt -subj "/CN=domain1.org"
@@ -106,7 +110,7 @@ Then deploy the TLS Ingress.
 ```
 $ kubectl create -f samples/tls.yaml
 ```
-Now you can access the two WLS domains with different hostnames using the HTTPS endpoint.
+Now you can access the two WebLogic domains with different host names using the HTTPS endpoint.
 ```
 $ curl -k -H 'host: domain1.org' https://${HOSTNAME}:30305/testwebapp/
 $ curl -k -H 'host: domain2.org' https://${HOSTNAME}:30307/testwebapp/

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -26,11 +26,13 @@ appscode/voyager        v12.0.0-rc.1    v12.0.0-rc.1    Voyager by AppsCode - Se
 ### 2. Install the Voyager operator with Helm 2 support
 ```
 $ kubectl create ns voyager
-$ helm install appscode/voyager --name voyager-operator \
+$ helm install appscode/voyager --name voyager-operator --version v12.0.0-rc.1 \
   --namespace voyager \
   --set cloudProvider=baremetal \
   --set apiserver.enableValidatingWebhook=false
 ```
+> **NOTE**: The Voyager version used for the install should match the version found with `helm search`.
+
 Wait until the Voyager Operator is running.
 ```
 $ kubectl -n voyager get all

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -15,6 +15,12 @@ $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
 ```
 Verify that the chart repository has been added.
+
+Using Helm 3:
+```
+$ helm search repo appscode/voyager
+```
+Using Helm 2:
 ```
 $ helm search appscode/voyager
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
@@ -22,8 +28,19 @@ appscode/voyager        v12.0.0-rc.1    v12.0.0-rc.1    Voyager by AppsCode - Se
 ```
 > **NOTE**: After updating the helm repository, the Voyager version listed maybe newer that the one appearing here, please check with the Voyager site for the lastest supported versions.
 
+### 2. Install the Voyager operator
 
-### 2. Install the Voyager operator with Helm 2 support
+> **NOTE**: The Voyager version used for the install should match the version found with `helm search`.
+
+Using Helm 3:
+```
+$ kubectl create ns voyager
+$ helm install voyager-operator appscode/voyager --version v12.0.0-rc.1 \
+  --namespace voyager \
+  --set cloudProvider=baremetal \
+  --set apiserver.enableValidatingWebhook=false
+```
+Using Helm 2:
 ```
 $ kubectl create ns voyager
 $ helm install appscode/voyager --name voyager-operator --version v12.0.0-rc.1 \
@@ -31,7 +48,6 @@ $ helm install appscode/voyager --name voyager-operator --version v12.0.0-rc.1 \
   --set cloudProvider=baremetal \
   --set apiserver.enableValidatingWebhook=false
 ```
-> **NOTE**: The Voyager version used for the install should match the version found with `helm search`.
 
 Wait until the Voyager Operator is running.
 ```

--- a/kubernetes/samples/charts/voyager/README.md
+++ b/kubernetes/samples/charts/voyager/README.md
@@ -136,12 +136,18 @@ $ curl -k -H 'host: domain2.org' https://${HOSTNAME}:30307/testwebapp/
 
 ## Uninstall the Voyager Operator
 After removing all the Voyager Ingress resources, uninstall the Voyager operator:
+
+Using Helm 3:
+```
+$ helm uninstall voyager-operator --namespace voyager
+```
+Using Helm 2:
 ```
 $ helm delete --purge voyager-operator
 ```
 
 ## Install and uninstall the Voyager operator with setup.sh
-Alternatively, you can run the helper script `setup.sh`, under the `kubernetes/samples/charts/util` folder, to install and uninstall Voyager.
+Alternatively, you can run the helper script `setup.sh` when using Helm 2, under the `kubernetes/samples/charts/util` folder, to install and uninstall Voyager.
 
 To install Voyager:
 ```


### PR DESCRIPTION
Hi Monica, Ryan, this PR updates the Voyager sample that Lily originally added so as to reflect the latest Voyager version, provide reference links to the Voyager sites for formal install instructions and the Kubernetes support matrix along with a note to clarify the `Host` header value when using a web browser and `NodePort` for the load balancer.

I've requested the merge against `master` since there is no impact on the WebLogic operator handling and this should resolve OWLS-79355 from Monica.

Thanks, -Craig