### PR TITLE
Remove the build badge 

### DIFF
--- a/docs-source/themes/hugo-theme-learn/layouts/partials/menu-footer.html
+++ b/docs-source/themes/hugo-theme-learn/layouts/partials/menu-footer.html
@@ -2,5 +2,3 @@
 <p>&nbsp;</p>
 <p><a href="https://github.com/oracle/weblogic-kubernetes-operator"><i class="fab fa-github"></i> GitHub repo</a></p>
 <p><a href="https://weblogic-slack-inviter.herokuapp.com/"><i class="fab fa-slack"></i> Public Slack #operator</a></p>
-<p>&nbsp;</p>
-<img src="http://build.weblogick8s.org:8080/buildStatus/icon?job=weblogic-kubernetes-operator">


### PR DESCRIPTION
Remove the build badge  which is not using https, does not have a valid cert, and which is not being used 'right' anyway - not pointing to a consistent branch.