### PR TITLE
Add FAQ entry for persistent volume using OCI FSS

### DIFF
--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -2,6 +2,7 @@
 title: "Using OCI File Storage (FSS) for Persistent Volumes"
 date: 2020-02-12T12:12:12-05:00
 draft: false
+weight: 6
 ---
 
 If you are running your Kubernetes cluster on Oracle Container Engine 

--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -79,7 +79,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "find %DOMAIN_ROOT_DIR%/. -maxdepth ! -name '.snapshot' ! -name '.' -print0 | xargs -0 chown 1000:1000"]
+          command: ["sh", "-c", "find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown 1000:1000"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%

--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -79,7 +79,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "find %DOMAIN_ROOT_DIR% ! -name '.snapshot' | xargs chown 1000:1000"]
+          command: ["sh", "-c", "find %DOMAIN_ROOT_DIR%/. -maxdepth ! -name '.snapshot' ! -name '.' -print0 | xargs -0 chown 1000:1000"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%

--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -6,7 +6,7 @@ draft: false
 
 If you are running your Kubernetes cluster on Oracle Container Engine 
 for Kubernetes (commonly known as OKE), and you use OCI File Storage (FSS)
-for persistent volumes to store the WebLogic domain home then the file system
+for persistent volumes to store the WebLogic domain home, then the file system
 handling demonstrated in the operator persistent volume sample will require
 an update to properly initialize the file ownership on the persistent volume
 when the domain is initially created.
@@ -16,7 +16,7 @@ File permission handling on persistent volumes can differ between
 cloud providers and even with the underlying storage handling on
 Linux based systems. These instructions provide one option to
 update file ownership used by the standard Oracle images where
-UID `1000` and GID `1000` normally represent the `oracle` or `opc` user.
+UID `1000` and GID `1000` typically represent the `oracle` or `opc` user.
 For more information on persistent volume handling,
 see [Persistent storage]({{< relref "/userguide/managing-domains/persistent-storage/_index.md" >}}).
 {{% /notice %}}
@@ -30,7 +30,7 @@ uses a Kubernetes job to create the domain. The sample uses an
 fail for OCI FSS created volumes used with an OKE cluster.
 
 The OCI FSS volume contains some files that are not modifiable thus
-causing the Kubernetes job to fail. The failure is see from the
+causing the Kubernetes job to fail. The failure is seen in the
 description of the Kubernetes job pod:
 ```bash
 $ kubectl describe -n domain1-ns pod domain1-create-weblogic-sample-domain-job-wdkvs
@@ -60,8 +60,8 @@ Init Containers:
 ```
 
 ### Updating the domain on persistent volume sample
-In the snippet of the [create-domain-job-template.yaml](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml)
-below, you will see the updated `command` for the init container:
+In the following snippet of the [create-domain-job-template.yaml](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml),
+you can see the updated `command` for the init container:
 ```
 apiVersion: batch/v1
 kind: Job
@@ -78,7 +78,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "chown -R 1000:1000 $(ls -a %DOMAIN_ROOT_DIR% | grep -v '^\\.')"]
+          command: ["sh", "-c", "find %DOMAIN_ROOT_DIR% ! -name '.snapshot' | xargs chown 1000:1000"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%
@@ -91,6 +91,6 @@ spec:
 
   :
 ```
-The new `command` shown above should be made to your copy of this template file
-and will result in the ownership updated only for the expected files before
-the WebLogic domain is created on the persistent volume.
+Use this new `command` in your copy of this template file. This will result in
+the ownership being updated for the expected files only, before the WebLogic
+domain is created on the persistent volume.

--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -1,0 +1,96 @@
+---
+title: "Using OCI File Storage (FSS) for Persistent Volumes"
+date: 2020-02-12T12:12:12-05:00
+draft: false
+---
+
+If you are running your Kubernetes cluster on Oracle Container Engine 
+for Kubernetes (commonly known as OKE), and you use OCI File Storage (FSS)
+for persistent volumes to store the WebLogic domain home then the file system
+handling demonstrated in the operator persistent volume sample will require
+an update to properly initialize the file ownership on the persistent volume
+when the domain is initially created.
+
+{{% notice note %}}
+File permission handling on persistent volumes can differ between
+cloud providers and even with the underlying storage handling on
+Linux based systems. These instructions provide one option to
+update file ownership used by the standard Oracle images where
+UID `1000` and GID `1000` normally represent the `oracle` or `opc` user.
+For more information on persistent volume handling,
+see [Persistent storage]({{< relref "/userguide/managing-domains/persistent-storage/_index.md" >}}).
+{{% /notice %}}
+
+
+### Failure during domain creation with persistent volume sample
+
+The existing sample for [creation of a domain home on persistent volume](https://github.com/oracle/weblogic-kubernetes-operator/tree/master/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv)
+uses a Kubernetes job to create the domain. The sample uses an
+`initContainers` section to change the file ownership which will
+fail for OCI FSS created volumes used with an OKE cluster.
+
+The OCI FSS volume contains some files that are not modifiable thus
+causing the Kubernetes job to fail. The failure is see from the
+description of the Kubernetes job pod:
+```bash
+$ kubectl describe -n domain1-ns pod domain1-create-weblogic-sample-domain-job-wdkvs
+   :
+   :
+Init Containers:
+  fix-pvc-owner:
+    Container ID:  docker://7051b6abdc296c76e937246df03d157926f2f7477e63b6af3bf65f6ae1ceddee
+    Image:         container-registry.oracle.com/middleware/weblogic:12.2.1.3
+    Image ID:      docker-pullable://container-registry.oracle.com/middleware/weblogic@sha256:47dfd4fdf6b56210a6c49021b57dc2a6f2b0d3b3cfcd253af7a75ff6e7421498
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      sh
+      -c
+      chown -R 1000:1000 /shared
+    State:          Terminated
+      Reason:       Error
+      Exit Code:    1
+      Started:      Wed, 12 Feb 2020 18:28:53 +0000
+      Finished:     Wed, 12 Feb 2020 18:28:53 +0000
+    Ready:          False
+    Restart Count:  0
+    Environment:    <none>
+
+   :
+```
+
+### Updating the domain on persistent volume sample
+In the snippet of the [create-domain-job-template.yaml](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml)
+below, you will see the updated `command` for the init container:
+```
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: %DOMAIN_UID%-create-weblogic-sample-domain-job
+  namespace: %NAMESPACE%
+spec:
+  template:
+    metadata:
+  :
+  :
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: fix-pvc-owner
+          image: %WEBLOGIC_IMAGE%
+          command: ["sh", "-c", "chown -R 1000:1000 $(ls -a %DOMAIN_ROOT_DIR% | grep -v '^\\.')"]
+          volumeMounts:
+          - name: weblogic-sample-domain-storage-volume
+            mountPath: %DOMAIN_ROOT_DIR%
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+      containers:
+        - name: create-weblogic-sample-domain-job
+          image: %WEBLOGIC_IMAGE%
+
+  :
+```
+The new `command` shown above should be made to your copy of this template file
+and will result in the ownership updated only for the expected files before
+the WebLogic domain is created on the persistent volume.

--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -79,7 +79,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "chown %DOMAIN_ROOT_DIR%/. 1000:1000 && find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown -R 1000:1000"]
+          command: ["sh", "-c", "chown 1000:1000 %DOMAIN_ROOT_DIR%/. && find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown -R 1000:1000"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%

--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -79,7 +79,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown 1000:1000"]
+          command: ["sh", "-c", "chown %DOMAIN_ROOT_DIR%/. 1000:1000 && find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown -R 1000:1000"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%


### PR DESCRIPTION
Add documenation FAQ item about updating the `initContainers` with a different command for OCI FSS persistent volume handling as the domain-on-pv example fails when using OKE and a PV from OCI FSS.

This is the first cut at the information and I'm using the command that was initially discussed. I'm happy to change this command along with wording or the basic content layout I have started here.

The FAQ is trying to present the basic issue with some references and more details about how the problem shows up and where to go make the change.

Thanks, -Craig