### PR TITLE
Add weight to OCI FSS FAQ entry

### DIFF
--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -2,6 +2,7 @@
 title: "Using OCI File Storage (FSS) for Persistent Volumes"
 date: 2020-02-12T12:12:12-05:00
 draft: false
+weight: 12
 ---
 
 If you are running your Kubernetes cluster on Oracle Container Engine 


### PR DESCRIPTION
Rosemary, Ryan, Tom, so I'm adding the weight entry to this new FAQ as all the FAQ entries have one on `develop` branch.

I picked the highest number and I would suggest merging this for consistency and then "someone" should follow up and decide on actual ordering because there are gaps in the numbers and two .md files with the same `weight` excluding the sample page.

If you really want this PR to fix/adjust all the `weight` entries that is fine... Just tell me what order you want them in and I will add the files to the PR...

Thanks, -Craig