### PR TITLE
Fix what is broken

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -316,6 +316,9 @@
                         <exclude>
                             ${excludes-failsafe}
                         </exclude>
+                        <exclude>
+                            ItMonitoringExporter
+                        </exclude>
                     </excludes>
                 </configuration>
 

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -191,7 +191,7 @@ public class Main {
 
       Step strategy = Step.chain(
           new InitializeNamespacesSecurityStep(targetNamespaces),
-          new NamespaceRulesReviewStep(operatorNamespace),
+          new NamespaceRulesReviewStep(),
           CrdHelper.createDomainCrdStep(version,
               new StartNamespacesStep(targetNamespaces)));
       if (!isDedicated()) {
@@ -613,13 +613,18 @@ public class Main {
   private static class NamespaceRulesReviewStep extends Step {
     private final String ns;
 
+    NamespaceRulesReviewStep() {
+      this(null);
+    }
+
     NamespaceRulesReviewStep(String ns) {
       this.ns = ns;
     }
 
     @Override
     public NextAction apply(Packet packet) {
-      NamespaceStatus nss = namespaceStatuses.computeIfAbsent(ns, (key) -> new NamespaceStatus());
+      NamespaceStatus nss = namespaceStatuses.computeIfAbsent(
+          ns != null ? ns : operatorNamespace, (key) -> new NamespaceStatus());
       V1SubjectRulesReviewStatus srrs = nss.getRulesReviewStatus().updateAndGet(prev -> {
         if (prev != null) {
           return prev;

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -623,6 +623,9 @@ public class Main {
 
     @Override
     public NextAction apply(Packet packet) {
+      // Looking up namespace status.  If ns is null, then this step will check the status of the
+      // operator's own namespace.  If the namespace status is missing, then generate it with
+      // the health check helper.
       NamespaceStatus nss = namespaceStatuses.computeIfAbsent(
           ns != null ? ns : operatorNamespace, (key) -> new NamespaceStatus());
       V1SubjectRulesReviewStatus srrs = nss.getRulesReviewStatus().updateAndGet(prev -> {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -219,10 +219,8 @@ public class CrdHelper {
     }
 
     Step verifyCrd(Step next) {
-      return HealthCheckHelper.skipIfNotAuthorized(
-          AuthorizationProxy.Resource.CRDS, AuthorizationProxy.Operation.get,
-          new CallBuilder().readCustomResourceDefinitionAsync(
-              model.getMetadata().getName(), createReadResponseStep(next)), next);
+      return new CallBuilder().readCustomResourceDefinitionAsync(
+              model.getMetadata().getName(), createReadResponseStep(next));
     }
 
     ResponseStep<V1beta1CustomResourceDefinition> createReadResponseStep(Step next) {
@@ -230,12 +228,8 @@ public class CrdHelper {
     }
 
     Step createCrd(Step next) {
-      return HealthCheckHelper.failIfNotAuthorized(
-          AuthorizationProxy.Resource.CRDS, AuthorizationProxy.Operation.create,
-          new CallBuilder().createCustomResourceDefinitionAsync(
-              model, createCreateResponseStep(next)), () -> {
-            LOGGER.warning(MessageKeys.CRD_NO_WRITE_ACCESS, "create the CRD");
-          });
+      return new CallBuilder().createCustomResourceDefinitionAsync(
+              model, createCreateResponseStep(next));
     }
 
     ResponseStep<V1beta1CustomResourceDefinition> createCreateResponseStep(Step next) {
@@ -269,12 +263,8 @@ public class CrdHelper {
                   .name(KubernetesConstants.DOMAIN_VERSION)
                   .served(true));
 
-      return HealthCheckHelper.failIfNotAuthorized(
-          AuthorizationProxy.Resource.CRDS, AuthorizationProxy.Operation.replace,
-          new CallBuilder().replaceCustomResourceDefinitionAsync(
-              existingCrd.getMetadata().getName(), existingCrd, createReplaceResponseStep(next)), () -> {
-            LOGGER.warning(MessageKeys.CRD_NO_WRITE_ACCESS, "add a new version to the existing CRD");
-          });
+      return new CallBuilder().replaceCustomResourceDefinitionAsync(
+              existingCrd.getMetadata().getName(), existingCrd, createReplaceResponseStep(next));
     }
 
     Step updateCrd(Step next, V1beta1CustomResourceDefinition existingCrd) {
@@ -297,12 +287,8 @@ public class CrdHelper {
         }
       }
 
-      return HealthCheckHelper.failIfNotAuthorized(
-          AuthorizationProxy.Resource.CRDS, AuthorizationProxy.Operation.replace,
-          new CallBuilder().replaceCustomResourceDefinitionAsync(
-              model.getMetadata().getName(), model, createReplaceResponseStep(next)), () -> {
-            LOGGER.warning(MessageKeys.CRD_NO_WRITE_ACCESS, "replace the existing CRD");
-          });
+      return new CallBuilder().replaceCustomResourceDefinitionAsync(
+              model.getMetadata().getName(), model, createReplaceResponseStep(next));
     }
 
     ResponseStep<V1beta1CustomResourceDefinition> createReplaceResponseStep(Step next) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
@@ -132,10 +132,10 @@ public final class HealthCheckHelper {
       V1SubjectRulesReviewStatus status = review.getStatus();
       List<V1ResourceRule> rules = status.getResourceRules();
 
-      if (ns != null) {
+      if (namespace != null) {
         for (Resource r : namespaceAccessChecks.keySet()) {
           for (Operation op : namespaceAccessChecks.get(r)) {
-            check(rules, r, op, ns);
+            check(rules, r, op, namespace);
           }
         }
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
@@ -111,11 +111,12 @@ public final class HealthCheckHelper {
    *
    * @param version Kubernetes version
    * @param operatorNamespace operator namespace
-   * @param ns target namespace
+   * @param namespace target namespace
    * @return self subject rules review for the target namespace
    */
   public static V1SubjectRulesReviewStatus performSecurityChecks(
-      KubernetesVersion version, String operatorNamespace, String ns) {
+      KubernetesVersion version, String operatorNamespace, String namespace) {
+    String ns = namespace != null ? namespace : operatorNamespace;
 
     // Validate namespace
     if (DEFAULT_NAMESPACE.equals(operatorNamespace)) {
@@ -131,12 +132,14 @@ public final class HealthCheckHelper {
       V1SubjectRulesReviewStatus status = review.getStatus();
       List<V1ResourceRule> rules = status.getResourceRules();
 
-      for (Resource r : namespaceAccessChecks.keySet()) {
-        for (Operation op : namespaceAccessChecks.get(r)) {
-          check(rules, r, op, ns);
+      if (ns != null) {
+        for (Resource r : namespaceAccessChecks.keySet()) {
+          for (Operation op : namespaceAccessChecks.get(r)) {
+            check(rules, r, op, ns);
+          }
         }
       }
-      if (!Main.isDedicated()) {
+      if (!Main.isDedicated() && operatorNamespace.equals(ns)) {
         for (Resource r : clusterAccessChecks.keySet()) {
           for (Operation op : clusterAccessChecks.get(r)) {
             check(rules, r, op, ns);


### PR DESCRIPTION
1. Cherry-pick Marina's pom change to disable the monitoring exporter test that is hanging
2. No longer skip CRD operations based on the pre-auth, health check results, but stick with the pattern of trying the operation and having the operator handle failures
3. Clean-up some of the unnecessary pre-auth, access checks given the reduction in privileges.

Quick test is clean; waiting on full test, but looking good.