### PR TITLE
Dependency review

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -104,10 +104,6 @@
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
         <!-- JSON processing: jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -99,11 +99,6 @@
             <artifactId>snakeyaml</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -329,10 +329,6 @@
       <artifactId>javaee-web-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -248,6 +248,7 @@
     <dependency>
       <groupId>com.kjetland</groupId>
       <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- HTTP client: jersey-client -->

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-ext-jdk15on</artifactId>
+        <version>1.64</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>1.64</version>
+      </dependency>
+      <dependency>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java</artifactId>
         <version>8.0.0</version>
@@ -631,11 +641,6 @@
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>jersey-test-framework-provider-inmemory</artifactId>
         <version>${jersey-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava-version}</version>
       </dependency>
       <!-- JSON processing: jackson -->
       <dependency>
@@ -771,7 +776,6 @@
     <jackson-version>2.10.3</jackson-version>
     <jackson-databind-version>2.10.3</jackson-databind-version>
     <snakeyaml-version>1.26</snakeyaml-version>
-    <guava-version>28.2-jre</guava-version>
     <root-generated-swagger>${project.basedir}/src-generated-swagger</root-generated-swagger>
     <src-generated-swagger>${root-generated-swagger}/main/java</src-generated-swagger>
     <domain-swagger-file>${project.basedir}/swagger/domain.json</domain-swagger-file>

--- a/pom.xml
+++ b/pom.xml
@@ -773,8 +773,8 @@
     <junit.platform.surefire.version>1.3.2</junit.platform.surefire.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jersey-version>2.30.1</jersey-version>
-    <jackson-version>2.10.2</jackson-version>
-    <jackson-databind-version>2.10.2</jackson-databind-version>
+    <jackson-version>2.10.3</jackson-version>
+    <jackson-databind-version>2.10.3</jackson-databind-version>
     <snakeyaml-version>1.26</snakeyaml-version>
     <root-generated-swagger>${project.basedir}/src-generated-swagger</root-generated-swagger>
     <src-generated-swagger>${root-generated-swagger}/main/java</src-generated-swagger>

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,7 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Add direct bouncycastle dependency to override version from kubernetes/client-java until they update -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-ext-jdk15on</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -773,8 +773,8 @@
     <junit.platform.surefire.version>1.3.2</junit.platform.surefire.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jersey-version>2.30.1</jersey-version>
-    <jackson-version>2.10.3</jackson-version>
-    <jackson-databind-version>2.10.3</jackson-databind-version>
+    <jackson-version>2.10.2</jackson-version>
+    <jackson-databind-version>2.10.2</jackson-databind-version>
     <snakeyaml-version>1.26</snakeyaml-version>
     <root-generated-swagger>${project.basedir}/src-generated-swagger</root-generated-swagger>
     <src-generated-swagger>${root-generated-swagger}/main/java</src-generated-swagger>

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -71,10 +71,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
        </dependency>


### PR DESCRIPTION
- Remove direct dependency on Guava since this comes transitively
- Reduce scope of kjetland to test
- Add direct dependency on bouncy castle to update version.  

Note: kubernetes/client-java have updated bouncy castle to the latest version, but not yet released a version that includes this update.