### PR TITLE
Update fluentd example

### DIFF
--- a/docs-source/content/samples/simple/elastic-stack/weblogic-domain/_index.md
+++ b/docs-source/content/samples/simple/elastic-stack/weblogic-domain/_index.md
@@ -138,7 +138,7 @@ data:
       key_name timestamp 
       types timestamp:time
       # inject the @timestamp special field (as type time) into the record
-      # so you will can do time based queries.
+      # so you will be able to do time based queries.
       # not to be confused with timestamp which is of type string!!!
       include_timestamp true
     </match>

--- a/docs-source/content/samples/simple/elastic-stack/weblogic-domain/_index.md
+++ b/docs-source/content/samples/simple/elastic-stack/weblogic-domain/_index.md
@@ -120,6 +120,10 @@ data:
         format11 / <(?<severity>(.*?))>/
         format12 / <(?<messageID>(.*?))>/
         format13 / <(?<message>(.*?))>/
+        # use the timestamp field in the message as the timestamp
+        # instead of the time the message was actually read 
+        time_key timestamp
+        keep_time_key true
       </parse>
     </source>
     <match **>
@@ -131,6 +135,12 @@ data:
       index_name "#{ENV['DOMAIN_UID']}"
       scheme https
       ssl_version TLSv1_2
+      key_name timestamp 
+      types timestamp:time
+      # inject the @timestamp special field (as type time) into the record
+      # so you will can do time based queries.
+      # not to be confused with timestamp which is of type string!!!
+      include_timestamp true
     </match>
 EOF
 ```


### PR DESCRIPTION
This PR updates the fluentd sample that we have in the docs.  The current sample passes through the `timestamp` as a `string` which means you cannot do time-based queries like "before x" or "between x and y" or "in the last 15 minutes".

The PR updates the sample so that the special `@timestamp` field will be added, with type `time` and with the same value as the `string timestamp`.  This will allow users to do time based queries. 