### PR TITLE
couple of changes/fixes in cleanup.sh

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -63,7 +63,8 @@ public class ConfigMapHelperTest {
     "utils.sh",
     "wlst.sh",
     "tailLog.sh",
-    "monitorLog.sh"
+    "monitorLog.sh",
+    "encryption_util.py"
   };
   private static final String DOMAIN_NS = "namespace";
   private static final String OPERATOR_NS = "operator";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -64,7 +64,8 @@ public class ConfigMapHelperTest {
     "wlst.sh",
     "tailLog.sh",
     "monitorLog.sh",
-    "encryption_util.py"
+    "encryption_util.py",
+    "model_diff.py"
   };
   private static final String DOMAIN_NS = "namespace";
   private static final String OPERATOR_NS = "operator";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -65,7 +65,8 @@ public class ConfigMapHelperTest {
     "tailLog.sh",
     "monitorLog.sh",
     "encryption_util.py",
-    "model_diff.py"
+    "model_diff.py",
+    "wdt_create_filter.py"
   };
   private static final String DOMAIN_NS = "namespace";
   private static final String OPERATOR_NS = "operator";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ConfigMapHelperTest.java
@@ -64,9 +64,11 @@ public class ConfigMapHelperTest {
     "wlst.sh",
     "tailLog.sh",
     "monitorLog.sh",
-    "encryption_util.py",
     "model_diff.py",
-    "wdt_create_filter.py"
+    "modelInImage.sh",
+    "wdt_create_filter.py",
+    "model_filters.json",
+    "encryption_util.py"
   };
   private static final String DOMAIN_NS = "namespace";
   private static final String OPERATOR_NS = "operator";

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -328,7 +328,7 @@ if [ -x "$(command -v helm)" ]; then
   namespaces=`kubectl get ns | grep -v NAME | awk '{ print $1 }'`
   for ns in $namespaces
   do 
-     helm list --short --namespace $ns | while read helm_name; do
+     helm list --short | while read helm_name; do
      if [ "$HELM_VERSION" == "V2" ]; then
        echo "@@ Running command - helm delete --purge  $helm_name"
        helm delete --purge  $helm_name

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -196,14 +196,14 @@ function deleteWithLabels {
   getResWithLabel "$tempfile-0"
   echo @@ tempfile "$tempfile-0"
   deleteNamespaces "$tempfile-0"
-  deleteNonNamespacedResWithOneLabel "$tempfile-0"
+  #deleteNonNamespacedResWithOneLabel "$tempfile-0"
 
   #echo @@ Deleting wls operator resources.
   LABEL_SELECTOR="weblogic.operatorName"
   #deleteWithOneLabel "$tempfile-1"
   getResWithLabel "$tempfile-1"
   deleteNamespaces "$tempfile-1"
-  deleteNonNamespacedResWithOneLabel "$tempfile-1"
+  #deleteNonNamespacedResWithOneLabel "$tempfile-1"
 
   echo @@ Deleting voyager controller.
   if [ "$HANDLE_VOYAGER" = "true" ]; then

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -24,7 +24,7 @@
 #   DELETE_FILES    Delete local test files, and launch a job to delete PV
 #                   hosted test files (default true).
 #
-#   FAST_DELETE     Set to "--grace-period=1 --timeout=1" to speedup
+#   FAST_DELETE     Set to "--grace-period=1 --timeout=1s" to speedup
 #                   deletes and skip phase 2.
 #
 # --------------------
@@ -384,8 +384,8 @@ deleteWithLabels
 #   arg2 - non-namespaced artifacts
 #   arg3 - keywords in deletable artificats
 
-echo @@ Starting genericDelete
-genericDelete "all,cm,pvc,roles,rolebindings,serviceaccount,secrets,ingress" "crd,pv,ns,clusterroles,clusterrolebindings" "logstash|kibana|elastisearch|weblogic|elk|domain|traefik|voyager|apache-webtier|mysql"
+#echo @@ Starting genericDelete
+#genericDelete "all,cm,pvc,roles,rolebindings,serviceaccount,secrets,ingress" "crd,pv,ns,clusterroles,clusterrolebindings" "logstash|kibana|elastisearch|weblogic|elk|domain|traefik|voyager|apache-webtier|mysql"
 SUCCESS="$?"
 
 if [ "${DELETE_FILES:-true}" = "true" ]; then

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -102,12 +102,14 @@ function deleteWithOneLabel {
   getResWithLabel $1
   # delete namespaced types
   cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
+    echo "@@ Running command - kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l $LABEL_SELECTOR"
     kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l "$LABEL_SELECTOR"
   done
 
   # delete non-namespaced types
   local no_namespace_count=`grep -c -v " -n " $1`
   if [ ! "$no_namespace_count" = "0" ]; then
+    echo "@@ Running command - kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l $LABEL_SELECTOR"
     kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l "$LABEL_SELECTOR"
   fi
 
@@ -140,6 +142,7 @@ function deleteWithOneLabel {
 function deleteNamespaces {
   cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
     if [ "$line" != "default" ]; then
+      echo "@@ Running command - kubectl $FAST_DELETE delete namespace $line --ignore-not-found"
       kubectl $FAST_DELETE delete namespace $line --ignore-not-found
     fi
   done

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -330,9 +330,11 @@ if [ -x "$(command -v helm)" ]; then
   do 
      helm list --short --namespace $ns | while read helm_name; do
      if [ "$HELM_VERSION" == "V2" ]; then
+       echo "@@ Running command - helm delete --purge  $helm_name"
        helm delete --purge  $helm_name
-     else 
-      helm uninstall $helm_name -n $ns 
+     else
+       echo "@@ Running command - helm uninstall $helm_name -n $ns"
+       helm uninstall $helm_name -n $ns
      fi
      done
   done

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -338,9 +338,9 @@ if [ -x "$(command -v helm)" ]; then
   done
 
   # cleanup tiller artifacts
-  if [ "$SHARED_CLUSTER" = "true" ]; then
-    cleanup_tiller
-  fi
+  #if [ "$SHARED_CLUSTER" = "true" ]; then
+  #  cleanup_tiller
+  #fi
 fi
 
 # second, try to delete with labels since the conversion is that all created resources need to

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -101,10 +101,10 @@ function deleteWithOneLabel {
   echo @@ Deleting resources with label $LABEL_SELECTOR.
   getResWithLabel $1
   # delete namespaced types
-  cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
-    echo "@@ Running command - kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l $LABEL_SELECTOR"
-    kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l "$LABEL_SELECTOR"
-  done
+  #cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
+  #  echo "@@ Running command - kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l $LABEL_SELECTOR"
+  #  kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l "$LABEL_SELECTOR"
+  #done
 
   # delete non-namespaced types
   local no_namespace_count=`grep -c -v " -n " $1`
@@ -113,26 +113,26 @@ function deleteWithOneLabel {
     kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l "$LABEL_SELECTOR"
   fi
 
-  echo "@@ Waiting for pods to stop running."
-  local total=0
-  local mstart=`date +%s`
-  local mnow=mstart
-  local maxwaitsecs=60
-  while [ $((mnow - mstart)) -lt $maxwaitsecs ]; do
-    pods=($(kubectl get pods --all-namespaces -l $LABEL_SELECTOR -o jsonpath='{range .items[*]}{.metadata.name} {end}'))
-    total=${#pods[*]}
-    if [ $total -eq 0 ] ; then
-        break
-    else
-      echo "@@ There are $total running pods with label $LABEL_SELECTOR."
-    fi
-    sleep 3
-    mnow=`date +%s`
-  done
+  #echo "@@ Waiting for pods to stop running."
+  #local total=0
+  #local mstart=`date +%s`
+  #local mnow=mstart
+  #local maxwaitsecs=60
+  #while [ $((mnow - mstart)) -lt $maxwaitsecs ]; do
+  #  pods=($(kubectl get pods --all-namespaces -l $LABEL_SELECTOR -o jsonpath='{range .items[*]}{.metadata.name} {end}'))
+  #  total=${#pods[*]}
+  #  if [ $total -eq 0 ] ; then
+  #      break
+  #  else
+  #    echo "@@ There are $total running pods with label $LABEL_SELECTOR."
+  #  fi
+  #  sleep 3
+  #  mnow=`date +%s`
+  #done
 
-  if [ $total -gt 0 ]; then
-    echo "Warning: after waiting $maxwaitsecs seconds, there are still $total running pods with label $LABEL_SELECTOR."
-  fi
+  #if [ $total -gt 0 ]; then
+  #  echo "Warning: after waiting $maxwaitsecs seconds, there are still $total running pods with label $LABEL_SELECTOR."
+  #fi
 }
 
 #
@@ -327,7 +327,8 @@ if [ -x "$(command -v helm)" ]; then
   echo @@ Deleting installed helm charts
   namespaces=`kubectl get ns | grep -v NAME | awk '{ print $1 }'`
   for ns in $namespaces
-  do 
+  do
+     echo "@@ Running command - helm list --short | while read helm_name; do"
      helm list --short | while read helm_name; do
      if [ "$HELM_VERSION" == "V2" ]; then
        echo "@@ Running command - helm delete --purge  $helm_name"

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -85,7 +85,7 @@ function getResWithLabel {
           -l "$LABEL_SELECTOR" \
           -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{"\n"}{end}' \
           --all-namespaces=true >> $1
-  
+
 }
 
 #
@@ -159,6 +159,7 @@ function deleteWithOneLabel {
 # deleteNamespaces outputfile
 #
 function deleteNamespaces {
+  cat $1
   cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
     if [ "$line" != "default" ]; then
       echo "@@ Running command - kubectl $FAST_DELETE delete namespace $line --ignore-not-found"
@@ -191,6 +192,7 @@ function deleteWithLabels {
   LABEL_SELECTOR="weblogic.domainUID"
   #deleteWithOneLabel "$tempfile-0"
   getResWithLabel "$tempfile-0"
+  echo @@ tempfile "$tempfile-0"
   deleteNamespaces "$tempfile-0"
   deleteNonNamespacedResWithOneLabel "$tempfile-0"
 

--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -100,6 +100,8 @@ function deleteNonNamespacedResWithOneLabel {
   # delete non-namespaced types
   local no_namespace_count=`grep -c -v " -n " $1`
   if [ ! "$no_namespace_count" = "0" ]; then
+    echo "@@ Running command - kubectl $FAST_DELETE get $NOT_NAMESPACED_TYPES -l $LABEL_SELECTOR"
+    kubectl $FAST_DELETE get $NOT_NAMESPACED_TYPES -l "$LABEL_SELECTOR"
     echo "@@ Running command - kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l $LABEL_SELECTOR"
     kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l "$LABEL_SELECTOR"
   fi


### PR DESCRIPTION
changes made in cleanup.sh for the below

don't delete monitoring namespace
add date and time in debug messages
modified helm chart deletion not to loop for helm2 as its not needed. Current external jenkins uses helm 2.  For helm 3 @anpanigr or me will fix the code to not loop for namespaces instead use `helm list --all-namespaces`
comment out tiller deletion, not sure why we have it here 