### PR TITLE
Make cleanup script more orderly in its deletes.

### DIFF
--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -20,6 +20,7 @@
 #                   given lease on a failure.
 #
 #   SHARED_CLUSTER  Set this to true if you want cleanup to delete tiller
+#                   TBD tiller delete is disabled 
 #
 #   DELETE_FILES    Delete local test files, and launch a job to delete PV
 #                   hosted test files (default true).
@@ -27,14 +28,26 @@
 #   FAST_DELETE     Set to "--grace-period=1 --timeout=1" to speedup
 #                   deletes and skip phase 2.
 #
+# Dry run option: 
+#
+#   To show what the script would do without actually doing
+#   any deletes pass "-dryrun" as the first parameter.
+#
 # --------------------
 # Detailed Description
 # --------------------
 #
-# The test runs in phases:
+# The cleanup runs in phases:
+#
+#   Phase -3: Delete all domains
+#  
+#   Phase -2: Delete all operator deployments
+# 
+#   Phase -1: Delete all WL and introspector pods
 #
 #   Phase 0:  If helm is installed, helm delete all helm charts.
 #             Possibly also delete tiller (see SHARED_CLUSTER env var above.)
+#             TBD tiller delete is disabled 
 #
 #   Phase 1:  Delete test kubernetes artifacts with labels.
 #
@@ -60,128 +73,282 @@ RESULT_DIR="$RESULT_ROOT/acceptance_test_tmp"
 USER_PROJECTS_DIR="$RESULT_DIR/user-projects"
 TMP_DIR="$RESULT_DIR/cleanup_tmp"
 JOB_NAME="weblogic-command-job"
+DRY_RUN="false"
+[ "$1" = "-dryrun" ] && DRY_RUN="true"
 
+echo @@ Starting cleanup.
+script="${BASH_SOURCE[0]}"
+scriptDir="$( cd "$(dirname "${script}")" > /dev/null 2>&1 ; pwd -P)"
+source $PROJECT_ROOT/kubernetes/internal/utility.sh
+
+if [ ! "$1" = "" ] && [ ! "$1" = "-dryrun" ]; then
+  echo "@@ Usage: '$(basename $0) [-dryrun]'. Pass -dryrun to skip deletes."
+  exit 1  
+fi
 
 function fail {
   echo @@ cleanup.sh: Error "$@"
   exit 1
 }
 
-#!/bin/bash
-#
-# Usage:
-# getResWithLabel outfilename
-#
-function getResWithLabel {
+# use for kubectl delete of a specific name, exits silently if nothing found via 'get'
+# usage: doDeleteByName [-n foobar] kind name
+function doDeleteByName {
 
-  # first, let's get all namespaced types with -l $LABEL_SELECTOR
-  kubectl get $NAMESPACED_TYPES \
-          -l "$LABEL_SELECTOR" \
-          -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}{end}' \
-          --all-namespaces=true >> $1
+  local tmpfile="/tmp/$(basename $0).doDeleteByName.$PPID.$SECONDS"
 
-  # now, get all non-namespaced types with -l $LABEL_SELECTOR
-  kubectl get $NOT_NAMESPACED_TYPES \
-          -l "$LABEL_SELECTOR" \
-          -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{"\n"}{end}' \
-          --all-namespaces=true >> $1
+  kubectl get "$@" -o=jsonpath='{.items[*]}{.kind}{" "}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}' > $tmpfile
+
+  # exit silently if nothing to delete
+  [ `cat $tmpfile | wc -l` -eq 0 ] && return
+
+  local ttextt=""
+  [ "$DRY_RUN" = "true" ] && ttextt="DRYRUN"
+  echo @@ doDeleteByName $ttextt: kubectl $FAST_DELETE delete "$@" --ignore-not-found
+  cat $tmpfile 
+  rm $tmpfile
+
+  if [ ! "$DRY_RUN" = true ]; then
+    kubectl $FAST_DELETE delete "$@" --ignore-not-found 
+  fi
 }
 
-#
-# Usage:
-# deleteResWithLabel outputfile
-#
-function deleteWithOneLabel {
-  echo @@ Delete resources with label $LABEL_SELECTOR.
-  # clean the output file first
-  if [ -e $1 ]; then
-    rm $1
-  fi
+# use for kubectl delete of a potential set, exits silently if nothing found via 'get'
+# usage: doDeleteByRange [-n foobar] kind -l labelexpression -l labelexpression ...
+function doDeleteByRange {
 
-  echo @@ Deleting resources with label $LABEL_SELECTOR.
-  getResWithLabel $1
-  # delete namespaced types
-  cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
-    echo "@@ Running command - kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l $LABEL_SELECTOR"
-    kubectl $FAST_DELETE -n $line delete $NAMESPACED_TYPES -l "$LABEL_SELECTOR"
+  local tmpfile="/tmp/$(basename $0).doDeleteByRange.$PPID.$SECONDS"
+
+  kubectl get "$@" -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}' > $tmpfile
+
+  # exit silently if nothing to delete
+  [ `cat $tmpfile | wc -l` -eq 0 ] && return
+
+  local ttextt=""
+  [ "$DRY_RUN" = "true" ] && ttextt="DRYRUN"
+  echo @@ doDeleteByRange $ttextt: kubectl $FAST_DELETE delete "$@" --ignore-not-found
+  cat $tmpfile 
+  rm $tmpfile
+
+  if [ ! "$DRY_RUN" = true ]; then
+    kubectl $FAST_DELETE delete "$@" --ignore-not-found 
+  fi
+}
+
+# waits up to $1 seconds for WL pods and introspector pods to exit
+waitForWebLogicPods() {
+  local pod_count_wls=0
+  local pod_count_int=0
+  local pod_count_tot=0
+  local max_secs=${1:-60}
+  STARTSEC=$SECONDS
+  echo "@@ Info: Waiting $max_secs seconds for WebLogic server and introspector pods to exit."
+  echo -n "@@ Info: seconds/introspector-pod-count/wl-pod-count:"
+  while [ $((SECONDS - STARTSEC)) -lt $max_secs ]; do
+    # WebLogic server pods have the 'weblogic.serverName' label
+    pod_count_wls="$(kubectl --all-namespaces=true get pods -l weblogic.serverName -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | wc -l)"
+    # Introspector pods have the 'weblogic.domainUID' and 'job-name' labels
+    pod_count_int="$(kubectl --all-namespaces=true get pods -l weblogic.domainUID -l job-name -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | wc -l)"
+    pod_count_tot=$((pod_count_wls + pod_count_int))
+      if [ $((pod_count_tot)) -eq 0 ]; then
+      break
+    fi
+    echo -n " $((SECONDS - STARTSEC))/$pod_count_int/$pod_count_wls"
+    sleep 2
   done
+  echo
 
-  # delete non-namespaced types
-  local no_namespace_count=`grep -c -v " -n " $1`
-  if [ ! "$no_namespace_count" = "0" ]; then
-    echo "@@ Running command - kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l $LABEL_SELECTOR"
-    kubectl $FAST_DELETE delete $NOT_NAMESPACED_TYPES -l "$LABEL_SELECTOR"
+  if [ $((pod_count_tot)) -ne 0 ]; then
+    echo "@@ Warning: Wait timed out after $max_secs seconds. There are still $pod_count_tot pods running:"
+    kubectl --all-namespaces=true get pods -l weblogic.serverName
+    kubectl --all-namespaces=true get pods -l weblogic.domainUID -l job-name
+  else
+    echo "@@ Info: No pods detected after $((SECONDS - STARTSEC)) seconds."
   fi
+}
 
-  echo "@@ Waiting for pods to stop running."
+# waits up to $1 seconds for $LABEL_SELECTOR pods to exit
+waitForLabelPods() {
+  #
+  # wait for pods with label $LABEL_SELECTOR to exit
+  #
+
   local total=0
   local mstart=`date +%s`
   local mnow=mstart
-  local maxwaitsecs=60
+  local maxwaitsecs=$1
+  local pods
+  echo "@@ Waiting $maxwaitsecs for pods to stop running."
   while [ $((mnow - mstart)) -lt $maxwaitsecs ]; do
     pods=($(kubectl get pods --all-namespaces -l $LABEL_SELECTOR -o jsonpath='{range .items[*]}{.metadata.name} {end}'))
     total=${#pods[*]}
     if [ $total -eq 0 ] ; then
         break
     else
-      echo "@@ There are $total running pods with label $LABEL_SELECTOR."
+      echo "@@ There are $total running pods with label $LABEL_SELECTOR: $pods".
     fi
     sleep 3
     mnow=`date +%s`
   done
 
   if [ $total -gt 0 ]; then
-    echo "Warning: after waiting $maxwaitsecs seconds, there are still $total running pods with label $LABEL_SELECTOR."
+    echo "@@ Warning: after waiting $maxwaitsecs seconds, there are still $total running pods with label $LABEL_SELECTOR: $pods"
   fi
 }
 
-#
-# Usage:
-# deleteNamespaces outputfile
-#
+# delete all domains in all namespaces
+# operator(s) should detect domain deletion and shutdown the domain's pods
+deleteDomains() {
+  local ns
+  local dn
+  local domain_crd=domains.weblogic.oracle
+  local count=0
+  echo "@@ Info: About to delete each domain."
+  if [ $(kubectl get crd $domain_crd --ignore-not-found | grep $domain_crd | wc -l) = 1 ]; then
+    for ns in $(kubectl get namespace -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}')
+    do
+      for dn in $(kubectl -n $ns get domain -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}')
+      do
+        doDeleteByName -n $ns domain $dn
+        count=$((count + 1))
+      done
+    done
+  fi
+  echo "@@ Info: Found and deleted $count domains."
+  return 0
+}
+
+# delete all operator deployments
+deleteOperators() {
+  echo "@@ Info: Deleting operator deployments."
+  local ns
+  for ns in $(kubectl get namespace -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}')
+  do
+    doDeleteByRange -n $ns deployments -l weblogic.operatorName
+  done
+}
+
+# delete all WL pods
+deleteWebLogicPods() {
+  echo "@@ Info: Deleting WebLogic pods."
+  local ns
+  for ns in $(kubectl get namespace -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}')
+  do
+    # WLS pods
+    doDeleteByRange -n $ns pods -l weblogic.serverName
+    # Introspector pods
+    doDeleteByRange -n $ns pods -l weblogic.domainUID -l job-name
+  done
+}
+
+# delete everything with label $LABEL_SELECTOR
+# - the delete order is order of NAMESPACED_TYPES and then NOT_NAMESPACED_TYPES
+# - uses $1 as a temporary file
+function deleteLabel {
+  echo @@ Delete resources with label $LABEL_SELECTOR.
+
+  # clean the output file first
+
+  rm -f $1
+
+  #
+  # first, let's get all namespaced types with -l $LABEL_SELECTOR
+  #        in the order they're specified in NAMESPACED_TYPES
+  #
+
+  for resource_type in $NAMESPACED_TYPES
+  do
+    kubectl get $resource_type \
+      -l "$LABEL_SELECTOR" \
+      -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}{end}' \
+      --all-namespaces=true >> $1
+  done
+
+  #
+  # now, get all non-namespaced types with -l $LABEL_SELECTOR
+  #      in the order they're specified in NOT_NAMESPACED_TYPES
+  #
+
+  for resource_type in $NOT_NAMESPACED_TYPES
+  do
+    kubectl get $resource_type \
+      -l "$LABEL_SELECTOR" \
+      -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{"\n"}{end}' \
+      --all-namespaces=true >> $1
+  done
+
+  #
+  # now, let's do the actual deletes, one by one, in the order above
+  #
+
+  cat $1 | while read line; do
+    doDeleteByName $line 
+  done
+
+  #
+  # finally, let's wait for pods with label $LABEL_SELECTOR to exit
+  #
+
+  if [ "$DRY_RUN" = "true" ]; then
+    waitForLabelPods 10
+  else
+    waitForLabelPods 60
+  fi
+}
+
+# deletes all namespaces in the $1 file, assumes the namespaces are in column 4 of $1
+# TBD: Currently not called
 function deleteNamespaces {
   cat $1 | awk '{ print $4 }' | grep -v "^$" | sort -u | while read line; do
     if [ "$line" != "default" ]; then
-      echo "@@ Running command - kubectl $FAST_DELETE delete namespace $line --ignore-not-found"
       kubectl $FAST_DELETE delete namespace $line --ignore-not-found
     fi
   done
-
 }
 
-function deleteWithLabels {
-  NAMESPACED_TYPES="pod,job,deploy,rs,service,pvc,ingress,cm,serviceaccount,role,rolebinding,secret"
-
+# Delete everything individually by name, one by one, in order of type, that matches given label $LABEL_SELECTOR
+# The order is determined by NAMESPACED_TYPES NOT_NAMESPACED_TYPES below...
+function deleteByTypeAndLabel {
   HANDLE_VOYAGER="false"
   VOYAGER_ING_NAME="ingresses.voyager.appscode.com"
   if [ `kubectl get crd $VOYAGER_ING_NAME --ignore-not-found | grep $VOYAGER_ING_NAME | wc -l` = 1 ]; then
-    NAMESPACED_TYPES="$VOYAGER_ING_NAME,$NAMESPACED_TYPES"
     HANDLE_VOYAGER="true"
+  else
+    VOYAGER_ING_NAME=""
   fi
 
   DOMAIN_CRD="domains.weblogic.oracle"
-  if [ `kubectl get crd $DOMAIN_CRD --ignore-not-found | grep $DOMAIN_CRD | wc -l` = 1 ]; then
-    NAMESPACED_TYPES="$DOMAIN_CRD,$NAMESPACED_TYPES"
+  if [ ! `kubectl get crd $DOMAIN_CRD --ignore-not-found | grep $DOMAIN_CRD | wc -l` = 1 ]; then
+    DOMAIN_CRD=""
   fi
 
-  NOT_NAMESPACED_TYPES="pv,crd,clusterroles,clusterrolebindings"
+  NAMESPACED_TYPES="$DOMAIN_CRD pod job deploy rs service ingress $VOYAGER_ING_NAME pvc cm serviceaccount role rolebinding secret"
+
+  NOT_NAMESPACED_TYPES="pv crd clusterroles clusterrolebindings"
 
   tempfile="/tmp/$(basename $0).tmp.$$"  # == /tmp/[script-file-name].tmp.[pid]
 
-  echo @@ Deleting domain resources.
   LABEL_SELECTOR="weblogic.domainUID"
-  deleteWithOneLabel "$tempfile-0"
+  echo "@@ Deleting wls domain resources by LABEL_SELECTOR='$LABEL_SELECTOR', NAMESPACED_TYPES='$NAMESPACED_TYPES', NOT_NAMESPACED_TYPES='$NOT_NAMESPACED_TYPES'."
+  deleteLabel "$tempfile-0"
 
-  echo @@ Deleting wls operator resources.
   LABEL_SELECTOR="weblogic.operatorName"
-  deleteWithOneLabel "$tempfile-1"
+  echo "@@ Deleting wls operator resources by LABEL_SELECTOR='$LABEL_SELECTOR', NAMESPACED_TYPES='$NAMESPACED_TYPES', NOT_NAMESPACED_TYPES='$NOT_NAMESPACED_TYPES'."
+  deleteLabel "$tempfile-1"
 
-  deleteNamespaces "$tempfile-0"
-  deleteNamespaces "$tempfile-1"
+  # TBD: This appears to hurt more than it helps. Doesn't protect against out of order deletes.
+  # deleteNamespaces "$tempfile-0"
+  # deleteNamespaces "$tempfile-1"
 
-  echo @@ Deleting voyager controller.
+  rm -f $tempfile-0
+  rm -f $tempfile-1
+  
   if [ "$HANDLE_VOYAGER" = "true" ]; then
-    deleteVoyagerOperator
+    if [ ! "$DRY_RUN" = "true" ]; then
+      echo @@ Deleting voyager controller.
+      # calls script in utility.sh
+      deleteVoyagerOperator
+    fi
   fi
 }
 
@@ -213,7 +380,11 @@ function genericDelete {
     if [ "$iteration" = "first" ]; then
       local maxwaitsecs=15
     else
-      local maxwaitsecs=60
+      if [ "$DRY_RUN" = "true" ]; then
+        local maxwaitsecs=15
+      else
+        local maxwaitsecs=60
+      fi
     fi
 
     echo "@@ Waiting up to $maxwaitsecs seconds for ${1:?} and ${2:?} artifacts that contain string ${3:?} to delete."
@@ -268,16 +439,14 @@ function genericDelete {
 
         if [ ${artcount_yes} -gt 0 ]; then
           cat "$resfile_yes" | while read line; do
-            local args="`echo \"$line\" | awk '{ print "-n " $1 " delete " $2 " --ignore-not-found" }'`"
-            echo "kubectl $args"
-            kubectl $args
+            local args="`echo \"$line\" | awk '{ print " " $2 " -n " $1  }'`"
+            doDeleteByName $args
           done
         fi
 
         if [ ${artcount_no} -gt 0 ]; then
           cat "$resfile_no" | while read line; do
-            echo "kubectl $FAST_DELETE delete $line --ignore-not-found"
-            kubectl $FAST_DELETE delete $line --ignore-not-found
+            doDeleteByName $line
           done
         fi
 
@@ -298,27 +467,52 @@ function genericDelete {
   return 1
 }
 
-function cleanup_tiller {
-  kubectl $FAST_DELETE -n kube-system delete deployment tiller-deploy --ignore-not-found=true
-  kubectl $FAST_DELETE delete clusterrolebinding tiller-cluster-rule --ignore-not-found=true
-  kubectl $FAST_DELETE -n kube-system delete serviceaccount tiller --ignore-not-found=true
-}
 
 function fail {
   echo @@ cleanup.sh: Error "$@"
   exit 1
 }
 
-echo @@ Starting cleanup.
-script="${BASH_SOURCE[0]}"
-scriptDir="$( cd "$(dirname "${script}")" > /dev/null 2>&1 ; pwd -P)"
-source $PROJECT_ROOT/kubernetes/internal/utility.sh
 
 echo "@@ RESULT_ROOT=$RESULT_ROOT TMP_DIR=$TMP_DIR RESULT_DIR=$RESULT_DIR PROJECT_ROOT=$PROJECT_ROOT PV_ROOT=$PV_ROOT"
 
 mkdir -p $TMP_DIR || fail No permision to create directory $TMP_DIR
 
-# first, if helm is installed, delete all installed helm charts
+#
+# Phase -3: Delete every domain, then wait for their pods to go away
+#
+
+deleteDomains
+
+if [ "$DRY_RUN" = "true" ]; then
+  waitForWebLogicPods 10
+else
+  waitForWebLogicPods 60
+fi
+
+#
+# Phase -2: Delete every operator deployment
+#
+
+deleteOperators
+
+#
+# Phase -1: Delete every WL pod, including introspector pods, then wait for the pods to go away
+#  (If the operators were healthy when domains were deleted above, there should be no pods, but just in case.)
+#
+
+deleteWebLogicPods
+
+if [ "$DRY_RUN" = "true" ]; then
+  waitForWebLogicPods 10
+else
+  waitForWebLogicPods 60
+fi
+
+#
+# Phase 0: if helm is installed, delete all installed helm charts
+#
+
 if [ -x "$(command -v helm)" ]; then
   helm version --short --client  | grep v2
   [[ $? == 0 ]] && HELM_VERSION=V2
@@ -328,39 +522,64 @@ if [ -x "$(command -v helm)" ]; then
   namespaces=`kubectl get ns | grep -v NAME | awk '{ print $1 }'`
   for ns in $namespaces
   do 
+   if [ ! "$DRY_RUN" = "true" ]; then
+     (
+     set -x
      helm list --short --namespace $ns | while read helm_name; do
-     if [ "$HELM_VERSION" == "V2" ]; then
-       helm delete --purge  $helm_name
-     else 
-      helm uninstall $helm_name -n $ns 
-     fi
+       if [ "$HELM_VERSION" == "V2" ]; then
+         helm delete --purge  $helm_name
+       else 
+         helm uninstall $helm_name -n $ns 
+       fi
      done
+     )
+   else
+     (
+     helm list --short --namespace $ns | while read helm_name; do
+       if [ "$HELM_VERSION" == "V2" ]; then
+         echo @@ Info: DRYRUN: helm delete --purge  $helm_name
+       else 
+         echo @@ Info: DRYRUN: helm uninstall $helm_name -n $ns 
+       fi
+     done
+     )
+   fi
   done
 
   # cleanup tiller artifacts
   if [ "$SHARED_CLUSTER" = "true" ]; then
-    cleanup_tiller
+    echo @@ Skipping tiller delete.
+    # TBD: According to MarkN no Tiller delete is needed.
+    # kubectl $FAST_DELETE -n kube-system delete deployment tiller-deploy --ignore-not-found=true
+    # kubectl $FAST_DELETE delete clusterrolebinding tiller-cluster-rule --ignore-not-found=true
+    # kubectl $FAST_DELETE -n kube-system delete serviceaccount tiller --ignore-not-found=true
   fi
 fi
 
-# second, try to delete with labels since the conversion is that all created resources need to
-# have the proper label(s)
-echo @@ Starting deleteWithLabels
-deleteWithLabels
+#
+# Phase 1, try an orderly mass delete, in order of type, looking for Operator related labels 
+#
 
-# third, try a generic delete in case there are some leftover resources, this runs in two phases:
-#   phase 1:  wait to see if artifacts dissappear naturally due to the above 
-#   phase 2:  kubectl delete left over artifacts
+deleteByTypeAndLabel
+
+#
+#   Phase 1 (continued):  wait to see if artifacts dissappear naturally due phase 1 effort
+#   Phase 2: kubectl delete left over artifacts individually in no specific order
+#            (Try a generic delete in case there are some leftover resources.)
 # arguments
 #   arg1 - namespaced kubernetes artifacts
 #   arg2 - non-namespaced artifacts
-#   arg3 - keywords in deletable artificats
+#   arg3 - keywords in deletable artifacts
 
 echo @@ Starting genericDelete
 genericDelete "all,cm,pvc,roles,rolebindings,serviceaccount,secrets,ingress" "crd,pv,ns,clusterroles,clusterrolebindings" "logstash|kibana|elastisearch|weblogic|elk|domain|traefik|voyager|apache-webtier|mysql"
 SUCCESS="$?"
 
-if [ "${DELETE_FILES:-true}" = "true" ]; then
+#
+# Phase 3: Delete pv host directories.
+#
+
+if [ "${DELETE_FILES:-true}" = "true" ] && [ "$DRY_RUN" = "false" ]; then
 
   # Delete pv directories using a run (/sharedparent maps to PV_ROOT on the k8s cluster machines).
 


### PR DESCRIPTION
Various updates to cleanup script:

- Additional tracing throughout

- Added a 'dry run' mode. This is useful for debugging the script itself. If you pass '-dryrun' on the command line, then the script will proceed without deleting anything - it will just echo potential delete commands - plus it will reduce it's wait-for-pods timeouts (since we know the pods aren't going away).

- Add timestamps to trace statements

- Remove its delete of tiller.

- Remove its direct delete of namespaces.

- Add new deletes before attempting its 'usual' deletes:
  - Delete domains and wait up to 60 seconds for their pods to go away (assumes operators will do this)
  - Delete operator deployments
  - Delete any leftover WLS and introspector pods and wait up to 60 seconds for them to go away

- Modify the 'old' path a bit. Here's the 'old' path in order of occurrence:
  - Uninstall every helm install as before
  - Delete by type-and-label is now updated to delete each type individually in a specific order, instead of all types in one command
  - Note that the final catch-all 'generic' delete step is still random in ordering, but hopefully the new and ordered deletes above will mitigate issues with this...
  - Delete hostpath directory as before