### PR TITLE
Remove mii section from samples domain-template.yaml

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1707,6 +1707,14 @@ public class Domain {
               + "/integration-tests/src/test/resources/model-in-image "
               + resultsDir + "/samples",
           true);
+      //append mii section to domain-template.yaml
+      Path domainTemplateFile = Paths.get(
+          resultsDir + "/samples/scripts/common/domain-template.yaml");
+      Path miiConfigPartFile = Paths.get(
+          resultsDir + "/samples/model-in-image/miisection-toaddin-domain-template.yaml");
+      Files.write(domainTemplateFile, Files.readAllBytes(miiConfigPartFile),
+          StandardOpenOption.APPEND);
+
     }
 
     this.voyager =

--- a/integration-tests/src/test/resources/model-in-image/miisection-toaddin-domain-template.yaml
+++ b/integration-tests/src/test/resources/model-in-image/miisection-toaddin-domain-template.yaml
@@ -1,0 +1,26 @@
+  %MII_PREFIX%configuration:
+  # secrets: [ %DOMAIN_UID%-rcu-access ]
+
+    %MII_PREFIX%  model:
+  #
+  # Optional configmap for additional models and variable files
+  #
+    %MII_CONFIG_MAP_PREFIX%    configMap: %MII_CONFIG_MAP%
+
+     #
+     # wdt domain type for model in image case
+     # Valid WDT_DOMAIN_TYPE_VALUES are 'WLS', 'JRF', and 'RestrictedJRF'
+  #
+    %MII_PREFIX%    domainType: %WDT_DOMAIN_TYPE%
+    %MII_PREFIX%    runtimeEncryptionSecret: %WEBLOGIC_CREDENTIALS_SECRET_NAME%
+
+     #opss:
+     #
+     # k8 secret for the opss extract wallet.  It contains the key passphrase used to extract the wallet
+     #
+     #walletPasswordSecret: %DOMAIN_UID%-opss-key-passphrase-secret
+     #
+     # opss wallet file secret containing key ewallet.p12 containing the base64 encoded opss wallet
+     #walletFileSecret: %DOMAIN_UID%-opss-walletfile-secret
+     #
+  #

--- a/kubernetes/samples/scripts/common/domain-template.yaml
+++ b/kubernetes/samples/scripts/common/domain-template.yaml
@@ -16,7 +16,6 @@ spec:
   domainHome: %DOMAIN_HOME%
 
   # The domain home source type
-  # Set to PersistentVolume for domain-in-pv, Image for domain-in-image, or FromModel for model-in-image
   domainHomeSourceType: %DOMAIN_HOME_SOURCE_TYPE%
 
   # The WebLogic Server Docker image that the Operator uses to start the domain
@@ -98,30 +97,3 @@ spec:
     replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
   # The number of managed servers to start for unlisted clusters
   # replicas: 1
-
-  %MII_PREFIX%configuration:
-    # secrets: [ %DOMAIN_UID%-rcu-access ]
-
-  %MII_PREFIX%  model:
-      #
-      # Optional configmap for additional models and variable files
-      #
-  %MII_CONFIG_MAP_PREFIX%    configMap: %MII_CONFIG_MAP%
-
-      #
-      # wdt domain type for model in image case
-      # Valid WDT_DOMAIN_TYPE_VALUES are 'WLS', 'JRF', and 'RestrictedJRF'
-      #
-  %MII_PREFIX%    domainType: %WDT_DOMAIN_TYPE%
-  %MII_PREFIX%    runtimeEncryptionSecret: %WEBLOGIC_CREDENTIALS_SECRET_NAME%
-
-    #opss:
-      #
-      # k8 secret for the opss extract wallet.  It contains the key passphrase used to extract the wallet
-      #
-      #walletPasswordSecret: %DOMAIN_UID%-opss-key-passphrase-secret
-      #
-      # opss wallet file secret containing key ewallet.p12 containing the base64 encoded opss wallet
-      #walletFileSecret: %DOMAIN_UID%-opss-walletfile-secret
-      #
-      #

--- a/kubernetes/samples/scripts/common/domain-template.yaml
+++ b/kubernetes/samples/scripts/common/domain-template.yaml
@@ -16,6 +16,7 @@ spec:
   domainHome: %DOMAIN_HOME%
 
   # The domain home source type
+  # Set to PersistentVolume for domain-in-pv, Image for domain-in-image, or FromModel for model-in-image
   domainHomeSourceType: %DOMAIN_HOME_SOURCE_TYPE%
 
   # The WebLogic Server Docker image that the Operator uses to start the domain

--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -302,12 +302,14 @@ function createFiles {
     istioPrefix="${disabledPrefix}"
   fi
 
+  # MII settings are used for model-in-image integration testing
   if [ "${domainHomeSourceType}" == "FromModel" ]; then
     miiPrefix="${enabledPrefix}"
   else
     miiPrefix="${disabledPrefix}"
   fi
 
+  # MII settings are used for model-in-image integration testing
   if [ -z "${miiConfigMap}" ]; then
     miiConfigMapPrefix="${disabledPrefix}"
   else
@@ -502,6 +504,7 @@ function createFiles {
   sed -i -e "s:%ISTIO_PREFIX%:${istioPrefix}:g" ${dcrOutput}
   sed -i -e "s:%ISTIO_ENABLED%:${istioEnabled}:g" ${dcrOutput}
   sed -i -e "s:%ISTIO_READINESS_PORT%:${istioReadinessPort}:g" ${dcrOutput}
+  # MII settings are used for model-in-image integration testing
   sed -i -e "s:%MII_PREFIX%:${miiPrefix}:g" ${dcrOutput}
   sed -i -e "s:%MII_CONFIG_MAP_PREFIX%:${miiConfigMapPrefix}:g" ${dcrOutput}
   sed -i -e "s:%MII_CONFIG_MAP%:${miiConfigMap}:g" ${dcrOutput}

--- a/kubernetes/samples/scripts/common/validate.sh
+++ b/kubernetes/samples/scripts/common/validate.sh
@@ -393,6 +393,7 @@ function validateCommonInputs {
   validateWeblogicImagePullPolicy
   validateWeblogicImagePullSecretName
   validateFmwDomainType
+  # Below three validate methods are used for MII integration testing
   validateWdtDomainType
   validateWdtModelFile
   validateWdtModelPropertiesFile
@@ -414,6 +415,7 @@ function validateDomainPVC {
 
 #
 # Function to validate the WDT model file exists
+# used for MII integration testing
 #
 function validateWdtModelFile {
   # Check if the model file exists
@@ -427,6 +429,7 @@ function validateWdtModelFile {
 
 #
 # Function to validate the WDT model property file exists
+# used for MII integration testing
 #
 function validateWdtModelPropertiesFile {
   # Check if the model property file exists
@@ -439,7 +442,7 @@ function validateWdtModelPropertiesFile {
 }
 
 # Function to validate the wdtDomainType
-#
+# used for MII integration testing
 function validateWdtDomainType {
   if [ ! -z ${wdtDomainType} ]; then
     case ${wdtDomainType} in


### PR DESCRIPTION
Remove mii section from samples domain-template.yaml as suggested by Tom/Dongbo as this file is used only for domain on pv and domain in image samples.
Integration tests append mii section to the domain-template.yaml
added comments in samples scripts utility.sh and validate.sh

Clean full test run on external jenkins - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-quicktest/1181/