### PR TITLE
remove mention of Helm 2.x

### DIFF
--- a/docs-source/content/quickstart/cleanup.md
+++ b/docs-source/content/quickstart/cleanup.md
@@ -10,14 +10,6 @@ weight: 7
 
 1.	Remove the domain's Ingress by using `helm`:
 
-    For Helm 2.x:
-    
-    ```bash
-    $ helm delete --purge sample-domain1-ingress
-    ```
-    
-    For Helm 3.x:
-
     ```bash
     $ helm uninstall sample-domain1-ingress -n sample-domain1-ns
     ```
@@ -37,17 +29,17 @@ weight: 7
 
 #### Remove the domain namespace.
 1.	Configure the Traefik load balancer to stop managing the Ingresses in the domain namespace:
-    
+
     ```bash
     $ helm upgrade traefik-operator stable/traefik \
         --namespace traefik \
         --reuse-values \
         --set "kubernetes.namespaces={traefik}" \
-        --wait 
+        --wait
     ```
 
 1.	Configure the operator to stop managing the domain:
-    
+
     ```bash
     $ helm upgrade  sample-weblogic-operator \
                   kubernetes/charts/weblogic-operator \
@@ -67,18 +59,10 @@ weight: 7
 
 1.	Remove the operator:
 
-    For Helm 2.x:
-    
-    ```bash
-    $ helm delete --purge sample-weblogic-operator
-    ```
-
-    For Helm 3.x:
-    
     ```bash
     $ helm uninstall sample-weblogic-operator -n sample-weblogic-operator-ns
     ```
-    
+
 1.	Remove the operator's namespace:
 
     ```bash
@@ -88,19 +72,11 @@ weight: 7
 #### Remove the load balancer.
 
 1.	Remove the Traefik load balancer:
-
-    For Helm 2.x:
-    
-    ```bash
-    $ helm delete --purge traefik-operator
-    ```
-
-    For Helm 3.x:
     
     ```bash
     $ helm uninstall traefik-operator -n traefik
     ```
-    
+
 1.	Remove the Traefik namespace:
 
     ```bash

--- a/docs-source/content/quickstart/create-domain.md
+++ b/docs-source/content/quickstart/create-domain.md
@@ -60,26 +60,14 @@ weight: 6
     ```
 
 1.	Create an Ingress for the domain, in the domain namespace, by using the [sample](http://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/ingress-per-domain/README.md) Helm chart:
-
-    For Helm 2.x:
-    
-    ```bash
-    $ helm install kubernetes/samples/charts/ingress-per-domain \
-      --name sample-domain1-ingress \
-      --namespace sample-domain1-ns \
-      --set wlsDomain.domainUID=sample-domain1 \
-      --set traefik.hostname=sample-domain1.org
-    ```
   
-    For Helm 3.x:
-    
     ```bash
     $ helm install sample-domain1-ingress kubernetes/samples/charts/ingress-per-domain \
       --namespace sample-domain1-ns \
       --set wlsDomain.domainUID=sample-domain1 \
       --set traefik.hostname=sample-domain1.org
     ```
-    
+
 
 1.	To confirm that the load balancer noticed the new Ingress and is successfully routing to the domain's server pods,
     you can send a request to the URL for the "WebLogic ReadyApp framework" which will return a HTTP 200 status code, as

--- a/docs-source/content/quickstart/install.md
+++ b/docs-source/content/quickstart/install.md
@@ -51,18 +51,6 @@ $ kubectl create namespace traefik
 
 Use the [values.yaml](http://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/traefik/values.yaml) in the sample but set `kubernetes.namespaces` specifically.
 
-For Helm 2.x:
-
-```bash
-$ helm install stable/traefik \
-  --name traefik-operator \
-  --namespace traefik \
-  --values kubernetes/samples/charts/traefik/values.yaml \
-  --set "kubernetes.namespaces={traefik}" \
-  --wait
-```
-
-For Helm 3.x:
 
 ```bash
 $ helm install traefik-operator stable/traefik \
@@ -88,19 +76,6 @@ $ helm install traefik-operator stable/traefik \
 
 3.  Use `helm` to install and start the operator from the directory you just cloned:	 
 
-    For Helm 2.x:
-
-    ```bash
-    $ helm install kubernetes/charts/weblogic-operator \
-      --name sample-weblogic-operator \
-      --namespace sample-weblogic-operator-ns \
-      --set image=oracle/weblogic-kubernetes-operator:2.5.0 \
-      --set serviceAccount=sample-weblogic-operator-sa \
-      --set "domainNamespaces={}" \
-      --wait
-    ```
-
-    For Helm 3.x:
 
     ```bash
     $ helm install sample-weblogic-operator kubernetes/charts/weblogic-operator \

--- a/docs-source/content/samples/simple/rest/_index.md
+++ b/docs-source/content/samples/simple/rest/_index.md
@@ -45,21 +45,6 @@ in the ***Security*** section.
 The script as used below will create the `tls secret` named `weblogic-operator-identity` in the namespace `weblogic-operator-ns` using a self-signed
 certificate and private key:
 
-For Helm 2.x:
-
-```
-$ echo "externalRestEnabled: true" > my_values.yaml
-$ generate-external-rest-identity.sh \
-  -a "DNS:${HOSTNAME},DNS:localhost,IP:127.0.0.1" \
-  -n weblogic-operator-ns -s weblogic-operator-identity >> my_values.yaml
-#
-$ kubectl -n weblogic-operator-ns describe secret weblogic-operator-identity
-$ helm install kubernetes/charts/weblogic-operator --name my_operator \
-  --namespace weblogic-operator-ns --values my_values.yaml --wait
-```
-
-For Helm 3.x:
-
 ```
 $ echo "externalRestEnabled: true" > my_values.yaml
 $ generate-external-rest-identity.sh \

--- a/docs-source/content/security/certificates.md
+++ b/docs-source/content/security/certificates.md
@@ -21,23 +21,11 @@ For example, if the operator was installed with the Helm release name `weblogic-
 in the namespace `weblogic-operator-ns` and the kubernetes `tls secret` is named
 `weblogic-operator-cert`, the following commands can be used to update the operator
 certificate(s) and key:
+
 ```bash
 $ kubectl create secret tls weblogic-operator-cert -n weblogic-operator-ns \
   --cert=<path-to-certificate> --key=<path-to-private-key>
 ```
-
-For Helm 2.x:
-
-```bash
-$ helm get values weblogic-operator
-
-$ helm upgrade --wait --recreate-pods --reuse-values \
-  --set externalRestEnabled=true \
-  --set externalRestIdentitySecret=weblogic-operator-cert \
-  weblogic-operator kubernetes/charts/weblogic-operator
-```
-
-For Helm 3.x:
 
 ```bash
 $ helm get values weblogic-operator -n weblogic-operator-ns
@@ -45,7 +33,7 @@ $ helm get values weblogic-operator -n weblogic-operator-ns
 $ helm -n weblogic-operator-ns upgrade weblogic-operator kubernetes/charts/weblogic-operator \
   --wait --recreate-pods --reuse-values \
   --set externalRestEnabled=true \
-  --set externalRestIdentitySecret=weblogic-operator-cert 
+  --set externalRestIdentitySecret=weblogic-operator-cert
 ```
 
 

--- a/docs-source/content/security/secrets.md
+++ b/docs-source/content/security/secrets.md
@@ -89,18 +89,6 @@ where the operator is deployed.
 
 Here is an example of using the `helm install` command to set the image name and image pull secret:
 
-For Helm 2.x:
-
-```bash
-$ helm install kubernetes/charts/weblogic-operator \
-  --set "image=my.io/my-operator-image:1.0" \
-  --set "imagePullSecrets[0].name=my-operator-image-pull-secret" \
-  --name my-weblogic-operator --namespace weblogic-operator-ns \
-  --wait
-```
-
-For Helm 3.x:
-
 ```bash
 $ helm install my-weblogic-operator kubernetes/charts/weblogic-operator \
   --set "image=my.io/my-operator-image:1.0" \

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -20,13 +20,13 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
   See note below for OpenShift.
 * Flannel networking v0.9.1-amd64 or later (check with `docker images | grep flannel`) *or* OpenShift SDN on OpenShift 4.3 systems.
 * Docker 18.9.1 or 19.03.1 (check with `docker version`) *or* CRI-O 1.14.7 (check with `crictl version | grep RuntimeVersion`).
-* Helm 2.14.3+, 3.0.3+ (check with `helm version --client --short`).
+* Helm 3.0.3+ (check with `helm version --client --short`).
 * Either Oracle WebLogic Server 12.2.1.3.0 with patch 29135930, or Oracle WebLogic Server 12.2.1.4.0.
    * The existing WebLogic Docker image, `container-registry.oracle.com/middleware/weblogic:12.2.1.3 `,
    has all the necessary patches applied.
    * Check the WLS version with `docker run container-registry.oracle.com/middleware/weblogic:12.2.1.3 sh -c` `'source $ORACLE_HOME/wlserver/server/bin/setWLSEnv.sh > /dev/null 2>&1 && java weblogic.version'`.
    * Check the WLS patches with `docker run container-registry.oracle.com/middleware/weblogic:12.2.1.3 sh -c` `'$ORACLE_HOME/OPatch/opatch lspatches'`.
-* You must have the `cluster-admin` role to install the operator.  The operator does 
+* You must have the `cluster-admin` role to install the operator.  The operator does
   not need the `cluster-admin` role at runtime.
 * We do not currently support running WebLogic in non-Linux containers.
 
@@ -54,15 +54,15 @@ Container Services for use with Kubernetes* on OCI Compute, and on "authorized c
 
 [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/) is a hosted Kubernetes environment.  The WebLogic Kubernetes
 Operator, Oracle WebLogic Sever 12c and Oracle Fusion Middleware Infrastructure 12c are fully supported and certified on Azure Kubernetes Service (as per the documents
-referenced above). 
+referenced above).
 
-AKE support and limitations: 
+AKE support and limitations:
 
 * Both "domain in image" and "domain on persistent volume" models are supported.  
-* For domain on persistent volume we support Azure Files volumes accessed through 
+* For domain on persistent volume we support Azure Files volumes accessed through
   a persistent volume claim - see [here](https://docs.microsoft.com/en-us/azure/aks/azure-files-volume).
 * Azure Load Balancers are supported when provisioned using a Kubernetes service of `type=LoadBalancer`.
-* Oracle databases running in Oracle Cloud Infrastructure are supported for Fusion Middleware 
+* Oracle databases running in Oracle Cloud Infrastructure are supported for Fusion Middleware
   Infrastructure MDS data stores only when accessed through an OCI FastConnect.
 * Windows Server containers are not currently supported, only Linux containers.
 

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/_index.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/_index.md
@@ -1,8 +1,8 @@
 +++
-title = "Accessing the domain"
+title = "Access the domain"
 date = 2019-02-23T17:39:00-05:00
 weight = 7
 pre = "<b> </b>"
 +++
 
-{{% children style="h4" description="true" %}} 
+{{% children style="h4" description="true" %}}

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/wlst.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/wlst.md
@@ -1,5 +1,5 @@
 ---
-title: "Using WLST"
+title: "Use WLST"
 date: 2019-02-23T17:39:19-05:00
 draft: false
 weight: 3

--- a/docs-source/content/userguide/managing-operators/installation/_index.md
+++ b/docs-source/content/userguide/managing-operators/installation/_index.md
@@ -21,26 +21,7 @@ You supply the `–namespace` argument from the `helm install` command line to s
 
 Similarly, you may override the default `serviceAccount` configuration value to specify which service account in the operator's namespace, the operator should use.  If not specified, then it defaults to `default` (for example, the namespace's default service account).  If you want to use a different service account, then you must create the operator's namespace and the service account before installing the operator Helm chart.
 
-For example:
-
-Using Helm 2.x:
-
-```
-$ helm install kubernetes/charts/weblogic-operator \
-  --name weblogic-operator --namespace weblogic-operator-namespace \
-  --values custom-values.yaml --wait
-```
-Or:
-```
-$ helm install kubernetes/charts/weblogic-operator \
-  --name weblogic-operator --namespace weblogic-operator-namespace \
-  --set "javaLoggingLevel=FINE" --wait
-```
-
-If `weblogic-operator-namespace` exists, then it will be used.  If it does not exist, then Helm 2.x will create it.
-
-
-Using Helm 3.x:
+For example, using Helm 3.x:
 
 ```
 $ kubectl create namespace weblogic-operator-namespace
@@ -92,14 +73,6 @@ $ helm repo update
 
 Install the operator from the repository:
 
-For Helm 2.x:
-
-```
-$ helm install weblogic-operator/weblogic-operator --name weblogic-operator
-```
-
-For Helm 3.x:
-
 ```
 $ helm install weblogic-operator weblogic-operator/weblogic-operator
 ```
@@ -107,14 +80,6 @@ $ helm install weblogic-operator weblogic-operator/weblogic-operator
 #### Removing the operator
 
 The `helm delete` command is used to remove an operator release and its associated resources from the Kubernetes cluster.  The release name used with the `helm delete` command is the same release name used with the `helm install` command (see [Install the Helm chart](#install-the-operator-helm-chart)).  For example:
-
-For Helm 2.x:
-
-```
-$ helm delete --purge weblogic-operator
-```
-
-For Helm 3.x:
 
 ```
 $ helm uninstall weblogic-operator


### PR DESCRIPTION
Removed all refs to Helm 2.x except for SOA domain prereqs. (And, edited two user guide headings to align them with the others.)