### PR TITLE
PR: enable custom MaxIterations count for verifyDomainCreated

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
@@ -58,7 +58,7 @@ public class ItJrfPvWlst extends BaseTest {
   public void prepare() throws Exception {
     if (QUICKTEST) {
       createResultAndPvDirs(testClassName);
-      setMaxIterationsPod(80);
+      //setMaxIterationsPod(80);
       
       TestUtils.exec(
           "cp -rf " 
@@ -133,7 +133,7 @@ public class ItJrfPvWlst extends BaseTest {
             "Creating and verifying the domain creation with domainUid: " + domainUid);
 
         jrfdomain = new JrfDomain(domainMap);
-        jrfdomain.verifyDomainCreated();
+        jrfdomain.verifyDomainCreated(80);
         
         // basic test cases
         testBasicUseCases(jrfdomain, false);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
@@ -58,6 +58,7 @@ public class ItJrfPvWlst extends BaseTest {
   public void prepare() throws Exception {
     if (QUICKTEST) {
       createResultAndPvDirs(testClassName);
+      setMaxIterationsPod(80);
       
       TestUtils.exec(
           "cp -rf " 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
@@ -58,7 +58,6 @@ public class ItJrfPvWlst extends BaseTest {
   public void prepare() throws Exception {
     if (QUICKTEST) {
       createResultAndPvDirs(testClassName);
-      //setMaxIterationsPod(80);
       
       TestUtils.exec(
           "cp -rf " 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -150,7 +150,7 @@ public class Domain {
    * Verifies the required pods are created, services are created and the servers are ready.
    *
    * @param maxIterations max iteration count
-   * @throws Exception exception
+   * @throws RuntimeException if pods/services of the domain are not created or WLS is not running
    */
   public void verifyDomainCreated(int maxIterations) throws Exception {
     StringBuffer command = new StringBuffer();
@@ -200,7 +200,7 @@ public class Domain {
    * verify pods are created.
    *
    * @param maxIterations max iteration count
-   * @throws Exception exception
+   * @throws RuntimeException if pod is not in running state
    */
   public void verifyPodsCreated(int maxIterations) throws Exception {
     // check admin pod
@@ -237,7 +237,7 @@ public class Domain {
    * 
    * @param maxIterations max iteration counts
    *
-   * @throws Exception exception
+   * @throws RuntimeException if service is not created
    */
   public void verifyServicesCreated(int maxIterations) throws Exception {
     verifyServicesCreated(false, maxIterations);
@@ -248,7 +248,7 @@ public class Domain {
    *
    * @param precreateService - if true check services are created for configuredManagedServerCount
    *                         number of servers else check for initialManagedServerReplicas number of servers
-   * @throws Exception exception
+   * @throws RuntimeException if service is not created
    */
   public void verifyServicesCreated(boolean precreateService, int maxIterations) throws Exception {
     // check admin service
@@ -401,7 +401,7 @@ public class Domain {
    * 
    * @param maxIterations max iterations count
    *
-   * @throws Exception exception
+   * @throws RuntimeException if WLS pod is not ready and pod output doesn't contain 1/1
    */
   public void verifyServersReady(int maxIterations) throws Exception {
     // check admin pod

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -42,14 +42,10 @@ public class TestUtils {
    *
    * @param podName  pod name
    * @param domainNS namespace
-   * @throws Exception exception
+   * @throws RuntimeException if pod is not ready and output doesn't contain 1/1
    */
   public static void checkPodReady(String podName, String domainNS) throws Exception {
-    StringBuffer cmd = new StringBuffer();
-    cmd.append("kubectl get pod ").append(podName).append(" -n ").append(domainNS);
-
-    // check for admin pod
-    checkCmdInLoop(cmd.toString(), "1/1", podName);
+    checkPodReady(podName, domainNS, BaseTest.getMaxIterationsPod());    
   }
   
   /**
@@ -90,14 +86,10 @@ public class TestUtils {
    *
    * @param podName  - pod name
    * @param domainNS - domain namespace name
+   * @Exception RuntimeException if pod is not in Running state
    */
   public static void checkPodCreated(String podName, String domainNS) throws Exception {
-
-    StringBuffer cmd = new StringBuffer();
-    cmd.append("kubectl get pod ").append(podName).append(" -n ").append(domainNS);
-
-    // check for pod to be running
-    checkCmdInLoop(cmd.toString(), "Running", podName);
+    checkPodCreated(podName, domainNS, BaseTest.getMaxIterationsPod());
   }
   
   /**
@@ -187,41 +179,10 @@ public class TestUtils {
    *
    * @param serviceName service name
    * @param domainNS    namespace
-   * @throws Exception exception
+   * @throws RuntimeException if service is not created
    */
   public static void checkServiceCreated(String serviceName, String domainNS) throws Exception {
-    int i = 0;
-    StringBuffer cmd = new StringBuffer();
-    cmd.append("kubectl get service ").append(serviceName).append(" -n ").append(domainNS);
-
-    // check for service
-    while (i < BaseTest.getMaxIterationsPod()) {
-      ExecResult result = ExecCommand.exec(cmd.toString());
-
-      // service might not have been created
-      if (result.exitValue() != 0
-          || (result.exitValue() == 0 && !result.stdout().contains(serviceName))) {
-        LoggerHelper.getLocal().log(Level.INFO, "Output for " + cmd + "\n" + result.stdout() + "\n " + result.stderr());
-
-        // check for last iteration
-        if (i == (BaseTest.getMaxIterationsPod() - 1)) {
-          throw new RuntimeException("FAILURE: service is not created, exiting!");
-        }
-        LoggerHelper.getLocal().log(Level.INFO,
-            "Service is not created Ite ["
-                + i
-                + "/"
-                + BaseTest.getMaxIterationsPod()
-                + "], sleeping "
-                + BaseTest.getWaitTimePod()
-                + " seconds more");
-        Thread.sleep(BaseTest.getWaitTimePod() * 1000);
-        i++;
-      } else {
-        LoggerHelper.getLocal().log(Level.INFO, "Service " + serviceName + " is Created");
-        break;
-      }
-    }
+    checkServiceCreated(serviceName, domainNS,BaseTest.getMaxIterationsPod());
   }
   
   /**
@@ -1680,41 +1641,11 @@ public class TestUtils {
    * @param cmd command
    * @param matchStr matcher
    * @param k8sObjName object name
-   * @throws Exception on failure
+   * @throws RuntimeException if pod output does not contain match string defined by caller
    */
   public static void checkCmdInLoop(String cmd, String matchStr, String k8sObjName)
       throws Exception {
-    int i = 0;
-    while (i < BaseTest.getMaxIterationsPod()) {
-      ExecResult result = ExecCommand.exec(cmd);
-
-      // loop command till condition
-      if (result.exitValue() != 0
-          || (result.exitValue() == 0 && !result.stdout().contains(matchStr))) {
-        LoggerHelper.getLocal().log(Level.INFO, "Output for " + cmd + "\n" + result.stdout() + "\n " + result.stderr());
-        // check for last iteration
-        if (i == (BaseTest.getMaxIterationsPod() - 1)) {
-          throw new RuntimeException(
-              "FAILURE: Timeout - pod " + k8sObjName + " output does not contain '" + matchStr + "'");
-        }
-        LoggerHelper.getLocal().log(Level.INFO,
-            "Pod "
-                + k8sObjName
-                + "  output does not contain '" + matchStr + "'  Iteration ["
-                + i
-                + "/"
-                + BaseTest.getMaxIterationsPod()
-                + "], sleeping "
-                + BaseTest.getWaitTimePod()
-                + " seconds more");
-
-        Thread.sleep(BaseTest.getWaitTimePod() * 1000);
-        i++;
-      } else {
-        LoggerHelper.getLocal().log(Level.INFO, "SUCCESS: Pod " + k8sObjName + " output contains '" + matchStr + "'");
-        break;
-      }
-    }
+    checkCmdInLoop(cmd, matchStr, k8sObjName, BaseTest.getMaxIterationsPod());
   }
   
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -58,7 +58,7 @@ public class TestUtils {
    * @param podName  pod name
    * @param domainNS namespace
    * @param maxIterations  max iterations count
-   * @throws Exception exception
+   * @throws RuntimeException if pod is not ready and output doesn't contain 1/1
    */
   public static void checkPodReady(String podName, String domainNS, int maxIterations) throws Exception {
     StringBuffer cmd = new StringBuffer();
@@ -106,6 +106,7 @@ public class TestUtils {
    * @param podName  - pod name
    * @param domainNS - domain namespace name
    * @param maxIterations max iterations count
+   * @throws Exception RuntimeException if pod is not in Running state 
    */
   public static void checkPodCreated(String podName, String domainNS, int maxIterations) throws Exception {
 
@@ -229,7 +230,7 @@ public class TestUtils {
    * @param serviceName service name
    * @param domainNS    namespace
    * @param maxIterations max iterations count
-   * @throws Exception exception
+   * @throws RuntimeException if service is not created
    */
   public static void checkServiceCreated(String serviceName, String domainNS, int maxIterations) throws Exception {
     int i = 0;
@@ -1722,7 +1723,7 @@ public class TestUtils {
    * @param matchStr matcher
    * @param k8sObjName object name
    * @param maxIterationsPod pod max iteration count
-   * @throws Exception on failure
+   * @throws RuntimeException if pod output does not contain match string defined by caller
    */
   public static void checkCmdInLoop(String cmd, String matchStr, String k8sObjName, int maxIterationsPod)
       throws Exception {


### PR DESCRIPTION
This PR is to improve stability of JRF domain on external Jenkins  by enabling custom MaxIterations count for verifyDomainCreated from 40 to 80.
Latest clean Jenkins run after code refactoring:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-quicktest/1236/