### PR TITLE
adding config delete and app delete tests using mode file

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItModelInImageConfigUpdate.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItModelInImageConfigUpdate.java
@@ -3,8 +3,10 @@
 
 package oracle.kubernetes.operator;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -40,6 +42,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
   private static StringBuffer namespaceList;
   private static final String configMapSuffix = "-mii-config-map";
   private static final String dsName = "MyDataSource";
+  private static final String appName = "myear";
   private static final String readTimeout_1 = "30001";
   private static final String readTimeout_2 = "30002";
 
@@ -242,7 +245,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
       // verify that JDBC DS is created by checking JDBC DS name and read timeout
       // verify the test result by checking override config file on server pod
       // verify that application is accessible from inside the managed server pod
-      verifyJdbcOverride();
+      verifyJdbcUpdate();
       Assertions.assertTrue(verifyApp().contains("Hello"), "Application is not found");
 
       // delete config and application using new model file
@@ -454,4 +457,56 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
 
     return result.stdout();
   }
+
+  private void wdtConfigDeleteOverride() throws Exception {
+    LoggerHelper.getLocal().log(Level.INFO, "Creating configMap");
+    String origDir = BaseTest.getProjectRoot()
+        + "/integration-tests/src/test/resources/model-in-image";
+    String origModelFile = origDir + "/model.jdbc.yaml";
+    String origPropFile = origDir + "/model.jdbc.properties";
+    String destDir = getResultDir() + "/samples/model-in-image-override";;
+    String destModelFile = destDir + "/model.jdbc_2.yaml";
+    String destPropFile = destDir + "/model.jdbc_2.properties";
+    Files.createDirectories(Paths.get(destDir));
+
+    Path path = Paths.get(origModelFile);
+    Charset charset = StandardCharsets.UTF_8;
+    String content = new String(Files.readAllBytes(path), charset);
+    // prefix the JDBC DataSource and application name with !
+    content = content.replaceAll(dsName, "!" + dsName);
+    content = content.replaceAll(appName, "!" + appName);
+    Files.write(Paths.get(destModelFile), content.getBytes(charset));
+    TestUtils.copyFile(origPropFile, destPropFile);
+
+    // Re-create config map after deploying domain crd
+    final String domainUid = domain.getDomainUid();
+    final String cmName = domainUid + configMapSuffix;
+    final String label = "weblogic.domainUID=" + domainUid;
+
+    TestUtils.createConfigMap(cmName, destDir, domainNS, label);
+  }
+
+  private String verifyApp() throws Exception {
+    // get managed server pod name
+    StringBuffer cmdStrBuff = new StringBuffer();
+    cmdStrBuff
+        .append("kubectl get pod -n ")
+        .append(domainNS)
+        .append(" -o=jsonpath='{.items[1].metadata.name}' | grep managed-server1");
+    String msPodName = TestUtils.exec(cmdStrBuff.toString()).stdout();
+
+    // access the application deployed in managed-server1
+    cmdStrBuff = new StringBuffer();
+    cmdStrBuff
+        .append("kubectl -n ")
+        .append(domainNS)
+        .append(" exec -it ")
+        .append(msPodName)
+        .append(" -- bash -c ")
+        .append("'curl http://" + msPodName + ":8001/sample_war/")
+        .append("'");
+    ExecResult exec = TestUtils.exec(cmdStrBuff.toString(), true);
+    return exec.stdout();
+  }
+
 }


### PR DESCRIPTION
The test deletes a existing JDBC data source and application using the model file with ! annotation on the resources.

The tests are passed locally.

[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,798.153 s - in oracle.kubernetes.operator.ItModelInImageConfigUpdate
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]


[INFO] Reactor Summary:
[INFO]
[INFO] Build Tools 1.0 .................................... SUCCESS [  1.150 s]
[INFO] weblogic-kubernetes-operator 3.0.0 ................. SUCCESS [  2.748 s]
[INFO] operator-swagger 3.0.0 ............................. SUCCESS [  8.218 s]
[INFO] json-schema 3.0.0 .................................. SUCCESS [ 10.684 s]
[INFO] jsonschema-maven-plugin Maven Mojo 3.0.0 ........... SUCCESS [  8.344 s]
[INFO] operator-runtime 3.0.0 ............................. SUCCESS [ 59.095 s]
[INFO] operator-integration-tests 3.0.0 ................... SUCCESS [31:54 min]
[INFO] installation-tests 3.0.0 ........................... SUCCESS [  3.133 s]
[INFO] Project Reports 3.0.0 .............................. SUCCESS [  1.218 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33:29 min
[INFO] Finished at: 2020-03-31T20:46:28Z
[INFO] ------------------------------------------------------------------------


