### PR TITLE
Enhance the cleanup script to include deletion of few namesapce(s) 

### DIFF
--- a/src/integration-tests/bash/cleanup.sh
+++ b/src/integration-tests/bash/cleanup.sh
@@ -574,7 +574,7 @@ deleteByTypeAndLabel
 #   arg3 - keywords in deletable artifacts
 
 echo @@ `timestamp` Starting genericDelete
-genericDelete "all,cm,pvc,roles,rolebindings,serviceaccount,secrets,ingress" "crd,pv,ns,clusterroles,clusterrolebindings" "logstash|kibana|elastisearch|weblogic|elk|domain|traefik|voyager|apache-webtier|mysql"
+genericDelete "all,cm,pvc,roles,rolebindings,serviceaccount,secrets,ingress" "crd,pv,ns,clusterroles,clusterrolebindings" "logstash|kibana|elastisearch|weblogic|elk|domain|traefik|voyager|apache-webtier|mysql|test|opns"
 SUCCESS="$?"
 
 #


### PR DESCRIPTION
Modify the filter expression to delete few NameSpace(s) created by Integration Test. Due to this we see lot of hanging NameSpaces ever after successful completion of Tests