### PR TITLE
Missing secret dir fix

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -53,6 +53,11 @@ RCU_PASSWORD_CHANGED=5
 SCRIPT_ERROR=255
 
 export WDT_MODEL_SECRETS_DIRS="/weblogic-operator/config-overrides-secrets"
+if [ ! -d ${WDT_MODEL_SECRETS_DIRS} ] ; then
+  # Temporary work around for WDT to avoid non zero return code if the directory doesn't exist
+  mkdir -p /tmp/nosuchdir
+  export WDT_MODEL_SECRETS_DIRS="/tmp/nosuchdir"
+fi
 
 #TBD: CREDENTIALS_SECRET_NAME is unexpectedly empty. Maybe that's a regression?
 #  export WDT_MODEL_SECRETS_NAME_DIR_PAIRS="__weblogic-credentials__=/weblogic-operator/secrets,__WEBLOGIC-CREDENTIALS__=/weblogic-operator/secrets,${CREDENTIALS_SECRET_NAME}=/weblogic-operator/secret"

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -53,11 +53,7 @@ RCU_PASSWORD_CHANGED=5
 SCRIPT_ERROR=255
 
 export WDT_MODEL_SECRETS_DIRS="/weblogic-operator/config-overrides-secrets"
-if [ ! -d ${WDT_MODEL_SECRETS_DIRS} ] ; then
-  # Temporary work around for WDT to avoid non zero return code if the directory doesn't exist
-  mkdir -p /tmp/nosuchdir
-  export WDT_MODEL_SECRETS_DIRS="/tmp/nosuchdir"
-fi
+[ ! -d ${WDT_MODEL_SECRETS_DIRS} ] && unset WDT_MODEL_SECRETS_DIRS
 
 #TBD: CREDENTIALS_SECRET_NAME is unexpectedly empty. Maybe that's a regression?
 #  export WDT_MODEL_SECRETS_NAME_DIR_PAIRS="__weblogic-credentials__=/weblogic-operator/secrets,__WEBLOGIC-CREDENTIALS__=/weblogic-operator/secrets,${CREDENTIALS_SECRET_NAME}=/weblogic-operator/secret"


### PR DESCRIPTION
This is a temporary work around for WDT returning 1 instead of 0,  when the model has only credential secrets but no other custom secret, in this case the operator will not mount the directory ```/weblogic-operator/config-overrides-secrets``` and WDT checks whether the directory exists and return 1 for warning if not there.  