### PR TITLE
OWLS-80829 - Fix ConcurrentModificationException in JobWatcher and DomainStatus

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -3,7 +3,6 @@
 
 package oracle.kubernetes.operator;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,7 +35,7 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 /** Watches for Jobs to become Ready or leave Ready state. */
 public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-  private static final Map<String, JobWatcher> JOB_WATCHERS = new HashMap<>();
+  private static final Map<String, JobWatcher> JOB_WATCHERS = new ConcurrentHashMap<>();
   private static JobWatcherFactory factory;
 
   private final String namespace;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -275,11 +275,12 @@ public class DomainStatus {
   /**
    * Status of WebLogic servers in this domain.
    *
-   * @return servers
+   * @return servers sorted list of ServerStatus containing status of WebLogic servers in this domain
    */
   public List<ServerStatus> getServers() {
-    servers.sort(Comparator.naturalOrder());
-    return servers;
+    List<ServerStatus> sortedServers = new ArrayList<>(servers);
+    sortedServers.sort(Comparator.naturalOrder());
+    return sortedServers;
   }
 
   /**
@@ -326,9 +327,15 @@ public class DomainStatus {
     return this;
   }
 
+  /**
+   * Status of WebLogic clusters in this domain.
+   *
+   * @return clusters sorted list of ClusterStatus containing status of WebLogic clusters in this domain
+   */
   public List<ClusterStatus> getClusters() {
-    clusters.sort(Comparator.naturalOrder());
-    return clusters;
+    List<ClusterStatus> sortedClusters = new ArrayList<>(clusters);
+    sortedClusters.sort(Comparator.naturalOrder());
+    return sortedClusters;
   }
 
   /**


### PR DESCRIPTION
Fixes `ConcurrentModificationException` from `JobWatcher.getOrCreateFor()` as described in OWLS-80829

Also fixes `ConcurrentModificationException` from `DomainStatus.getServers()` and `getClusters()` in the `Array sort()` method calls.