### PR TITLE
Resolve docs and testing review comments from PRs 1531, 1532, and 1536

### DIFF
--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -317,7 +317,7 @@
           "type": "string"
         },
         "includeServerOutInPodLog": {
-          "description": "If true (the default), the server .out file will be included in the pod\u0027s stdout.",
+          "description": "If true (the default), then the server .out file will be included in the pod\u0027s stdout.",
           "type": "boolean"
         },
         "managedServers": {

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -29,7 +29,7 @@ DomainSpec is a description of a domain.
 | `image` | string | The WebLogic Docker image; required when domainHomeInImage is true; otherwise, defaults to container-registry.oracle.com/middleware/weblogic:12.2.1.3. |
 | `imagePullPolicy` | string | The image pull policy for the WebLogic Docker image. Legal values are Always, Never and IfNotPresent. Defaults to Always if image ends in :latest, IfNotPresent otherwise. |
 | `imagePullSecrets` | array of [Local Object Reference](k8s1.13.5.md#local-object-reference) | A list of image pull secrets for the WebLogic Docker image. |
-| `includeServerOutInPodLog` | Boolean | If true (the default), the server .out file will be included in the pod's stdout. |
+| `includeServerOutInPodLog` | Boolean | If true (the default), then the server .out file will be included in the pod's stdout. |
 | `logHome` | string | The in-pod name of the directory in which to store the domain, Node Manager, server logs, server  *.out, and optionally HTTP access log files if `httpAccessLogInLogHome` is true. |
 | `logHomeEnabled` | Boolean | Specified whether the log home folder is enabled. Not required. Defaults to true if domainHomeInImage is false. Defaults to false if domainHomeInImage is true.  |
 | `managedServers` | array of [Managed Server](#managed-server) | Configuration for individual Managed Servers. |

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1233,11 +1233,11 @@ window.onload = function() {
           "$ref": "#/definitions/ServerPod"
         },
         "logHome": {
-          "description": "The in-pod name of the directory in which to store the domain, node manager, server logs, server  *.out, and optionally HTTP access log files if `httpAccessLogInLogHome` is true.",
+          "description": "The in-pod name of the directory in which to store the domain, Node Manager, server logs, server  *.out, and optionally HTTP access log files if `httpAccessLogInLogHome` is true.",
           "type": "string"
         },
         "includeServerOutInPodLog": {
-          "description": "If true (the default), the server .out file will be included in the pod\u0027s stdout.",
+          "description": "If true (the default), then the server .out file will be included in the pod\u0027s stdout.",
           "type": "boolean"
         },
         "managedServers": {

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -10385,8 +10385,8 @@ spec:
                   HTTP access log files if `httpAccessLogInLogHome` is true.
               includeServerOutInPodLog:
                 type: boolean
-                description: If true (the default), the server .out file will be included
-                  in the pod's stdout.
+                description: If true (the default), then the server .out file will
+                  be included in the pod's stdout.
               managedServers:
                 type: array
                 description: Configuration for individual Managed Servers.

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -10177,8 +10177,8 @@ spec:
                 access log files if `httpAccessLogInLogHome` is true.
             includeServerOutInPodLog:
               type: boolean
-              description: If true (the default), the server .out file will be included
-                in the pod's stdout.
+              description: If true (the default), then the server .out file will be
+                included in the pod's stdout.
             managedServers:
               type: array
               description: Configuration for individual Managed Servers.

--- a/operator/src/main/java/oracle/kubernetes/utils/OperatorUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/utils/OperatorUtils.java
@@ -28,7 +28,7 @@ public class OperatorUtils {
 
   /**
    * Create a Map using the elements from the given map, with their keys sorted
-   * using the 'numero lexi sorting name'.
+   * using the sorted name as returned by {@link #getSortingString(String)}.
    *
    * @param map Map containing elements to be sorted by the keys
    * @param <T> Type of map entries
@@ -49,8 +49,7 @@ public class OperatorUtils {
   }
 
   /**
-   * Compare the 'numero lexi sorting name' as defined in {@link #getSortingString(String)} of the
-   * given 2 Strings.
+   * Compare the given 2 Strings using the sorted name as returned by {@link #getSortingString(String)}.
    *
    * @param str1 First string for comparison
    * @param str2 Second string for comparison

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -108,7 +108,7 @@ public class DomainSpec extends BaseConfiguration {
   private String dataHome;
 
   /** Whether to include the server .out file to the pod's stdout. Default is true. */
-  @Description("If true (the default), the server .out file will be included in the pod's stdout.")
+  @Description("If true (the default), then the server .out file will be included in the pod's stdout.")
   private Boolean includeServerOutInPodLog;
 
   /** Whether to include the server HTTP access log file to the  directory specified in {@link #logHome}
@@ -457,12 +457,12 @@ public class DomainSpec extends BaseConfiguration {
   }
 
   /**
-   * Whether to write the server HTTP access log file to the directory specified in
+   * Whether to write server HTTP access log files to the directory specified in
    * {@link #logHome} if {@link #logHomeEnabled} is true.
    *
-   * @return true if the server HTTP access log file should be included in the directory
-   *     specified in {@link #logHome}, false if server HTTP access log file should be written
-   *     to the directory as configured in WebLogic domain home configuration
+   * @return true if server HTTP access log files should be included in the directory
+   *     specified in {@link #logHome}, false if server HTTP access log files should be written
+   *     to the directory as configured in the WebLogic domain home configuration
    */
   boolean getHttpAccessLogInLogHome() {
     return Optional.ofNullable(httpAccessLogInLogHome)

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -275,7 +275,7 @@ public class DomainStatus {
   /**
    * Status of WebLogic servers in this domain.
    *
-   * @return servers sorted list of ServerStatus containing status of WebLogic servers in this domain
+   * @return a sorted list of ServerStatus containing status of WebLogic servers in this domain
    */
   public List<ServerStatus> getServers() {
     List<ServerStatus> sortedServers = new ArrayList<>(servers);
@@ -330,7 +330,7 @@ public class DomainStatus {
   /**
    * Status of WebLogic clusters in this domain.
    *
-   * @return clusters sorted list of ClusterStatus containing status of WebLogic clusters in this domain
+   * @return a sorted list of ClusterStatus containing status of WebLogic clusters in this domain
    */
   public List<ClusterStatus> getClusters() {
     List<ClusterStatus> sortedClusters = new ArrayList<>(clusters);

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ClusterStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ClusterStatusTest.java
@@ -19,31 +19,41 @@ public class ClusterStatusTest {
 
   @Test
   public void verify_Equal_compareTo() {
-    assertThat(nullCluster.compareTo(nullCluster), equalTo(0));
-    assertThat(cluster1.compareTo(cluster1), equalTo(0));
+    assertThat("compareTo should return 0 if both Cluster have null cluster name",
+        nullCluster.compareTo(new ClusterStatus()), equalTo(0));
+    assertThat("compareTo should return 0 if both ClusterStatus have same cluster name",
+        cluster1.compareTo(new ClusterStatus().withClusterName("cluster1")), equalTo(0));
   }
 
   @Test
   public void verifyThat_cluster1_before_cluster2() {
-    assertThat(cluster1.compareTo(cluster2), lessThan(0));
-    assertThat(cluster2.compareTo(cluster1), greaterThan(0));
+    assertThat("ClusterStatus for cluster1 should be ordered before ClusterStatus for cluster2",
+        cluster1.compareTo(cluster2), lessThan(0));
+    assertThat("ClusterStatus for cluster2 should be ordered after ClusterStatus for cluster1",
+        cluster2.compareTo(cluster1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_cluster1_before_cluster10() {
-    assertThat(cluster1.compareTo(cluster10), lessThan(0));
-    assertThat(cluster10.compareTo(cluster1), greaterThan(0));
+    assertThat("ClusterStatus for cluster1 should be ordered before ClusterStatus for cluster10",
+        cluster1.compareTo(cluster10), lessThan(0));
+    assertThat("ClusterStatus for cluster10 should be ordered after ClusterStatus for cluster1",
+        cluster10.compareTo(cluster1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_cluster2_before_cluster10() {
-    assertThat(cluster2.compareTo(cluster10), lessThan(0));
-    assertThat(cluster10.compareTo(cluster2), greaterThan(0));
+    assertThat("ClusterStatus for cluster2 should be ordered before ClusterStatus for cluster10",
+        cluster2.compareTo(cluster10), lessThan(0));
+    assertThat("ClusterStatus for cluster10 should be ordered after ClusterStatus for cluster2",
+        cluster10.compareTo(cluster2), greaterThan(0));
   }
 
   @Test
   public void verifyThat_nullCluster_before_cluster1() {
-    assertThat(nullCluster.compareTo(cluster1), lessThan(0));
-    assertThat(cluster1.compareTo(nullCluster), greaterThan(0));
+    assertThat("ClusterStatus without cluster name should be ordered before ClusterStatus for cluster1",
+        nullCluster.compareTo(cluster1), lessThan(0));
+    assertThat("ClusterStatus for cluster1 should be ordered after ClusterStatus without cluster name",
+        cluster1.compareTo(nullCluster), greaterThan(0));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -277,6 +277,34 @@ public class DomainStatusTest {
     assertThat(clusterStatuses, contains(cluster1, cluster2, cluster10));
   }
 
+  @Test
+  public void verifyThat_getServers_returnCopyOfServersList() {
+    ServerStatus server1 = new ServerStatus().withServerName("server1");
+    ServerStatus server2 = new ServerStatus().withServerName("server2");
+
+    domainStatus.addServer(server1);
+
+    List<ServerStatus> serverStatuses = domainStatus.getServers();
+
+    domainStatus.addServer(server2);
+
+    assertThat(serverStatuses.size(), is(equalTo(1)));
+  }
+
+  @Test
+  public void verifyThat_getClusters_returnCopyOfClustersList() {
+    ClusterStatus cluster1 = new ClusterStatus().withClusterName("cluster1");
+    ClusterStatus cluster2 = new ClusterStatus().withClusterName("cluster2");
+
+    domainStatus.addCluster(cluster1);
+
+    List<ClusterStatus> clusterStatuses = domainStatus.getClusters();
+
+    domainStatus.addCluster(cluster2);
+
+    assertThat(clusterStatuses.size(), is(equalTo(1)));
+  }
+
   static class ClusterStatusMatcher extends org.hamcrest.TypeSafeDiagnosingMatcher<ClusterStatus> {
     private String name;
     private Integer replicas;

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ServerStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ServerStatusTest.java
@@ -31,70 +31,108 @@ public class ServerStatusTest {
 
   @Test
   public void verify_Equal_compareTo() {
-    assertThat(nullClusterNullServer.compareTo(nullClusterNullServer), equalTo(0));
-    assertThat(cluster1Server1.compareTo(cluster1Server1), equalTo(0));
-    assertThat(standAloneServer1.compareTo(standAloneServer1), equalTo(0));
-    assertThat(adminServer.compareTo(adminServer), equalTo(0));
+    assertThat("compareTo should return 0 if both ServerStatus have null cluster and server names",
+        nullClusterNullServer.compareTo(new ServerStatus()), equalTo(0));
+    assertThat("compareTo should return 0 if both ServerStatus have same cluster and server names",
+        cluster1Server1.compareTo(new ServerStatus().withClusterName("cluster-1").withServerName("server1")),
+        equalTo(0));
+    assertThat("compareTo should return 0 if both ServerStatus have null cluster name, and same server name",
+        standAloneServer1.compareTo(new ServerStatus().withServerName("server1")), equalTo(0));
+    assertThat("compareTo should return 0 if both ServerStatus are for admin server with same server name",
+        adminServer.compareTo(new ServerStatus().withServerName("admin-server").withIsAdminServer(true)),
+        equalTo(0));
+  }
+
+  @Test
+  public void verifyThat_adminServer_before_notAdminServerWithSameServerName() {
+    assertThat("ServerStatus for admin server should be ordered before ServerStatus for non admin server",
+        adminServer.compareTo(new ServerStatus().withServerName("admin-server")), equalTo(-1));
+    assertThat("ServerStatus for non admin server should be ordered after ServerStatus for admin server",
+        new ServerStatus().withServerName("admin-server").compareTo(adminServer), equalTo(1));
   }
 
   @Test
   public void verifyThat_statusWithoutCluster_before_statusWithCluster() {
-    assertThat(standAloneServer1.compareTo(cluster1Server1), lessThan(0));
-    assertThat(cluster1Server1.compareTo(standAloneServer2), greaterThan(0));
+    assertThat("ServerStatus without cluster name should be ordered before ServerStatus with cluster name",
+        standAloneServer1.compareTo(cluster1Server1), lessThan(0));
+    assertThat("ServerStatus with cluster name should be ordered after ServerStatus without cluster name",
+        cluster1Server1.compareTo(standAloneServer2), greaterThan(0));
   }
 
   @Test
   public void verifyThat_cluster1_before_cluster2() {
-    assertThat(cluster1Server1.compareTo(cluster2Server1), lessThan(0));
-    assertThat(cluster2Server1.compareTo(cluster1Server1), greaterThan(0));
+    assertThat("ServerStatus for cluster-1 should be ordered before ServerStatus for cluster-2",
+        cluster1Server1.compareTo(cluster2Server1), lessThan(0));
+    assertThat("ServerStatus for cluster-2 should be ordered after ServerStatus for cluster-1",
+        cluster2Server1.compareTo(cluster1Server1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_cluster1_before_cluster10() {
-    assertThat(cluster1Server1.compareTo(cluster10Server1), lessThan(0));
-    assertThat(cluster10Server1.compareTo(cluster1Server1), greaterThan(0));
+    assertThat("ServerStatus for cluster-1 should be ordered before ServerStatus for cluster-10",
+        cluster1Server1.compareTo(cluster10Server1), lessThan(0));
+    assertThat("ServerStatus for cluster-10 should be ordered after ServerStatus for cluster-1",
+        cluster10Server1.compareTo(cluster1Server1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_cluster2_before_cluster10() {
-    assertThat(cluster2Server1.compareTo(cluster10Server1), lessThan(0));
-    assertThat(cluster10Server1.compareTo(cluster2Server1), greaterThan(0));
+    assertThat("ServerStatus for cluster-2 should be ordered before ServerStatus for cluster-10",
+        cluster2Server1.compareTo(cluster10Server1), lessThan(0));
+    assertThat("ServerStatus for cluster-10 should be ordered after ServerStatus for cluster-2",
+        cluster10Server1.compareTo(cluster2Server1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_server1_before_server2() {
-    assertThat(standAloneServer1.compareTo(standAloneServer2), lessThan(0));
-    assertThat(standAloneServer2.compareTo(standAloneServer1), greaterThan(0));
+    assertThat("ServerStatus for server1 should be ordered before ServerStatus for server2",
+        standAloneServer1.compareTo(standAloneServer2), lessThan(0));
+    assertThat("ServerStatus for server2 should be ordered after ServerStatus for server1",
+        standAloneServer2.compareTo(standAloneServer1), greaterThan(0));
 
-    assertThat(cluster1Server1.compareTo(cluster1Server2), lessThan(0));
-    assertThat(cluster1Server2.compareTo(cluster1Server1), greaterThan(0));
+    assertThat("ServerStatus for server1 should be ordered before ServerStatus for server2 in same cluster",
+        cluster1Server1.compareTo(cluster1Server2), lessThan(0));
+    assertThat("ServerStatus for server2 should be ordered after ServerStatus for server1 in same cluster",
+        cluster1Server2.compareTo(cluster1Server1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_server1_before_server10() {
-    assertThat(standAloneServer1.compareTo(standAloneServer10), lessThan(0));
-    assertThat(standAloneServer10.compareTo(standAloneServer1), greaterThan(0));
+    assertThat("ServerStatus for server1 should be ordered before ServerStatus for server10",
+        standAloneServer1.compareTo(standAloneServer10), lessThan(0));
+    assertThat("ServerStatus for server10 should be ordered after ServerStatus for server1",
+        standAloneServer10.compareTo(standAloneServer1), greaterThan(0));
 
-    assertThat(cluster1Server1.compareTo(cluster1Server10), lessThan(0));
-    assertThat(cluster1Server10.compareTo(cluster1Server1), greaterThan(0));
+    assertThat("ServerStatus for server1 should be ordered before ServerStatus for server10 in same cluster",
+        cluster1Server1.compareTo(cluster1Server10), lessThan(0));
+    assertThat("ServerStatus for server10 should be ordered after ServerStatus for server1 in same cluster",
+        cluster1Server10.compareTo(cluster1Server1), greaterThan(0));
   }
 
   @Test
   public void verifyThat_server2_before_server10() {
-    assertThat(standAloneServer2.compareTo(standAloneServer10), lessThan(0));
-    assertThat(standAloneServer10.compareTo(standAloneServer2), greaterThan(0));
+    assertThat("ServerStatus for server2 should be ordered before ServerStatus for server10",
+        standAloneServer2.compareTo(standAloneServer10), lessThan(0));
+    assertThat("ServerStatus for server10 should be ordered after ServerStatus for server2",
+        standAloneServer10.compareTo(standAloneServer2), greaterThan(0));
 
-    assertThat(cluster1Server2.compareTo(cluster1Server10), lessThan(0));
-    assertThat(cluster1Server10.compareTo(cluster1Server2), greaterThan(0));
+    assertThat("ServerStatus for server2 should be ordered before ServerStatus for server10 in same cluster",
+        cluster1Server2.compareTo(cluster1Server10), lessThan(0));
+    assertThat("ServerStatus for server10 should be ordered after ServerStatus for server2 in same cluster",
+        cluster1Server10.compareTo(cluster1Server2), greaterThan(0));
   }
 
   @Test
   public void verifyThat_adminServer_before_serverA() {
-    assertThat(adminServer.compareTo(standAloneServerA), lessThan(0));
-    assertThat(standAloneServerA.compareTo(adminServer), greaterThan(0));
+    assertThat("ServerStatus for admin server should be ordered before ServerStatus for non admin server",
+        adminServer.compareTo(standAloneServerA), lessThan(0));
+    assertThat("ServerStatus for non admin server should be ordered after ServerStatus for admin server",
+        standAloneServerA.compareTo(adminServer), greaterThan(0));
 
-    assertThat(adminServer.compareTo(cluster1ServerA), lessThan(0));
-    assertThat(cluster1ServerA.compareTo(adminServer), greaterThan(0));
+    assertThat("ServerStatus for admin server should be ordered before ServerStatus for non admin server in a cluster",
+        adminServer.compareTo(cluster1ServerA), lessThan(0));
+    assertThat("ServerStatus for non admin server in a cluster should be ordered after ServerStatus for admin server",
+        cluster1ServerA.compareTo(adminServer), greaterThan(0));
   }
 
 }


### PR DESCRIPTION
PR 1531:
- Lack of assert messages in ServerStatusTest
https://github.com/oracle/weblogic-kubernetes-operator/pull/1531/files#r403143296 (OWLS-80945)

- Clarify sorting method in javadoc for OperatorUtils.createSortedMap()
https://github.com/oracle/weblogic-kubernetes-operator/pull/1531/files#r403139882 (OWLS-80943)

PR 1532:
- javadoc for DomainSpec.getHttpAccessLogInLogHome()
https://github.com/oracle/weblogic-kubernetes-operator/pull/1532#discussion_r403218811

- minor javadoc fix to description for includeServerOutInPodLog in DomainSpec

PR 1536:
- DomainStatus javadoc fix
https://github.com/oracle/weblogic-kubernetes-operator/pull/1536#discussion_r403405689

- Add more unit tests to DomainStatusTest for DomainStatus.getServers() and getClusters()
https://github.com/oracle/weblogic-kubernetes-operator/pull/1536#pullrequestreview-387653410