### PR TITLE
Use OpenJDK 11.0.7 JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,28 +4,49 @@
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build -t weblogic-kubernetes-operator:latest .
+#      $ ./buildDockerImage.sh [-t <image-name>]
 #
-# Pull base image
-# From the Docker store
 # -------------------------
-FROM openjdk:11-oracle
-RUN yum -y install openssl && yum clean all
+FROM oraclelinux:7-slim
 
 # Maintainer
 # ----------
 MAINTAINER Ryan Eberhard <ryan.eberhard@oracle.com>
 
-# make the operator run with a non-root user id (1000 is the `oracle` user)
-RUN groupadd -g 1000 oracle && \
-    useradd -d /operator -M -s /bin/bash -g 1000 -u 1000 oracle && \
-    mkdir /operator && \
-    mkdir /operator/lib && \
-    mkdir /logs && \
+RUN set -eux; \
+    yum -y install gzip tar openssl; \
+    rm -rf /var/cache/yum
+
+# Default to UTF-8 file.encoding
+ENV LANG en_US.UTF-8
+
+ENV JAVA_HOME /usr/local/openjdk-11
+ENV PATH /operator:$JAVA_HOME/bin:$PATH
+
+ENV JAVA_VERSION 11.0.7
+ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_x64_linux_11.0.7_10.tar.gz
+
+# Install Java and make the operator run with a non-root user id (1000 is the `oracle` user)
+RUN set -eux; \
+	curl -fL -o /openjdk.tgz "$JAVA_URL"; \
+	mkdir -p "$JAVA_HOME"; \
+	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
+	rm /openjdk.tgz; \
+	mkdir /usr/java; \
+	ln -sfT "$JAVA_HOME" /usr/java/default; \
+	ln -sfT "$JAVA_HOME" /usr/java/latest; \
+	for bin in "$JAVA_HOME/bin/"*; do \
+		base="$(basename "$bin")"; \
+		[ ! -e "/usr/bin/$base" ]; \
+		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+	done; \
+	java -Xshare:dump; \
+	groupadd -g 1000 oracle; \
+    useradd -d /operator -M -s /bin/bash -g 1000 -u 1000 oracle; \
+    mkdir -p /operator/lib; \
+    mkdir /logs; \
     chown -R 1000:1000 /operator /logs
 USER 1000
-
-ENV PATH=$PATH:/operator
 
 COPY src/scripts/* /operator/
 COPY operator/target/weblogic-kubernetes-operator.jar /operator/weblogic-kubernetes-operator.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,24 +28,25 @@ ENV JAVA_URL https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/release
 
 # Install Java and make the operator run with a non-root user id (1000 is the `oracle` user)
 RUN set -eux; \
-	curl -fL -o /openjdk.tgz "$JAVA_URL"; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
-	rm /openjdk.tgz; \
-	mkdir /usr/java; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
-	java -Xshare:dump; \
-	groupadd -g 1000 oracle; \
+    curl -fL -o /openjdk.tgz "$JAVA_URL"; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /openjdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
+    rm /openjdk.tgz; \
+    mkdir /usr/java; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
+    java -Xshare:dump; \
+    groupadd -g 1000 oracle; \
     useradd -d /operator -M -s /bin/bash -g 1000 -u 1000 oracle; \
     mkdir -p /operator/lib; \
     mkdir /logs; \
     chown -R 1000:1000 /operator /logs
+
 USER 1000
 
 COPY src/scripts/* /operator/


### PR DESCRIPTION
Updates the operator's Dockerfile to use the OpenJDK 11.0.7 JRE.

Based on a discussion with Aurelio, I've changed the Dockerfile to start with oraclelinux:7-slim and to download the OpenJDK 11.0.7 JRE installer rather than base on an openjdk:11-oracle image.  This saves 200MB!!!

With 11.0.7, we should now be able to run against k8s 1.16+.