### PR TITLE
call out prerequisites

### DIFF
--- a/docs-source/content/_index.md
+++ b/docs-source/content/_index.md
@@ -20,7 +20,7 @@ The fastest way to experience the operator is to follow the [Quick Start guide](
 ##### Current release
 
 The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 2.5.0.
-This release was published on February 26, 2020.
+This release was published on February 26, 2020. See the operator prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction#operator-prerequisites" >}}).
 
 ##### Preview of next planned release
 
@@ -34,7 +34,7 @@ The planned feature changes in 3.0.0-rc1 are:
 
 * Introduction of a new "Model In Image" feature which allows you to have a domain
   created at pod startup time from a WebLogic Deploy Tool model and archive.
-  This supports user-requested use cases like creating multiple domains from 
+  This supports user-requested use cases like creating multiple domains from
   the same model and automated updating of the domain based on model changes.
   The operator automates management of the domain encryption keys to ensure
   that they are not changed during domain updates.
@@ -48,9 +48,6 @@ The planned feature changes in 3.0.0-rc1 are:
 
 ***
 
-{{% notice note %}}
-Please review the prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction" >}}).
-{{% /notice %}}
 
 #### Operator earlier versions
 

--- a/docs-source/content/userguide/introduction/_index.md
+++ b/docs-source/content/userguide/introduction/_index.md
@@ -2,7 +2,7 @@
 title: "Introduction"
 date: 2019-02-23T16:43:10-05:00
 weight: 2
-description: "Learn about the operator's design, architecture, and important terms."
+description: "Learn about the operator's design, architecture, important terms, prerequisites, and supported environments."
 ---
 {{% children style="h4" description="true" %}}
 

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -2,7 +2,7 @@
 title: "Get started"
 date: 2019-02-23T16:40:54-05:00
 weight: 1
-description: "Review the operator prerequisites."
+description: "Review the operator prerequisites and supported environments."
 ---
 
 An operator is an application-specific controller that extends Kubernetes to create, configure, and manage instances
@@ -26,7 +26,7 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
    has all the necessary patches applied.
    * Check the WLS version with `docker run container-registry.oracle.com/middleware/weblogic:12.2.1.3 sh -c` `'source $ORACLE_HOME/wlserver/server/bin/setWLSEnv.sh > /dev/null 2>&1 && java weblogic.version'`.
    * Check the WLS patches with `docker run container-registry.oracle.com/middleware/weblogic:12.2.1.3 sh -c` `'$ORACLE_HOME/OPatch/opatch lspatches'`.
-* You must have the `cluster-admin` role to install the operator.  The operator does 
+* You must have the `cluster-admin` role to install the operator.  The operator does
   not need the `cluster-admin` role at runtime.
 * We do not currently support running WebLogic in non-Linux containers.
 
@@ -54,15 +54,15 @@ Container Services for use with Kubernetes* on OCI Compute, and on "authorized c
 
 [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/) is a hosted Kubernetes environment.  The WebLogic Kubernetes
 Operator, Oracle WebLogic Sever 12c and Oracle Fusion Middleware Infrastructure 12c are fully supported and certified on Azure Kubernetes Service (as per the documents
-referenced above). 
+referenced above).
 
-AKE support and limitations: 
+AKE support and limitations:
 
 * Both "domain in image" and "domain on persistent volume" models are supported.  
-* For domain on persistent volume we support Azure Files volumes accessed through 
+* For domain on persistent volume we support Azure Files volumes accessed through
   a persistent volume claim - see [here](https://docs.microsoft.com/en-us/azure/aks/azure-files-volume).
 * Azure Load Balancers are supported when provisioned using a Kubernetes service of `type=LoadBalancer`.
-* Oracle databases running in Oracle Cloud Infrastructure are supported for Fusion Middleware 
+* Oracle databases running in Oracle Cloud Infrastructure are supported for Fusion Middleware
   Infrastructure MDS data stores only when accessed through an OCI FastConnect.
 * Windows Server containers are not currently supported, only Linux containers.
 


### PR DESCRIPTION
An attempt to elevate the visibility and access to the prerequisites and supported environments. Despite the previous link in a Note on the Home page, I thought this information might be more visible (i.e., read by more users) by placing it with the current release number and date published text.