### PR TITLE
Setting WLSDEPLOY_PROPERTIES cause WDT failed to start

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -37,7 +37,7 @@ WDT_BINDIR="${WDT_ROOT}/bin"
 WDT_FILTER_JSON="/weblogic-operator/scripts/model_filters.json"
 WDT_CREATE_FILTER="/weblogic-operator/scripts/wdt_create_filter.py"
 UPDATE_RCUPWD_FLAG=""
-WLSDEPLOY_PROPERTIES="${WLSDEPLOY_PROPERTIES} -Djava.security.egd=file:/dev/./urandom -skipWLSModuleScanning"
+WLSDEPLOY_PROPERTIES="${WLSDEPLOY_PROPERTIES} -Djava.security.egd=file:/dev/./urandom"
 ARCHIVE_ZIP_CHANGED=0
 WDT_ARTIFACTS_CHANGED=0
 ROLLBACK_ERROR=3


### PR DESCRIPTION
CGBU discovered a problem, when setting WLSDEPLOY_PROPERTIES with -Doracle.jdbc.fanEnabled in the domain resource, it caused the WDT create fails. The reason is -skipWLSModuleScanning is not a JVM properties and it caused the the wlst failed to start.  It shouldn't be there in the first place, I am removing for now. In order to add this, it requires a WDT enhancement.