### PR TITLE
Fix command stdout

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
@@ -85,8 +85,8 @@ public class ExecCommand {
                   }
                 });
         out.start();
-      } 
-      
+      }
+
       p.waitFor();
       
       // if we have not read the stdout, we do it now

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
@@ -64,8 +64,13 @@ public class ExecCommand {
     Thread out = null;
 
     try {
+      String stdout = null;
       if (isRedirectToOut) {
         InputStream i = in.getInputStream();
+        i.mark(0);
+        // read the stdout first, and reset before we redirect the output
+        stdout = read(i);
+        i.reset();
         @SuppressWarnings("resource")
         CopyingOutputStream copyOut = new CopyingOutputStream(System.out);
         // this makes sense because CopyingOutputStream is an InputStreamWrapper
@@ -80,10 +85,16 @@ public class ExecCommand {
                   }
                 });
         out.start();
-      }
-
+      } 
+      
       p.waitFor();
-      return new ExecResult(p.exitValue(), read(in.getInputStream()), read(p.getErrorStream()));
+      
+      // if we have not read the stdout, we do it now
+      if (stdout == null) {
+        stdout = read(in.getInputStream());
+      }
+      return new ExecResult(p.exitValue(), stdout, read(p.getErrorStream()));
+    
     } finally {
       if (out != null) {
         out.join();


### PR DESCRIPTION
Fix a problem in ExecCommand util. When both redirect and saveResults enabled, the stdout is not correctly saved because both work on the same InputStream.