### PR TITLE
Break the code in to BeforeAll, Test and AfterAll blocks

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
@@ -54,6 +54,10 @@ class ItSimpleDomainValidation implements LoggedTest {
   String pvcName;
   String pvName;
 
+  /**
+   * Setup for test suite. Creates service account, namespace, and persistent volumes.
+   * @param namespaces injected by Junit extension
+   */
   @BeforeAll
   public void setup(@Namespaces(1) List<String> namespaces) {
 
@@ -117,6 +121,9 @@ class ItSimpleDomainValidation implements LoggedTest {
     assertTrue(success, "PersistentVolume creation failed");
   }
 
+  /**
+   * Create a simple domain and checks if pods are coming up.
+   */
   @Test
   @DisplayName("Create a domain")
   @Slow
@@ -158,6 +165,9 @@ class ItSimpleDomainValidation implements LoggedTest {
         .until(domainExists(domainUid, "v7", namespace));
   }
 
+  /**
+   * Delete artifacts.
+   */
   @AfterAll
   public void cleanup() {
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
@@ -156,9 +156,6 @@ class ItSimpleDomainValidation implements LoggedTest {
         .await().atMost(5, MINUTES)
         // operatorIsRunning() is one of our custom, reusable assertions
         .until(domainExists(domainUid, "v7", namespace));
-
-    // wait for the admin server pod to exist
-    // wait for the managed servers to exist
   }
 
   @AfterAll

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
@@ -23,6 +23,8 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.annotations.tags.Slow;
 import oracle.weblogic.kubernetes.extensions.LoggedTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -45,28 +47,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @IntegrationTest
 class ItSimpleDomainValidation implements LoggedTest {
 
-  @Test
-  @DisplayName("Create a domain")
-  @Slow
-  public void testCreatingDomain(@Namespaces(1) List<String> namespaces) {
+  final String domainUid = "domain1";
+  String namespace;
+  String serviceAccountName;
+  V1ServiceAccount serviceAccount;
+  String pvcName;
+  String pvName;
 
-    final String domainUid = "domain1";
+  @BeforeAll
+  public void setup(@Namespaces(1) List<String> namespaces) {
 
     // get a new unique namespace
     logger.info("Creating unique namespace for Operator");
     assertNotNull(namespaces.get(0), "Namespace list is null");
-    String namespace = namespaces.get(0);
+    namespace = namespaces.get(0);
 
     // Create a service account for the unique namespace
-    final String serviceAccountName = namespace + "-sa";
-    final V1ServiceAccount serviceAccount = assertDoesNotThrow(
+    serviceAccountName = namespace + "-sa";
+    serviceAccount = assertDoesNotThrow(
         () -> Kubernetes.createServiceAccount(new V1ServiceAccount()
             .metadata(new V1ObjectMeta().namespace(namespace).name(serviceAccountName))));
     logger.info("Created service account: {0}", serviceAccount.getMetadata().getName());
 
     // create persistent volume and persistent volume claim
-    final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
-    final String pvName = domainUid + "-pv"; // name of the persistent volume
+    pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+    pvName = domainUid + "-pv"; // name of the persistent volume
 
     V1PersistentVolumeClaim v1pvc = new V1PersistentVolumeClaim()
         .spec(new V1PersistentVolumeClaimSpec()
@@ -85,7 +90,7 @@ class ItSimpleDomainValidation implements LoggedTest {
     boolean success = assertDoesNotThrow(
         () -> TestActions.createPersistentVolumeClaim(v1pvc),
         "Persistent volume claim creation failed, "
-            + "look at the above console log messages for failure reason in ApiException responsebody"
+        + "look at the above console log messages for failure reason in ApiException responsebody"
     );
     assertTrue(success, "PersistentVolumeClaim creation failed");
 
@@ -98,7 +103,7 @@ class ItSimpleDomainValidation implements LoggedTest {
             .persistentVolumeReclaimPolicy("Recycle")
             .hostPath(new V1HostPathVolumeSource()
                 .path(System.getProperty("java.io.tmpdir") + "/" + domainUid + "-persistentVolume")))
-                .metadata(new V1ObjectMetaBuilder()
+        .metadata(new V1ObjectMetaBuilder()
             .withName(pvName)
             .withNamespace(namespace)
             .build()
@@ -107,9 +112,15 @@ class ItSimpleDomainValidation implements LoggedTest {
     success = assertDoesNotThrow(
         () -> TestActions.createPersistentVolume(v1pv),
         "Persistent volume creation failed, "
-            + "look at the above console log messages for failure reason in ApiException responsebody"
+        + "look at the above console log messages for failure reason in ApiException responsebody"
     );
     assertTrue(success, "PersistentVolume creation failed");
+  }
+
+  @Test
+  @DisplayName("Create a domain")
+  @Slow
+  public void testCreatingDomain() {
 
     // create the domain CR
     V1ObjectMeta metadata = new V1ObjectMetaBuilder()
@@ -126,10 +137,10 @@ class ItSimpleDomainValidation implements LoggedTest {
         .kind("Domain")
         .metadata(metadata)
         .spec(domainSpec);
-    success = assertDoesNotThrow(
+    boolean success = assertDoesNotThrow(
         () -> createDomainCustomResource(domain),
         "Domain failed to be created, "
-            + "look at the above console log messages for failure reason in ApiException responsebody"
+        + "look at the above console log messages for failure reason in ApiException responsebody"
     );
     assertTrue(success);
 
@@ -138,7 +149,7 @@ class ItSimpleDomainValidation implements LoggedTest {
         .and().with().pollInterval(10, SECONDS)
         .conditionEvaluationListener(
             condition -> logger.info(
-                "Waiting for domain to be running (elapsed time {0}ms, remaining time {1}ms)",
+                "Waiting for domain to be running (elapsed time {0} ms, remaining time {1} ms)",
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
         // and here we can set the maximum time we are prepared to wait
@@ -147,8 +158,11 @@ class ItSimpleDomainValidation implements LoggedTest {
         .until(domainExists(domainUid, "v7", namespace));
 
     // wait for the admin server pod to exist
-
     // wait for the managed servers to exist
+  }
+
+  @AfterAll
+  public void cleanup() {
 
     // Delete domain custom resource
     assertTrue(deleteDomainCustomResource(domainUid, namespace), "Domain failed to be deleted, "
@@ -165,7 +179,7 @@ class ItSimpleDomainValidation implements LoggedTest {
     // Delete the persistent volume claim and persistent volume
     assertTrue(deletePersistentVolumeClaim(pvcName, namespace),
         "Persistent volume claim deletion failed, "
-            + "look at the above console log messages for failure reason in ApiException responsebody");
+        + "look at the above console log messages for failure reason in ApiException responsebody");
 
     assertTrue(deletePersistentVolume(pvName), "Persistent volume deletion failed, "
         + "look at the above console log messages for failure reason in ApiException responsebody");
@@ -175,5 +189,4 @@ class ItSimpleDomainValidation implements LoggedTest {
         + "look at the above console log messages for failure reason in ApiException responsebody");
     logger.info("Deleted namespace: {0}", namespace);
   }
-
 }


### PR DESCRIPTION
This PR addresses the cleanup failures in ItSimpleDomainValidation test suite, in case test fails and leave behind the various artifacts. By breaking up the code into BeforeAll, Test and After methods the artifacts are cleaned up even when test fails.