### PR TITLE
Check fileext wdt

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -424,7 +424,7 @@ function checkWDTVersion() {
     versionGE ${wdt_version} ${WDT_MINIMUM_VERSION}
     if [ $? != "0" ] ; then
       trace SEVERE "Model in Image domain requires Weblogic Deploy Tool minimum version ${WDT_MINIMUM_VERSION}. " \
-      "Your version in the image is ${wdt_version}. You need to update the Weblogic Deploy Tool version in the image."
+      "The version in the image is ${wdt_version}, you need to update the Weblogic Deploy Tool version in the image."
       exitOrLoop
     fi
   else

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -428,7 +428,8 @@ function checkWDTVersion() {
       exitOrLoop
     fi
   else
-    trace SEVERE "Unknown Weblogic Deploy Tool version. Operator requires WDT minimum version ${WDT_MINIMUM_VERSION}"
+    trace SEVERE "Unknown Weblogic Deploy Tool version. Model in Image domain requires Weblogic Deploy Tool " \
+      "minimum version ${WDT_MINIMUM_VERSION}"
     exitOrLoop
   fi
 

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -430,14 +430,16 @@ function checkWDTVersion() {
       trace SEVERE "Domain Source Type is 'FromModel' and it requires WebLogic Deploy Tool with a minimum " \
       "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the WebLogic Deploy Tool installed " \
       "in the image is ${wdt_version}, you can create another image with an updated version of the WebLogic Deploy " \
-      "Tool and redeploy the domain again."
+      "Tool and redeploy the domain again. To bypass this check, set environment variable " \
+      "'WDT_BYPASS_WDT_VERSION_CHECK' to 'true'"
       exitOrLoop
     fi
   else
       trace SEVERE "Domain Source Type is 'FromModel' and it requires WebLogic Deploy Tool with a minimum " \
       "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the WebLogic Deploy Tool installed " \
-      "in the image cannot be determined, you can create another image with an updated version of the WebLogic " \
-      "Deploy Tool and redeploy the domain again."
+      "in the image cannot be determined, you can create another image with an updated version of the WebLogic Deploy" \
+      " Tool and redeploy the domain again. To bypass this check, set environment variable " \
+      "'WDT_BYPASS_WDT_VERSION_CHECK' to 'true'"
     exitOrLoop
   fi
 

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -284,7 +284,9 @@ function createWLDomain() {
   checkDirNotExistsOrEmpty ${WDT_BINDIR}
 
   checkModelDirectoryExtensions
-  checkWDTVersion
+  if [ -z "${WDT_BYPASS_WDT_VERSION_CHECK}" ] ; then
+    checkWDTVersion
+  fi
 
   # copy the filter related files to the wdt lib
 
@@ -395,18 +397,18 @@ function checkModelDirectoryExtensions() {
   cd ${IMG_MODELS_HOME}
   counter=$(ls  -I  *.yaml -I *.zip -I *.properties | wc -l)
   if [ $counter -ne 0 ] ; then
-        trace SEVERE "Directory ${IMG_MODELS_HOME} contains files with unsupported extension. Extension must be" \
+        trace SEVERE "Model image directory ${IMG_MODELS_HOME} contains files with unsupported extensions. Expected extensions: " \
           ".yaml, .properties, or .zip"
-        trace SEVERE $(ls -I  *.yaml -I *.zip -I *.properties)
+        trace SEVERE "Model files with unsupported extensions: '$(ls -I  *.yaml -I *.zip -I *.properties)'"
         exitOrLoop
   fi
   if [ -d ${WDT_CONFIGMAP_ROOT} ] ; then
     cd ${WDT_CONFIGMAP_ROOT}
     counter=$(ls  -I  *.yaml -I *.properties | wc -l)
     if [ $counter -ne 0 ] ; then
-          trace SEVERE "Directory ${WDT_CONFIGMAP_ROOT} contains files with unsupported extension. Extension must be" \
-            ".yaml or .properties"
-          trace SEVERE $(ls -I  *.yaml -I *.properties)
+          trace SEVERE "Model configmap directory ${WDT_CONFIGMAP_ROOT} contains files with unsupported extensions. " \
+          "Expected extensions: .yaml or .properties"
+          trace SEVERE "Model files with unsupported extensions: '$(ls -I  *.yaml -I *.properties)'"
           exitOrLoop
     fi
   fi

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -428,15 +428,15 @@ function checkWDTVersion() {
     versionGE ${wdt_version} ${WDT_MINIMUM_VERSION}
     if [ $? != "0" ] ; then
       trace SEVERE "Domain Source Type is 'FromModel' and it requires WebLogic Deploy Tool with a minimum " \
-      "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the Weblogic Deploy Tool installed " \
-      "in the image is ${wdt_version}, you can create another image with an updated version of the Weblogic Deploy " \
+      "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the WebLogic Deploy Tool installed " \
+      "in the image is ${wdt_version}, you can create another image with an updated version of the WebLogic Deploy " \
       "Tool and redeploy the domain again."
       exitOrLoop
     fi
   else
       trace SEVERE "Domain Source Type is 'FromModel' and it requires WebLogic Deploy Tool with a minimum " \
-      "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the Weblogic Deploy Tool installed " \
-      "in the image cannot be determined, you can create another image with an updated version of the Weblogic " \
+      "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the WebLogic Deploy Tool installed " \
+      "in the image cannot be determined, you can create another image with an updated version of the WebLogic " \
       "Deploy Tool and redeploy the domain again."
     exitOrLoop
   fi

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -402,11 +402,11 @@ function checkModelDirectoryExtensions() {
   fi
   if [ -d ${WDT_CONFIGMAP_ROOT} ] ; then
     cd ${WDT_CONFIGMAP_ROOT}
-    counter=$(ls  -I  *.yaml -I *.zip -I *.properties | wc -l)
+    counter=$(ls  -I  *.yaml -I *.properties | wc -l)
     if [ $counter -ne 0 ] ; then
           trace SEVERE "Directory ${WDT_CONFIGMAP_ROOT} contains files with unsupported extension. Extension must be" \
-            ".yaml, .properties, or .zip"
-          trace SEVERE $(ls -I  *.yaml -I *.zip -I *.properties)
+            ".yaml or .properties"
+          trace SEVERE $(ls -I  *.yaml -I *.properties)
           exitOrLoop
     fi
   fi

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -421,7 +421,8 @@ function checkWDTVersion() {
   unzip -c ${WDT_ROOT}/lib/weblogic-deploy-core.jar META-INF/MANIFEST.MF > /tmp/wdtversion.txt || exitOrLoop
   local wdt_version="$(grep "Implementation-Version" /tmp/wdtversion.txt | cut -f2 -d' ' | tr -d '\r' )" || exitOrLoop
   if  [ ! -z ${wdt_version} ]; then
-    if [ "$(versionGE ${wdt_version} ${WDT_MINIMUM_VERSION})" != "0" ] ; then
+    versionGE ${wdt_version} ${WDT_MINIMUM_VERSION}
+    if [ $? != "0" ] ; then
       trace SEVERE "Model in Image domain requires Weblogic Deploy Tool minimum version ${WDT_MINIMUM_VERSION}. " \
       "Your version in the image is ${wdt_version}. You need to update the Weblogic Deploy Tool version in the image."
       exitOrLoop

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -284,7 +284,7 @@ function createWLDomain() {
   checkDirNotExistsOrEmpty ${WDT_BINDIR}
 
   checkModelDirectoryExtensions
-  if [ -z "${WDT_BYPASS_WDT_VERSION_CHECK}" ] ; then
+  if [ -z "${WDT_BYPASS_WDT_VERSION_CHECK}" ] || [ "true" != "${WDT_BYPASS_WDT_VERSION_CHECK}" ] ; then
     checkWDTVersion
   fi
 

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -427,13 +427,17 @@ function checkWDTVersion() {
   if  [ ! -z ${wdt_version} ]; then
     versionGE ${wdt_version} ${WDT_MINIMUM_VERSION}
     if [ $? != "0" ] ; then
-      trace SEVERE "Model in Image domain requires Weblogic Deploy Tool minimum version ${WDT_MINIMUM_VERSION}. " \
-      "The version in the image is ${wdt_version}, you need to update the Weblogic Deploy Tool version in the image."
+      trace SEVERE "Domain Source Type is 'FromModel' and it requires WebLogic Deploy Tool with a minimum " \
+      "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the Weblogic Deploy Tool installed " \
+      "in the image is ${wdt_version}, you can create another image with an updated version of the Weblogic Deploy " \
+      "Tool and redeploy the domain again."
       exitOrLoop
     fi
   else
-    trace SEVERE "Unknown Weblogic Deploy Tool version. Model in Image domain requires Weblogic Deploy Tool " \
-      "minimum version ${WDT_MINIMUM_VERSION}"
+      trace SEVERE "Domain Source Type is 'FromModel' and it requires WebLogic Deploy Tool with a minimum " \
+      "version of ${WDT_MINIMUM_VERSION} installed in the image. The version of the Weblogic Deploy Tool installed " \
+      "in the image cannot be determined, you can create another image with an updated version of the Weblogic " \
+      "Deploy Tool and redeploy the domain again."
     exitOrLoop
   fi
 

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -284,7 +284,7 @@ function createWLDomain() {
   checkDirNotExistsOrEmpty ${WDT_BINDIR}
 
   checkModelDirectoryExtensions
-  if [ -z "${WDT_BYPASS_WDT_VERSION_CHECK}" ] || [ "true" != "${WDT_BYPASS_WDT_VERSION_CHECK}" ] ; then
+  if [ "true" != "${WDT_BYPASS_WDT_VERSION_CHECK}" ] ; then
     checkWDTVersion
   fi
 
@@ -395,20 +395,20 @@ function checkModelDirectoryExtensions() {
   trace "Entering checkModelDirectoryExtensions"
 
   cd ${IMG_MODELS_HOME}
-  counter=$(ls  -I  *.yaml -I *.zip -I *.properties | wc -l)
+  counter=$(ls  -I  "*.yaml" -I "*.zip" -I "*.properties" | wc -l)
   if [ $counter -ne 0 ] ; then
         trace SEVERE "Model image directory ${IMG_MODELS_HOME} contains files with unsupported extensions. Expected extensions: " \
           ".yaml, .properties, or .zip"
-        trace SEVERE "Model files with unsupported extensions: '$(ls -I  *.yaml -I *.zip -I *.properties)'"
+        trace SEVERE "Model files with unsupported extensions: '$(ls -I "*.yaml" -I "*.zip" -I "*.properties")'"
         exitOrLoop
   fi
   if [ -d ${WDT_CONFIGMAP_ROOT} ] ; then
     cd ${WDT_CONFIGMAP_ROOT}
-    counter=$(ls  -I  *.yaml -I *.properties | wc -l)
+    counter=$(ls  -I  "*.yaml" -I "*.properties" | wc -l)
     if [ $counter -ne 0 ] ; then
           trace SEVERE "Model configmap directory ${WDT_CONFIGMAP_ROOT} contains files with unsupported extensions. " \
           "Expected extensions: .yaml or .properties"
-          trace SEVERE "Model files with unsupported extensions: '$(ls -I  *.yaml -I *.properties)'"
+          trace SEVERE "Model files with unsupported extensions: '$(ls -I "*.yaml" -I "*.properties")'"
           exitOrLoop
     fi
   fi

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -397,19 +397,21 @@ function checkModelDirectoryExtensions() {
   cd ${IMG_MODELS_HOME}
   counter=$(ls  -I  "*.yaml" -I "*.zip" -I "*.properties" | wc -l)
   if [ $counter -ne 0 ] ; then
-        trace SEVERE "Model image directory ${IMG_MODELS_HOME} contains files with unsupported extensions. Expected extensions: " \
-          ".yaml, .properties, or .zip"
-        trace SEVERE "Model files with unsupported extensions: '$(ls -I "*.yaml" -I "*.zip" -I "*.properties")'"
-        exitOrLoop
+    trace SEVERE "Model image directory ${IMG_MODELS_HOME} contains files with unsupported extensions. " \
+      "Expected extensions: .yaml, .properties, or .zip"
+    trace SEVERE "Model image directory files with unsupported extensions: " \
+      "'$(ls -I "*.yaml" -I "*.zip" -I "*.properties")'"
+    exitOrLoop
   fi
   if [ -d ${WDT_CONFIGMAP_ROOT} ] ; then
     cd ${WDT_CONFIGMAP_ROOT}
     counter=$(ls  -I  "*.yaml" -I "*.properties" | wc -l)
     if [ $counter -ne 0 ] ; then
-          trace SEVERE "Model configmap directory ${WDT_CONFIGMAP_ROOT} contains files with unsupported extensions. " \
-          "Expected extensions: .yaml or .properties"
-          trace SEVERE "Model files with unsupported extensions: '$(ls -I "*.yaml" -I "*.properties")'"
-          exitOrLoop
+      trace SEVERE "Model configmap directory ${WDT_CONFIGMAP_ROOT} contains files with unsupported extensions. " \
+      "Expected extensions: .yaml or .properties"
+      trace SEVERE "Model configmap directory files with unsupported extensions: " \
+        "'$(ls -I "*.yaml" -I "*.properties")'"
+      exitOrLoop
     fi
   fi
 


### PR DESCRIPTION
This PR provides two additional checks

1.  Minimum WDT version 1.7.3
2.  Check and fail if user put unsupported file extension in the model directories, supported are .yaml, .properties, or .zip (only in the image)