### PR TITLE
Fix exec command

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
@@ -64,13 +64,8 @@ public class ExecCommand {
     Thread out = null;
 
     try {
-      String stdout = null;
       if (isRedirectToOut) {
         InputStream i = in.getInputStream();
-        i.mark(0);
-        // read the stdout first, and reset before we redirect the output
-        stdout = read(i);
-        i.reset();
         @SuppressWarnings("resource")
         CopyingOutputStream copyOut = new CopyingOutputStream(System.out);
         // this makes sense because CopyingOutputStream is an InputStreamWrapper
@@ -88,12 +83,8 @@ public class ExecCommand {
       }
 
       p.waitFor();
-      
-      // if we have not read the stdout, we do it now
-      if (stdout == null) {
-        stdout = read(in.getInputStream());
-      }
-      return new ExecResult(p.exitValue(), stdout, read(p.getErrorStream()));
+
+      return new ExecResult(p.exitValue(), read(in.getInputStream()), read(p.getErrorStream()));
     
     } finally {
       if (out != null) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ExecCommand.java
@@ -84,9 +84,16 @@ public class ExecCommand {
 
       p.waitFor();
 
+      // we need to join the thread before we read the stdout so that the saved stdout is complete
+      if (out != null) {
+        out.join();
+        out = null;
+      }
+
       return new ExecResult(p.exitValue(), read(in.getInputStream()), read(p.getErrorStream()));
     
     } finally {
+      // we try to join again if for any reason the code failed before the previous attempt
       if (out != null) {
         out.join();
       }


### PR DESCRIPTION
Fix intermittent issues on Jenkins in exec command util.
1) revert the changes that perform mark and reset.
2) force the thread to join so that the copied input stream is ready to be read for getting the stdout.