### PR TITLE
do not fail the whole test if the curl command returns a non-zero status

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1713,7 +1713,7 @@ public class Domain {
 
   private void callWebAppAndWaitTillReady(String curlCmd) throws Exception {
     for (int i = 0; i < maxIterations; i++) {
-      ExecResult result = TestUtils.exec(curlCmd, true);
+      ExecResult result = TestUtils.execAndIgnoreNonzeroReturnCode(curlCmd, true);
       String responseCode = result.stdout().trim();
       if (result.exitValue() != 0 || !responseCode.equals("200")) {
         LoggerHelper.getLocal().log(Level.INFO,

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1713,7 +1713,7 @@ public class Domain {
 
   private void callWebAppAndWaitTillReady(String curlCmd) throws Exception {
     for (int i = 0; i < maxIterations; i++) {
-      ExecResult result = TestUtils.execAndIgnoreNonzeroReturnCode(curlCmd, true);
+      ExecResult result = ExecCommand.exec(curlCmd);
       String responseCode = result.stdout().trim();
       if (result.exitValue() != 0 || !responseCode.equals("200")) {
         LoggerHelper.getLocal().log(Level.INFO,

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -407,30 +407,6 @@ public class TestUtils {
   }
 
   /**
-   * exec command but do not throw a runtime exception if the command has a non-zero return code.
-   * @param cmd command
-   * @param debug debug flag
-   * @return executor
-   * @throws Exception on failure
-   */
-  public static ExecResult execAndIgnoreNonzeroReturnCode(String cmd, boolean debug) throws Exception {
-    ExecResult result = ExecCommand.exec(cmd);
-    if (result.exitValue() != 0 || debug) {
-      LoggerHelper.getLocal().log(Level.INFO,
-          "\nCommand "
-              + cmd
-              + "\nreturn value: "
-              + result.exitValue()
-              + "\nstderr = "
-              + result.stderr()
-              + "\nstdout = "
-              + result.stdout());
-    }
-
-    return result;
-  }
-
-  /**
    * Check PV is released.
    * @param pvBaseName PV base name
    * @param namespace namespace

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -407,6 +407,30 @@ public class TestUtils {
   }
 
   /**
+   * exec command but do not throw a runtime exception if the command has a non-zero return code.
+   * @param cmd command
+   * @param debug debug flag
+   * @return executor
+   * @throws Exception on failure
+   */
+  public static ExecResult execAndIgnoreNonzeroReturnCode(String cmd, boolean debug) throws Exception {
+    ExecResult result = ExecCommand.exec(cmd);
+    if (result.exitValue() != 0 || debug) {
+      LoggerHelper.getLocal().log(Level.INFO,
+          "\nCommand "
+              + cmd
+              + "\nreturn value: "
+              + result.exitValue()
+              + "\nstderr = "
+              + result.stderr()
+              + "\nstdout = "
+              + result.stdout());
+    }
+
+    return result;
+  }
+
+  /**
    * Check PV is released.
    * @param pvBaseName PV base name
    * @param namespace namespace


### PR DESCRIPTION
we expect if to fail, and want to retry it until it is successful.  it
can fail because the web app has not had time to start up yet.  the
current code throws a runtime exception on a non-zero return code, which
causes this test to fail too fast and incorrectly.

I was investigating the failure in test  oracle.kubernetes.operator.ItDomainInImage.testDomainInImageUsingWdt.  Here is the relevant part of the log:

```
<04-26-2020 09:39:52> <INFO> <oracle.kubernetes.operator.BaseTest testAdminT3Channel> <Inside testAdminT3Channel>
<04-26-2020 09:39:52> <INFO> <oracle.kubernetes.operator.utils.TestUtils kubectlexecNoCheck> <Command to call kubectl sh file kubectl -n itdomaininimage-domainns-2 exec -it itdomaininimage-domain-9-admin-server  -- mkdir -p /u01/oracle/apps>
<04-26-2020 09:39:53> <INFO> <oracle.kubernetes.operator.utils.TestUtils kubectlexecNoCheck> <Command to call kubectl sh file kubectl -n itdomaininimage-domainns-2 exec -it itdomaininimage-domain-9-admin-server  -- bash -c 'cat > /u01/oracle/apps/testwebapp.war' < /home/opc/jenkins/workspace/weblogic-kubernetes-operator-nightly-full-test/integration-tests/../src/integration-tests/apps/testwebapp.war>
<04-26-2020 09:39:53> <INFO> <oracle.kubernetes.operator.utils.TestUtils kubectlexecNoCheck> <Command to call kubectl sh file kubectl -n itdomaininimage-domainns-2 exec -it itdomaininimage-domain-9-admin-server  -- bash -c 'cat > /u01/oracle/apps/deploywebapp.py' < /home/opc/jenkins/workspace/weblogic-kubernetes-operator-nightly-full-test/integration-tests/../integration-tests/src/test/resources/deploywebapp.py>
<04-26-2020 09:39:53> <INFO> <oracle.kubernetes.operator.utils.TestUtils kubectlexecNoCheck> <Command to call kubectl sh file kubectl -n itdomaininimage-domainns-2 exec -it itdomaininimage-domain-9-admin-server  -- bash -c 'cat > /u01/oracle/apps/callpyscript.sh' < /home/opc/jenkins/workspace/weblogic-kubernetes-operator-nightly-full-test/integration-tests/../integration-tests/src/test/resources/callpyscript.sh>
<04-26-2020 09:39:54> <INFO> <oracle.kubernetes.operator.utils.TestUtils callShellScriptByExecToPod> <Command to call kubectl sh file kubectl -n itdomaininimage-domainns-2 exec -it itdomaininimage-domain-9-admin-server -- bash -c 'chmod +x -R /u01/oracle/apps  && /u01/oracle/apps/callpyscript.sh /u01/oracle/apps/deploywebapp.py weblogic welcome1 t3://itdomaininimage-domain-9-admin-server:31009 testwebapp /u01/oracle/apps/testwebapp.war cluster-1'>
<04-26-2020 09:40:09> <INFO> <oracle.kubernetes.operator.utils.Domain callWebAppAndVerifyLoadBalancing> <Curl cmd with response code curl --silent --noproxy '*'  -H 'host: itdomaininimage-domain-9.org' http://130.61.57.23:30305/testwebapp/ --write-out %{http_code} -o /dev/null>
<04-26-2020 09:40:09> <INFO> <oracle.kubernetes.operator.utils.Domain callWebAppAndVerifyLoadBalancing> <Curl cmd curl --silent --noproxy '*'  -H 'host: itdomaininimage-domain-9.org' http://130.61.57.23:30305/testwebapp/>
<04-26-2020 09:40:44> <INFO> <oracle.kubernetes.operator.utils.TestUtils exec> <
Command curl --silent --noproxy '*'  -H 'host: itdomaininimage-domain-9.org' http://130.61.57.23:30305/testwebapp/ --write-out %{http_code} -o /dev/null
return value: 7
stderr = 
stdout = 000>
<04-26-2020 09:40:44> <INFO> <oracle.kubernetes.operator.utils.TestUtils exec> <
Command docker rmi -f phx.ocir.io/weblogick8s/itdomaininimage-dominimage:2020-04-26-1587893612794
return value: 0
stderr = 
stdout = Untagged: phx.ocir.io/weblogick8s/itdomaininimage-dominimage:2020-04-26-1587893612794
```

you can see that as soon as it gets that curl rc=7, which is coming from BaseTest.java:617
      domain.callWebAppAndVerifyLoadBalancing(TESTWEBAPP, verifyLoadBalancing);
it immediately goes on to the finally/cleanup which starts by deleting the image

```
      testBasicUseCases(domain, false);
      testClusterScaling(operator1, domain, true);
      testCompletedSuccessfully = true;
    } finally {
      // if (domain != null && (JENKINS || testCompletedSuccessfully)) {
      if (domain != null && testCompletedSuccessfully) {
        TestUtils.deleteWeblogicDomainResources(domain.getDomainUid());
        TestUtils.verifyAfterDeletion(domain);
      }
      if (domain != null) {
        domain.deleteImage();
      }
    }
    LoggerHelper.getLocal().log(Level.INFO, "SUCCESS - " + testMethodName);
  }
```

so testClusterScaling() is failing silently and it goes to the finally

```
callWebAppAndVerifyLoadBalancing calls into callWebAppAndWaitTillReady which does this
private void callWebAppAndWaitTillReady(String curlCmd) throws Exception {
    for (int i = 0; i < maxIterations; i++) {
      ExecResult result = TestUtils.exec(curlCmd, true)
      String responseCode = result.stdout().trim();
      if (result.exitValue() != 0 || !responseCode.equals("200")) {

that TestUtils.exec() does this:
  public static ExecResult exec(String cmd, boolean debug) throws Exception {
    ExecResult result = ExecCommand.exec(cmd);
    if (result.exitValue() != 0 || debug) {
      LoggerHelper.getLocal().log(Level.INFO,
          "\nCommand "
              + cmd
              + "\nreturn value: "
              + result.exitValue()
              + "\nstderr = "
              + result.stderr()
              + "\nstdout = "
              + result.stdout());
    }
    if (result.exitValue() != 0) {
      throw new RuntimeException(
          "FAILURE: Command "
              + cmd
              + " failed with stderr = "
              + result.stderr()
              + " \n stdout = "
              + result.stdout());
    }
    return result;
  }
```

so you can see, since it got a rc=7 here, it just throws a RuntimeException and so the test fails
this is not what we want, we want to capture the rc and return it to the caller so they can decide whether or not to fail
of course this method is used everywhere - 45 callers :disappointed: -- so this is going to take some work to fix without breaking other things

a quick guess might be to change it to this
```
  public static ExecResult exec(String cmd, boolean debug) throws Exception {
    ExecResult result = ExecCommand.exec(cmd);
    if (result.exitValue() != 0 || debug) {
      LoggerHelper.getLocal().log(Level.INFO,
          "\nCommand "
              + cmd
              + "\nreturn value: "
              + result.exitValue()
              + "\nstderr = "
              + result.stderr()
              + "\nstdout = "
              + result.stdout());
      return result;
    }
    if (result.exitValue() != 0) {
      throw new RuntimeException(
          "FAILURE: Command "
              + cmd
              + " failed with stderr = "
              + result.stderr()
              + " \n stdout = "
              + result.stdout());
    }
    return result;
  }
```

but we will need to work through what all those 45 callers do...
a quick look tells me a lot of the set debug to true, so this wont work :disappointed:
we probably have to introduce a new argument to determine whether to fail on a non-zero rc
I am going to put in a hack for now to try to fix this one test

