### PR TITLE
Rethrow the exception caught in the BeforeAll, BeforeEach and AfterEach

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
@@ -81,7 +81,7 @@ class ItSimpleDomainValidation implements LoggedTest {
         .spec(new V1PersistentVolumeClaimSpec()
             .addAccessModesItem("ReadWriteMany")
             .storageClassName(domainUid + "-weblogic-domain-storage-class")
-            .volumeName(domainUid + "-weblogic-pv")
+            .volumeName(pvName)
             .resources(new V1ResourceRequirements()
                 .putRequestsItem("storage", Quantity.fromString("10Gi"))))
         .metadata(new V1ObjectMetaBuilder()

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -30,4 +30,6 @@ public interface TestConstants {
       .orElse("");
   public static final String BRANCH_NAME_FROM_JENKINS = Optional.ofNullable(System.getenv("BRANCH"))
       .orElse("");
+  public static final String LOGS_DIR = System.getenv().getOrDefault("RESULT_ROOT",
+      System.getProperty("java.io.tmpdir")) + "/diagnosticlogs";
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.kubernetes.client.openapi.ApiException;
+import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.utils.LoggingUtil;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -58,12 +59,6 @@ public class IntegrationTestWatcher implements
   private String methodName;
   private List namespaces = null;
   private static final String START_TIME = "start time";
-
-  /**
-   * Directory to store logs.
-   */
-  private static final String LOGS_DIR = System.getProperty("RESULT_ROOT",
-        System.getProperty("java.io.tmpdir"));
 
   /**
    * Determine if this resolver supports resolution of an argument for the
@@ -329,7 +324,7 @@ public class IntegrationTestWatcher implements
     }
     Path resultDir = null;
     try {
-      resultDir = Files.createDirectories(Paths.get(LOGS_DIR,
+      resultDir = Files.createDirectories(Paths.get(TestConstants.LOGS_DIR,
               extensionContext.getRequiredTestClass().getSimpleName(),
               getExtDir(extensionContext, failedStage)));
     } catch (IOException ex) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
@@ -129,6 +129,7 @@ public class IntegrationTestWatcher implements
       throws Throwable {
     printHeader(String.format("BeforeAll failed %s", className), "!");
     collectLogs(context, "beforeAll");
+    throw throwable;
   }
 
   /**
@@ -153,6 +154,7 @@ public class IntegrationTestWatcher implements
       throws Throwable {
     printHeader(String.format("BeforeEach failed for %s", methodName), "!");
     collectLogs(context, "beforeEach");
+    throw throwable;
   }
 
   /**
@@ -252,6 +254,7 @@ public class IntegrationTestWatcher implements
       throws Throwable {
     printHeader(String.format("AfterEach failed for %s", methodName), "!");
     collectLogs(context, "afterEach");
+    throw throwable;
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 
 import io.kubernetes.client.openapi.ApiException;
+import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 
 import static io.kubernetes.client.util.Yaml.dump;
@@ -24,15 +25,9 @@ import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
 public class LoggingUtil {
 
   /**
-   * Directory to store logs.
-   */
-  private static final String LOGS_DIR = System.getProperty("RESULT_ROOT",
-        System.getProperty("java.io.tmpdir"));
-
-  /**
    * Collect logs for artifacts in Kubernetes cluster for current running test object. This method can be called
    * anywhere in the test by passing the test instance object and list namespaces.
-   * 
+   *
    * <p>The collected logs are written in the LOGS_DIR/IT_TEST_CLASSNAME/CURRENT_TIMESTAMP directory.
    *
    * @param itInstance the integration test instance
@@ -43,7 +38,7 @@ public class LoggingUtil {
     String resultDirExt = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
     try {
       Path resultDir = Files.createDirectories(
-          Paths.get(LOGS_DIR, itInstance.getClass().getSimpleName(),
+          Paths.get(TestConstants.LOGS_DIR, itInstance.getClass().getSimpleName(),
               resultDirExt));
       for (var namespace : namespaces) {
         LoggingUtil.generateLog((String) namespace, resultDir);


### PR DESCRIPTION
If a exception is thrown in BeforeAll, BeforeEach and AfterEach methods the extension is catching that but not re throwing it, which causes the test to continue if those methods fail.

The fix is to re throw the throwable in the LifecycleMethodExecutionExceptionHandler methods.

Changed the code to get the LOGS_DIR to store diagnostic logs from TestConstants.java

Changed the volumeName in persistent volume claim to pv name.