### PR TITLE
WIP: Add some debugging for ITElasticLogging test

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import oracle.kubernetes.operator.utils.Domain;
+import oracle.kubernetes.operator.utils.ExecCommand;
 import oracle.kubernetes.operator.utils.ExecResult;
 import oracle.kubernetes.operator.utils.LoggerHelper;
 import oracle.kubernetes.operator.utils.Operator;
@@ -424,7 +425,7 @@ public class ItElasticLogging extends BaseTest {
 
     int i = 0;
     while (i < BaseTest.getMaxIterationsPod()) {
-      result = TestUtils.exec(cmd);
+      result = ExecCommand.exec(cmd);
       LoggerHelper.getLocal().log(Level.INFO, "Result: " + result.stdout());
       if (null != result.stdout()) {
         break;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
@@ -165,6 +165,7 @@ public class ItElasticLogging extends BaseTest {
 
         // Create a dir to hold required WebLogic logging exporter archive files
         loggingExpArchiveLoc = getResultDir() + "/loggingExpArchDir";
+        LoggerHelper.getLocal().log(Level.INFO,"In prepare, attempting to create directory " + loggingExpArchiveLoc);
         Files.createDirectories(Paths.get(loggingExpArchiveLoc));
       }
     }
@@ -520,6 +521,7 @@ public class ItElasticLogging extends BaseTest {
   }
 
   private void downloadWlsLoggingExporterJars() throws Exception {
+    LoggerHelper.getLocal().log(Level.INFO,"In downloadWlsLoggingExporterJars, attempting to get file " + loggingExpArchiveLoc);
     File loggingJatReposDir = new File(loggingExpArchiveLoc);
     File wlsLoggingExpFile =
         new File(loggingExpArchiveLoc + "/" + wlsLoggingExpJar);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
@@ -521,7 +521,8 @@ public class ItElasticLogging extends BaseTest {
   }
 
   private void downloadWlsLoggingExporterJars() throws Exception {
-    LoggerHelper.getLocal().log(Level.INFO,"In downloadWlsLoggingExporterJars, attempting to get file " + loggingExpArchiveLoc);
+    LoggerHelper.getLocal().log(Level.INFO,
+        "In downloadWlsLoggingExporterJars, attempting to get file " + loggingExpArchiveLoc);
     File loggingJatReposDir = new File(loggingExpArchiveLoc);
     File wlsLoggingExpFile =
         new File(loggingExpArchiveLoc + "/" + wlsLoggingExpJar);


### PR DESCRIPTION
This test failed with a file error, it is not clear why, so this PR seeks to add some extra logging to help with problem determination.

Example failure: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-quicktest/1375/testReport/oracle.kubernetes.operator/ItElasticLogging/testWlsLoggingExporter/

```
java.lang.NullPointerException
	at java.base/java.io.File.<init>(File.java:276)
	at oracle.kubernetes.operator.ItElasticLogging.downloadWlsLoggingExporterJars(ItElasticLogging.java:523)
	at oracle.kubernetes.operator.ItElasticLogging.testWlsLoggingExporter(ItElasticLogging.java:336)
```


