### PR TITLE
Cleanup artifacts in Kubernetes cluster

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -37,7 +37,6 @@ import oracle.weblogic.kubernetes.annotations.tags.MustNotRunInParallel;
 import oracle.weblogic.kubernetes.annotations.tags.Slow;
 import oracle.weblogic.kubernetes.extensions.LoggedTest;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -70,13 +69,10 @@ import static oracle.weblogic.kubernetes.actions.TestActions.defaultAppParams;
 import static oracle.weblogic.kubernetes.actions.TestActions.defaultWitParams;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteImage;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteNamespace;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteServiceAccount;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
-import static oracle.weblogic.kubernetes.actions.TestActions.uninstallOperator;
 import static oracle.weblogic.kubernetes.actions.TestActions.upgradeOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
@@ -519,51 +515,6 @@ class ItMiiDomain implements LoggedTest {
     // delete the domain image created for the test
     if (miiImage != null) {
       deleteImage(miiImage);
-    }
-
-  }
-
-  /**
-   * Uninstall Operator, delete service account, domain namespace and
-   * operator namespace.
-   */
-  @AfterAll
-  public void tearDownAll() {
-    tearDown();
-    // uninstall operator release
-    logger.info("Uninstall Operator in namespace {0}", opNamespace);
-    if (opHelmParams != null) {
-      uninstallOperator(opHelmParams);
-    }
-    // Delete service account from unique opNamespace
-    logger.info("Delete service account in namespace {0}", opNamespace);
-    if (serviceAccount != null) {
-      assertDoesNotThrow(() -> deleteServiceAccount(serviceAccount.getMetadata().getName(),
-              serviceAccount.getMetadata().getNamespace()),
-              "deleteServiceAccount failed with ApiException");
-    }
-    // Delete domain namespaces
-    logger.info("Deleting domain namespace {0}", domainNamespace);
-    if (domainNamespace != null) {
-      assertDoesNotThrow(() -> deleteNamespace(domainNamespace),
-          "deleteNamespace failed with ApiException");
-      logger.info("Deleted namespace: " + domainNamespace);
-    }
-
-    // Delete domain namespaces
-    logger.info("Deleting domain namespace {0}", domainNamespace1);
-    if (domainNamespace1 != null) {
-      assertDoesNotThrow(() -> deleteNamespace(domainNamespace1),
-              "deleteNamespace failed with ApiException");
-      logger.info("Deleted namespace: " + domainNamespace1);
-    }
-
-    // Delete opNamespace
-    logger.info("Deleting Operator namespace {0}", opNamespace);
-    if (opNamespace != null) {
-      assertDoesNotThrow(() -> deleteNamespace(opNamespace),
-          "deleteNamespace failed with ApiException");
-      logger.info("Deleted namespace: " + opNamespace);
     }
 
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleDomainValidation.java
@@ -23,7 +23,6 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.annotations.tags.Slow;
 import oracle.weblogic.kubernetes.extensions.LoggedTest;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,10 +30,6 @@ import org.junit.jupiter.api.Test;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteDomainCustomResource;
-import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVolume;
-import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVolumeClaim;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteServiceAccount;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -165,35 +160,4 @@ class ItSimpleDomainValidation implements LoggedTest {
         .until(domainExists(domainUid, "v7", namespace));
   }
 
-  /**
-   * Delete artifacts.
-   */
-  @AfterAll
-  public void cleanup() {
-
-    // Delete domain custom resource
-    assertTrue(deleteDomainCustomResource(domainUid, namespace), "Domain failed to be deleted, "
-        + "look at the above console log messages for failure reason in ApiException responsebody");
-    logger.info("Deleted Domain Custom Resource {0} from {1}", domainUid, namespace);
-
-    // Delete service account from unique namespace
-    assertTrue(deleteServiceAccount(serviceAccount.getMetadata().getName(),
-        serviceAccount.getMetadata().getNamespace()), "Service account failed to be deleted, "
-        + "look at the above console log messages for failure reason in ApiException responsebody");
-    logger.info("Deleted service account \'" + serviceAccount.getMetadata().getName()
-        + "\' in namespace: " + serviceAccount.getMetadata().getNamespace());
-
-    // Delete the persistent volume claim and persistent volume
-    assertTrue(deletePersistentVolumeClaim(pvcName, namespace),
-        "Persistent volume claim deletion failed, "
-        + "look at the above console log messages for failure reason in ApiException responsebody");
-
-    assertTrue(deletePersistentVolume(pvName), "Persistent volume deletion failed, "
-        + "look at the above console log messages for failure reason in ApiException responsebody");
-
-    // Delete namespace
-    assertTrue(TestActions.deleteNamespace(namespace), "Namespace failed to be deleted, "
-        + "look at the above console log messages for failure reason in ApiException responsebody");
-    logger.info("Deleted namespace: {0}", namespace);
-  }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleOperatorValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleOperatorValidation.java
@@ -19,7 +19,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.annotations.tags.MustNotRunInParallel;
 import oracle.weblogic.kubernetes.annotations.tags.Slow;
 import oracle.weblogic.kubernetes.extensions.LoggedTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -38,11 +37,8 @@ import static oracle.weblogic.kubernetes.TestConstants.REPO_USERNAME;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDockerConfigJson;
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.createServiceAccount;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteNamespace;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteServiceAccount;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
-import static oracle.weblogic.kubernetes.actions.TestActions.uninstallOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsRunning;
 import static org.awaitility.Awaitility.with;
@@ -160,45 +156,6 @@ class ItSimpleOperatorValidation implements LoggedTest {
                 condition.getRemainingTimeInMS()))
         .until(operatorIsRunning(opNamespace));
 
-  }
-
-  @AfterEach
-  public void tearDown() {
-    // To Do: Remove this after we have common cleanup
-    // uninstall operator release
-    logger.info("Uninstall Operator in namespace {0}", opNamespace);
-    if (opHelmParams != null) {
-      uninstallOperator(opHelmParams);
-    }
-    // Delete service account from unique opNamespace
-    logger.info("Delete service account in namespace {0}", opNamespace);
-    if (serviceAccount != null) {
-      assertDoesNotThrow(() -> deleteServiceAccount(serviceAccount.getMetadata().getName(),
-          serviceAccount.getMetadata().getNamespace()),
-          "deleteServiceAccount failed with ApiException");
-    }
-    // Delete domain namespaces
-    logger.info("Deleting domain namespace {0}", domainNamespace1);
-    if (domainNamespace1 != null) {
-      assertDoesNotThrow(() -> deleteNamespace(domainNamespace1),
-          "deleteNamespace failed with ApiException");
-      logger.info("Deleted namespace: " + domainNamespace1);
-    }
-
-    logger.info("Deleting domain namespace {0}", domainNamespace2);
-    if (domainNamespace2 != null) {
-      assertDoesNotThrow(() -> deleteNamespace(domainNamespace2),
-          "deleteNamespace failed with ApiException");
-      logger.info("Deleted namespace: " + domainNamespace2);
-    }
-
-    // Delete opNamespace
-    logger.info("Deleting Operator namespace {0}", opNamespace);
-    if (opNamespace != null) {
-      assertDoesNotThrow(() -> deleteNamespace(opNamespace),
-          "deleteNamespace failed with ApiException");
-      logger.info("Deleted namespace: " + opNamespace);
-    }
   }
 
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -4,23 +4,32 @@
 package oracle.weblogic.kubernetes.actions.impl.primitive;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import io.kubernetes.client.Copy;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.extended.generic.GenericKubernetesApi;
 import io.kubernetes.client.extended.generic.KubernetesApiResponse;
+import io.kubernetes.client.extended.generic.options.DeleteOptions;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.apis.ExtensionsV1beta1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
+import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
+import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressList;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBindingList;
+import io.kubernetes.client.openapi.models.V1ClusterRoleList;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
 import io.kubernetes.client.openapi.models.V1Deployment;
@@ -40,6 +49,8 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1ReplicaSet;
 import io.kubernetes.client.openapi.models.V1ReplicaSetList;
+import io.kubernetes.client.openapi.models.V1RoleBindingList;
+import io.kubernetes.client.openapi.models.V1RoleList;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1Service;
@@ -64,12 +75,16 @@ public class Kubernetes implements LoggedTest {
   private static String DOMAIN_GROUP = "weblogic.oracle";
   private static String DOMAIN_VERSION = "v7";
   private static String DOMAIN_PLURAL = "domains";
+  private static String FOREGROUND = "Foreground";
+  private static String BACKGROUND = "Background";
+  private static int GRACE_PERIOD = 0;
 
   // Core Kubernetes API clients
   private static ApiClient apiClient = null;
   private static CoreV1Api coreV1Api = null;
   private static CustomObjectsApi customObjectsApi = null;
   private static RbacAuthorizationV1Api rbacAuthApi = null;
+  private static DeleteOptions deleteOptions = null;
 
   // Extended GenericKubernetesApi clients
   private static GenericKubernetesApi<V1ConfigMap, V1ConfigMapList> configMapClient = null;
@@ -233,6 +248,9 @@ public class Kubernetes implements LoggedTest {
             "serviceaccounts", // the resource plural
             apiClient //the api client
         );
+    deleteOptions = new DeleteOptions();
+    deleteOptions.setGracePeriodSeconds(0L);
+    deleteOptions.setPropagationPolicy(FOREGROUND);
   }
 
   // ------------------------  deployments -----------------------------------
@@ -242,18 +260,61 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * List all deployments in a given namespace.
-   * @param namespace Namespace in which to list the deployments
-   * @return V1DeploymentList of deployments in the Kubernetes cluster
+   * List deployments in the given namespace.
+   *
+   * @param namespace namespace in which to list the deployments
+   * @return list of deployment objects as {@link V1DeploymentList}
+   * @throws ApiException when listing fails
    */
-  public static V1DeploymentList listDeployments(String namespace) {
-    KubernetesApiResponse<V1DeploymentList> list = deploymentClient.list(namespace);
-    if (list.isSuccess()) {
-      return list.getObject();
-    } else {
-      logger.warning("Failed to list deployments, status code {0}", list.getHttpStatusCode());
-      return null;
+  public static V1DeploymentList listDeployments(String namespace) throws ApiException {
+    V1DeploymentList deployments;
+    try {
+      AppsV1Api apiInstance = new AppsV1Api(apiClient);
+      deployments = apiInstance.listNamespacedDeployment(
+          namespace, // String | namespace.
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          null, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
     }
+    return deployments;
+  }
+
+  /**
+   * Delete the deployment.
+   *
+   * @param namespace namespace in which to delete the deployment
+   * @param name deployment name
+   * @return true if deletion is successful
+   * @throws ApiException when delete fails
+   */
+  public static boolean deleteDeployment(String namespace, String name) throws ApiException {
+    try {
+      AppsV1Api apiInstance = new AppsV1Api(apiClient);
+      apiInstance.deleteNamespacedDeployment(
+          name, // String | deployment object name.
+          namespace, // String | namespace in which the deployment exists.
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          null, // String | When present, indicates that modifications should not be persisted.
+          GRACE_PERIOD, // Integer | The duration in seconds before the object should be deleted.
+          null, // Boolean | Deprecated: use the PropagationPolicy.
+          FOREGROUND, // String | Whether and how garbage collection will be performed.
+          null // V1DeleteOptions.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return true;
   }
 
   // --------------------------- pods -----------------------------------------
@@ -300,6 +361,25 @@ public class Kubernetes implements LoggedTest {
     }
 
     return log;
+  }
+
+  /**
+   * Create a pod.
+   *
+   * @param namespace name of the namespace
+   * @param podBody V1Pod object containing pod configuration data
+   * @return V1Pod object
+   * @throws ApiException when create pod fails
+   */
+  public static V1Pod createPod(String namespace, V1Pod podBody) throws ApiException {
+    V1Pod pod;
+    try {
+      pod = coreV1Api.createNamespacedPod(namespace, podBody, null, null, null);
+    } catch (ApiException apex) {
+      logger.severe(apex.getResponseBody());
+      throw apex;
+    }
+    return pod;
   }
 
   /**
@@ -359,6 +439,20 @@ public class Kubernetes implements LoggedTest {
     return v1PodList;
   }
 
+  /**
+   * Copy a directory from Kubernetes pod to local destination path.
+   * @param pod V1Pod object
+   * @param srcPath source directory location
+   * @param destination destination directory path
+   * @throws IOException when copy fails
+   * @throws ApiException when pod interaction fails
+   */
+  public static void copyDirectoryFromPod(V1Pod pod, String srcPath, Path destination)
+      throws IOException, ApiException {
+    Copy copy = new Copy();
+    copy.copyDirectoryFromPod(pod, srcPath, destination);
+  }
+
   // --------------------------- namespaces -----------------------------------
   /**
    * Create a Kubernetes namespace.
@@ -372,7 +466,7 @@ public class Kubernetes implements LoggedTest {
     V1Namespace namespace = new V1NamespaceBuilder().withMetadata(meta).build();
 
     try {
-      namespace = coreV1Api.createNamespace(
+      coreV1Api.createNamespace(
           namespace, // name of the Namespace
           PRETTY, // pretty print output
           null, // indicates that modifications should not be persisted
@@ -474,6 +568,7 @@ public class Kubernetes implements LoggedTest {
     return namespaceList;
   }
 
+
   /**
    * Delete a namespace for the given name.
    *
@@ -485,9 +580,16 @@ public class Kubernetes implements LoggedTest {
     KubernetesApiResponse<V1Namespace> response = namespaceClient.delete(name);
 
     if (!response.isSuccess()) {
-      logger.warning("Failed to delete namespace: "
-          + name + " with HTTP status code: " + response.getHttpStatusCode());
-      return false;
+      // status 409 means contents in the namespace being removed,
+      // once done namespace will be purged
+      if (response.getHttpStatusCode() == 409) {
+        logger.warning(response.getStatus().getMessage());
+        return false;
+      } else {
+        logger.warning("Failed to delete namespace: "
+            + name + " with HTTP status code: " + response.getHttpStatusCode());
+        return false;
+      }
     }
 
     if (response.getObject() != null) {
@@ -565,7 +667,7 @@ public class Kubernetes implements LoggedTest {
    */
   public static boolean deleteDomainCustomResource(String domainUid, String namespace) {
 
-    KubernetesApiResponse<Domain> response = crdClient.delete(namespace, domainUid);
+    KubernetesApiResponse<Domain> response = crdClient.delete(namespace, domainUid, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning(
@@ -807,7 +909,7 @@ public class Kubernetes implements LoggedTest {
    */
   public static boolean deleteConfigMap(String name, String namespace) {
 
-    KubernetesApiResponse<V1ConfigMap> response = configMapClient.delete(namespace, name);
+    KubernetesApiResponse<V1ConfigMap> response = configMapClient.delete(namespace, name, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning("Failed to delete config map '" + name + "' from namespace: "
@@ -989,7 +1091,7 @@ public class Kubernetes implements LoggedTest {
    */
   public static boolean deletePv(String name) {
 
-    KubernetesApiResponse<V1PersistentVolume> response = pvClient.delete(name);
+    KubernetesApiResponse<V1PersistentVolume> response = pvClient.delete(name, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning("Failed to delete persistent volume '" + name + "' "
@@ -1015,7 +1117,7 @@ public class Kubernetes implements LoggedTest {
    */
   public static boolean deletePvc(String name, String namespace) {
 
-    KubernetesApiResponse<V1PersistentVolumeClaim> response = pvcClient.delete(namespace, name);
+    KubernetesApiResponse<V1PersistentVolumeClaim> response = pvcClient.delete(namespace, name, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning(
@@ -1143,7 +1245,7 @@ public class Kubernetes implements LoggedTest {
    */
   public static boolean deleteServiceAccount(String name, String namespace) {
 
-    KubernetesApiResponse<V1ServiceAccount> response = serviceAccountClient.delete(namespace, name);
+    KubernetesApiResponse<V1ServiceAccount> response = serviceAccountClient.delete(namespace, name, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning("Failed to delete Service Account '" + name + "' from namespace: "
@@ -1228,7 +1330,7 @@ public class Kubernetes implements LoggedTest {
    */
   public static boolean deleteService(String name, String namespace) {
 
-    KubernetesApiResponse<V1Service> response = serviceClient.delete(namespace, name);
+    KubernetesApiResponse<V1Service> response = serviceClient.delete(namespace, name, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning("Failed to delete Service '" + name + "' from namespace: "
@@ -1245,37 +1347,141 @@ public class Kubernetes implements LoggedTest {
     return true;
   }
 
-  // --------------------------- jobs ---------------------------
   /**
-   * Get a list of all jobs in the given namespace.
+   * List services in a given namespace.
    *
-   * @param namespace in which to list the jobs
-   * @return V1JobList of jobs from Kubernetes cluster
+   * @param namespace name of the namespace
+   * @return V1ServiceList list of {@link V1Service} objects
    */
-  public static V1JobList listJobs(String namespace) {
-    KubernetesApiResponse<V1JobList> list = jobClient.list(namespace);
+  public static V1ServiceList listServices(String namespace) {
+
+    KubernetesApiResponse<V1ServiceList> list = serviceClient.list(namespace);
     if (list.isSuccess()) {
       return list.getObject();
     } else {
-      logger.warning("Failed to list jobs, status code {0}", list.getHttpStatusCode());
+      logger.warning("Failed to list services, status code {0}", list.getHttpStatusCode());
       return null;
     }
   }
 
-  // --------------------------- replica sets ---------------------------
+  // --------------------------- jobs ---------------------------
+
+
   /**
-   * Get a list of all replica sets in the given namespace.
+   * Delete job.
+   *
+   * @param namespace name of the namespace
+   * @param name name of the job
+   * @return true if delete is successful
+   * @throws ApiException when delete job fails
+   */
+  public static boolean deleteJob(String namespace, String name) throws ApiException {
+    try {
+      BatchV1Api apiInstance = new BatchV1Api(apiClient);
+      apiInstance.deleteNamespacedJob(
+          name, // String | name of the job.
+          namespace, // String | name of the namespace.
+          PRETTY, // String | pretty print output.
+          null, // String | When present, indicates that modifications should not be persisted.
+          GRACE_PERIOD, // Integer | The duration in seconds before the object should be deleted.
+          null, // Boolean | Deprecated: use the PropagationPolicy.
+          FOREGROUND, // String | Whether and how garbage collection will be performed.
+          null // V1DeleteOptions.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return true;
+  }
+
+  /**
+   * List jobs in the given namespace.
+   *
+   * @param namespace in which to list the jobs
+   * @return V1JobList list of {@link V1Job} from Kubernetes cluster
+   * @throws ApiException when list fails
+   */
+  public static V1JobList listJobs(String namespace) throws ApiException {
+    V1JobList list;
+    try {
+      BatchV1Api apiInstance = new BatchV1Api(apiClient);
+      list = apiInstance.listNamespacedJob(
+          namespace, // String | name of the namespace.
+          PRETTY, // String | pretty print output.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          null, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list/watch call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return list;
+  }
+
+  // --------------------------- replica sets ---------------------------
+
+
+  /**
+   * Delete replica set.
+   *
+   * @param namespace name of the namespace
+   * @param name name of the replica set
+   * @return true if delete is successful
+   * @throws ApiException if delete fails
+   */
+  public static boolean deleteReplicaSet(String namespace, String name) throws ApiException {
+    try {
+      AppsV1Api apiInstance = new AppsV1Api(apiClient);
+      apiInstance.deleteNamespacedReplicaSet(
+          name, // String | name of the replica set.
+          namespace, // String | name of the namespace.
+          PRETTY, // String | pretty print output.
+          null, // String | When present, indicates that modifications should not be persisted.
+          GRACE_PERIOD, // Integer | The duration in seconds before the object should be deleted.
+          null, // Boolean | Deprecated: use the PropagationPolicy.
+          FOREGROUND, // String | Whether and how garbage collection will be performed.
+          null // V1DeleteOptions.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return true;
+  }
+
+  /**
+   * List replica sets in the given namespace.
    *
    * @param namespace in which to list the replica sets
-   * @return V1ReplicaSetList of replica sets
+   * @return V1ReplicaSetList list of {@link V1ReplicaSet} objects
+   * @throws ApiException when list fails
    */
-  public static V1ReplicaSetList listReplicaSets(String namespace) {
-    KubernetesApiResponse<V1ReplicaSetList> list = rsClient.list(namespace);
-    if (list.isSuccess()) {
-      return list.getObject();
-    } else {
-      logger.warning("Failed to list replica sets, status code {0}", list.getHttpStatusCode());
-      return null;
+  public static V1ReplicaSetList listReplicaSets(String namespace) throws ApiException {
+    try {
+      AppsV1Api apiInstance = new AppsV1Api(apiClient);
+      V1ReplicaSetList list = apiInstance.listNamespacedReplicaSet(
+          namespace, // String | namespace.
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          null, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources.
+      );
+      return list;
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
     }
   }
 
@@ -1284,20 +1490,23 @@ public class Kubernetes implements LoggedTest {
   /**
    * Create a Cluster Role Binding.
    *
-   * @param clusterRoleBinding V1ClusterRoleBinding object containing role binding configuration
-   *     data
+   * @param clusterRoleBinding V1ClusterRoleBinding object containing role binding configuration data
    * @return true if successful
    * @throws ApiException if Kubernetes client API call fails
    */
   public static boolean createClusterRoleBinding(V1ClusterRoleBinding clusterRoleBinding)
       throws ApiException {
-
-    V1ClusterRoleBinding crb = rbacAuthApi.createClusterRoleBinding(
-        clusterRoleBinding, // role binding configuration data
-        PRETTY, // pretty print output
-        null, // indicates that modifications should not be persisted
-        null // fieldManager is a name associated with the actor
-    );
+    try {
+      V1ClusterRoleBinding crb = rbacAuthApi.createClusterRoleBinding(
+          clusterRoleBinding, // role binding configuration data
+          PRETTY, // pretty print output
+          null, // indicates that modifications should not be persisted
+          null // fieldManager is a name associated with the actor
+      );
+    } catch (ApiException apex) {
+      logger.severe(apex.getResponseBody());
+      throw apex;
+    }
 
     return true;
   }
@@ -1309,7 +1518,7 @@ public class Kubernetes implements LoggedTest {
    * @return true if successful, false otherwise
    */
   public static boolean deleteClusterRoleBinding(String name) {
-    KubernetesApiResponse<V1ClusterRoleBinding> response = roleBindingClient.delete(name);
+    KubernetesApiResponse<V1ClusterRoleBinding> response = roleBindingClient.delete(name, deleteOptions);
 
     if (!response.isSuccess()) {
       logger.warning(
@@ -1327,5 +1536,255 @@ public class Kubernetes implements LoggedTest {
     return true;
   }
 
+  /**
+   * List cluster role bindings.
+   *
+   * @param labelSelector labels to narrow the list
+   * @return V1RoleBindingList list of {@link V1RoleBinding} objects
+   * @throws ApiException when listing fails
+   */
+  public static V1RoleBindingList listClusterRoleBindings(String labelSelector) throws ApiException {
+    V1RoleBindingList roleBindings;
+    try {
+      roleBindings = rbacAuthApi.listRoleBindingForAllNamespaces(
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          labelSelector, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          PRETTY, // String | If true, then the output is pretty printed.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list/watch call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return roleBindings;
+  }
+
+  /**
+   * Delete role in the given namespace.
+   *
+   * @param namespace name of the namespace
+   * @param name name of the role
+   * @return return true if deletion is successful
+   * @throws ApiException when delete fails
+   */
+  public static boolean deleteNamespacedRoleBinding(String namespace, String name)
+      throws ApiException {
+    try {
+      rbacAuthApi.deleteNamespacedRoleBinding(
+          name, // String | name of the job.
+          namespace, // String | name of the namespace.
+          PRETTY, // String | pretty print output.
+          null, // String | When present, indicates that modifications should not be persisted.
+          GRACE_PERIOD, // Integer | The duration in seconds before the object should be deleted.
+          null, // Boolean | Deprecated: use the PropagationPolicy.
+          FOREGROUND, // String | Whether and how garbage collection will be performed.
+          null // V1DeleteOptions.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return true;
+  }
+
+  /**
+   * List role bindings in a given name space.
+   *
+   * @param namespace name of the namespace
+   * @return V1RoleBindingList list of {@link V1RoleBinding} objects
+   * @throws ApiException when listing fails
+   */
+  public static V1RoleBindingList listNamespacedRoleBinding(String namespace)
+      throws ApiException {
+    V1RoleBindingList roleBindings;
+    try {
+      roleBindings = rbacAuthApi.listNamespacedRoleBinding(
+          namespace, // String | namespace.
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          null, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return roleBindings;
+  }
+
+
+  /**
+   * Delete role in the Kubernetes cluster.
+   *
+   * @param name name of the cluster role to delete
+   * @return true if deletion is successful
+   * @throws ApiException when delete fails
+   */
+  public static boolean deleteClusterRole(String name) throws ApiException {
+    try {
+      rbacAuthApi.deleteClusterRole(
+          name, // String | name of the role.
+          PRETTY, // String | pretty print output.
+          null, // String | When present, indicates that modifications should not be persisted.
+          GRACE_PERIOD, // Integer | The duration in seconds before the object should be deleted.
+          null, // Boolean | Deprecated: use the PropagationPolicy.
+          FOREGROUND, // String | Whether and how garbage collection will be performed.
+          null // V1DeleteOptions.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return true;
+  }
+
+
+  /**
+   * List roles in the Kubernetes cluster.
+   *
+   * @param labelSelector labels to narrow the list
+   * @return V1ClusterRoleList list of {@link V1ClusterRole} objects
+   * @throws ApiException when listing fails
+   */
+  public static V1ClusterRoleList listClusterRoles(String labelSelector) throws ApiException {
+    V1ClusterRoleList roles;
+    try {
+      roles = rbacAuthApi.listClusterRole(
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          labelSelector, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return roles;
+  }
+
+  /**
+   * Delete role in the Kubernetes cluster in the given namespace.
+   *
+   * @param namespace name of the namespace
+   * @param name name of the role to delete
+   * @return true if deletion is successful
+   * @throws ApiException when delete fails
+   */
+  public static boolean deleteNamespacedRole(String namespace, String name) throws ApiException {
+    try {
+      rbacAuthApi.deleteNamespacedRole(
+          name, // String | name of the job.
+          namespace, // String | name of the namespace.
+          PRETTY, // String | pretty print output.
+          null, // String | When present, indicates that modifications should not be persisted.
+          GRACE_PERIOD, // Integer | The duration in seconds before the object should be deleted.
+          null, // Boolean | Deprecated: use the PropagationPolicy.
+          FOREGROUND, // String | Whether and how garbage collection will be performed.
+          null // V1DeleteOptions.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return true;
+  }
+
+  /**
+   * List roles in a given namespace.
+   *
+   * @param namespace name of the namespace
+   * @return V1RoleList list of {@link V1Role} object
+   * @throws ApiException when listing fails
+   */
+  public static V1RoleList listNamespacedRole(String namespace) throws ApiException {
+    V1RoleList roles;
+    try {
+      roles = rbacAuthApi.listNamespacedRole(
+          namespace, // String | namespace.
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          null, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list call.
+          Boolean.FALSE // Boolean | Watch for changes to the described resources.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return roles;
+  }
+
+  /**
+   * List Ingress extensions in the given namespace.
+   *
+   * @param namespace name of the namespace
+   * @return ExtensionsV1beta1IngressList list of {@link ExtensionsV1beta1Ingress} objects
+   * @throws ApiException when listing fails
+   */
+  public static ExtensionsV1beta1IngressList listIngressExtensions(String namespace) throws ApiException {
+    ExtensionsV1beta1IngressList ingressList;
+    try {
+      ExtensionsV1beta1Api apiInstance = new ExtensionsV1beta1Api(apiClient);
+      ingressList = apiInstance.listNamespacedIngress(
+          namespace, // namespace
+          PRETTY, // String | If 'true', then the output is pretty printed.
+          ALLOW_WATCH_BOOKMARKS, // Boolean | allowWatchBookmarks requests watch events with type "BOOKMARK".
+          null, // String | The continue option should be set when retrieving more results from the server.
+          null, // String | A selector to restrict the list of returned objects by their fields.
+          null, // String | A selector to restrict the list of returned objects by their labels.
+          null, // Integer | limit is a maximum number of responses to return for a list call.
+          RESOURCE_VERSION, // String | Shows changes that occur after that particular version of a resource.
+          TIMEOUT_SECONDS, // Integer | Timeout for the list/watch call.
+          ALLOW_WATCH_BOOKMARKS // Boolean | Watch for changes to the described resources.
+      );
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return ingressList;
+  }
+
+  /**
+   * Get Ingress extension in the given namespace by name.
+   *
+   * @param namespace name of the namespace
+   * @param name name of the Ingress extension
+   * @return ExtensionsV1beta1Ingress Ingress extension object when found, otherwise null
+   * @throws ApiException when get fails
+   */
+  public static ExtensionsV1beta1Ingress getIngressExtension(String namespace, String name)
+      throws ApiException {
+    try {
+      for (ExtensionsV1beta1Ingress item
+          : listIngressExtensions(namespace).getItems()) {
+        if (name.equals(item.getMetadata().getName())) {
+          return item;
+        }
+      }
+    } catch (ApiException apex) {
+      logger.warning(apex.getResponseBody());
+      throw apex;
+    }
+    return null;
+  }
   //------------------------
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1768,7 +1768,7 @@ public class Kubernetes implements LoggedTest {
    * Get Ingress in the given namespace by name.
    *
    * @param namespace name of the namespace
-   * @param name name of the Ingress
+   * @param name name of the Ingress object
    * @return ExtensionsV1beta1Ingress Ingress object when found, otherwise null
    * @throws ApiException when get fails
    */

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -290,11 +290,11 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Delete the deployment.
+   * Delete a deployment.
    *
    * @param namespace namespace in which to delete the deployment
    * @param name deployment name
-   * @return true if deletion is successful
+   * @return true if deletion was successful
    * @throws ApiException when delete fails
    */
   public static boolean deleteDeployment(String namespace, String name) throws ApiException {
@@ -1084,7 +1084,7 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Delete the Kubernetes Persistent Volume.
+   * Delete a Kubernetes Persistent Volume.
    *
    * @param name name of the Persistent Volume
    * @return true if successful
@@ -1109,7 +1109,7 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Delete the Kubernetes Persistent Volume Claim.
+   * Delete a Kubernetes Persistent Volume Claim.
    *
    * @param name name of the Persistent Volume Claim
    * @param namespace name of the namespace
@@ -1325,7 +1325,7 @@ public class Kubernetes implements LoggedTest {
    * Delete a Kubernetes Service.
    *
    * @param name name of the Service
-   * @param namespace name of namespace
+   * @param namespace name of the namespace
    * @return true if successful
    */
   public static boolean deleteService(String name, String namespace) {
@@ -1359,7 +1359,8 @@ public class Kubernetes implements LoggedTest {
     if (list.isSuccess()) {
       return list.getObject();
     } else {
-      logger.warning("Failed to list services, status code {0}", list.getHttpStatusCode());
+      logger.warning("Failed to list services in namespace {0}, status code {1}",
+          namespace, list.getHttpStatusCode());
       return null;
     }
   }
@@ -1368,12 +1369,12 @@ public class Kubernetes implements LoggedTest {
 
 
   /**
-   * Delete job.
+   * Delete a job.
    *
    * @param namespace name of the namespace
    * @param name name of the job
-   * @return true if delete is successful
-   * @throws ApiException when delete job fails
+   * @return true if delete was successful
+   * @throws ApiException when deletion of job fails
    */
   public static boolean deleteJob(String namespace, String name) throws ApiException {
     try {
@@ -1429,11 +1430,11 @@ public class Kubernetes implements LoggedTest {
 
 
   /**
-   * Delete replica set.
+   * Delete a replica set.
    *
    * @param namespace name of the namespace
    * @param name name of the replica set
-   * @return true if delete is successful
+   * @return true if delete was successful
    * @throws ApiException if delete fails
    */
   public static boolean deleteReplicaSet(String namespace, String name) throws ApiException {
@@ -1565,12 +1566,12 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Delete role in the given namespace.
+   * Delete a rolebinding in the given namespace.
    *
    * @param namespace name of the namespace
-   * @param name name of the role
-   * @return return true if deletion is successful
-   * @throws ApiException when delete fails
+   * @param name name of the rolebinding to delete
+   * @return return true if deletion was successful
+   * @throws ApiException when delete rolebinding fails
    */
   public static boolean deleteNamespacedRoleBinding(String namespace, String name)
       throws ApiException {
@@ -1593,7 +1594,7 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * List role bindings in a given name space.
+   * List role bindings in a given namespace.
    *
    * @param namespace name of the namespace
    * @return V1RoleBindingList list of {@link V1RoleBinding} objects
@@ -1624,11 +1625,11 @@ public class Kubernetes implements LoggedTest {
 
 
   /**
-   * Delete role in the Kubernetes cluster.
+   * Delete a cluster role.
    *
    * @param name name of the cluster role to delete
-   * @return true if deletion is successful
-   * @throws ApiException when delete fails
+   * @return true if deletion was successful
+   * @throws ApiException when delete cluster role fails
    */
   public static boolean deleteClusterRole(String name) throws ApiException {
     try {
@@ -1650,7 +1651,7 @@ public class Kubernetes implements LoggedTest {
 
 
   /**
-   * List roles in the Kubernetes cluster.
+   * List cluster roles in the Kubernetes cluster.
    *
    * @param labelSelector labels to narrow the list
    * @return V1ClusterRoleList list of {@link V1ClusterRole} objects
@@ -1678,11 +1679,11 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Delete role in the Kubernetes cluster in the given namespace.
+   * Delete a role in the Kubernetes cluster in the given namespace.
    *
    * @param namespace name of the namespace
    * @param name name of the role to delete
-   * @return true if deletion is successful
+   * @return true if deletion was successful
    * @throws ApiException when delete fails
    */
   public static boolean deleteNamespacedRole(String namespace, String name) throws ApiException {
@@ -1711,7 +1712,7 @@ public class Kubernetes implements LoggedTest {
    * @return V1RoleList list of {@link V1Role} object
    * @throws ApiException when listing fails
    */
-  public static V1RoleList listNamespacedRole(String namespace) throws ApiException {
+  public static V1RoleList listNamespacedRoles(String namespace) throws ApiException {
     V1RoleList roles;
     try {
       roles = rbacAuthApi.listNamespacedRole(
@@ -1734,13 +1735,13 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * List Ingress extensions in the given namespace.
+   * List Ingresses in the given namespace.
    *
    * @param namespace name of the namespace
    * @return ExtensionsV1beta1IngressList list of {@link ExtensionsV1beta1Ingress} objects
    * @throws ApiException when listing fails
    */
-  public static ExtensionsV1beta1IngressList listIngressExtensions(String namespace) throws ApiException {
+  public static ExtensionsV1beta1IngressList listNamespacedIngresses(String namespace) throws ApiException {
     ExtensionsV1beta1IngressList ingressList;
     try {
       ExtensionsV1beta1Api apiInstance = new ExtensionsV1beta1Api(apiClient);
@@ -1764,18 +1765,18 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Get Ingress extension in the given namespace by name.
+   * Get Ingress in the given namespace by name.
    *
    * @param namespace name of the namespace
-   * @param name name of the Ingress extension
-   * @return ExtensionsV1beta1Ingress Ingress extension object when found, otherwise null
+   * @param name name of the Ingress
+   * @return ExtensionsV1beta1Ingress Ingress object when found, otherwise null
    * @throws ApiException when get fails
    */
-  public static ExtensionsV1beta1Ingress getIngressExtension(String namespace, String name)
+  public static ExtensionsV1beta1Ingress getNamespacedIngress(String namespace, String name)
       throws ApiException {
     try {
       for (ExtensionsV1beta1Ingress item
-          : listIngressExtensions(namespace).getItems()) {
+          : listNamespacedIngresses(namespace).getItems()) {
         if (name.equals(item.getMetadata().getName())) {
           return item;
         }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import io.kubernetes.client.openapi.ApiException;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.utils.CleanupUtil;
 import oracle.weblogic.kubernetes.utils.LoggingUtil;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -296,6 +297,8 @@ public class IntegrationTestWatcher implements
   @Override
   public void afterAll(ExtensionContext context) {
     printHeader(String.format("Ending Test Suite %s", className), "+");
+    logger.info("Starting cleanup after test class");
+    CleanupUtil.cleanup(namespaces);
   }
 
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
@@ -78,7 +78,7 @@ public class CleanupUtil {
       // If put 30 seconds in pollDelay in below, its going to sleep 30 seconds for every namespace.
 
       // wait for the artifacts to be deleted, waiting for a maximum of 3 minutes
-      // with pollDeal 0, since already waited for 30 seconds
+      // with pollDelay 0, since already waited for 30 seconds
       ConditionFactory withStandardRetryPolicy = with().pollDelay(0, SECONDS)
           .and().with().pollInterval(10, SECONDS)
           .atMost(3, MINUTES).await();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
@@ -50,10 +50,8 @@ public class CleanupUtil {
    */
   public static void cleanup(List<String> namespaces) {
     try {
-      // If namespace list is empty or null,
-      // just delete the non namespaced artifacts and return
+      // If namespace list is empty or null return
       if (namespaces == null || namespaces.isEmpty()) {
-        deleteClusterArtifacts();
         return;
       }
       // iterate through the namespaces and delete domain as a
@@ -71,17 +69,13 @@ public class CleanupUtil {
         }
       }
 
-      // Delete all the artifacts
+      // Delete artifacts in namespace used by the test class
       for (var namespace : namespaces) {
         deleteNamespacedArtifacts(namespace);
       }
-      // If the tests are running in parallel how do we figure out
-      // which cluster artifacts are to be deleted.
-      deleteClusterArtifacts();
 
-
-      Thread.sleep(30 * 1000); // I am using Thread.sleep to have only one 30 sec sleep.
-      // If put in pollDelay in below, its going to sleep 30 seconds for every namespace.
+      Thread.sleep(30 * 1000); // I am using Thread.sleep for a one time 30 sec sleep.
+      // If put 30 seconds in pollDelay in below, its going to sleep 30 seconds for every namespace.
 
       // wait for the artifacts to be deleted, waiting for a maximum of 3 minutes
       // with pollDeal 0, since already waited for 30 seconds
@@ -363,36 +357,6 @@ public class CleanupUtil {
         logger.warning("Failed to list namespaced role bindings");
       }
 
-      /*
-      // check if cluster roles exist, check with selector 'weblogic.operatorName'
-      try {
-        if (!Kubernetes.listClusterRoles("weblogic.operatorName").getItems().isEmpty()) {
-          logger.info("Cluster Roles still exists!!!");
-          List<V1ClusterRole> items = Kubernetes.listClusterRoles("weblogic.operatorName").getItems();
-          for (var item : items) {
-            logger.info(item.getMetadata().getName());
-          }
-          doesnotExist = false;
-        }
-      } catch (Exception ex) {
-        logger.warning(ex.getMessage());
-        logger.warning("Failed to list cluster roles");
-      }
-      // check if cluster rolebindings exist, check with selector 'weblogic.operatorName'
-      try {
-        if (!Kubernetes.listClusterRoleBindings("weblogic.operatorName").getItems().isEmpty()) {
-          logger.info("Cluster RoleBindings still exists!!!");
-          List<V1RoleBinding> items = Kubernetes.listClusterRoleBindings("weblogic.operatorName").getItems();
-          for (var item : items) {
-            logger.info(item.getMetadata().getName());
-          }
-          doesnotExist = false;
-        }
-      } catch (Exception ex) {
-        logger.warning(ex.getMessage());
-        logger.warning("Failed to list Cluster Role Bindings");
-      }*/
-
       // get namespaces
       try {
         if (Kubernetes.listNamespaces().contains(namespace)) {
@@ -555,37 +519,6 @@ public class CleanupUtil {
     } catch (Exception ex) {
       logger.warning(ex.getMessage());
       logger.warning("Failed to delete namespace");
-    }
-  }
-
-  /**
-   * Deletes non name spaced artifacts in the Kubernetes cluster.
-   *
-   */
-  public static void deleteClusterArtifacts() {
-    logger.info("Deleting cluster artifacts");
-    // Delete cluster roles
-    try {
-      logger.info("Cluster Roles list");
-      for (var item : Kubernetes.listClusterRoles("weblogic.operatorName").getItems()) {
-        logger.info(item.getMetadata().getName());
-        //Kubernetes.deleteClusterRole(item.getMetadata().getName());
-      }
-    } catch (Exception ex) {
-      logger.warning(ex.getMessage());
-      logger.warning("Failed to delete cluster roles");
-    }
-
-    // Delete cluster rolebindings
-    try {
-      logger.info("Cluster Role Bindings list");
-      for (var item : Kubernetes.listClusterRoleBindings("weblogic.operatorName").getItems()) {
-        logger.info(item.getMetadata().getName());
-        //Kubernetes.deleteClusterRoleBinding(item.getMetadata().getName());
-      }
-    } catch (Exception ex) {
-      logger.warning(ex.getMessage());
-      logger.warning("Failed to delete cluster rolebindings");
     }
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
@@ -1,0 +1,592 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.utils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1PersistentVolume;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
+import io.kubernetes.client.openapi.models.V1ReplicaSet;
+import io.kubernetes.client.openapi.models.V1Role;
+import io.kubernetes.client.openapi.models.V1RoleBinding;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1ServiceAccount;
+import oracle.weblogic.domain.Domain;
+import oracle.weblogic.kubernetes.TestConstants;
+import oracle.weblogic.kubernetes.actions.TestActions;
+import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
+import org.awaitility.core.ConditionFactory;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
+import static org.awaitility.Awaitility.with;
+
+/**
+ * CleanupUtil is used for cleaning up all the Kubernetes artifacts left behind by the integration tests.
+ *
+ */
+public class CleanupUtil {
+
+  /**
+   * Cleanup all artifacts in the Kubernetes cluster.
+   *
+   * <p>Tries to gracefully delete the WebLogic domains and WebLogic Operator in the namespaces, if found.
+   * Then deletes everything in the namespaces.
+   *
+   * <p>Waits for the deletion task to be completed until up to 3 minutes.
+   *
+   * @param namespaces list of namespaces
+   */
+  public static void cleanup(List<String> namespaces) {
+    try {
+      // If namespace list is empty or null,
+      // just delete the non namespaced artifacts and return
+      if (namespaces == null || namespaces.isEmpty()) {
+        deleteClusterArtifacts();
+        return;
+      }
+      // iterate through the namespaces and delete domain as a
+      // first entity if its not operator namespace
+      for (var namespace : namespaces) {
+        if (!isOperatorNamespace(namespace)) {
+          deleteDomains(namespace);
+        }
+      }
+      // iterate through the namespaces and delete operator if
+      // its operator namespace.
+      for (var namespace : namespaces) {
+        if (isOperatorNamespace(namespace)) {
+          uninstallOperator(namespace);
+        }
+      }
+
+      // Delete all the artifacts
+      for (var namespace : namespaces) {
+        deleteNamespacedArtifacts(namespace);
+      }
+      // If the tests are running in parallel how do we figure out
+      // which cluster artifacts are to be deleted.
+      deleteClusterArtifacts();
+
+
+      Thread.sleep(30 * 1000); // I am using Thread.sleep to have only one 30 sec sleep.
+      // If put in pollDelay in below, its going to sleep 30 seconds for every namespace.
+
+      // wait for the artifacts to be deleted, waiting for a maximum of 3 minutes
+      // with pollDeal 0, since already waited for 30 seconds
+      ConditionFactory withStandardRetryPolicy = with().pollDelay(0, SECONDS)
+          .and().with().pollInterval(10, SECONDS)
+          .atMost(3, MINUTES).await();
+
+      for (var namespace : namespaces) {
+        logger.info("Check for artifacts in namespace {0}", namespace);
+        withStandardRetryPolicy
+            .conditionEvaluationListener(
+                condition -> logger.info("Waiting for artifacts to be deleted in namespace {0}, "
+                    + "(elapsed time {1} , remaining time {2}",
+                    namespace,
+                    condition.getElapsedTimeInMS(),
+                    condition.getRemainingTimeInMS()))
+            .until(artifactsDoesntExist(namespace));
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Cleanup failed");
+    }
+  }
+
+  /**
+   * Delete domains in the given namespace, if exists.
+   *
+   * @param namespace name of the namespace
+   */
+  private static void deleteDomains(String namespace) {
+    try {
+      for (var item : Kubernetes.listDomains(namespace).getItems()) {
+        String domainUid = item.getMetadata().getName();
+        Kubernetes.deleteDomainCustomResource(domainUid, namespace);
+      }
+    } catch (Exception ex) {
+      logger.severe(ex.getMessage());
+      logger.severe("Failed to delete domain or the {0} is not a domain namespace", namespace);
+    }
+  }
+
+  /**
+   * Uninstalls the operator.
+   *
+   * @param namespace name of the namespace
+   */
+  private static void uninstallOperator(String namespace) {
+    HelmParams opHelmParams = new HelmParams()
+        .releaseName(TestConstants.OPERATOR_RELEASE_NAME)
+        .namespace(namespace);
+    TestActions.uninstallOperator(opHelmParams);
+  }
+
+  /**
+   * Returns true if the namespace is operator namespace, otherwise false.
+   *
+   * @param namespace name of the namespace
+   * @return true if the namespace is operator namespace, otherwise false
+   * @throws ApiException when Kubernetes cluster query fails
+   */
+  public static boolean isOperatorNamespace(String namespace) throws ApiException {
+    return !Kubernetes.listPods(namespace, "weblogic.operatorName").getItems().isEmpty();
+  }
+
+  /**
+   * Returns true if artifacts doesn't exists in the Kubernetes cluster.
+   *
+   * @param namespace name of the namespace
+   * @return true if no artifacts exists otherwise false
+   */
+  public static Callable<Boolean> artifactsDoesntExist(String namespace) {
+    return () -> {
+      boolean doesnotExist = true;
+      logger.info("Checking for artifacts in namespace {0}\n", namespace);
+
+      // Check if domain exists
+      try {
+        if (!Kubernetes.listDomains(namespace).getItems().isEmpty()) {
+          logger.info("Domain still exists !!!");
+          List<Domain> items = Kubernetes.listDomains(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list domains");
+      }
+
+      // Check if the replica sets exist
+      try {
+        if (!Kubernetes.listReplicaSets(namespace).getItems().isEmpty()) {
+          logger.info("ReplicaSets still exists!!!");
+          List<V1ReplicaSet> items = Kubernetes.listReplicaSets(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list replica sets");
+      }
+
+      // check if the jobs exist
+      try {
+        if (!Kubernetes.listJobs(namespace).getItems().isEmpty()) {
+          logger.info("Jobs still exists!!!");
+          List<V1Job> items = Kubernetes.listJobs(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list jobs");
+      }
+
+      // check if the configmaps exist
+      try {
+        if (!Kubernetes.listConfigMaps(namespace).getItems().isEmpty()) {
+          logger.info("Config Maps still exists!!!");
+          List<V1ConfigMap> items = Kubernetes.listConfigMaps(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list config maps");
+      }
+
+      // check if the secrets exist
+      try {
+        if (!Kubernetes.listSecrets(namespace).getItems().isEmpty()) {
+          logger.info("Secrets still exists!!!");
+          List<V1Secret> items = Kubernetes.listSecrets(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list secrets");
+      }
+
+      // get pvc
+      try {
+        if (!Kubernetes.listPersistentVolumeClaims(namespace).getItems().isEmpty()) {
+          logger.info("Persistent Volumes Claims still exists!!!");
+          List<V1PersistentVolumeClaim> items = Kubernetes.listPersistentVolumeClaims(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list persistent volume claims");
+      }
+
+      // check if persistent volume exist
+      try {
+        for (var item : Kubernetes.listPersistentVolumeClaims(namespace).getItems()) {
+          String label = Optional.ofNullable(item)
+              .map(pvc -> pvc.getMetadata())
+              .map(metadata -> metadata.getLabels())
+              .map(labels -> labels.get("weblogic.domainUid")).get();
+
+          if (!Kubernetes.listPersistentVolumes(
+              String.format("weblogic.domainUid = %s", label))
+              .getItems().isEmpty()) {
+            logger.info("Persistent Volumes still exists!!!");
+            List<V1PersistentVolume> pvs = Kubernetes.listPersistentVolumes(
+                String.format("weblogic.domainUid = %s", label))
+                .getItems();
+            for (var pv : pvs) {
+              logger.info(pv.getMetadata().getName());
+            }
+            doesnotExist = false;
+          }
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list persistent volumes");
+      }
+
+      // check if deployments exist
+      try {
+        if (!Kubernetes.listDeployments(namespace).getItems().isEmpty()) {
+          logger.info("Deployments still exists!!!");
+          List<V1Deployment> items = Kubernetes.listDeployments(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list deployments");
+      }
+
+      // check if services exist
+      try {
+        if (!Kubernetes.listServices(namespace).getItems().isEmpty()) {
+          logger.info("Services still exists!!!");
+          List<V1Service> items = Kubernetes.listServices(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list services");
+      }
+
+      // check if service accounts exist
+      try {
+        if (!Kubernetes.listServiceAccounts(namespace).getItems().isEmpty()) {
+          logger.info("Service Accounts still exists!!!");
+          List<V1ServiceAccount> items = Kubernetes.listServiceAccounts(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list service accounts");
+      }
+
+      // check if ingress exist
+      try {
+        if (!Kubernetes.listIngressExtensions(namespace).getItems().isEmpty()) {
+          logger.info("Ingress Extensions still exists!!!");
+          List<ExtensionsV1beta1Ingress> items = Kubernetes.listIngressExtensions(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list Ingress Extensions");
+      }
+
+      // check if namespaced roles exist
+      try {
+        if (!Kubernetes.listNamespacedRole(namespace).getItems().isEmpty()) {
+          logger.info("Namespaced roles still exists!!!");
+          List<V1Role> items = Kubernetes.listNamespacedRole(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list namespaced roles");
+      }
+
+      // check if namespaced role bindings exist
+      try {
+        if (!Kubernetes.listNamespacedRoleBinding(namespace).getItems().isEmpty()) {
+          logger.info("Namespaced role bindings still exists!!!");
+          List<V1RoleBinding> items = Kubernetes.listNamespacedRoleBinding(namespace).getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list namespaced role bindings");
+      }
+
+      /*
+      // check if cluster roles exist, check with selector 'weblogic.operatorName'
+      try {
+        if (!Kubernetes.listClusterRoles("weblogic.operatorName").getItems().isEmpty()) {
+          logger.info("Cluster Roles still exists!!!");
+          List<V1ClusterRole> items = Kubernetes.listClusterRoles("weblogic.operatorName").getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list cluster roles");
+      }
+      // check if cluster rolebindings exist, check with selector 'weblogic.operatorName'
+      try {
+        if (!Kubernetes.listClusterRoleBindings("weblogic.operatorName").getItems().isEmpty()) {
+          logger.info("Cluster RoleBindings still exists!!!");
+          List<V1RoleBinding> items = Kubernetes.listClusterRoleBindings("weblogic.operatorName").getItems();
+          for (var item : items) {
+            logger.info(item.getMetadata().getName());
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list Cluster Role Bindings");
+      }*/
+
+      // get namespaces
+      try {
+        if (Kubernetes.listNamespaces().contains(namespace)) {
+          logger.info("Namespace still exists!!!");
+          List<String> items = Kubernetes.listNamespaces();
+          for (var item : items) {
+            logger.info(item);
+          }
+          doesnotExist = false;
+        }
+      } catch (Exception ex) {
+        logger.warning(ex.getMessage());
+        logger.warning("Failed to list namespaces");
+      }
+
+      return doesnotExist;
+    };
+
+  }
+
+  /**
+   * Deletes artifacts in the Kubernetes cluster in the given namespace.
+   *
+   * @param namespace name of the namespace
+   */
+  public static void deleteNamespacedArtifacts(String namespace) {
+    logger.info("Deleting artifacts in namespace {0}", namespace);
+
+    // Delete all Domain objects in given namespace
+    try {
+      for (var item : Kubernetes.listDomains(namespace).getItems()) {
+        Kubernetes.deleteDomainCustomResource(item.getMetadata().getName(), namespace);
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete domains");
+    }
+
+    // Delete replicasets
+    try {
+      for (var item : Kubernetes.listReplicaSets(namespace).getItems()) {
+        Kubernetes.deleteReplicaSet(namespace, item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete replica sets");
+    }
+
+    // Delete jobs
+    try {
+      for (var item : Kubernetes.listJobs(namespace).getItems()) {
+        Kubernetes.deleteJob(namespace, item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete jobs");
+    }
+
+    // Delete configmaps
+    try {
+      for (var item : Kubernetes.listConfigMaps(namespace).getItems()) {
+        Kubernetes.deleteConfigMap(item.getMetadata().getName(), namespace);
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete config maps");
+    }
+
+    // Delete secrets
+    try {
+      for (var item : Kubernetes.listSecrets(namespace).getItems()) {
+        Kubernetes.deleteSecret(item.getMetadata().getName(), namespace);
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete secrets");
+    }
+
+    // Delete pv
+    try {
+      for (var item : Kubernetes.listPersistentVolumeClaims(namespace).getItems()) {
+        String label = Optional.ofNullable(item)
+            .map(pvc -> pvc.getMetadata())
+            .map(metadata -> metadata.getLabels())
+            .map(labels -> labels.get("weblogic.domainUid")).get();
+        for (var pv : Kubernetes.listPersistentVolumes(
+            String.format("weblogic.domainUid = %s", label)).getItems()) {
+          Kubernetes.deletePv(pv.getMetadata().getName());
+        }
+      }
+    } catch (ApiException ex) {
+      logger.warning(ex.getResponseBody());
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete persistent volumes");
+    }
+
+    // Delete deployments
+    try {
+      for (var item : Kubernetes.listDeployments(namespace).getItems()) {
+        Kubernetes.deleteDeployment(namespace, item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete deployments");
+    }
+
+    // Delete pvc
+    try {
+      for (var item : Kubernetes.listPersistentVolumeClaims(namespace).getItems()) {
+        Kubernetes.deletePvc(item.getMetadata().getName(), namespace);
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete persistent volume claims");
+    }
+
+    // Delete services
+    try {
+      for (var item : Kubernetes.listServices(namespace).getItems()) {
+        Kubernetes.deleteService(item.getMetadata().getName(), namespace);
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete services");
+    }
+
+    // Delete namespaced roles
+    try {
+      for (var item : Kubernetes.listNamespacedRole(namespace).getItems()) {
+        Kubernetes.deleteNamespacedRole(namespace, item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete namespaced roles");
+    }
+
+    // Delete namespaced role bindings
+    try {
+      for (var item : Kubernetes.listNamespacedRoleBinding(namespace).getItems()) {
+        Kubernetes.deleteNamespacedRoleBinding(namespace, item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete namespaced rolebindings");
+    }
+
+    // Delete service accounts
+    try {
+      for (var item : Kubernetes.listServiceAccounts(namespace).getItems()) {
+        Kubernetes.deleteServiceAccount(item.getMetadata().getName(), namespace);
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete service accounts");
+    }
+    // Delete namespace
+    try {
+      Kubernetes.deleteNamespace(namespace);
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete namespace");
+    }
+  }
+
+  /**
+   * Deletes non name spaced artifacts in the Kubernetes cluster.
+   *
+   */
+  public static void deleteClusterArtifacts() {
+    logger.info("Deleting cluster artifacts");
+    // Delete cluster roles
+    try {
+      logger.info("Cluster Roles list");
+      for (var item : Kubernetes.listClusterRoles("weblogic.operatorName").getItems()) {
+        logger.info(item.getMetadata().getName());
+        //Kubernetes.deleteClusterRole(item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete cluster roles");
+    }
+
+    // Delete cluster rolebindings
+    try {
+      logger.info("Cluster Role Bindings list");
+      for (var item : Kubernetes.listClusterRoleBindings("weblogic.operatorName").getItems()) {
+        logger.info(item.getMetadata().getName());
+        //Kubernetes.deleteClusterRoleBinding(item.getMetadata().getName());
+      }
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+      logger.warning("Failed to delete cluster rolebindings");
+    }
+  }
+
+}

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
@@ -74,11 +74,10 @@ public class CleanupUtil {
         deleteNamespacedArtifacts(namespace);
       }
 
-      Thread.sleep(30 * 1000); // I am using Thread.sleep for a one time 30 sec sleep.
-      // If put 30 seconds in pollDelay in below, its going to sleep 30 seconds for every namespace.
+      Thread.sleep(30 * 1000); // Using Thread.sleep for a one time 30 sec sleep.
+      // If pollDelay is set to 30 seconds below, its going to sleep 30 seconds for every namespace.
 
       // wait for the artifacts to be deleted, waiting for a maximum of 3 minutes
-      // with pollDelay 0, since already waited for 30 seconds
       ConditionFactory withStandardRetryPolicy = with().pollDelay(0, SECONDS)
           .and().with().pollInterval(10, SECONDS)
           .atMost(3, MINUTES).await();
@@ -103,7 +102,7 @@ public class CleanupUtil {
   /**
    * Delete domains in the given namespace, if exists.
    *
-   * @param namespace name of the namespace
+   * @param namespace name
    */
   private static void deleteDomains(String namespace) {
     try {
@@ -120,7 +119,7 @@ public class CleanupUtil {
   /**
    * Uninstalls the operator.
    *
-   * @param namespace name of the namespace
+   * @param namespace name
    */
   private static void uninstallOperator(String namespace) {
     HelmParams opHelmParams = new HelmParams()
@@ -132,7 +131,7 @@ public class CleanupUtil {
   /**
    * Returns true if the namespace is operator namespace, otherwise false.
    *
-   * @param namespace name of the namespace
+   * @param namespace name
    * @return true if the namespace is operator namespace, otherwise false
    * @throws ApiException when Kubernetes cluster query fails
    */
@@ -143,7 +142,7 @@ public class CleanupUtil {
   /**
    * Returns true if artifacts doesn't exists in the Kubernetes cluster.
    *
-   * @param namespace name of the namespace
+   * @param namespace name
    * @return true if no artifacts exists otherwise false
    */
   public static Callable<Boolean> artifactsDoesntExist(String namespace) {
@@ -380,7 +379,7 @@ public class CleanupUtil {
   /**
    * Deletes artifacts in the Kubernetes cluster in the given namespace.
    *
-   * @param namespace name of the namespace
+   * @param namespace name
    */
   public static void deleteNamespacedArtifacts(String namespace) {
     logger.info("Deleting artifacts in namespace {0}", namespace);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
@@ -41,7 +41,7 @@ public class CleanupUtil {
   /**
    * Cleanup Kubernetes artifacts in the namespaces used by the test class.
    *
-   * <p>Tries to gracefully delete the WebLogic domains and WebLogic Operator in the namespaces, if found.
+   * <p>Tries to gracefully delete any existing WebLogic domains and WebLogic Operator in the namespaces.
    * Then deletes everything in the namespaces.
    *
    * <p>Waits for the deletion task to be completed, for up to 10 minutes.

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -32,7 +32,7 @@ public class LoggingUtil {
   /**
    * Collect logs for artifacts in Kubernetes cluster for current running test object. This method can be called
    * anywhere in the test by passing the test instance object and list namespaces.
-   * 
+   *
    * <p>The collected logs are written in the LOGS_DIR/IT_TEST_CLASSNAME/CURRENT_TIMESTAMP directory.
    *
    * @param itInstance the integration test instance
@@ -110,8 +110,12 @@ public class LoggingUtil {
     } catch (Exception ex) {
       logger.warning("Listing domain failed, not collecting any data for domain");
     }
-    // get all Domain objects in given namespace
-
+    // get all pod objects in given namespace
+    try {
+      writeToFile(Kubernetes.listPods(namespace, null), resultDir.toString(), namespace + "_all_pods.log");
+    } catch (Exception ex) {
+      logger.warning("Listing pods failed, not collecting any data pods");
+    }
 
     // get domain/operator pods
     for (var pod : Kubernetes.listPods(namespace, null).getItems()) {


### PR DESCRIPTION
Deletes all the artifacts in the namespaces left behind by the tests.

First it deletes the WebLogic domain if exists, then uninstalls the operator
Finally deletes everything else in the namespace. Waits for up to 3 minutes for the cleanup to be complete.
