### PR TITLE
Attempt to clean up use of bad exec()

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -274,7 +274,7 @@ public class BaseTest {
     // for manual/local run, create file handler, create PVROOT
     if (!SHARED_CLUSTER) {
       LoggerHelper.getLocal().log(Level.INFO, "Creating PVROOT " + pvRoot);
-      TestUtils.exec("/usr/local/packages/aime/ias/run_as_root \"mkdir -m777 -p "
+      TestUtils.execOrAbortProcess("/usr/local/packages/aime/ias/run_as_root \"mkdir -m777 -p "
           + pvRoot + "\"", true);
     }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItElasticLogging.java
@@ -104,7 +104,7 @@ public class ItElasticLogging extends BaseTest {
                 .append("/")
                 .append(elasticStackYamlLoc);
         LoggerHelper.getLocal().log(Level.INFO, "Command to Install Elastic Stack: " + cmd.toString());
-        TestUtils.exec(cmd.toString());
+        TestUtils.execOrAbortProcess(cmd.toString());
 
         LoggerHelper.getLocal().log(Level.INFO, "Creating Operator & waiting for the script to complete execution");
         Map<String, Object> operatorMap = createOperatorMap(
@@ -188,7 +188,7 @@ public class ItElasticLogging extends BaseTest {
               .append("/")
               .append(elasticStackYamlLoc);
       LoggerHelper.getLocal().log(Level.INFO, "Command to uninstall Elastic Stack: " + cmd.toString());
-      TestUtils.exec(cmd.toString());
+      TestUtils.execOrAbortProcess(cmd.toString());
 
       // Restore the test env
       Files.delete(new File(loggingYamlFileLoc + "/" + loggingYamlFile).toPath());
@@ -516,7 +516,7 @@ public class ItElasticLogging extends BaseTest {
             .append("'")
             .toString();
     LoggerHelper.getLocal().log(Level.INFO, "Command to search: " + cmd);
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
 
     return result.stdout();
   }
@@ -545,7 +545,7 @@ public class ItElasticLogging extends BaseTest {
       // Make sure downloading completed
       while (i < BaseTest.getMaxIterationsPod()) {
         try {
-          ExecResult result = TestUtils.exec(getJars.toString());
+          ExecResult result = TestUtils.execOrAbortProcess(getJars.toString());
           LoggerHelper.getLocal().log(Level.INFO,"exit code: " + result.exitValue());
           LoggerHelper.getLocal().log(Level.INFO,"Result: " + result.stdout());
         } catch (RuntimeException rtect) {
@@ -583,7 +583,7 @@ public class ItElasticLogging extends BaseTest {
       // Make sure downloading completed
       while (i < BaseTest.getMaxIterationsPod()) {
         try {
-          ExecResult result = TestUtils.exec(getJars.toString());
+          ExecResult result = TestUtils.execOrAbortProcess(getJars.toString());
           LoggerHelper.getLocal().log(Level.INFO, "exit code: " + result.exitValue());
           LoggerHelper.getLocal().log(Level.INFO, "Result: " + result.stdout());
         } catch (RuntimeException rtect) {
@@ -665,7 +665,7 @@ public class ItElasticLogging extends BaseTest {
         .append("'");
     LoggerHelper.getLocal().log(Level.INFO, "Executing cmd " + cmdLisDir.toString());
 
-    ExecResult result = TestUtils.exec(cmdLisDir.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmdLisDir.toString());
     LoggerHelper.getLocal().log(Level.INFO, "exit code: " + result.exitValue());
     LoggerHelper.getLocal().log(Level.INFO, "Result: " + result.stdout());
 
@@ -679,14 +679,14 @@ public class ItElasticLogging extends BaseTest {
         .append(domainUid)
         .append("/lib/'");
     LoggerHelper.getLocal().log(Level.INFO, "Executing cmd " + cmdLisDir.toString());
-    result = TestUtils.exec(cmdLisDir.toString());
+    result = TestUtils.execOrAbortProcess(cmdLisDir.toString());
     LoggerHelper.getLocal().log(Level.INFO, "exit code: " + result.exitValue());
     LoggerHelper.getLocal().log(Level.INFO, "Result: " + result.stdout());
 
     cmdLisDir.setLength(0);
     cmdLisDir = new StringBuffer("ls -l " + loggingExpArchiveLoc);
     LoggerHelper.getLocal().log(Level.INFO, "Executing cmd " + cmdLisDir.toString());
-    result = TestUtils.exec(cmdLisDir.toString());
+    result = TestUtils.execOrAbortProcess(cmdLisDir.toString());
     LoggerHelper.getLocal().log(Level.INFO, "exit code: " + result.exitValue());
     LoggerHelper.getLocal().log(Level.INFO, "Result: " + result.stdout());
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItImageTool.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItImageTool.java
@@ -202,7 +202,7 @@ public class ItImageTool extends BaseTest {
     LoggerHelper.getLocal().log(Level.INFO, "Command to get pod's image name: " + cmd);
 
     try {
-      result = TestUtils.exec(cmd);
+      result = TestUtils.execOrAbortProcess(cmd);
 
       Assumptions.assumeTrue((result.stdout()).equals(weblogicImageTagWIT),
           "Failed to use the image <" + weblogicImageTagWIT + "> built by imagetool");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItInitContainers.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItInitContainers.java
@@ -392,7 +392,7 @@ public class ItInitContainers extends BaseTest {
 
     // Apply the new yaml to update the domain
     LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-    ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+    ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
     LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItJrfPvWlst.java
@@ -59,7 +59,7 @@ public class ItJrfPvWlst extends BaseTest {
     if (QUICKTEST) {
       createResultAndPvDirs(testClassName);
       
-      TestUtils.exec(
+      TestUtils.execOrAbortProcess(
           "cp -rf " 
           + BaseTest.getProjectRoot() 
           + "/kubernetes/samples/scripts " 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItManagedCoherence.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItManagedCoherence.java
@@ -330,7 +330,7 @@ public class ItManagedCoherence extends BaseTest {
         .append(appToDeploy);
 
     LoggerHelper.getLocal().log(Level.INFO, "curlCmd is " + curlCmd.toString());
-    ExecResult result = TestUtils.exec(curlCmd.toString(), true);
+    ExecResult result = ExecCommand.exec(curlCmd.toString());
 
     return result;
   }
@@ -352,7 +352,7 @@ public class ItManagedCoherence extends BaseTest {
         .append(appToDeploy)
         .append("/")
         .append(appToDeploy);
-    ExecResult result = TestUtils.exec(curlCmd.toString(), true);
+    ExecResult result = ExecCommand.exec(curlCmd.toString());
     return result;
   }
 
@@ -373,7 +373,7 @@ public class ItManagedCoherence extends BaseTest {
         .append(appToDeploy)
         .append("/")
         .append(appToDeploy);
-    ExecResult result = TestUtils.exec(curlCmd.toString(), true);
+    ExecResult result = ExecCommand.exec(curlCmd.toString());
     return result;
   }
 
@@ -394,7 +394,7 @@ public class ItManagedCoherence extends BaseTest {
         .append(appToDeploy)
         .append("/")
         .append(appToDeploy);
-    ExecResult result = TestUtils.exec(curlCmd.toString(), true);
+    ExecResult result = ExecCommand.exec(curlCmd.toString());
     return result;
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItModelInImage.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItModelInImage.java
@@ -226,7 +226,7 @@ public class ItModelInImage extends MiiBaseTest {
 
       // Apply the new yaml to update the domain crd
       LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-      ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+      ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
       LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the domain is restarted");
       domain.verifyAdminServerRestarted();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItModelInImageConfigUpdate.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItModelInImageConfigUpdate.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import oracle.kubernetes.operator.utils.Domain;
+import oracle.kubernetes.operator.utils.ExecCommand;
 import oracle.kubernetes.operator.utils.ExecResult;
 import oracle.kubernetes.operator.utils.LoggerHelper;
 import oracle.kubernetes.operator.utils.Operator;
@@ -597,7 +598,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
 
     try {
       LoggerHelper.getLocal().log(Level.INFO, "Command to exec: " + cmdStrBuff);
-      result = TestUtils.exec(cmdStrBuff.toString());
+      result = TestUtils.execOrAbortProcess(cmdStrBuff.toString());
       LoggerHelper.getLocal().log(Level.INFO, "JDBC DS info from server pod: " + result.stdout());
       jdbcDsStr  = result.stdout();
     } catch (Exception ex) {
@@ -647,7 +648,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
           .append(domainNS)
           .append(" -o=jsonpath='{.items[0].metadata.name}' | grep admin-server");
       LoggerHelper.getLocal().log(Level.INFO, "Command to get pod name: " + cmdStrBuff);
-      result = TestUtils.exec(cmdStrBuff.toString());
+      result = TestUtils.execOrAbortProcess(cmdStrBuff.toString());
       String adminPodName = result.stdout();
       LoggerHelper.getLocal().log(Level.INFO, "pod name is: " + adminPodName);
 
@@ -661,7 +662,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
           .append(BaseTest.getAppLocationInPod())
           .append("'");
       LoggerHelper.getLocal().log(Level.INFO, "Command to exec: " + cmdStrBuff);
-      TestUtils.exec(cmdStrBuff.toString(), true);
+      TestUtils.execOrAbortProcess(cmdStrBuff.toString(), true);
 
       TestUtils.copyFileViaCat(
           Paths.get(tempDir, pyFileName).toString(),
@@ -680,7 +681,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
           .append(pyFileName)
           .append("'");
       LoggerHelper.getLocal().log(Level.INFO, "Command to exec: " + cmdStrBuff);
-      result = TestUtils.exec(cmdStrBuff.toString(), true);
+      result = ExecCommand.exec(cmdStrBuff.toString());
       jdbcDsStr  = result.stdout();
       //clean up
       LoggerHelper.getLocal().log(Level.INFO, "Deleting: " + destDir + "/" + pyFileName);
@@ -734,7 +735,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
         .append("kubectl get pod -n ")
         .append(domainNS)
         .append(" -o=jsonpath='{.items[1].metadata.name}' | grep managed-server1");
-    String msPodName = TestUtils.exec(cmdStrBuff.toString()).stdout();
+    String msPodName = TestUtils.execOrAbortProcess(cmdStrBuff.toString()).stdout();
 
     // access the application deployed in managed-server1
     cmdStrBuff = new StringBuffer();
@@ -748,7 +749,7 @@ public class ItModelInImageConfigUpdate extends MiiBaseTest {
         .append("'");
 
     try {
-      ExecResult exec = TestUtils.exec(cmdStrBuff.toString(), true);
+      ExecResult exec = ExecCommand.exec(cmdStrBuff.toString());
       appStr = exec.stdout();
     } catch (Exception ex) {
       LoggerHelper.getLocal().log(Level.INFO, "Varify app failed:\n " + ex.getMessage());

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItMonitoringExporter.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItMonitoringExporter.java
@@ -190,10 +190,10 @@ public class ItMonitoringExporter extends BaseTest {
               + domainNS2
               + "-image:" + currentDateTime;
           String cmd = "docker rmi -f " + image;
-          TestUtils.exec(cmd, true);
+          TestUtils.execOrAbortProcess(cmd, true);
         }
         String cmd = "docker rmi -f " + domainNS2 + "-image:" + currentDateTime;
-        TestUtils.exec(cmd, true);
+        TestUtils.execOrAbortProcess(cmd, true);
       }
       if (operator != null) {
         operator.destroy();
@@ -248,7 +248,7 @@ public class ItMonitoringExporter extends BaseTest {
       Files.createDirectories(Paths.get(destLoc));
     }
     String crdCmd = " cp " + srcLoc + "/" + fileName + " " + destLoc;
-    TestUtils.exec(crdCmd, true);
+    TestUtils.execOrAbortProcess(crdCmd, true);
     crdCmd =
         "cd "
             + destLoc
@@ -260,7 +260,7 @@ public class ItMonitoringExporter extends BaseTest {
             + args
             + " | tee "
             + outLogFile;
-    TestUtils.exec(crdCmd, true);
+    TestUtils.execOrAbortProcess(crdCmd, true);
     crdCmd = " cat " + destLoc + "/" + outLogFile;
     ExecResult result = ExecCommand.exec(crdCmd);
     assertFalse(
@@ -385,7 +385,7 @@ public class ItMonitoringExporter extends BaseTest {
     cmd.append(" -n " + domainNS1);
 
     LoggerHelper.getLocal().log(Level.INFO, " upgradeTraefikNamespace() Running " + cmd.toString());
-    TestUtils.exec(cmd.toString());
+    TestUtils.execOrAbortProcess(cmd.toString());
   }
 
   /**
@@ -860,7 +860,7 @@ public class ItMonitoringExporter extends BaseTest {
     // apply new domain yaml and verify pod restart
     String crdCmd =
         " kubectl apply -f " + monitoringExporterEndToEndDir + "/demo-domains/domainInImage.yaml";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
 
     TestUtils.checkPodReady(domainNS2 + "-admin-server", domainNS2);
     TestUtils.checkPodReady(domainNS2 + "-managed-server-1", domainNS2);
@@ -889,7 +889,7 @@ public class ItMonitoringExporter extends BaseTest {
         " kubectl -n " + monitoringNS + " get cm prometheus-server -oyaml > "
             + monitoringExporterEndToEndDir
             + "/cm.yaml";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
     ExecResult result = ExecCommand.exec("cat " + monitoringExporterEndToEndDir + "/cm.yaml");
     LoggerHelper.getLocal().log(Level.INFO, " output for cm " + result.stdout());
     replaceStringInFile(
@@ -900,7 +900,7 @@ public class ItMonitoringExporter extends BaseTest {
         + " apply -f "
         + monitoringExporterEndToEndDir
         + "/cm.yaml";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
   }
 
   private static String getPodName(String labelExp, String namespace) throws Exception {
@@ -1095,12 +1095,12 @@ public class ItMonitoringExporter extends BaseTest {
             + wlsUser
             + "  --from-literal=password="
             + wlsPassword;
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
 
     // apply new domain yaml and verify pod restart
     crdCmd =
         " kubectl apply -f " + monitoringExporterEndToEndDir + "/demo-domains/domainInImage.yaml";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
 
     TestUtils.checkPodReady(domainNS2 + "-admin-server", domainNS2);
     TestUtils.checkPodReady(domainNS2 + "-managed-server-1", domainNS2);
@@ -1109,7 +1109,7 @@ public class ItMonitoringExporter extends BaseTest {
     replaceStringInFile(monitoringExporterEndToEndDir + "/util/curl.yaml", "default", domainNS2);
     // apply curl to the pod
     crdCmd = " kubectl apply -f " + monitoringExporterEndToEndDir + "/util/curl.yaml";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
 
     TestUtils.checkPodReady("curl", domainNS2);
     // access metrics
@@ -1119,7 +1119,7 @@ public class ItMonitoringExporter extends BaseTest {
             + ":"
             + wlsPassword
             + "@" + domainNS2 + "-managed-server-1:8001/wls-exporter/metrics";
-    ExecResult result = TestUtils.exec(crdCmd);
+    ExecResult result = TestUtils.execOrAbortProcess(crdCmd);
     assertTrue((result.stdout().contains("wls_servlet_execution_time_average")));
     crdCmd =
         "kubectl exec -n " + domainNS2 + " curl -- curl http://"
@@ -1127,7 +1127,7 @@ public class ItMonitoringExporter extends BaseTest {
             + ":"
             + wlsPassword
             + "@" + domainNS2 + "-managed-server-2:8001/wls-exporter/metrics";
-    result = TestUtils.exec(crdCmd);
+    result = TestUtils.execOrAbortProcess(crdCmd);
     assertTrue((result.stdout().contains("wls_servlet_execution_time_average")));
   }
 
@@ -1143,7 +1143,7 @@ public class ItMonitoringExporter extends BaseTest {
             + oldImageName
             + " "
             + newImageName;
-    ExecResult result = TestUtils.exec(dockerLoginAndTagCmd);
+    ExecResult result = TestUtils.execOrAbortProcess(dockerLoginAndTagCmd);
     LoggerHelper.getLocal().log(Level.INFO,
         "cmd "
             + dockerLoginAndTagCmd
@@ -1164,7 +1164,7 @@ public class ItMonitoringExporter extends BaseTest {
     String crdCmd = " cp " + resourceExporterDir + "/promvalues.yaml"
         + " " + monitoringExporterEndToEndDir
         + "/prometheus/promvalues.yaml";
-    TestUtils.exec(crdCmd, true);
+    TestUtils.execOrAbortProcess(crdCmd, true);
     String promalertmanagerPort = String.valueOf(32500 + getNewSuffixCount());
     replaceStringInFile(
         monitoringExporterEndToEndDir + "/prometheus/promvalues.yaml", "32500", promalertmanagerPort);
@@ -1223,7 +1223,7 @@ public class ItMonitoringExporter extends BaseTest {
             + " && curl -v -H 'Content-Type: application/json' -H \"Content-Type: application/json\""
             + "  -X POST http://admin:12345678@" + myhost + ":" + grafanaPort + "/api/datasources/"
             + "  --data-binary @grafana/datasource.json";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
 
     crdCmd =
         " cd "
@@ -1231,7 +1231,7 @@ public class ItMonitoringExporter extends BaseTest {
             + " && curl -v -H 'Content-Type: application/json' -H \"Content-Type: application/json\""
             + "  -X POST http://admin:12345678@" + myhost + ":" + grafanaPort + "/api/dashboards/db/"
             + "  --data-binary @grafana/dashboard.json";
-    TestUtils.exec(crdCmd);
+    TestUtils.execOrAbortProcess(crdCmd);
     crdCmd = " cd "
         + monitoringExporterEndToEndDir
         + " && "
@@ -1310,7 +1310,7 @@ public class ItMonitoringExporter extends BaseTest {
         if (new File(pvDir).exists()) {
 
           LoggerHelper.getLocal().log(Level.INFO, "Deleting pv created dir " + pvDir);
-          TestUtils.exec("/usr/local/packages/aime/ias/run_as_root \"rm -rf " + pvDir + "\"");
+          TestUtils.execOrAbortProcess("/usr/local/packages/aime/ias/run_as_root \"rm -rf " + pvDir + "\"");
         }
       }
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperatorUpgrade.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItOperatorUpgrade.java
@@ -105,8 +105,8 @@ public class ItOperatorUpgrade extends BaseTest {
       if (operator != null) {
         operator.destroy();
       }
-      TestUtils.exec("rm -rf " + Paths.get(opUpgradeTmpDir).toString());
-      TestUtils.exec("kubectl delete crd domains.weblogic.oracle --ignore-not-found");
+      TestUtils.execOrAbortProcess("rm -rf " + Paths.get(opUpgradeTmpDir).toString());
+      TestUtils.execOrAbortProcess("kubectl delete crd domains.weblogic.oracle --ignore-not-found");
       // Make sure domain CRD is deleted form k8s 
       ExecResult result = ExecCommand.exec("kubectl get crd domains.weblogic.oracle",true);
       Assertions.assertEquals(1, result.exitValue());
@@ -171,8 +171,8 @@ public class ItOperatorUpgrade extends BaseTest {
             + getCrdVersion()
             + " in a loop ");
     for (int i = 0; i < BaseTest.getMaxIterationsPod(); i++) {
-      exec = TestUtils.exec(
-              "kubectl get crd domains.weblogic.oracle -o jsonpath='{.spec.versions[?(@.storage==true)].name}'", true);
+      exec = ExecCommand.exec(
+              "kubectl get crd domains.weblogic.oracle -o jsonpath='{.spec.versions[?(@.storage==true)].name}'");
       if (exec.stdout().contains(getCrdVersion())) {
         LoggerHelper.getLocal().log(Level.INFO, "Got Expected CRD Version");
         result = true;
@@ -223,7 +223,7 @@ public class ItOperatorUpgrade extends BaseTest {
       throws Exception {
     LoggerHelper.getLocal().log(Level.INFO, "+++++++++++++++Beginning Test Setup+++++++++++++++++++++");
     opUpgradeTmpDir = getResultDir() + "/operatorupgrade";
-    TestUtils.exec("rm -rf " + Paths.get(opUpgradeTmpDir).toString());
+    TestUtils.execOrAbortProcess("rm -rf " + Paths.get(opUpgradeTmpDir).toString());
     Files.createDirectories(Paths.get(opUpgradeTmpDir));
     Map<String, Object> operatorMap = createOperatorMap(getNewSuffixCount(), true, "");
     operatorMap.put("operatorImageName", "oracle/weblogic-kubernetes-operator");

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodTemplates.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodTemplates.java
@@ -161,7 +161,7 @@ public class ItPodTemplates extends BaseTest {
 
       // Apply the new yaml to update the domain
       LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-      ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+      ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
       LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
 
       domain.verifyDomainCreated();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItPodsRestart.java
@@ -246,7 +246,7 @@ public class ItPodsRestart extends BaseTest {
     logTestBegin(testMethodName);
     testCompletedSuccessfully = false;
 
-    TestUtils.exec("docker images", true);
+    TestUtils.execOrAbortProcess("docker images", true);
     LoggerHelper.getLocal().log(Level.INFO,
         "About to verifyDomainServerPodRestart for Domain: "
             + domain.getDomainUid()
@@ -416,7 +416,7 @@ public class ItPodsRestart extends BaseTest {
 
       // Apply the new yaml to update the domain
       LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-      ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+      ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
       LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
 
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the admin server pod is recreated");
@@ -424,7 +424,7 @@ public class ItPodsRestart extends BaseTest {
     } finally {
       LoggerHelper.getLocal().log(
           Level.INFO, "Reverting back the domain to old crd\n kubectl apply -f {0}", originalYaml);
-      TestUtils.exec("kubectl apply -f " + originalYaml);
+      TestUtils.execOrAbortProcess("kubectl apply -f " + originalYaml);
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the admin server pod is recreated");
       domain.verifyAdminServerRestarted();
     }
@@ -464,14 +464,14 @@ public class ItPodsRestart extends BaseTest {
 
       // Apply the new yaml to update the domain crd
       LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-      ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+      ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
       LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the cluster is restarted");
       domain.verifyManagedServersRestarted();
     } finally {
       LoggerHelper.getLocal().log(
           Level.INFO, "Reverting back the domain to old crd\n kubectl apply -f {0}", originalYaml);
-      TestUtils.exec("kubectl apply -f " + originalYaml);
+      TestUtils.execOrAbortProcess("kubectl apply -f " + originalYaml);
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the cluster is restarted");
       domain.verifyManagedServersRestarted();
     }
@@ -515,14 +515,14 @@ public class ItPodsRestart extends BaseTest {
 
       // Apply the new yaml to update the domain crd
       LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-      ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+      ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
       LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the managed server is restarted");
       domain.verifyManagedServersRestarted();
     } finally {
       LoggerHelper.getLocal().log(
           Level.INFO, "Reverting back the domain to old crd\n kubectl apply -f {0}", originalYaml);
-      TestUtils.exec("kubectl apply -f " + originalYaml);
+      TestUtils.execOrAbortProcess("kubectl apply -f " + originalYaml);
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the managed server is restarted");
       domain.verifyManagedServersRestarted();
     }
@@ -562,7 +562,7 @@ public class ItPodsRestart extends BaseTest {
 
       // Apply the new yaml to update the domain crd
       LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-      ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+      ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
       LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the domain is restarted");
       this.domain.verifyAdminServerRestarted();
@@ -570,7 +570,7 @@ public class ItPodsRestart extends BaseTest {
     } finally {
       LoggerHelper.getLocal().log(
           Level.INFO, "Reverting back the domain to old crd\n kubectl apply -f {0}", originalYaml);
-      TestUtils.exec("kubectl apply -f " + originalYaml);
+      TestUtils.execOrAbortProcess("kubectl apply -f " + originalYaml);
       LoggerHelper.getLocal().log(Level.INFO, "Verifying if the domain is restarted");
       this.domain.verifyAdminServerRestarted();
       this.domain.verifyManagedServersRestarted();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItServerDiscovery.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItServerDiscovery.java
@@ -142,7 +142,7 @@ public class ItServerDiscovery extends BaseTest {
 
     String cmd = "kubectl apply -f " + testDomainYamlFile;
     LoggerHelper.getLocal().log(Level.INFO, "Start a new managed server, managed-server3 using command:\n" + cmd);
-    TestUtils.exec(cmd);
+    TestUtils.execOrAbortProcess(cmd);
 
     LoggerHelper.getLocal().log(Level.INFO, "Restart the Operator");
     operator.startUsingReplicas();
@@ -185,7 +185,7 @@ public class ItServerDiscovery extends BaseTest {
     // Stop admin server
     String cmd = "kubectl delete po/" + adminServerPodName + " -n " + domainNS;
     LoggerHelper.getLocal().log(Level.INFO, "Stop admin server <" + adminServerPodName + "> using command:\n" + cmd);
-    TestUtils.exec(cmd);
+    TestUtils.execOrAbortProcess(cmd);
 
     LoggerHelper.getLocal().log(Level.INFO, "Check if admin pod <" + adminServerPodName + "> is deleted");
     TestUtils.checkPodDeleted(adminServerPodName, domainNS);
@@ -197,7 +197,7 @@ public class ItServerDiscovery extends BaseTest {
       String msPodName = domainUid + "-" + managedServerNameBase + i;
       cmd = "kubectl delete po/" + msPodName + " -n " + domainNS;
       LoggerHelper.getLocal().log(Level.INFO, "Stop managed server <" + msPodName + "> using command:\n" + cmd);
-      TestUtils.exec(cmd);
+      TestUtils.execOrAbortProcess(cmd);
 
       LoggerHelper.getLocal().log(Level.INFO, "Checking if ms pod <" + msPodName + "> is deleted");
       TestUtils.checkPodDeleted(msPodName, domainNS);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItSessionMigration.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItSessionMigration.java
@@ -252,7 +252,7 @@ public class ItSessionMigration extends BaseTest {
     String curlCmd = buildWebServiceUrl(webServiceUrl, headerOption + httpHeaderFile);
     LoggerHelper.getLocal().log(Level.INFO, "Send a HTTP request: " + curlCmd);
 
-    ExecResult result = TestUtils.exec(curlCmd);
+    ExecResult result = TestUtils.execOrAbortProcess(curlCmd);
 
     return result;
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItSitConfigDomainInImage.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItSitConfigDomainInImage.java
@@ -89,7 +89,7 @@ public class ItSitConfigDomainInImage extends SitConfig {
   @AfterAll
   public static void staticUnPrepare() throws Exception {
     if (FULLTEST) {
-      ExecResult result = TestUtils.exec("kubectl delete -f " + mysqlYamlFile);
+      ExecResult result = TestUtils.execOrAbortProcess("kubectl delete -f " + mysqlYamlFile);
       LoggerHelper.getLocal().log(Level.INFO, "Deleting domain and domain image...");
       if (domain != null) {
         domain.destroy();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItSitConfigDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItSitConfigDomainInPV.java
@@ -89,7 +89,7 @@ public class ItSitConfigDomainInPV extends SitConfig {
   @AfterAll
   public static void staticUnPrepare() throws Exception {
     if (FULLTEST) {
-      ExecResult result = TestUtils.exec("kubectl delete -f " + mysqlYamlFile);
+      ExecResult result = TestUtils.execOrAbortProcess("kubectl delete -f " + mysqlYamlFile);
       LoggerHelper.getLocal().log(Level.INFO, "Deleting domain...");
       if (domain != null) {
         domain.destroy();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItStickySession.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItStickySession.java
@@ -310,7 +310,7 @@ public class ItStickySession extends BaseTest {
     // Send a HTTP request
     String curlCmd = buildWebServiceUrl(webServiceUrl, headerOption);
     LoggerHelper.getLocal().log(Level.INFO, "Send a HTTP request: " + curlCmd);
-    ExecResult result = TestUtils.exec(curlCmd);
+    ExecResult result = TestUtils.execOrAbortProcess(curlCmd);
 
     return result;
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItUsabilityOperatorHelmChart.java
@@ -209,7 +209,7 @@ public class ItUsabilityOperatorHelmChart extends BaseTest {
             true,
             RestCertType.SELF_SIGNED);
     String command = " kubectl delete namespace " + operator.getOperatorNamespace();
-    TestUtils.exec(command);
+    TestUtils.execOrAbortProcess(command);
     try {
       operator.callHelmInstall();
       gotException = false;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/MiiBaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/MiiBaseTest.java
@@ -173,7 +173,7 @@ public class MiiBaseTest extends BaseTest {
     try {
       // patching the domain
       LoggerHelper.getLocal().log(Level.INFO, "Command to patch domain: " + patchDomainCmd);
-      result = TestUtils.exec(patchDomainCmd.toString());
+      result = TestUtils.execOrAbortProcess(patchDomainCmd.toString());
       LoggerHelper.getLocal().log(Level.INFO, "Domain patch result: " + result.stdout());
 
       // verify the domain restarted
@@ -228,7 +228,7 @@ public class MiiBaseTest extends BaseTest {
 
     // Apply the new yaml to update the domain crd
     LoggerHelper.getLocal().log(Level.INFO, "kubectl apply -f {0}", path.toString());
-    ExecResult exec = TestUtils.exec("kubectl apply -f " + path.toString());
+    ExecResult exec = TestUtils.execOrAbortProcess("kubectl apply -f " + path.toString());
     LoggerHelper.getLocal().log(Level.INFO, exec.stdout());
 
   }
@@ -255,7 +255,7 @@ public class MiiBaseTest extends BaseTest {
     try {
       // patching the domain
       LoggerHelper.getLocal().log(Level.INFO, "Command to patch domain: " + patchDomainCmd);
-      result = TestUtils.exec(patchDomainCmd.toString());
+      result = TestUtils.execOrAbortProcess(patchDomainCmd.toString());
       LoggerHelper.getLocal().log(Level.INFO, "Domain patch result: " + result.stdout());
 
       // verify the domain restarted
@@ -286,7 +286,7 @@ public class MiiBaseTest extends BaseTest {
 
     LoggerHelper.getLocal().log(Level.INFO, "Command to get restartVersion: " + getVersionCmd);
     try {
-      ExecResult result = TestUtils.exec(getVersionCmd.toString());
+      ExecResult result = TestUtils.execOrAbortProcess(getVersionCmd.toString());
       String existinVersion = result.stdout();
       LoggerHelper.getLocal().log(Level.INFO, "Existing restartVersion is: " + existinVersion);
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/SitConfig.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/SitConfig.java
@@ -98,7 +98,7 @@ public class SitConfig extends BaseTest {
     if (!OPENSHIFT) {
       fqdn = TestUtils.getHostName();
     } else {
-      ExecResult result = TestUtils.exec("hostname -i");
+      ExecResult result = TestUtils.execOrAbortProcess("hostname -i");
       fqdn = result.stdout().trim();
     }
     String jdbcUrl = "jdbc:mysql://" + fqdn + ":" + mysqldbport + "/";
@@ -206,7 +206,7 @@ public class SitConfig extends BaseTest {
     content = content.replaceAll("@DOMAIN_UID@", domainUid);
     content = content.replaceAll("@MYSQLPORT@", mysqldbport);
     Files.write(dst, content.getBytes(charset));
-    ExecResult result = TestUtils.exec("kubectl create -f " + mysqlYamlFile);
+    ExecResult result = TestUtils.execOrAbortProcess("kubectl create -f " + mysqlYamlFile);
     Assertions.assertEquals(0, result.exitValue());
   }
 
@@ -229,7 +229,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -259,7 +259,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -294,7 +294,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -326,7 +326,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -358,7 +358,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -399,7 +399,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -437,7 +437,7 @@ public class SitConfig extends BaseTest {
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
     ExecResult result =
-        TestUtils.exec(
+        TestUtils.execOrAbortProcess(
             kubeExecCmd
                 + " 'sh runSitConfigTests.sh "
                 + fqdn
@@ -471,7 +471,7 @@ public class SitConfig extends BaseTest {
       String kubeExecCmd =
           "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
       ExecResult result =
-          TestUtils.exec(
+          TestUtils.execOrAbortProcess(
               kubeExecCmd
                   + " 'sh runSitConfigTests.sh "
                   + fqdn
@@ -517,7 +517,7 @@ public class SitConfig extends BaseTest {
         domain.getDomainNs());
     String kubeExecCmd =
         "kubectl -n " + domain.getDomainNs() + "  exec -it " + adminpodname + "  -- bash -c";
-    TestUtils.exec(kubeExecCmd + " 'wlst.sh create-jdbc-resource.py'", true);
+    TestUtils.execOrAbortProcess(kubeExecCmd + " 'wlst.sh create-jdbc-resource.py'", true);
   }
 
   /**
@@ -542,7 +542,7 @@ public class SitConfig extends BaseTest {
           StandardOpenOption.TRUNCATE_EXISTING);
 
       // delete the old secret and add new secret to domain.yaml
-      TestUtils.exec("kubectl delete secret -n "
+      TestUtils.execOrAbortProcess("kubectl delete secret -n "
           + domain.getDomainNs() + " "
           + domain.getDomainUid() + "-" + oldSecret, true);
       String cmd =
@@ -556,8 +556,8 @@ public class SitConfig extends BaseTest {
               + TestUtils.getHostName()
               + " --from-literal=dbusername=root"
               + " --from-literal=dbpassword=root123";
-      TestUtils.exec(cmd, true);
-      TestUtils.exec("kubectl apply -f " + domainYaml, true);
+      TestUtils.execOrAbortProcess(cmd, true);
+      TestUtils.execOrAbortProcess("kubectl apply -f " + domainYaml, true);
     }
 
     int clusterReplicas =
@@ -576,9 +576,9 @@ public class SitConfig extends BaseTest {
             + "-sitconfigcm --from-file="
             + (String)domain.getDomainMap().get("configOverridesFile")
             + " -o yaml --dry-run | kubectl replace -f -";
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
     cmd = "kubectl describe cm -n " + domain.getDomainNs() + " " + domain.getDomainUid() + "-sitconfigcm";
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
 
     patchStr = "'{\"spec\":{\"serverStartPolicy\":\"IF_NEEDED\"}}'";
     TestUtils.kubectlpatch(domain.getDomainUid(), domain.getDomainNs(), patchStr);

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/DbUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/DbUtils.java
@@ -33,7 +33,7 @@ public class DbUtils {
     String dbnamespace = oracledb.getNamespace();
     String cmd = "kubectl get pod -n " + dbnamespace + " -o jsonpath=\"{.items[0].metadata.name}\"";
     logger.info("running command " + cmd);
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
     String podName = result.stdout();
 
     logger.info("DEBUG: db namespace=" + dbnamespace);
@@ -57,9 +57,9 @@ public class DbUtils {
         + scriptsDir
         + "/scripts/create-oracle-db-service/start-db-service.sh -i "
         + BaseTest.getOracledbImageName() + ":" + BaseTest.getOracledbImageTag();
-    TestUtils.exec(cmd1, true);
+    TestUtils.execOrAbortProcess(cmd1, true);
     String cmd2 = "kubectl get pod | grep oracle-db | cut -f1 -d \" \" ";
-    ExecResult result = TestUtils.exec(cmd2);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd2);
     String podName = result.stdout();
 
     logger.info("DEBUG: DB podname=" + podName);
@@ -80,7 +80,7 @@ public class DbUtils {
     String cmd = "sh " 
         + scriptsDir
         + "/scripts/create-oracle-db-service/stop-db-service.sh";
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
   }
   
   /**
@@ -95,7 +95,7 @@ public class DbUtils {
         + rcuSchemaPrefix
         + " -i "
         + BaseTest.getfmwImageName() + ":" + BaseTest.getfmwImageTag();
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
   }
   
   /**
@@ -107,7 +107,7 @@ public class DbUtils {
     String cmd = "sh " 
         + scriptsDir
         + "/scripts/create-rcu-schema/drop-rcu-schema.sh -s rcuSchemaPrefix";
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
   }
   
   /**
@@ -119,7 +119,7 @@ public class DbUtils {
     String cmd = "kubectl delete -f " 
         + scriptsDir
         + "/scripts/create-rcu-schema/common/rcu.yaml --ignore-not-found";
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
   }
 
   /**
@@ -197,12 +197,12 @@ public class DbUtils {
             + DEFAULT_FMWINFRA_DOCKER_IMAGETAG
             + " -- sleep 100000";
     logger.info("running command " + cmd);
-    TestUtils.exec(cmd);
+    TestUtils.execOrAbortProcess(cmd);
 
     // get rcu pod name
     cmd = "kubectl get pod -n " + rcuNamespace + " -o jsonpath=\"{.items[0].metadata.name}\"";
     logger.info("running command " + cmd);
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
     String podName = result.stdout();
     logger.info("DEBUG: rcuPodName=" + podName);
 
@@ -239,7 +239,7 @@ public class DbUtils {
     if (!namespace.equalsIgnoreCase("default")) {
       String command = "kubectl create ns " + namespace;
       logger.info("Running " + command);
-      TestUtils.exec(command);
+      TestUtils.execOrAbortProcess(command);
     }
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -1713,7 +1713,7 @@ public class Domain {
 
   private void callWebAppAndWaitTillReady(String curlCmd) throws Exception {
     for (int i = 0; i < maxIterations; i++) {
-      ExecResult result = TestUtils.exec(curlCmd, true);
+      ExecResult result = ExecCommand.exec(curlCmd);
       String responseCode = result.stdout().trim();
       if (result.exitValue() != 0 || !responseCode.equals("200")) {
         LoggerHelper.getLocal().log(Level.INFO,

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -151,7 +151,7 @@ public class Domain {
   public void verifyDomainCreated(int maxIterations) throws Exception {
     StringBuffer command = new StringBuffer();
     command.append("kubectl get domain ").append(domainUid).append(" -n ").append(domainNS);
-    ExecResult result = TestUtils.exec(command.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(command.toString());
     if (!result.stdout().contains(domainUid)) {
       throw new RuntimeException("FAILURE: domain not found, exiting!");
     }
@@ -399,7 +399,7 @@ public class Domain {
       StringBuffer wlsServerCurlCmd = getCurlCmdForHttps(podName, sslPortEnvVariable);
 
       LoggerHelper.getLocal().log(Level.INFO, "kubectl execute with command: " + wlsServerCurlCmd.toString());
-      execResult = TestUtils.exec(wlsServerCurlCmd.toString(), true);
+      execResult = ExecCommand.exec(wlsServerCurlCmd.toString());
     }
 
     return  execResult;
@@ -451,7 +451,7 @@ public class Domain {
           .append(password)
           .append(" -H X-Requested-By:Integration-Test --write-out %{http_code} -o /dev/null");
       LoggerHelper.getLocal().log(Level.INFO, "cmd for curl " + cmd);
-      ExecResult result = TestUtils.exec(cmd.toString());
+      ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
       String output = result.stdout().trim();
       LoggerHelper.getLocal().log(Level.INFO, "output " + output);
       if (!output.equals("200")) {
@@ -564,7 +564,7 @@ public class Domain {
         .append("/management/weblogic/latest/edit/appDeployments")
         .append(" --write-out %{http_code} ");
     LoggerHelper.getLocal().log(Level.INFO, "Command to deploy webapp " + cmd);
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     String output = result.stdout().trim();
     LoggerHelper.getLocal().log(Level.INFO, "curl output " + output + " \n err " + result.stderr());
     if (!output.contains("202")) {
@@ -594,7 +594,7 @@ public class Domain {
         .append(webappName)
         .append(" --write-out %{http_code} -o /dev/null");
     LoggerHelper.getLocal().fine("Command to undeploy webapp " + cmd);
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     String output = result.stdout().trim();
     if (!output.contains("200")) {
       throw new RuntimeException(
@@ -828,7 +828,7 @@ public class Domain {
         .append(domainUid)
         .append("/domain.yaml");
     LoggerHelper.getLocal().log(Level.INFO, "Running " + cmd);
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     String outputStr = result.stdout().trim();
     LoggerHelper.getLocal().log(Level.INFO, "Command returned " + outputStr);
 
@@ -847,7 +847,7 @@ public class Domain {
         .append("/weblogic-domains/")
         .append(domainUid)
         .append("/domain.yaml");
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     String output = result.stdout().trim();
     LoggerHelper.getLocal().log(Level.INFO,
         "command to delete domain " + cmd + " \n returned " + output);
@@ -864,7 +864,7 @@ public class Domain {
     if (domainMap.containsKey("image")
         && !(((String)domainMap.get("image")).startsWith("container-registry.oracle.com"))) {
       String cmd = "docker rmi -f " + domainMap.get("image");
-      TestUtils.exec(cmd, true);
+      TestUtils.execOrAbortProcess(cmd, true);
     }
   }
 
@@ -876,7 +876,7 @@ public class Domain {
   public void shutdown() throws Exception {
     int replicas = TestUtils.getClusterReplicas(domainUid, clusterName, domainNS);
     String cmd = "kubectl delete domain " + domainUid + " -n " + domainNS;
-    ExecResult result = TestUtils.exec(cmd.toString(), true);
+    ExecResult result = ExecCommand.exec(cmd.toString());
     verifyDomainDeleted(replicas);
   }
 
@@ -1073,7 +1073,7 @@ public class Domain {
         .append(responseBodyFile);
     LoggerHelper.getLocal().log(Level.INFO, "cmd for curl " + cmd);
 
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
 
     String output = result.stdout().trim();
     LoggerHelper.getLocal().log(Level.INFO, "output " + output);
@@ -1144,7 +1144,7 @@ public class Domain {
         .append(domainNS)
         .append(" | grep Endpoints | awk '{print $2}'");
 
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     LoggerHelper.getLocal().log(Level.INFO, "Cluster service Endpoint " + result.stdout());
     return new StringTokenizer(result.stdout(), ",").countTokens();
   }
@@ -1161,7 +1161,7 @@ public class Domain {
 
     LoggerHelper.getLocal().log(Level.INFO, "Cmd to get the admins service node port " + cmd);
 
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     return new Integer(result.stdout().trim()).intValue();
   }
 
@@ -1293,7 +1293,7 @@ public class Domain {
                   + domainUid
                   + "/domain_new.yaml");
       LoggerHelper.getLocal().log(Level.INFO, "kubectl execute with command: " + command.toString());
-      TestUtils.exec(command.toString());
+      TestUtils.execOrAbortProcess(command.toString());
 
       // verify the servers in the domain are being restarted in a sequence
       verifyAdminServerRestarted();
@@ -1347,7 +1347,7 @@ public class Domain {
     StringBuffer command = new StringBuffer();
     command.append("kubectl apply  -f ").append(newDomainYamlFile);
     LoggerHelper.getLocal().log(Level.INFO, "kubectl execute with command: " + command.toString());
-    TestUtils.exec(command.toString());
+    TestUtils.execOrAbortProcess(command.toString());
 
     // verify the servers in the domain are being restarted in a sequence
     verifyAdminServerRestarted();
@@ -1424,9 +1424,9 @@ public class Domain {
                 + changedProperty
                 + "\"");
     LoggerHelper.getLocal().log(Level.INFO, "kubectl execute with command: " + command.toString());
-    TestUtils.exec(command.toString());
+    TestUtils.execOrAbortProcess(command.toString());
 
-    String result = ((TestUtils.exec(command.toString())).stdout());
+    String result = ((TestUtils.execOrAbortProcess(command.toString())).stdout());
     LoggerHelper.getLocal().log(Level.INFO,
         "in the method findServerPropertyChange, " + command.toString() + " return " + result);
     if (!result.contains(changedProperty)) {
@@ -1536,7 +1536,7 @@ public class Domain {
         String.format(
             "kubectl label secret %s weblogic.domainUID=%s -n %s",
             secret.getSecretName(), domainUid, domainNS);
-    TestUtils.exec(labelCmd);
+    TestUtils.execOrAbortProcess(labelCmd);
   }
   
   /**
@@ -1809,9 +1809,9 @@ public class Domain {
     }
     // copy samples to RESULT_DIR
     if (Files.exists(Paths.get(resultsDir + "/samples"))) {
-      TestUtils.exec("rm -rf " + resultsDir + "/samples");
+      TestUtils.execOrAbortProcess("rm -rf " + resultsDir + "/samples");
     }
-    TestUtils.exec("cp -rf "
+    TestUtils.execOrAbortProcess("cp -rf "
             + (domainMap.containsKey("projectRoot")
             ? domainMap.get("projectRoot") : BaseTest.getProjectRoot())
             + "/kubernetes/samples "
@@ -1819,7 +1819,7 @@ public class Domain {
         true);
 
     if (domainHomeSourceType.equals("FromModel")) {
-      TestUtils.exec("cp -rf "
+      TestUtils.execOrAbortProcess("cp -rf "
               + (domainMap.containsKey("projectRoot")
               ? domainMap.get("projectRoot") : BaseTest.getProjectRoot())
               + "/integration-tests/src/test/resources/model-in-image "
@@ -2005,7 +2005,7 @@ public class Domain {
             + domainNS
             + " | grep Node:";
 
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
     String nodePortHost = result.stdout();
     // LoggerHelper.getLocal().log(Level.INFO, "nodePortHost "+nodePortHost);
     if (nodePortHost.contains(":") && nodePortHost.contains("/")) {
@@ -2024,7 +2024,7 @@ public class Domain {
         .append(" -n ")
         .append(domainNS)
         .append(" | grep \"Node Port:\"");
-    ExecResult result = TestUtils.exec(cmd.toString());
+    ExecResult result = TestUtils.execOrAbortProcess(cmd.toString());
     String output = result.stdout();
     if (output.contains("Node Port")) {
       return output.substring(output.indexOf(":") + 1).trim();
@@ -2069,7 +2069,7 @@ public class Domain {
           .append(resultsDir)
           .append("/docker-images");
       LoggerHelper.getLocal().log(Level.INFO, "Executing cmd " + removeAndClone);
-      TestUtils.exec(removeAndClone.toString());
+      TestUtils.execOrAbortProcess(removeAndClone.toString());
     }
   }
 
@@ -2142,7 +2142,7 @@ public class Domain {
     }
 
     String command = "kubectl create -f " + domainYaml;
-    ExecResult result = TestUtils.exec(command);
+    ExecResult result = TestUtils.execOrAbortProcess(command);
     LoggerHelper.getLocal().log(Level.INFO, "Command returned " + result.stdout().trim());
   }
 
@@ -2289,7 +2289,7 @@ public class Domain {
               + "/docker-images/OracleWebLogic/samples/"
               + "12213-domain-home-in-image-wdt/simple-topology.yaml");
       ExecResult exec =
-          TestUtils.exec(
+          TestUtils.execOrAbortProcess(
               "cat " + resultsDir
                   + "/docker-images/OracleWebLogic/samples/"
                   + "12213-domain-home-in-image-wdt/simple-topology.yaml");
@@ -2300,7 +2300,7 @@ public class Domain {
       createDomainJobTemplateFile.append(
           "/samples/scripts/create-weblogic-domain/domain-home-on-pv/"
               + "create-domain-job-template.yaml");
-      TestUtils.exec("sed -i -e 's?DYNAMIC?CONFIGURED?g' " + createDomainJobTemplateFile);
+      TestUtils.execOrAbortProcess("sed -i -e 's?DYNAMIC?CONFIGURED?g' " + createDomainJobTemplateFile);
     }
   }
 
@@ -2496,7 +2496,7 @@ public class Domain {
               + domainMap.get("configOverrides")
               + " --from-file "
               + configOverridesFile;
-      TestUtils.exec(cmd);
+      TestUtils.execOrAbortProcess(cmd);
 
       // create label for configmap
       cmd =
@@ -2508,7 +2508,7 @@ public class Domain {
               + domainMap.get("configOverrides")
               + " weblogic.domainUID="
               + domainUid;
-      TestUtils.exec(cmd);
+      TestUtils.execOrAbortProcess(cmd);
 
       // create secret for custom sit config t3 public address
       // create datasource secret for user and password
@@ -2522,7 +2522,7 @@ public class Domain {
               + TestUtils.getHostName()
               + " --from-literal=dbusername=root"
               + " --from-literal=dbpassword=root123";
-      TestUtils.exec(cmd);
+      TestUtils.execOrAbortProcess(cmd);
     }
   }
 
@@ -2625,7 +2625,7 @@ public class Domain {
     String adminPodName = domainUid + "-" + adminServerName;
     LoggerHelper.getLocal().log(Level.INFO,
         "Writing admin pod(" + adminPodName + ") log");
-    TestUtils.exec("kubectl logs " + adminPodName + " -n "
+    TestUtils.execOrAbortProcess("kubectl logs " + adminPodName + " -n "
         + domainNS + " > " + resultsDir + "/pod-" + adminPodName + ".log", true);
 
     if (!serverStartPolicy.equals("ADMIN_ONLY")) {
@@ -2634,7 +2634,7 @@ public class Domain {
         String msPodName = domainUid + "-" + managedServerNameBase + i;
         LoggerHelper.getLocal().log(Level.INFO,
             "Writing managed pod(" + msPodName + ") log");
-        TestUtils.exec("kubectl logs " + msPodName
+        TestUtils.execOrAbortProcess("kubectl logs " + msPodName
             + " -n " + domainNS + " > " + resultsDir + "/pod-" + msPodName + ".log", true);
       }
     }
@@ -2656,6 +2656,6 @@ public class Domain {
 
     String contentToAppend = "  overridesConfigMap: " + domainMap.get("overridesConfigMap");
     Files.write(Paths.get(domainYaml), contentToAppend.getBytes(), StandardOpenOption.APPEND);
-    TestUtils.exec("kubectl apply -f " + domainYaml, true);
+    TestUtils.execOrAbortProcess("kubectl apply -f " + domainYaml, true);
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/JrfDomain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/JrfDomain.java
@@ -103,6 +103,6 @@ public class JrfDomain extends Domain {
             "kubectl label secret %s -n %s weblogic.domainUID=%s weblogic.domainName=%s",
             rucSecret.getSecretName(), domainNS, domainUid, domainUid);
     LoggerHelper.getLocal().log(Level.INFO, "running command " + labelCmd);
-    TestUtils.exec(labelCmd);
+    TestUtils.execOrAbortProcess(labelCmd);
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -166,7 +166,7 @@ public class LoadBalancer {
   private String getKubernetesNamespaceToUpdate(String domainNamespace) throws Exception {
     String cmd = "helm get values traefik-operator ";
     cmd = cmd + " --namespace traefik ";
-    ExecResult result = TestUtils.exec(cmd, true);
+    ExecResult result = ExecCommand.exec(cmd);
     Map<String, Object> yamlMap = TestUtils.loadYamlFromString(result.stdout());
     LoggerHelper.getLocal().log(Level.INFO, "map " + yamlMap);
     if (yamlMap.containsKey("kubernetes")) {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Operator.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Operator.java
@@ -309,7 +309,7 @@ public class Operator {
     StringBuffer cmd = new StringBuffer("");
     if (operatorMap.containsKey("operatorGitVersion")
         && operatorMap.containsKey("operatorGitVersionDir")) {
-      TestUtils.exec(
+      TestUtils.execOrAbortProcess(
           "cd "
               + operatorMap.get("operatorGitVersionDir")
               + " && git clone -b "
@@ -489,7 +489,7 @@ public class Operator {
       ExecCommand.exec("kubectl --grace-period=1 --timeout=1s delete namespace " + operatorNS + " --ignore-not-found");
       Thread.sleep(10000);
       // create operator namespace
-      TestUtils.exec("kubectl create namespace " + operatorNS, true);
+      ExecCommand.exec("kubectl create namespace " + operatorNS);
     }
     if (opSA) {
       // create operator service account
@@ -586,7 +586,7 @@ public class Operator {
     String cmd = "kubectl scale --replicas=0 deployment/weblogic-operator" + " -n " + operatorNS;
     LoggerHelper.getLocal().log(Level.INFO, "Undeploy Operator using command:\n" + cmd);
 
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
 
     LoggerHelper.getLocal().log(Level.INFO, "stdout : \n" + result.stdout());
 
@@ -603,7 +603,7 @@ public class Operator {
     String cmd = "kubectl scale --replicas=1 deployment/weblogic-operator" + " -n " + operatorNS;
     LoggerHelper.getLocal().log(Level.INFO, "Deploy Operator using command:\n" + cmd);
 
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
 
     LoggerHelper.getLocal().log(Level.INFO, "Checking if operator pod is running");
     verifyPodCreated();
@@ -634,7 +634,7 @@ public class Operator {
             + getOperatorNamespace()
             + " -o jsonpath=\"{.items[0].metadata.name}\"";
     LoggerHelper.getLocal().log(Level.INFO, "Command to query Operator pod name: " + cmd);
-    ExecResult result = TestUtils.exec(cmd);
+    ExecResult result = TestUtils.execOrAbortProcess(cmd);
 
     return result.stdout().trim();
   }
@@ -657,18 +657,18 @@ public class Operator {
    */
   public void writePodLog(String logLocation) throws Exception {
     //create dir
-    TestUtils.exec("mkdir -p " + logLocation);
+    TestUtils.execOrAbortProcess("mkdir -p " + logLocation);
 
     //write operator pod describe
     String cmd = "kubectl describe pod " + getOperatorPodName() + " -n "
         + getOperatorNamespace() + " >> " + logLocation
         + "/pod-describe." + operatorNS + "." + getOperatorPodName();
-    TestUtils.exec(cmd, true);
+    ExecCommand.exec(cmd);
 
     //write operator pod logs
     cmd = "kubectl logs pod/" + getOperatorPodName() + " -n "
         + getOperatorNamespace() + " >> " + logLocation
         + "/pod-log." + operatorNS + "." + getOperatorPodName();
-    TestUtils.exec(cmd, true);
+    ExecCommand.exec(cmd);
   }
 }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/OracleDB.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/OracleDB.java
@@ -72,7 +72,7 @@ public class OracleDB {
             + dbbundle
             + "\" --expose";
     LoggerHelper.getLocal().log(Level.INFO, "Running " + command);
-    TestUtils.exec(command);
+    TestUtils.execOrAbortProcess(command);
   }
 
   public String getName() {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/PersistentVolume.java
@@ -84,7 +84,7 @@ public class PersistentVolume {
             + userProjectsDir;
     LoggerHelper.getLocal().log(Level.INFO, "Executing cmd " + cmdPvPvc);
 
-    TestUtils.exec(cmdPvPvc, true);
+    TestUtils.execOrAbortProcess(cmdPvPvc, true);
   }
 
   public String getDirPath() {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/RcuSecret.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/RcuSecret.java
@@ -53,7 +53,7 @@ public class RcuSecret extends Secret {
             + " --from-literal=sys_password="
             + this.sysPassword;
     LoggerHelper.getLocal().log(Level.INFO, "Running " + command);
-    ExecResult result = TestUtils.exec(command);
+    ExecResult result = TestUtils.execOrAbortProcess(command);
     LoggerHelper.getLocal().log(Level.INFO, "command result " + result.stdout().trim());
   }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -361,16 +361,16 @@ public class TestUtils {
     StringBuffer cmdDelJob = new StringBuffer("kubectl delete job ");
     cmdDelJob.append(domainUid).append("-" + jobName + " -n ").append(namespace);
     LoggerHelper.getLocal().log(Level.INFO, "Deleting job " + cmdDelJob);
-    exec(cmdDelJob.toString());
+    execOrAbortProcess(cmdDelJob.toString());
 
     StringBuffer cmdDelPvc = new StringBuffer("kubectl delete pvc ");
     cmdDelPvc.append(pvcName).append(" -n ").append(namespace);
     LoggerHelper.getLocal().log(Level.INFO, "Deleting PVC " + cmdDelPvc);
-    exec(cmdDelPvc.toString());
+    execOrAbortProcess(cmdDelPvc.toString());
   }
 
-  public static ExecResult exec(String cmd) throws Exception {
-    return exec(cmd, false);
+  public static ExecResult execOrAbortProcess(String cmd) throws Exception {
+    return execOrAbortProcess(cmd, false);
   }
 
   /**
@@ -380,7 +380,7 @@ public class TestUtils {
    * @return executor
    * @throws Exception on failure
    */
-  public static ExecResult exec(String cmd, boolean debug) throws Exception {
+  public static ExecResult execOrAbortProcess(String cmd, boolean debug) throws Exception {
     ExecResult result = ExecCommand.exec(cmd);
     if (result.exitValue() != 0 || debug) {
       LoggerHelper.getLocal().log(Level.INFO,
@@ -1374,7 +1374,7 @@ public class TestUtils {
         .append("'");
 
     LoggerHelper.getLocal().log(Level.INFO, "Command to call kubectl sh file " + cmdKubectlSh);
-    TestUtils.exec(cmdKubectlSh.toString());
+    TestUtils.execOrAbortProcess(cmdKubectlSh.toString());
   }
 
   /**
@@ -1547,7 +1547,7 @@ public class TestUtils {
                 "/kubernetes/samples/scripts/delete-domain/delete-weblogic-domain-resources.sh ")
             .append("-d ")
             .append(domainUid);
-    TestUtils.exec(cmd.toString(), true);
+    TestUtils.execOrAbortProcess(cmd.toString(), true);
   }
 
   /**
@@ -2000,7 +2000,7 @@ public class TestUtils {
             + " -u ****** -p ******* "
             + "\" && docker push "
             + image;
-    ExecResult result = TestUtils.exec(dockerLoginAndPushCmd);
+    ExecResult result = TestUtils.execOrAbortProcess(dockerLoginAndPushCmd);
     LoggerHelper.getLocal().log(Level.INFO,
         "cmd "
             + cmdForDebug
@@ -2029,7 +2029,7 @@ public class TestUtils {
             + " -p "
             + patchStr
             + " --type merge";
-    return exec(cmd, true);
+    return execOrAbortProcess(cmd, true);
   }
 
   /**
@@ -2044,12 +2044,12 @@ public class TestUtils {
     String cmd = "kubectl -n " + namespace
         + " delete configmap " + cmName
         + " --ignore-not-found";
-    TestUtils.exec(cmd);
+    TestUtils.execOrAbortProcess(cmd);
 
     cmd = "kubectl -n " + namespace
         + " create configmap " + cmName
         + " --from-file=" + fileOrDirPath;
-    TestUtils.exec(cmd, true);
+    TestUtils.execOrAbortProcess(cmd, true);
 
     // create label for configmap
     cmd =
@@ -2059,7 +2059,7 @@ public class TestUtils {
             + cmName
             + " "
             + label;
-    TestUtils.exec(cmd);
+    TestUtils.execOrAbortProcess(cmd);
   }
 
   /**


### PR DESCRIPTION
This PR attempts to resolve a number of test failures that occur due
to the bad use of the TestUtils.exec() method.  This method throws a
RuntimeException if the return code of the executed command is non-zero.
This method is being used in many places (over 40).  Many of those do
not appear to need or want that behavior, and should instead be using
the ExecCommand.exec() method which executes a command and then returns
the result, without throwing an exception if the command fails.

In this PR, I have done a visual inspection of each use of
TestUtils.exec() and changed them to ExecCommand.exec() where it
appeared to make sense.  This includes every case where the call was
using the return value from the method, and those where it appears clear
from the subsequent logic that a failed command was not expected to
terminate the process.

There were some calls that I left because I could not be sure of the
intent, and these will require more study.

In order to make the code clearer, and make people think twice about
using TestUtils.exec(), which has caused so many failures, I renamed
that method to TestUtils.execOrAbortProcess().  Hopefully that will make
it clearer that that method has a dangerous and unexpected side effect.

Note: This PR does include unmerged changes from PR 1601
