### PR TITLE
added option to configure operator pod resource requests and limit

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -58,8 +58,15 @@ spec:
         {{- end }}
         resources:
           requests:
-            cpu: "100m"
-            memory: "512Mi"
+            cpu: {{ .cpuRequests | default "100m" }}
+            memory: {{ .memoryRequests | default "512Mi" }}
+          limits:
+            {{- if .cpuLimits}}
+            cpu: {{ .cpuLimits }}
+            {{- end }}
+            {{- if .memoryLimits}}
+            memory: {{ .memoryLimits }}
+            {{- end }}
         volumeMounts:
         - name: "weblogic-operator-cm-volume"
           mountPath: "/operator/config"

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -58,7 +58,7 @@ spec:
         {{- end }}
         resources:
           requests:
-            cpu: {{ .cpuRequests | default "100m" }}
+            cpu: {{ .cpuRequests | default "250m" }}
             memory: {{ .memoryRequests | default "512Mi" }}
           limits:
             {{- if .cpuLimits}}


### PR DESCRIPTION
Make resource requests and limits configurable for operator pod. Resource requests and limits can be configured by specifying below 4 properties in values yaml file.  
cpuRequests  
memoryRequests
cpuLimits
memoryLimits