### PR TITLE
OWLS-81272 - Fix domain status for 'desired state'

### DIFF
--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -725,7 +725,7 @@
           "type": "string"
         },
         "desiredState": {
-          "description": "Desired state of this WebLogic Server.",
+          "description": "Desired state of this WebLogic Server. Values are RUNNING, ADMIN, or SHUTDOWN.",
           "type": "string"
         },
         "clusterName": {

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -181,7 +181,7 @@ ServerPod describes the configuration for a Kubernetes pod for a server.
 | Name | Type | Description |
 | --- | --- | --- |
 | `clusterName` | string | WebLogic cluster name, if the server is part of a cluster. |
-| `desiredState` | string | Desired state of this WebLogic Server. |
+| `desiredState` | string | Desired state of this WebLogic Server. Values are RUNNING, ADMIN, or SHUTDOWN. |
 | `health` | [Server Health](#server-health) | Current status and health of a specific WebLogic Server. |
 | `nodeName` | string | Name of node that is hosting the Pod containing this WebLogic Server. |
 | `serverName` | string | WebLogic Server name. Required. |

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1645,7 +1645,7 @@ window.onload = function() {
           "type": "string"
         },
         "desiredState": {
-          "description": "Desired state of this WebLogic Server.",
+          "description": "Desired state of this WebLogic Server. Values are RUNNING, ADMIN, or SHUTDOWN.",
           "type": "string"
         },
         "clusterName": {

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -21131,7 +21131,8 @@ spec:
                         this WebLogic Server.
                       type: string
                     desiredState:
-                      description: Desired state of this WebLogic Server.
+                      description: Desired state of this WebLogic Server. Values are
+                        RUNNING, ADMIN, or SHUTDOWN.
                       type: string
                     clusterName:
                       description: WebLogic cluster name, if the server is part of

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -20709,7 +20709,8 @@ spec:
                       WebLogic Server.
                     type: string
                   desiredState:
-                    description: Desired state of this WebLogic Server.
+                    description: Desired state of this WebLogic Server. Values are
+                      RUNNING, ADMIN, or SHUTDOWN.
                     type: string
                   clusterName:
                     description: WebLogic cluster name, if the server is part of a

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -505,6 +505,8 @@ public class DomainStatusUpdater {
                   Optional.ofNullable(cluster.getDynamicServersConfig())
                         .flatMap(dynamicConfig -> Optional.ofNullable(dynamicConfig.getServerConfigs()))
                         .ifPresent(servers -> servers.forEach(item -> result.add(item.getName())));
+                  Optional.ofNullable(cluster.getServerConfigs())
+                      .ifPresent(servers -> servers.forEach(item -> result.add(item.getName())));
                 }
               });
         return result;

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -422,8 +422,7 @@ public class DomainStatusUpdater {
       }
 
       private String getDesiredState(String serverName, String clusterName, boolean isAdminServer) {
-        boolean shouldStart = isAdminServer | shouldStart(serverName);
-        return shouldStart
+        return isAdminServer | shouldStart(serverName)
             ? getDomain().getServer(serverName, clusterName).getDesiredState()
             : SHUTDOWN_STATE;
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -399,19 +399,19 @@ public class DomainStatusUpdater {
       Map<String, ServerStatus> getServerStatuses(final String adminServerName) {
         return getServerNames().stream()
             .collect(Collectors.toMap(Function.identity(),
-                s -> createServerStatus(s,adminServerName)));
+                s -> createServerStatus(s, Objects.equals(s, adminServerName))));
       }
 
-      private ServerStatus createServerStatus(String serverName, String adminServerName) {
+      private ServerStatus createServerStatus(String serverName, boolean isAdminServer) {
         String clusterName = getClusterName(serverName);
         return new ServerStatus()
             .withServerName(serverName)
             .withState(getRunningState(serverName))
-            .withDesiredState(getDesiredState(serverName, clusterName, serverName.equals(adminServerName)))
+            .withDesiredState(getDesiredState(serverName, clusterName, isAdminServer))
             .withHealth(serverHealth == null ? null : serverHealth.get(serverName))
             .withClusterName(clusterName)
             .withNodeName(getNodeName(serverName))
-            .withIsAdminServer(serverName.equals(adminServerName));
+            .withIsAdminServer(isAdminServer);
       }
 
       private String getRunningState(String serverName) {

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServersConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDynamicServersConfig.java
@@ -273,26 +273,6 @@ public class WlsDynamicServersConfig {
   }
 
   /**
-   * Returns the configuration for the dynamic WLS server with the given name.
-   *
-   * @param serverName name of the WLS server
-   * @return The WlsServerConfig object containing configuration of the WLS server with the given
-   *     name. This methods return null if no WLS configuration is found for the given server name.
-   */
-  public synchronized WlsServerConfig getServerConfig(String serverName) {
-    WlsServerConfig result = null;
-    if (serverName != null && serverConfigs != null) {
-      for (WlsServerConfig serverConfig : serverConfigs) {
-        if (serverConfig.getName().equals(serverName)) {
-          result = serverConfig;
-          break;
-        }
-      }
-    }
-    return result;
-  }
-
-  /**
    * Return the server template associated with this dynamic servers configuration.
    *
    * @return The server template associated with this dynamic servers configuration

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -30,7 +30,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
   @NotNull
   private String state;
 
-  @Description("Desired state of this WebLogic Server.")
+  @Description("Desired state of this WebLogic Server. Values are RUNNING, ADMIN, or SHUTDOWN.")
   @Expose
   private String desiredState;
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.meterware.simplestub.Memento;
@@ -248,6 +249,36 @@ public class DomainStatusTest {
   }
 
   @Test
+  public void verifyThat_addServers_serverSortedInExpectedOrdering() {
+    ServerStatus cluster1Server1 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server1");
+    ServerStatus cluster1Server2 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server2");
+    ServerStatus cluster2Server1 = new ServerStatus().withClusterName("cluster-2").withServerName("cluster2-server1");
+    ServerStatus adminServer = new ServerStatus().withServerName("admin-server").withIsAdminServer(true);
+    ServerStatus standAloneServerA = new ServerStatus().withServerName("a");
+
+    domainStatus.addServer(cluster1Server1).addServer(cluster2Server1)
+        .addServer(cluster1Server2).addServer(standAloneServerA).addServer(adminServer);
+
+    assertThat(domainStatus.servers,
+        contains(adminServer, standAloneServerA, cluster1Server1, cluster1Server2, cluster2Server1));
+  }
+
+  @Test
+  public void verifyThat_setServers_serverSortedInExpectedOrdering() {
+    ServerStatus cluster1Server1 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server1");
+    ServerStatus cluster1Server2 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server2");
+    ServerStatus cluster2Server1 = new ServerStatus().withClusterName("cluster-2").withServerName("cluster2-server1");
+    ServerStatus adminServer = new ServerStatus().withServerName("admin-server").withIsAdminServer(true);
+    ServerStatus standAloneServerA = new ServerStatus().withServerName("a");
+
+    domainStatus.setServers(Arrays.asList(cluster1Server1,
+        cluster2Server1, cluster1Server2, standAloneServerA, adminServer));
+
+    assertThat(domainStatus.servers,
+        contains(adminServer, standAloneServerA, cluster1Server1, cluster1Server2, cluster2Server1));
+  }
+
+  @Test
   public void verifyThat_getServers_serverInExpectedOrdering() {
     ServerStatus cluster1Server1 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server1");
     ServerStatus cluster1Server2 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server2");
@@ -262,6 +293,30 @@ public class DomainStatusTest {
 
     assertThat(serverStatuses,
         contains(adminServer, standAloneServerA, cluster1Server1, cluster1Server2, cluster2Server1));
+  }
+
+  @Test
+  public void verifyThat_addClusters_clustersSortedInExpectedOrdering() {
+    ClusterStatus cluster1 = new ClusterStatus().withClusterName("cluster-1");
+    ClusterStatus cluster2 = new ClusterStatus().withClusterName("cluster-2");
+    ClusterStatus cluster10 = new ClusterStatus().withClusterName("cluster-10");
+
+    domainStatus.addCluster(cluster10).addCluster(cluster1).addCluster(cluster2);
+
+    assertThat(domainStatus.clusters, contains(cluster1, cluster2, cluster10));
+  }
+
+  @Test
+  public void verifyThat_setClusters_clustersSortedInExpectedOrdering() {
+    ClusterStatus cluster1 = new ClusterStatus().withClusterName("cluster-1");
+    ClusterStatus cluster2 = new ClusterStatus().withClusterName("cluster-2");
+    ClusterStatus cluster10 = new ClusterStatus().withClusterName("cluster-10");
+
+    domainStatus.setClusters(Arrays.asList(cluster10, cluster1, cluster2));
+
+    List<ClusterStatus> clusterStatuses = domainStatus.clusters;
+
+    assertThat(clusterStatuses, contains(cluster1, cluster2, cluster10));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes the following:

- Desired State in server status should not be 'RUNNING' if the server will not be started due to replicas value or serverStartPolicy. It is now shown as 'SHUTDOWN'.
- Server status and cluster status ordering not working since the use of status subresource.
- Server status missing for configured servers in a cluster.
- Health state for configured servers in a cluster were not read.
