### PR TITLE
Managed server not starting with FINER logging level

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -228,7 +228,7 @@ public class DomainStatusUpdater {
     }
 
     public Step createRetry(DomainStatusUpdaterContext context, Step next) {
-      return Step.chain(createDomainRefreshStep(context), updaterStep, next);
+      return Step.chain(createDomainRefreshStep(context), updaterStep);
     }
 
     private Step createDomainRefreshStep(DomainStatusUpdaterContext context) {

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
@@ -59,16 +59,44 @@ public abstract class Step {
   }
 
   private static void addLink(Step stepGroup1, Step stepGroup2) {
-    lastStep(stepGroup1).next = stepGroup2;
+    Step lastStep = lastStepIfNoDuplicate(stepGroup1, stepGroup2);
+    if (lastStep != null) {
+      // add steps in stepGroup2 to the end of stepGroup1 only if no steps
+      // appears in both groups to avoid introducing a loop
+      lastStep.next = stepGroup2;
+    }
   }
 
-  private static Step lastStep(Step stepGroup) {
-    Step s = stepGroup;
+  /**
+   * Return last step in stepGroup1, or null if any step appears in both step groups.
+   *
+   * @param stepGroup1 Step that we want to find the last step for
+   * @param stepGroup2 Step to check for duplicates
+   *
+   * @return last step in stepGroup1, or null if any step appears in both step groups.
+   */
+  private static Step lastStepIfNoDuplicate(Step stepGroup1, Step stepGroup2) {
+    Step s = stepGroup1;
+    List<Step> stepGroup2Array = stepToArray(stepGroup2);
     while (s.next != null) {
+      if (stepGroup2Array.contains(s.next)) {
+        return null;
+      }
       s = s.next;
     }
     return s;
   }
+
+  private static List<Step> stepToArray(Step stepGroup) {
+    ArrayList<Step> stepsArray = new ArrayList<>();
+    Step s = stepGroup;
+    while (s != null) {
+      stepsArray.add(s);
+      s = s.next;
+    }
+    return stepsArray;
+  }
+
 
   String getName() {
     String name = getClass().getName();

--- a/operator/src/test/java/oracle/kubernetes/operator/work/StepChainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/StepChainTest.java
@@ -82,6 +82,41 @@ public class StepChainTest {
     Step.chain();
   }
 
+  @Test
+  public void doNotChainGroupThatContainsDuplicateStep() throws Exception {
+    Step duplicateStep = new NamedStep("duplicate", new NamedStep("two"));
+    Step group1 = new NamedStep("one", duplicateStep);
+    Step group2 = new NamedStep("three", duplicateStep);
+
+    Step chain = Step.chain(group1, group2);
+
+    assertThat(stepNamesInStepChain(chain), contains("one", "duplicate", "two"));
+  }
+
+  @Test
+  public void addGroupThatContainsStepsWithSameName() throws Exception {
+    Step group1 = new NamedStep("one", new NamedStep("two"));
+    Step group2 = new NamedStep("two", new NamedStep("three"));
+
+    Step chain = Step.chain(group1, group2);
+
+    assertThat(stepNamesInStepChain(chain), contains("one", "two", "two", "three"));
+  }
+
+  private static List<String> stepNamesInStepChain(Step steps) {
+    return stepNamesInStepChain(steps, 10);
+  }
+
+  private static List<String> stepNamesInStepChain(Step steps, int maxNumSteps) {
+    List<String> stepNames = new ArrayList<>(maxNumSteps);
+    Step s = steps;
+    while (s != null && stepNames.size() < maxNumSteps) {
+      stepNames.add(s.getName());
+      s = s.getNext();
+    }
+    return stepNames;
+  }
+
   private static class NamedStep extends Step {
     private static final String NAMES = "names";
     private String name;
@@ -93,6 +128,10 @@ public class StepChainTest {
     NamedStep(String name, Step next) {
       super(next);
       this.name = name;
+    }
+
+    String getName() {
+      return name;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes an issue causing one of the managed servers to not startup with cluster replica of 2, when operator logging level is set to FINER or FINEST. 

Cause
- This is due to the log message
`LOGGER.finer(CURRENT_STEPS, na.next);`
in Fiber.java:586 getting a StackOverflowError from `Step.toString()` when there is a loop in the na.next chain.

```
DomainStatusUpdaterStep$ProgressingStep @7205
next -> AsyncRequestStep @7209  (for createPod)
        next -> PodStepContext$CreateResponseStep @7213
                next -> AsyncRequestStep @7209 (for createPod)
                        next -> PodStepContext$CreateResponseStep @7213
                                ...

```
Fix
- `DomainStatusUpdater.createRetry()` does not need to chain both `updaterStep` and `next`, as next is included in the chain of `updaterStep.next`
- Also modify `Step.chain(`) method to avoid creating loop
