### PR TITLE
change helm list command

### DIFF
--- a/docs-source/content/userguide/managing-operators/using-the-operator/using-helm.md
+++ b/docs-source/content/userguide/managing-operators/using-the-operator/using-helm.md
@@ -36,9 +36,10 @@ Show all of the values your operator Helm release is using:
 $ helm get values --all weblogic-operator
 ```
 
-List the Helm releases that have been installed in this Kubernetes cluster:
+List the Helm releases for a specified namespace or all namespaces:
 ```
-$ helm list
+$ helm list namespace
+$ helm list --all-namespaces
 ```
 
 Get the status of the operator Helm release:


### PR DESCRIPTION
As per "OWLS-80278 - Helm 3 documentation needs to inform user that `helm list` is per namespace," I changed the description of the helm list command. Also, please advise regarding `helm ls` found in Frequently asked questions > Managing domain namespaces, at https://oracle.github.io/weblogic-kubernetes-operator/faq/namespace-management/ 