### PR TITLE
Fix assertion and add events log to the logs list

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -666,7 +666,8 @@ class ItMiiDomain implements LoggedTest {
                     .configuration(new Configuration()
                             .model(new Model()
                                     .domainType("WLS")
-                                    .runtimeEncryptionSecret(encryptionSecretName))));
+                                    .runtimeEncryptionSecret(encryptionSecretName))
+                        .introspectorJobActiveDeadlineSeconds(300L)));
 
     logger.info("Create domain custom resource for domainUid {0} in namespace {1}",
             domainUid, domNamespace);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -136,7 +136,7 @@ class ItMiiDomain implements LoggedTest {
     // create standard, reusable retry/backoff policy
     withStandardRetryPolicy = with().pollDelay(2, SECONDS)
         .and().with().pollInterval(10, SECONDS)
-        .atMost(5, MINUTES).await();
+        .atMost(10, MINUTES).await();
 
     // get a new unique opNamespace
     logger.info("Creating unique namespace for Operator");

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -81,7 +81,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.upgradeOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsRunning;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceExists;
@@ -136,7 +136,7 @@ class ItMiiDomain implements LoggedTest {
     // create standard, reusable retry/backoff policy
     withStandardRetryPolicy = with().pollDelay(2, SECONDS)
         .and().with().pollInterval(10, SECONDS)
-        .atMost(10, MINUTES).await();
+        .atMost(5, MINUTES).await();
 
     // get a new unique opNamespace
     logger.info("Creating unique namespace for Operator");
@@ -225,7 +225,7 @@ class ItMiiDomain implements LoggedTest {
                 opNamespace,
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
-        .until(operatorIsRunning(opNamespace));
+        .until(operatorIsReady(opNamespace));
 
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleOperatorValidation.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSimpleOperatorValidation.java
@@ -40,7 +40,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createServiceAccoun
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsRunning;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -154,7 +154,7 @@ class ItSimpleOperatorValidation implements LoggedTest {
                 opNamespace,
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
-        .until(operatorIsRunning(opNamespace));
+        .until(operatorIsReady(opNamespace));
 
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -91,10 +91,11 @@ public class TestAssertions {
    * @param domainUid WebLogic domain uid in which the pod belongs
    * @param namespace in which the pod is running
    * @return true if the pod is running otherwise false
+   * @throws ApiException when Kubernetes cluster query fails to get pod
    */
   public static Callable<Boolean> podReady(String podName, String domainUid, String namespace) throws ApiException {
     return () -> {
-      return Kubernetes.isPodRunning(namespace, domainUid, podName);
+      return Kubernetes.isPodReady(namespace, domainUid, podName);
     };
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -26,8 +26,8 @@ public class TestAssertions {
    * @param namespace in which is operator is running
    * @return true if running false otherwise
    */
-  public static Callable<Boolean> operatorIsRunning(String namespace) {
-    return Operator.isRunning(namespace);
+  public static Callable<Boolean> operatorIsReady(String namespace) {
+    return Operator.isReady(namespace);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -198,10 +198,10 @@ public class Kubernetes {
         );
     for (V1Pod item : v1PodList.getItems()) {
       if (item.getMetadata().getName().startsWith(podName.trim())) {
-        logger.info("Pod Name :" + item.getMetadata().getName());
-        logger.info("Pod Namespace :" + item.getMetadata().getNamespace());
-        logger.info("Pod UID :" + item.getMetadata().getUid());
-        logger.info("Pod Status :" + item.getStatus().getPhase());
+        logger.info("Pod Name: " + item.getMetadata().getName());
+        logger.info("Pod Namespace: " + item.getMetadata().getNamespace());
+        logger.info("Pod UID: " + item.getMetadata().getUid());
+        logger.info("Pod Status: " + item.getStatus().getPhase());
         return item;
       }
     }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -154,12 +154,20 @@ public class Kubernetes {
    * @return true if pod exists and running otherwise false
    * @throws ApiException when there is error in querying the cluster
    */
-  public static boolean isOperatorPodRunning(String namespace) throws ApiException {
+  public static boolean isOperatorPodReady(String namespace) throws ApiException {
     boolean status = false;
     String labelSelector = String.format("weblogic.operatorName in (%s)", namespace);
     V1Pod pod = getPod(namespace, labelSelector, "weblogic-operator-");
     if (pod != null) {
-      status = pod.getStatus().getPhase().equals(RUNNING);
+      // get the podCondition with the 'Ready' type field
+      V1PodCondition v1PodReadyCondition = pod.getStatus().getConditions().stream()
+          .filter(v1PodCondition -> "Ready".equals(v1PodCondition.getType()))
+          .findAny()
+          .orElse(null);
+
+      if (v1PodReadyCondition != null) {
+        status = v1PodReadyCondition.getStatus().equalsIgnoreCase("true");
+      }
     } else {
       logger.info("Pod doesn't exist");
     }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Operator.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Operator.java
@@ -16,9 +16,9 @@ public class Operator {
    * @param namespace in which to check for the operator pod
    * @return true if found and running otherwise false
    */
-  public static Callable<Boolean> isRunning(String namespace) {
+  public static Callable<Boolean> isReady(String namespace) {
     return () -> {
-      return Kubernetes.isOperatorPodRunning(namespace);
+      return Kubernetes.isOperatorPodReady(namespace);
     };
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -78,6 +78,13 @@ public class LoggingUtil {
   public static void collectLogs(String namespace, String resultDir) {
     logger.info("Collecting logs in namespace : {0}", namespace);
 
+    // get events
+    try {
+      writeToFile(Kubernetes.listNamespacedEvents(namespace), resultDir, namespace + ".list.events.log");
+    } catch (Exception ex) {
+      logger.warning("Listing events failed, not collecting any data for events");
+    }
+
     // get service accounts
     try {
       writeToFile(Kubernetes.listServiceAccounts(namespace), resultDir,
@@ -130,7 +137,7 @@ public class LoggingUtil {
     }
     // write pv list
     try {
-      writeToFile(pvList, resultDir, ".list.persistent-volumes.log");
+      writeToFile(pvList, resultDir, "list.persistent-volumes.log");
     } catch (IOException ex) {
       logger.warning(ex.getMessage());
     }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -199,7 +199,7 @@ public class LoggingUtil {
     // get namespaced roles
     try {
       writeToFile(Kubernetes.listNamespacedRoles(namespace), resultDir,
-          namespace + ".list.cluster-roles.log");
+          namespace + ".list.roles.log");
     } catch (Exception ex) {
       logger.warning(ex.getMessage());
     }
@@ -207,7 +207,7 @@ public class LoggingUtil {
     // get namespaced rolebindings
     try {
       writeToFile(Kubernetes.listNamespacedRoleBinding(namespace), resultDir,
-          namespace + ".list.cluster-rolebindings.log");
+          namespace + ".list.rolebindings.log");
     } catch (Exception ex) {
       logger.warning(ex.getMessage());
     }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -180,6 +180,38 @@ public class LoggingUtil {
       logger.warning(ex.getMessage());
     }
 
+    // get cluster roles
+    try {
+      writeToFile(Kubernetes.listClusterRoles(null), resultDir,
+          "list.cluster-roles.log");
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+    }
+
+    // get cluster role bindings
+    try {
+      writeToFile(Kubernetes.listClusterRoleBindings(null), resultDir,
+          "list.cluster-rolebindings.log");
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+    }
+
+    // get namespaced roles
+    try {
+      writeToFile(Kubernetes.listNamespacedRoles(namespace), resultDir,
+          namespace + ".list.cluster-roles.log");
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+    }
+
+    // get namespaced rolebindings
+    try {
+      writeToFile(Kubernetes.listNamespacedRoleBinding(namespace), resultDir,
+          namespace + ".list.cluster-rolebindings.log");
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
+    }
+
     // get domain objects in the given namespace
     try {
       writeToFile(Kubernetes.listDomains(namespace), resultDir, namespace + ".list.domains.log");


### PR DESCRIPTION
Add namespaced events in the collected logs list
Fix the persistent volume claim log file name
Fix the isPodReady test assertion to check for pod readiness instead of Running status
Change the domain/operator wait time from 5 to 10 minutes.