### PR TITLE
update helm ls

### DIFF
--- a/docs-source/content/faq/namespace-management.md
+++ b/docs-source/content/faq/namespace-management.md
@@ -51,10 +51,11 @@ suspendOnDebugStartup: false
 
 ```
 
-If you don't know the release name of the operator, you can use `helm ls` to list all the releases:
+If you don't know the release name of the operator, you can use `helm ls` to list all the releases for a specified namespace or all namespaces:
 
 ```
-$ helm ls
+$ helm ls --namespace <namespace>
+$ helm list --all-namespaces
 ```
 
 #### Add a Kubernetes namespace to the operator

--- a/docs-source/content/faq/namespace-management.md
+++ b/docs-source/content/faq/namespace-management.md
@@ -51,10 +51,10 @@ suspendOnDebugStartup: false
 
 ```
 
-If you don't know the release name of the operator, you can use `helm ls` to list all the releases for a specified namespace or all namespaces:
+If you don't know the release name of the operator, you can use `helm list` to list all the releases for a specified namespace or all namespaces:
 
 ```
-$ helm ls --namespace <namespace>
+$ helm list --namespace <namespace>
 $ helm list --all-namespaces
 ```
 


### PR DESCRIPTION
OWLS-80278 - Helm 3 documentation needs to inform user that `helm list` is per namespace, part II. Edit `helm ls` command in Managing Domain Namespaces FAQ.