### PR TITLE
OWLS-80960 - Allow replicas count to drop below min dynamic cluster size

### DIFF
--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -109,6 +109,10 @@
           "description": "The name of this cluster. Required",
           "type": "string"
         },
+        "allowReplicasBelowMinDynClusterSize": {
+          "description": "Whether to allow the number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration.",
+          "type": "boolean"
+        },
         "serverPod": {
           "description": "Configuration affecting server pods.",
           "$ref": "#/definitions/ServerPod"

--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -110,7 +110,7 @@
           "type": "string"
         },
         "allowReplicasBelowMinDynClusterSize": {
-          "description": "If true (the default), the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not below the minimum dynamic cluster. This setting applies to dynamic clusters only.",
+          "description": "If true (the default), then the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not less than the minimum dynamic cluster setting. This setting applies to dynamic clusters only.",
           "type": "boolean"
         },
         "serverPod": {

--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -110,7 +110,7 @@
           "type": "string"
         },
         "allowReplicasBelowMinDynClusterSize": {
-          "description": "Whether to allow the number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration.",
+          "description": "If true (the default), the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not below the minimum dynamic cluster. This setting applies to dynamic clusters only.",
           "type": "boolean"
         },
         "serverPod": {

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -77,7 +77,7 @@ An element representing a cluster in the domain configuration.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `allowReplicasBelowMinDynClusterSize` | Boolean | Whether to allow the number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. |
+| `allowReplicasBelowMinDynClusterSize` | Boolean | If true (the default), the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not below the minimum dynamic cluster. This setting applies to dynamic clusters only. |
 | `clusterName` | string | The name of this cluster. Required |
 | `clusterService` | [Kubernetes Resource](#kubernetes-resource) | Customization affecting ClusterIP Kubernetes services for the WebLogic cluster. |
 | `maxUnavailable` | number | The maximum number of cluster members that can be temporarily unavailable. Defaults to 1. |

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -77,6 +77,7 @@ An element representing a cluster in the domain configuration.
 
 | Name | Type | Description |
 | --- | --- | --- |
+| `allowReplicasBelowMinDynClusterSize` | Boolean | Whether to allow the number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. |
 | `clusterName` | string | The name of this cluster. Required |
 | `clusterService` | [Kubernetes Resource](#kubernetes-resource) | Customization affecting ClusterIP Kubernetes services for the WebLogic cluster. |
 | `maxUnavailable` | number | The maximum number of cluster members that can be temporarily unavailable. Defaults to 1. |

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -77,7 +77,7 @@ An element representing a cluster in the domain configuration.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `allowReplicasBelowMinDynClusterSize` | Boolean | If true (the default), the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not below the minimum dynamic cluster. This setting applies to dynamic clusters only. |
+| `allowReplicasBelowMinDynClusterSize` | Boolean | If true (the default), then the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not less than the minimum dynamic cluster setting. This setting applies to dynamic clusters only. |
 | `clusterName` | string | The name of this cluster. Required |
 | `clusterService` | [Kubernetes Resource](#kubernetes-resource) | Customization affecting ClusterIP Kubernetes services for the WebLogic cluster. |
 | `maxUnavailable` | number | The maximum number of cluster members that can be temporarily unavailable. Defaults to 1. |

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1030,7 +1030,7 @@ window.onload = function() {
           "type": "string"
         },
         "allowReplicasBelowMinDynClusterSize": {
-          "description": "Whether to allow the number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration.",
+          "description": "If true (the default), the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not below the minimum dynamic cluster. This setting applies to dynamic clusters only.",
           "type": "boolean"
         },
         "serverPod": {

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1030,7 +1030,7 @@ window.onload = function() {
           "type": "string"
         },
         "allowReplicasBelowMinDynClusterSize": {
-          "description": "Whether to allow number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration.",
+          "description": "Whether to allow the number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration.",
           "type": "boolean"
         },
         "serverPod": {

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1029,6 +1029,10 @@ window.onload = function() {
           "description": "The name of this cluster. Required",
           "type": "string"
         },
+        "allowReplicasBelowMinDynClusterSize": {
+          "description": "Whether to allow number of replicas to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration.",
+          "type": "boolean"
+        },
         "serverPod": {
           "description": "Configuration affecting server pods.",
           "$ref": "#/definitions/ServerPod"

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1030,7 +1030,7 @@ window.onload = function() {
           "type": "string"
         },
         "allowReplicasBelowMinDynClusterSize": {
-          "description": "If true (the default), the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not below the minimum dynamic cluster. This setting applies to dynamic clusters only.",
+          "description": "If true (the default), then the number of replicas is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain home configuration. Otherwise, the operator will ensure that the number of replicas is not less than the minimum dynamic cluster setting. This setting applies to dynamic clusters only.",
           "type": "boolean"
         },
         "serverPod": {

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5478,6 +5478,11 @@ spec:
                     clusterName:
                       description: The name of this cluster. Required
                       type: string
+                    allowReplicasBelowMinDynClusterSize:
+                      description: Whether to allow the number of replicas to drop
+                        below the minimum dynamic cluster size configured in the WebLogic
+                        domain home configuration.
+                      type: boolean
                     serverPod:
                       description: Configuration affecting server pods.
                       type: object

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5479,9 +5479,12 @@ spec:
                       description: The name of this cluster. Required
                       type: string
                     allowReplicasBelowMinDynClusterSize:
-                      description: Whether to allow the number of replicas to drop
-                        below the minimum dynamic cluster size configured in the WebLogic
-                        domain home configuration.
+                      description: If true (the default), the number of replicas is
+                        allowed to drop below the minimum dynamic cluster size configured
+                        in the WebLogic domain home configuration. Otherwise, the
+                        operator will ensure that the number of replicas is not below
+                        the minimum dynamic cluster. This setting applies to dynamic
+                        clusters only.
                       type: boolean
                     serverPod:
                       description: Configuration affecting server pods.

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5479,12 +5479,12 @@ spec:
                       description: The name of this cluster. Required
                       type: string
                     allowReplicasBelowMinDynClusterSize:
-                      description: If true (the default), the number of replicas is
-                        allowed to drop below the minimum dynamic cluster size configured
-                        in the WebLogic domain home configuration. Otherwise, the
-                        operator will ensure that the number of replicas is not below
-                        the minimum dynamic cluster. This setting applies to dynamic
-                        clusters only.
+                      description: If true (the default), then the number of replicas
+                        is allowed to drop below the minimum dynamic cluster size
+                        configured in the WebLogic domain home configuration. Otherwise,
+                        the operator will ensure that the number of replicas is not
+                        less than the minimum dynamic cluster setting. This setting
+                        applies to dynamic clusters only.
                       type: boolean
                     serverPod:
                       description: Configuration affecting server pods.

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -5368,11 +5368,12 @@ spec:
                     description: The name of this cluster. Required
                     type: string
                   allowReplicasBelowMinDynClusterSize:
-                    description: If true (the default), the number of replicas is
-                      allowed to drop below the minimum dynamic cluster size configured
+                    description: If true (the default), then the number of replicas
+                      is allowed to drop below the minimum dynamic cluster size configured
                       in the WebLogic domain home configuration. Otherwise, the operator
-                      will ensure that the number of replicas is not below the minimum
-                      dynamic cluster. This setting applies to dynamic clusters only.
+                      will ensure that the number of replicas is not less than the
+                      minimum dynamic cluster setting. This setting applies to dynamic
+                      clusters only.
                     type: boolean
                   serverPod:
                     description: Configuration affecting server pods.

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -5368,9 +5368,11 @@ spec:
                     description: The name of this cluster. Required
                     type: string
                   allowReplicasBelowMinDynClusterSize:
-                    description: Whether to allow the number of replicas to drop below
-                      the minimum dynamic cluster size configured in the WebLogic
-                      domain home configuration.
+                    description: If true (the default), the number of replicas is
+                      allowed to drop below the minimum dynamic cluster size configured
+                      in the WebLogic domain home configuration. Otherwise, the operator
+                      will ensure that the number of replicas is not below the minimum
+                      dynamic cluster. This setting applies to dynamic clusters only.
                     type: boolean
                   serverPod:
                     description: Configuration affecting server pods.

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -5367,6 +5367,11 @@ spec:
                   clusterName:
                     description: The name of this cluster. Required
                     type: string
+                  allowReplicasBelowMinDynClusterSize:
+                    description: Whether to allow the number of replicas to drop below
+                      the minimum dynamic cluster size configured in the WebLogic
+                      domain home configuration.
+                    type: boolean
                   serverPod:
                     description: Configuration affecting server pods.
                     type: object

--- a/operator/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
@@ -25,6 +25,7 @@ public interface KubernetesConstants {
 
   boolean DEFAULT_HTTP_ACCESS_LOG_IN_LOG_HOME = true;
   boolean DEFAULT_INCLUDE_SERVER_OUT_IN_POD_LOG = true;
+  boolean DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE = true;
 
   String CONTAINER_NAME = "weblogic-server";
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -246,10 +246,11 @@ public class ManagedServersUpStep extends Step {
     private boolean lessThanMinConfiguredClusterSize(WlsClusterConfig clusterConfig) {
       if (clusterConfig != null) {
         String clusterName = clusterConfig.getClusterName();
-        int configMinClusterSize
-                = clusterConfig.getMinDynamicClusterSize();
-        return clusterConfig.hasDynamicServers()
-                && domain.getReplicaCount(clusterName) < configMinClusterSize;
+        if (clusterConfig.hasDynamicServers()
+            && !domain.isAllowReplicasBelowMinDynClusterSize(clusterName)) {
+          int configMinClusterSize = clusterConfig.getMinDynamicClusterSize();
+          return domain.getReplicaCount(clusterName) < configMinClusterSize;
+        }
       }
       return false;
     }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -128,4 +128,6 @@ public interface ClusterConfigurator extends ServiceConfigurator {
   ClusterConfigurator withToleration(V1Toleration toleration);
 
   ClusterConfigurator withPrecreateServerService(boolean precreateServerService);
+
+  ClusterConfigurator withAllowReplicasBelowDynClusterSize(boolean allowReplicasBelowDynClusterSize);
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/EffectiveConfigurationFactory.java
@@ -30,4 +30,6 @@ public interface EffectiveConfigurationFactory {
   boolean isShuttingDown();
 
   List<String> getAdminServerChannelNames();
+
+  boolean isAllowReplicasBelowMinDynClusterSize(String clusterName);
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -12,6 +13,7 @@ import com.google.gson.annotations.SerializedName;
 import oracle.kubernetes.json.Description;
 import oracle.kubernetes.json.EnumClass;
 import oracle.kubernetes.json.Range;
+import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.ServerStartPolicy;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -57,6 +59,10 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
   @Expose
   private KubernetesResource clusterService = new KubernetesResource();
 
+  @Description("Whether to allow the number of replicas to drop below the minimum dynamic cluster "
+      + "size configured in the WebLogic domain home configuration.")
+  private Boolean allowReplicasBelowMinDynClusterSize;
+
   protected Cluster getConfiguration() {
     Cluster configuration = new Cluster();
     configuration.fillInFrom(this);
@@ -83,6 +89,22 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
 
   public void setReplicas(Integer replicas) {
     this.replicas = replicas;
+  }
+
+  /**
+   * Whether to allow number of replicas to drop below the minimum dynamic cluster size configured
+   * in the WebLogic domain home configuration.
+   *
+   * @return whether to allow number of replicas to drop below the minimum dynamic cluster size
+   *     configured in the WebLogic domain home configuration.
+   */
+  public boolean isAllowReplicasBelowMinDynClusterSize() {
+    return Optional.ofNullable(allowReplicasBelowMinDynClusterSize)
+        .orElse(KubernetesConstants.DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE);
+  }
+
+  public void setAllowReplicasBelowMinDynClusterSize(boolean value) {
+    allowReplicasBelowMinDynClusterSize = value;
   }
 
   @Nullable
@@ -145,6 +167,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
         .append("serverStartPolicy", serverStartPolicy)
         .append("clusterService", clusterService)
         .append("maxUnavailable", maxUnavailable)
+        .append("allowReplicasBelowMinDynClusterSize", allowReplicasBelowMinDynClusterSize)
         .toString();
   }
 
@@ -167,6 +190,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
         .append(serverStartPolicy, cluster.serverStartPolicy)
         .append(clusterService, cluster.clusterService)
         .append(maxUnavailable, cluster.maxUnavailable)
+        .append(allowReplicasBelowMinDynClusterSize, cluster.allowReplicasBelowMinDynClusterSize)
         .isEquals();
   }
 
@@ -179,6 +203,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
         .append(serverStartPolicy)
         .append(clusterService)
         .append(maxUnavailable)
+        .append(allowReplicasBelowMinDynClusterSize)
         .toHashCode();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
@@ -61,10 +61,10 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
 
   /** Whether to allow the number of replicas to drop below the minimum dynamic cluster
    *  size configured in the WebLogic domain home configuration. Default is true. */
-  @Description("If true (the default), the number of replicas is allowed to drop below the "
+  @Description("If true (the default), then the number of replicas is allowed to drop below the "
       + "minimum dynamic cluster size configured in the WebLogic domain home configuration. "
-      + "Otherwise, the operator will ensure that the number of replicas is not below "
-      + "the minimum dynamic cluster. This setting applies to dynamic clusters only."
+      + "Otherwise, the operator will ensure that the number of replicas is not less than "
+      + "the minimum dynamic cluster setting. This setting applies to dynamic clusters only."
   )
   private Boolean allowReplicasBelowMinDynClusterSize;
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
@@ -59,8 +59,13 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
   @Expose
   private KubernetesResource clusterService = new KubernetesResource();
 
-  @Description("Whether to allow the number of replicas to drop below the minimum dynamic cluster "
-      + "size configured in the WebLogic domain home configuration.")
+  /** Whether to allow the number of replicas to drop below the minimum dynamic cluster
+   *  size configured in the WebLogic domain home configuration. Default is true. */
+  @Description("If true (the default), the number of replicas is allowed to drop below the "
+      + "minimum dynamic cluster size configured in the WebLogic domain home configuration. "
+      + "Otherwise, the operator will ensure that the number of replicas is not below "
+      + "the minimum dynamic cluster. This setting applies to dynamic clusters only."
+  )
   private Boolean allowReplicasBelowMinDynClusterSize;
 
   protected Cluster getConfiguration() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -298,6 +298,19 @@ public class Domain {
   }
 
   /**
+   * Returns whether the specified cluster is allowed to have replica count below the minimum
+   * dynamic cluster size configured in WebLogic domain configuration.
+   *
+   * @param clusterName the name of the cluster
+   * @return whether the specified cluster is allowed to have replica count below the minimum
+   *     dynamic cluster size configured in WebLogic domain configuration
+   */
+  public boolean isAllowReplicasBelowMinDynClusterSize(String clusterName) {
+    return getEffectiveConfigurationFactory().isAllowReplicasBelowMinDynClusterSize(clusterName);
+  }
+
+
+  /**
    * DomainSpec is a description of a domain.
    *
    * @return Specification

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
@@ -708,6 +708,12 @@ public class DomainCommonConfigurator extends DomainConfigurator {
     }
 
     @Override
+    public ClusterConfigurator withAllowReplicasBelowDynClusterSize(boolean allowReplicasBelowDynClusterSize) {
+      cluster.setAllowReplicasBelowMinDynClusterSize(allowReplicasBelowDynClusterSize);
+      return this;
+    }
+
+    @Override
     public ClusterConfigurator withSchedulerName(String schedulerName) {
       getDomainSpec().setSchedulerName(schedulerName);
       return this;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -842,6 +842,10 @@ public class DomainSpec extends BaseConfiguration {
     return cluster != null && cluster.getMaxUnavailable() != null;
   }
 
+  private boolean isAllowReplicasBelowDynClusterSizeFor(Cluster cluster) {
+    return cluster.isAllowReplicasBelowMinDynClusterSize();
+  }
+
   public AdminServer getAdminServer() {
     return adminServer;
   }
@@ -905,6 +909,11 @@ public class DomainSpec extends BaseConfiguration {
     @Override
     public List<String> getAdminServerChannelNames() {
       return adminServer != null ? adminServer.getChannelNames() : Collections.emptyList();
+    }
+
+    @Override
+    public boolean isAllowReplicasBelowMinDynClusterSize(String clusterName) {
+      return isAllowReplicasBelowDynClusterSizeFor(getCluster(clusterName));
     }
 
     private Cluster getOrCreateCluster(String clusterName) {

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -319,6 +319,20 @@ public abstract class DomainTestBase {
   }
 
   @Test
+  public void afterAllowReplicasBelowMinDynamicClusterSizeSetForCluster_canReadIt() {
+    configureCluster("cluster1").withAllowReplicasBelowDynClusterSize(false);
+
+    assertThat(domain.isAllowReplicasBelowMinDynClusterSize("cluster1"), equalTo(false));
+  }
+
+  @Test
+  public void whenAllowReplicasBelowMinDynamicClusterSizeNotSet_readGetDefaultValue() {
+    configureCluster("cluster1");
+
+    assertThat(domain.isAllowReplicasBelowMinDynClusterSize("cluster1"), equalTo(true));
+  }
+
+  @Test
   public void whenBothClusterAndServerStateSpecified_managedServerUsesServerState() {
     configureServer(SERVER1).withDesiredState("STAND-BY");
     configureCluster(CLUSTER_NAME).withDesiredState("NEVER");

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -20,6 +20,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import org.junit.Test;
 
 import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE;
 import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_IMAGE;
 import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
 import static oracle.kubernetes.operator.KubernetesConstants.LATEST_IMAGE_SUFFIX;
@@ -28,7 +29,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public abstract class DomainTestBase {
   protected static final String CLUSTER_NAME = "cluster1";
@@ -326,10 +327,11 @@ public abstract class DomainTestBase {
   }
 
   @Test
-  public void whenAllowReplicasBelowMinDynamicClusterSizeNotSet_readGetDefaultValue() {
+  public void whenNotSpecified_allowReplicasBelowMinDynamicClusterSizeHasDefault() {
     configureCluster("cluster1");
 
-    assertThat(domain.isAllowReplicasBelowMinDynClusterSize("cluster1"), equalTo(true));
+    assertThat(domain.isAllowReplicasBelowMinDynClusterSize("cluster1"),
+        equalTo(DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE));
   }
 
   @Test


### PR DESCRIPTION
Introduce a new Cluster CRD element `allowReplicasBelowMinDynClusterSize` that if set to true (the default), the operator would allow replicas count to be set below the minimum dynamic cluster size configured in the WebLogic domain home configuration. 

This allows users to shut down all servers in a dynamic cluster by setting the cluster replicas count to 0. This also prevents managed servers in a dynamic cluster from starting by operator even if the replicas is 0. This was the behavior before OWLS-79994.

To prevent WLDF from scaling below the min dynamic cluster size, set  `allowReplicasBelowMinDynClusterSize` to false.