### PR TITLE
Handle null cluster in isAllowReplicasBelowDynClusterSizeFor

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -29,6 +29,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE;
+
 /** DomainSpec is a description of a domain. */
 @Description("DomainSpec is a description of a domain.")
 public class DomainSpec extends BaseConfiguration {
@@ -843,7 +845,8 @@ public class DomainSpec extends BaseConfiguration {
   }
 
   private boolean isAllowReplicasBelowDynClusterSizeFor(Cluster cluster) {
-    return cluster.isAllowReplicasBelowMinDynClusterSize();
+    return cluster == null ? DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE :
+        cluster.isAllowReplicasBelowMinDynClusterSize();
   }
 
   public AdminServer getAdminServer() {

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainTestBase.java
@@ -335,6 +335,12 @@ public abstract class DomainTestBase {
   }
 
   @Test
+  public void whenNoClusterSpec_allowReplicasBelowMinDynamicClusterSizeHasDefault() {
+    assertThat(domain.isAllowReplicasBelowMinDynClusterSize("cluster-with-no-spec"),
+        equalTo(DEFAULT_ALLOW_REPLICAS_BELOW_MIN_DYN_CLUSTER_SIZE));
+  }
+
+  @Test
   public void whenBothClusterAndServerStateSpecified_managedServerUsesServerState() {
     configureServer(SERVER1).withDesiredState("STAND-BY");
     configureCluster(CLUSTER_NAME).withDesiredState("NEVER");


### PR DESCRIPTION
Fix regression introduced in owls-80960 causing managed servers not starting up when no cluster spec is specified for a dynamic cluster in the domain CRD.