### PR TITLE
fix issue 1457 (and sundry)

### DIFF
--- a/integration-tests/src/test/resources/setupenv.sh
+++ b/integration-tests/src/test/resources/setupenv.sh
@@ -9,31 +9,41 @@ function cleanup {
 function create_image_pull_secret_wl {
 
   set +x 
+
+  if [ "$LOCAL_RUN" = "true" ]; then
+    if [ ! -z "$(docker images -q $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC)" ]; then
+      return 0
+    fi
+    docker pull $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC
+    if [ $? -eq 0 ]; then
+      return 0
+    fi
+  fi
+
   if [ -z "$OCR_USERNAME" ] || [ -z "$OCR_PASSWORD" ]; then
-		echo "Provide Docker login details using env variables OCR_USERNAME and OCR_PASSWORD to pull the WebLogic image."
-	  exit 1
-	fi
+    echo "Provide Docker login details using env variables OCR_USERNAME and OCR_PASSWORD to pull the WebLogic image."
+    exit 1
+  fi
   
   if [ -n "$OCR_USERNAME" ] && [ -n "$OCR_PASSWORD" ]; then  
-	  echo "Creating Docker Secret"
-	  kubectl create secret docker-registry $IMAGE_PULL_SECRET_WEBLOGIC  \
-	    --docker-server=${OCR_SERVER}/ \
-	    --docker-username=$OCR_USERNAME \
-	    --docker-password=$OCR_PASSWORD \
-	    --docker-email=$OCR_USERNAME@oracle.com \
-            --dry-run -o yaml | kubectl apply -f -
+    echo "Creating Docker Secret"
+    kubectl create secret docker-registry $IMAGE_PULL_SECRET_WEBLOGIC  \
+      --docker-server=${OCR_SERVER}/ \
+      --docker-username=$OCR_USERNAME \
+      --docker-password=$OCR_PASSWORD \
+      --docker-email=$OCR_USERNAME@oracle.com \
+      --dry-run -o yaml | kubectl apply -f -
 	  
-	  echo "Checking Secret"
-	  SECRET="`kubectl get secret $IMAGE_PULL_SECRET_WEBLOGIC | grep $IMAGE_PULL_SECRET_WEBLOGIC | wc | awk ' { print $1; }'`"
-	  if [ "$SECRET" != "1" ]; then
-	    echo "secret $IMAGE_PULL_SECRET_WEBLOGIC was not created successfully"
-	    exit 1
-	  fi
+    echo "Checking Secret"
+    SECRET="`kubectl get secret $IMAGE_PULL_SECRET_WEBLOGIC | grep $IMAGE_PULL_SECRET_WEBLOGIC | wc | awk ' { print $1; }'`"
+    if [ "$SECRET" != "1" ]; then
+      echo "secret $IMAGE_PULL_SECRET_WEBLOGIC was not created successfully"
+      exit 1
+    fi
 	  
-	  # below docker pull is needed to for domain home in image tests the base image should be in local repo
-	  docker login -u $OCR_USERNAME -p $OCR_PASSWORD ${OCR_SERVER}
-	  docker pull $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC
-	  
+    # below docker pull is needed to for domain home in image tests the base image should be in local repo
+    docker login -u $OCR_USERNAME -p $OCR_PASSWORD ${OCR_SERVER}
+    docker pull $IMAGE_NAME_WEBLOGIC:$IMAGE_TAG_WEBLOGIC
   fi
   set -x
 }

--- a/integration-tests/src/test/resources/wdt/config.cluster.topology.yaml
+++ b/integration-tests/src/test/resources/wdt/config.cluster.topology.yaml
@@ -12,6 +12,11 @@ topology:
     Server:
         '@@PROP:ADMIN_NAME@@':
             ListenPort: '@@PROP:ADMIN_PORT@@'
+            SSL:
+                Enabled: false
+                ListenPort: 7002
+                HostnameVerificationIgnored: true
+                JSSEEnabled: true
             NetworkAccessPoint:
                 T3Channel:
                     ListenPort: '@@PROP:T3_CHANNEL_PORT@@'
@@ -20,9 +25,24 @@ topology:
         'managed-server1':
             Cluster: '@@PROP:CLUSTER_NAME@@'
             ListenPort: '@@PROP:MANAGED_SERVER_PORT@@'
+            SSL:
+                Enabled: false
+                ListenPort: 7123
+                HostnameVerificationIgnored: true
+                JSSEEnabled: true
         'managed-server2':
             Cluster: '@@PROP:CLUSTER_NAME@@'
             ListenPort: '@@PROP:MANAGED_SERVER_PORT@@'
+            SSL:
+                Enabled: false
+                ListenPort: 7123
+                HostnameVerificationIgnored: true
+                JSSEEnabled: true
         'managed-server3':
             Cluster: '@@PROP:CLUSTER_NAME@@'
             ListenPort: '@@PROP:MANAGED_SERVER_PORT@@'
+            SSL:
+                Enabled: false
+                ListenPort: 7123
+                HostnameVerificationIgnored: true
+                JSSEEnabled: true

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -395,9 +395,15 @@ class TopologyGenerator(Generator):
       ret = None
     return ret
 
+  # Work-around bugs in off-line WLST when accessing an SSL mbean
   def getSSLOrNone(self,server):
     try:
+      # this can throw if SSL mbean not there
       ret = server.getSSL()
+      # this can throw if SSL mbean is there but enabled is false 
+      ssl.getListenPort()
+      # this can throw if SSL mbean is there but enabled is false
+      ssl.isListenPortEnabled()
     except:
       trace("Ignoring getSSL() exception, this is expected.")
       ret = None

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -451,8 +451,7 @@ function createMII_Image() {
 
   tracen "Info: Downloading WDT and WIT"
   printdots_start
-  ${SOURCEPATH}/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/build_download.sh \
-   > ${test_home}/miibuild_download.out 2>&1
+  ${SCRIPTPATH}/util_download_mii_tools.sh > ${test_home}/miibuild_download.out 2>&1
   local rc=$?
   printdots_end
   if [ $rc -ne 0 ] ; then
@@ -464,8 +463,7 @@ function createMII_Image() {
   tracen "Info: Launching WIT to build the image"
   printdots_start
 
-  ${SOURCEPATH}/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/build_image_model.sh \
-   > ${test_home}/miibuild_image.out  2>&1
+  ${SCRIPTPATH}/util_build_mii_image.sh > ${test_home}/miibuild_image.out  2>&1
   local rc=$?
   printdots_end
 

--- a/src/integration-tests/introspector/util_build_mii_image.sh
+++ b/src/integration-tests/introspector/util_build_mii_image.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+#  This script uses the WebLogic Image Tool to build a Docker image with model in image
+#  artifacts. By default, it uses the base image obtained earlier with build_image_base.sh,
+#  and it gets model files from the WORKDIR/models directory that was setup by the build_model.sh script.
+#
+#  The model image is named MODEL_IMAGE_NAME:MODEL_IMAGE_TAG. 
+#
+#  Assumptions:
+#
+#    This script should be called by build.sh.
+#    The WebLogic Image Tool is downloaded to WORKDIR/weblogic-image-tool.zip (see ./build_download.sh).
+#    The WebLogic Deploy Tool is downloaded to WORKDIR/weblogic-deploy-tooling.zip (see ./build_download.sh).
+#    Model files have been staged in the "WORKDIR/models" directory (see ./build_model.sh) or
+#    MODEL_DIR has been explicitly set to point to a different location.
+#
+#  Optional environment variables:
+#
+#    WORKDIR
+#      Working directory for the sample with at least 10g of space.
+#      Defaults to '/tmp/$USER/model-in-image-sample-work-dir'.
+#
+#    MODEL_DIR:
+#      Location of the model .zip, .properties, and .yaml files
+#      that will be copied in to the image.  Default is 'WORKDIR/models'
+#      which is populated by the ./build_model.sh script.
+#
+#    MODEL_YAML_FILES, MODEL_ARCHIVE_FILES, MODEL_VARIABLES_FILES:
+#      Optionally, set one or more of these with comma-separated lists of file
+#      locations to override the corresponding .yaml, .zip, and .properties
+#      files normally obtained from MODEL_DIR.
+#
+#    WDT_DOMAIN_TYPE   - WLS (default), RestrictedJRF, or JRF
+#    BASE_IMAGE_NAME   - defaults to container-registry.oracle.com/middleware/weblogic for
+#                        the 'WLS' domain type, and otherwise defaults to
+#                        container-registry.oracle.com/middleware/fmw-infrastructure
+#    BASE_IMAGE_TAG    - defaults to 12.2.1.4
+#    MODEL_IMAGE_NAME  - defaults to 'model-in-image'
+#    MODEL_IMAGE_TAG   - defaults to 'v1'
+#    MODEL_IMAGE_BUILD - 'when-missing' or 'always' (default)
+#
+
+set -eu
+
+SCRIPTDIR="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
+echo "@@ Info: Running '$(basename "$0")'."
+
+WORKDIR=${WORKDIR:-/tmp/$USER/model-in-image-sample-work-dir}
+
+echo "@@ Info: WORKDIR='$WORKDIR'."
+
+mkdir -p ${WORKDIR}
+cd ${WORKDIR}
+
+WDT_DOMAIN_TYPE=${WDT_DOMAIN_TYPE:-WLS}
+
+case "$WDT_DOMAIN_TYPE" in
+  WLS)
+    BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-container-registry.oracle.com/middleware/weblogic}" ;;
+  JRF|RestrictedJRF)
+    BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-container-registry.oracle.com/middleware/fmw-infrastructure}" ;;
+  *)
+    echo "@@ Error: Invalid domain type WDT_DOMAIN_TYPE '$WDT_DOMAIN_TYPE': expected 'WLS', 'JRF', or 'RestrictedJRF'." && exit 1 ;;
+esac
+
+BASE_IMAGE_TAG=${BASE_IMAGE_TAG:-12.2.1.4}
+
+MODEL_IMAGE_NAME=${MODEL_IMAGE_NAME:-model-in-image}
+MODEL_IMAGE_TAG=${MODEL_IMAGE_TAG:-v1}
+MODEL_IMAGE_BUILD=${MODEL_IMAGE_BUILD:-always}
+
+if [ ! "$MODEL_IMAGE_BUILD" = "always" ] && \
+   [ "`docker images $MODEL_IMAGE_NAME:$MODEL_IMAGE_TAG | awk '{ print $1 ":" $2 }' | grep -c $MODEL_IMAGE_NAME:$MODEL_IMAGE_TAG`" = "1" ]; then
+  echo @@
+  echo "@@ Info: --------------------------------------------------------------------------------------------------"
+  echo "@@ Info: NOTE!!!                                                                                           "
+  echo "@@ Info:   Skipping model image build because image '$MODEL_IMAGE_NAME:$MODEL_IMAGE_TAG' already exists.   "
+  echo "@@ Info:   To always build the model image, 'export MODEL_IMAGE_BUILD=always'.                             "
+  echo "@@ Info: --------------------------------------------------------------------------------------------------"
+  echo @@
+  sleep 3
+  exit 0
+fi
+
+echo @@
+echo @@ Info: Obtaining model files
+echo @@
+
+MODEL_DIR=${MODEL_DIR:-$WORKDIR/models}
+MODEL_YAML_FILES="${MODEL_YAML_FILES:-$(ls $MODEL_DIR/*.yaml | xargs | sed 's/ /,/g')}"
+MODEL_ARCHIVE_FILES="${MODEL_ARCHIVE_FILES:-$(ls $MODEL_DIR/*.zip | xargs | sed 's/ /,/g')}"
+MODEL_VARIABLE_FILES="${MODEL_VARIABLE_FILES:-$(ls $MODEL_DIR/*.properties | xargs | sed 's/ /,/g')}"
+
+echo @@ MODEL_YAML_FILES=${MODEL_YAML_FILES}
+echo @@ MODEL_ARCHIVE_FILES=${MODEL_ARCHIVE_FILES}
+echo @@ MODEL_VARIABLE_FILES=${MODEL_VARIABLE_FILES}
+
+echo @@
+echo @@ Info: Setting up imagetool and populating its caches
+echo @@
+
+mkdir -p cache
+unzip -o weblogic-image-tool.zip
+
+IMGTOOL_BIN=${WORKDIR}/imagetool/bin/imagetool.sh
+
+# The image tool uses the WLSIMG_CACHEDIR and WLSIMG_BLDIR env vars:
+export WLSIMG_CACHEDIR=${WORKDIR}/cache
+export WLSIMG_BLDDIR=${WORKDIR}
+
+${IMGTOOL_BIN} cache deleteEntry --key wdt_myversion
+${IMGTOOL_BIN} cache addInstaller \
+  --type wdt --version myversion --path ${WORKDIR}/weblogic-deploy-tooling.zip
+
+echo "@@"
+echo "@@ Info: Starting model image build for '$MODEL_IMAGE_NAME:$MODEL_IMAGE_TAG'"
+echo "@@"
+
+#
+# Run the image tool to create the image. It will use the WDT binaries
+# in the local image tool cache marked with key 'myversion' (see 'cache' commands above).
+#
+
+${IMGTOOL_BIN} update \
+  --tag $MODEL_IMAGE_NAME:$MODEL_IMAGE_TAG \
+  --fromImage $BASE_IMAGE_NAME:$BASE_IMAGE_TAG \
+  --wdtModel ${MODEL_YAML_FILES} \
+  --wdtVariables ${MODEL_VARIABLE_FILES} \
+  --wdtArchive ${MODEL_ARCHIVE_FILES} \
+  --wdtModelOnly \
+  --wdtVersion myversion \
+  --wdtDomainType ${WDT_DOMAIN_TYPE}

--- a/src/integration-tests/introspector/util_build_mii_image.sh
+++ b/src/integration-tests/introspector/util_build_mii_image.sh
@@ -3,24 +3,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 #  This script uses the WebLogic Image Tool to build a Docker image with model in image
-#  artifacts. By default, it uses the base image obtained earlier with build_image_base.sh,
-#  and it gets model files from the WORKDIR/models directory that was setup by the build_model.sh script.
-#
-#  The model image is named MODEL_IMAGE_NAME:MODEL_IMAGE_TAG. 
+#  artifacts. 
 #
 #  Assumptions:
 #
-#    This script should be called by build.sh.
-#    The WebLogic Image Tool is downloaded to WORKDIR/weblogic-image-tool.zip (see ./build_download.sh).
-#    The WebLogic Deploy Tool is downloaded to WORKDIR/weblogic-deploy-tooling.zip (see ./build_download.sh).
-#    Model files have been staged in the "WORKDIR/models" directory (see ./build_model.sh) or
-#    MODEL_DIR has been explicitly set to point to a different location.
-#
-#  Optional environment variables:
-#
 #    WORKDIR
-#      Working directory for the sample with at least 10g of space.
-#      Defaults to '/tmp/$USER/model-in-image-sample-work-dir'.
+#      Working directory. Defaults to '/tmp/$USER/model-in-image-sample-work-dir'.
 #
 #    MODEL_DIR:
 #      Location of the model .zip, .properties, and .yaml files

--- a/src/integration-tests/introspector/util_download_mii_tools.sh
+++ b/src/integration-tests/introspector/util_download_mii_tools.sh
@@ -9,7 +9,7 @@
 # Optional environment variables:
 #
 #    WORKDIR 
-#      working directory for the sample with at least 10g of space
+#      working directory with at least 10g of space
 #      defaults to /tmp/$USER/model-in-image-sample-work-dir
 #
 #    http_proxy https_proxy

--- a/src/integration-tests/introspector/util_download_mii_tools.sh
+++ b/src/integration-tests/introspector/util_download_mii_tools.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+#
+# This script downloads the latest WebLogic Deploy Tool and WebLogic Image Tool 
+# to the WORKDIR directory.
+#
+# Optional environment variables:
+#
+#    WORKDIR 
+#      working directory for the sample with at least 10g of space
+#      defaults to /tmp/$USER/model-in-image-sample-work-dir
+#
+#    http_proxy https_proxy
+#      If running behind a proxy, then set as needed to allow curl access to github.com.
+#
+#    DOWNLOAD_WDT DOWNLOAD_WIT
+#      Default to 'when-missing'. Set to 'always' to force download even
+#      if local installer zip is missing.
+#
+#    WDT_INSTALLER_URL WIT_INSTALLER_URL
+#      Defaults to 'https://github.com/oracle/weblogic-deploy-tooling/releases/latest'
+#      and 'https://github.com/oracle/weblogic-image-tool/releases/latest' respectively.
+#
+#      To override an installer URL, export the URL env to point to a specific zip file, for example:
+#      export WDT_INSTALLER_URL=https://github.com/oracle/weblogic-deploy-tooling/releases/download/weblogic-deploy-tooling-1.7.0/weblogic-deploy.zip
+#
+
+set -o pipefail
+
+set -eu
+
+SCRIPTDIR="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
+echo "@@ Info: Running '$(basename "$0")'."
+
+DOWNLOAD_WIT=${DOWNLOAD_WIT:-when-missing}
+DOWNLOAD_WDT=${DOWNLOAD_WDT:-when-missing}
+WDT_INSTALLER_URL=${WDT_INSTALLER_URL:-https://github.com/oracle/weblogic-deploy-tooling/releases/latest}
+WIT_INSTALLER_URL=${WIT_INSTALLER_URL:-https://github.com/oracle/weblogic-image-tool/releases/latest}
+WORKDIR=${WORKDIR:-/tmp/$USER/model-in-image-sample-work-dir}
+
+echo "@@ Info: WORKDIR='$WORKDIR'."
+
+mkdir -p ${WORKDIR}
+cd ${WORKDIR}
+
+download_zip() {
+  set -eu
+  local ZIPFILE=$1
+  local LOCATION=$2
+  local DOWNLOAD_VAR_NAME=$3
+  local DOWNLOAD=${!DOWNLOAD_VAR_NAME}
+
+  if [ ! "$DOWNLOAD" = "always" ] && [ -f $ZIPFILE ]; then
+    echo "@@"
+    echo "@@ -----------------------------------------------------------------------"
+    echo "@@ Info: NOTE! Skipping '$LOCATION' download since local                  "
+    echo "@@             file '$WORKDIR/$ZIPFILE' already exists.                   "
+    echo "@@             To force a download, 'export $DOWNLOAD_VAR_NAME=always'.   "
+    echo "@@ -----------------------------------------------------------------------"
+    echo "@@"
+    sleep 2
+    return
+  fi
+
+  echo "@@ Downloading '$LOCATION' to '$WORKDIR/$ZIPFILE'."
+
+  local iurl="$LOCATION"
+  if [ "`echo $iurl | grep -c 'https://github.com.*/latest$'`" = "1" ]; then
+    echo "@@ The location URL matches regex 'https://github.com.*/latest$'. About to convert to direct location."
+    local tempfile="$(mktemp -u).$(basename $0).$SECONDS.$PPID.$RANDOM"
+    curl -fL $LOCATION -o $tempfile
+    LOCATION=https://github.com/$(cat $tempfile | grep "releases/download" | awk '{ split($0,a,/href="/); print a[2]}' | cut -d\" -f 1)
+    rm -f $tempfile
+    echo "@@ The location URL matched regex 'https://github.com.*/latest$' so it was converted to '$LOCATION'"
+    echo "@@ Now downloading '$LOCATION' to '$WORKDIR/$ZIPFILE'."
+  fi
+
+  rm -f $ZIPFILE
+  curl -fL $LOCATION -o $ZIPFILE
+}
+
+download_zip weblogic-deploy-tooling.zip $WDT_INSTALLER_URL DOWNLOAD_WDT
+download_zip weblogic-image-tool.zip $WIT_INSTALLER_URL DOWNLOAD_WIT


### PR DESCRIPTION
- issue https://github.com/oracle/weblogic-kubernetes-operator/issues/1457: 
  - update introspector job's jython script to work around an off-line WLST bug in SSL bean access (an attempt to access the bean when it's disabled throws an NPE)
  - update 'old WDT integration test' to reproduce/test

- fix stand-alone introspector test's MII path (depended on scripts that were removed)

- add option to old integration tests to bypass its desire for a docker login when running locally