### PR TITLE
Endless status updates

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -176,7 +176,7 @@ public class DomainStatusUpdater {
       DomainStatusUpdaterContext context = createContext(packet);
       DomainStatus newStatus = context.getNewStatus();
 
-      return context.isStatusChanged(newStatus)
+      return context.isStatusUnchanged(newStatus)
             ? doNext(packet)
             : doNext(createDomainStatusReplaceStep(context, newStatus), packet);
     }
@@ -277,7 +277,7 @@ public class DomainStatusUpdater {
       return getDomain().getDomainUid();
     }
 
-    boolean isStatusChanged(DomainStatus newStatus) {
+    boolean isStatusUnchanged(DomainStatus newStatus) {
       return newStatus.equals(getStatus());
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -426,10 +426,7 @@ public class DomainStatusUpdater {
       }
 
       private String getRunningState(String serverName) {
-        if (serverState != null) {
-          return serverState.getOrDefault(serverName, SHUTDOWN_STATE);
-        }
-        return SHUTDOWN_STATE;
+        return Optional.ofNullable(serverState).map(m -> m.get(serverName)).orElse(null);
       }
 
       private String getDesiredState(String serverName, String clusterName, boolean isAdminServer) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -14,6 +14,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.json.Json;
+import javax.json.JsonPatchBuilder;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -181,6 +183,9 @@ public class DomainStatusUpdater {
 
     private Step createDomainStatusReplaceStep(DomainStatusUpdaterContext context, DomainStatus newStatus) {
       LOGGER.fine(MessageKeys.DOMAIN_STATUS, context.getDomainUid(), newStatus);
+      if (LOGGER.isFinerEnabled()) {
+        LOGGER.finer("status change: " + createPatchString(context, newStatus));
+      }
       Domain oldDomain = context.getDomain();
       Domain newDomain = new Domain()
           .withKind(KubernetesConstants.DOMAIN)
@@ -194,6 +199,12 @@ public class DomainStatusUpdater {
             context.getNamespace(),
             newDomain,
             createResponseStep(context, getNext()));
+    }
+
+    private String createPatchString(DomainStatusUpdaterContext context, DomainStatus newStatus) {
+      JsonPatchBuilder builder = Json.createPatchBuilder();
+      newStatus.createPatchFrom(builder, context.getStatus());
+      return builder.build().toString();
     }
 
     private ResponseStep<Domain> createResponseStep(DomainStatusUpdaterContext context, Step next) {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -322,8 +322,8 @@ public class DomainStatus {
   private ServerStatus getMatchingServer(ServerStatus server) {
     return getServers()
           .stream()
-          .filter(s -> s.getClusterName().equals(server.getClusterName()))
-          .filter(s -> s.getServerName().equals(server.getServerName()))
+          .filter(s -> Objects.equals(s.getClusterName(), server.getClusterName()))
+          .filter(s -> Objects.equals(s.getServerName(), server.getServerName()))
           .findFirst()
           .orElse(null);
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.joda.time.DateTime;
 
+import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
 
 /**
@@ -51,7 +52,7 @@ public class DomainStatus {
   @Description("Status of WebLogic Servers in this domain.")
   @Valid
   // sorted list of ServerStatus
-  List<ServerStatus> servers = new ArrayList<>();
+  private final List<ServerStatus> servers;
 
   @Description("Status of WebLogic clusters in this domain.")
   @Valid
@@ -72,6 +73,7 @@ public class DomainStatus {
   private Integer replicas;
 
   public DomainStatus() {
+    servers = new ArrayList<>();
   }
 
   /**
@@ -293,19 +295,39 @@ public class DomainStatus {
    */
   public void setServers(List<ServerStatus> servers) {
     synchronized (this.servers) {
-      if (isServersEqualIgnoringOrder(servers, this.servers)) {
+      if (this.servers.equals(servers)) {
         return;
       }
-      List<ServerStatus> sortedServers = new ArrayList<>(servers);
-      sortedServers.sort(Comparator.naturalOrder());
 
-      this.servers = sortedServers;
+      List<ServerStatus> newServers = servers
+            .stream()
+            .map(ServerStatus::new)
+            .map(this::adjust)
+            .sorted(Comparator.naturalOrder())
+            .collect(Collectors.toList());
+
+      this.servers.clear();
+      this.servers.addAll(newServers);
     }
   }
 
-  private boolean isServersEqualIgnoringOrder(List<ServerStatus> servers1, List<ServerStatus> servers2) {
-    return new HashSet<>(servers1).equals(new HashSet<>(servers2));
+  private ServerStatus adjust(ServerStatus server) {
+    if (server.getState() == null) {
+      ServerStatus oldServer = getMatchingServer(server);
+      server.setState(oldServer == null ? SHUTDOWN_STATE : oldServer.getState());
+    }
+    return server;
   }
+
+  private ServerStatus getMatchingServer(ServerStatus server) {
+    return getServers()
+          .stream()
+          .filter(s -> s.getClusterName().equals(server.getClusterName()))
+          .filter(s -> s.getServerName().equals(server.getServerName()))
+          .findFirst()
+          .orElse(null);
+  }
+
 
   /**
    * Status of WebLogic servers in this domain.
@@ -314,7 +336,7 @@ public class DomainStatus {
    * @return this
    */
   public DomainStatus withServers(List<ServerStatus> servers) {
-    this.servers = servers;
+    setServers(servers);
     return this;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -456,7 +456,7 @@ public class DomainStatus {
     return new EqualsBuilder()
         .append(reason, rhs.reason)
         .append(startTime, rhs.startTime)
-        .append(Domain.sortOrNull(servers), Domain.sortOrNull(rhs.servers))
+        .append(servers, rhs.servers)
         .append(Domain.sortOrNull(clusters), Domain.sortOrNull(rhs.clusters))
         .append(Domain.sortOrNull(conditions), Domain.sortOrNull(rhs.conditions))
         .append(message, rhs.message)

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
@@ -51,6 +51,11 @@ class ObjectPatch<T> {
     return this;
   }
 
+  ObjectPatch<T> withBooleanField(String fieldName, Function<T,Boolean> getter) {
+    fields.add(new BooleanField<>(fieldName, getter));
+    return this;
+  }
+
   ObjectPatch<T> withStringField(String fieldName, Function<T,String> getter) {
     fields.add(new StringField<>(fieldName, getter));
     return this;
@@ -196,6 +201,28 @@ class ObjectPatch<T> {
 
     @Override
     void addField(JsonPatchBuilder builder, String path, Integer newValue) {
+      builder.add(path, newValue);
+    }
+  }
+
+  static class BooleanField<T> extends ScalarFieldPatch<T,Boolean> {
+
+    BooleanField(String name, Function<T, Boolean> getter) {
+      super(name, getter);
+    }
+
+    @Override
+    void addToObject(JsonObjectBuilder builder, String name, Boolean value) {
+      builder.add(name, value);
+    }
+
+    @Override
+    void replaceField(JsonPatchBuilder builder, String path, Boolean oldValue, Boolean newValue) {
+      builder.replace(path, newValue);
+    }
+
+    @Override
+    void addField(JsonPatchBuilder builder, String path, Boolean newValue) {
       builder.add(path, newValue);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -310,6 +310,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .withStringField("state", ServerStatus::getState)
         .withStringField("desiredState", ServerStatus::getDesiredState)
         .withStringField("nodeName", ServerStatus::getNodeName)
+        .withBooleanField("isAdminServer", ServerStatus::isAdminServer)
         .withObjectField("health", ServerStatus::getHealth, ServerHealth.getObjectPatch());
 
   static ObjectPatch<ServerStatus> getObjectPatch() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -260,7 +260,6 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .append(state)
         .append(desiredState)
         .append(clusterName)
-        .append(isAdminServer)
         .toHashCode();
   }
 
@@ -280,7 +279,6 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .append(state, rhs.state)
         .append(desiredState, rhs.desiredState)
         .append(clusterName, rhs.clusterName)
-        .append(isAdminServer, rhs.isAdminServer)
         .isEquals();
   }
 
@@ -310,7 +308,6 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .withStringField("state", ServerStatus::getState)
         .withStringField("desiredState", ServerStatus::getDesiredState)
         .withStringField("nodeName", ServerStatus::getNodeName)
-        .withBooleanField("isAdminServer", ServerStatus::isAdminServer)
         .withObjectField("health", ServerStatus::getHealth, ServerHealth.getObjectPatch());
 
   static ObjectPatch<ServerStatus> getObjectPatch() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -293,8 +293,9 @@ public class DomainStatusPatchTest {
     assertThat(builder.getPatches(),
           hasItemsInOrder(
              "ADD /status/servers/- {'clusterName':'cluster1','desiredState':'RUNNING',"
-                 + "'nodeName':'node1','serverName':'ms1','state':'RUNNING'}",
-             "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
+                 + "'isAdminServer':'false','nodeName':'node1','serverName':'ms1','state':'RUNNING'}",
+             "ADD /status/servers/- {'clusterName':'cluster1','isAdminServer':'false',"
+                 + "'serverName':'ms2','state':'STARTING'}"
              ));
   }
 
@@ -327,8 +328,9 @@ public class DomainStatusPatchTest {
           hasItemsInOrder(
                 "ADD /status/servers/- {'clusterName':'cluster1',"
                       + "'health':{'activationTime':'" + activationTime + "','overallHealth':'AOK'},"
-                      + "'serverName':'ms1'}",
-                "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
+                      + "'isAdminServer':'false','serverName':'ms1'}",
+                "ADD /status/servers/- {'clusterName':'cluster1',"
+                      + "'isAdminServer':'false','serverName':'ms2','state':'STARTING'}"
                 ));
   }
 
@@ -355,7 +357,8 @@ public class DomainStatusPatchTest {
           hasItemsInOrder(
                 "REPLACE /status/servers/1/health/overallHealth 'AOK'",
                 "REMOVE /status/servers/0",
-                "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms3','state':'STARTING'}"
+                "ADD /status/servers/- {'clusterName':'cluster1','isAdminServer':'false',"
+                      + "'serverName':'ms3','state':'STARTING'}"
                 ));
   }
 
@@ -394,7 +397,7 @@ public class DomainStatusPatchTest {
                       +         "{'health':'obsolete','subsystemName':'jmx'},"
                       +         "{'health':'uninitialized','subsystemName':'sockets'}"
                       +      "]},"
-                      + "'serverName':'ms3'}"
+                      + "'isAdminServer':'false','serverName':'ms3'}"
                 ));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -293,9 +293,8 @@ public class DomainStatusPatchTest {
     assertThat(builder.getPatches(),
           hasItemsInOrder(
              "ADD /status/servers/- {'clusterName':'cluster1','desiredState':'RUNNING',"
-                 + "'isAdminServer':'false','nodeName':'node1','serverName':'ms1','state':'RUNNING'}",
-             "ADD /status/servers/- {'clusterName':'cluster1','isAdminServer':'false',"
-                 + "'serverName':'ms2','state':'STARTING'}"
+                 + "'nodeName':'node1','serverName':'ms1','state':'RUNNING'}",
+             "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
              ));
   }
 
@@ -328,9 +327,8 @@ public class DomainStatusPatchTest {
           hasItemsInOrder(
                 "ADD /status/servers/- {'clusterName':'cluster1',"
                       + "'health':{'activationTime':'" + activationTime + "','overallHealth':'AOK'},"
-                      + "'isAdminServer':'false','serverName':'ms1'}",
-                "ADD /status/servers/- {'clusterName':'cluster1',"
-                      + "'isAdminServer':'false','serverName':'ms2','state':'STARTING'}"
+                      + "'serverName':'ms1'}",
+                "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
                 ));
   }
 
@@ -357,8 +355,7 @@ public class DomainStatusPatchTest {
           hasItemsInOrder(
                 "REPLACE /status/servers/1/health/overallHealth 'AOK'",
                 "REMOVE /status/servers/0",
-                "ADD /status/servers/- {'clusterName':'cluster1','isAdminServer':'false',"
-                      + "'serverName':'ms3','state':'STARTING'}"
+                "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms3','state':'STARTING'}"
                 ));
   }
 
@@ -397,7 +394,7 @@ public class DomainStatusPatchTest {
                       +         "{'health':'obsolete','subsystemName':'jmx'},"
                       +         "{'health':'uninitialized','subsystemName':'sockets'}"
                       +      "]},"
-                      + "'isAdminServer':'false','serverName':'ms3'}"
+                      + "'serverName':'ms3'}"
                 ));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -14,6 +14,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionMatcher.hasCondition;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Available;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed;
@@ -259,23 +260,84 @@ public class DomainStatusTest {
     domainStatus.addServer(cluster1Server1).addServer(cluster2Server1)
         .addServer(cluster1Server2).addServer(standAloneServerA).addServer(adminServer);
 
-    assertThat(domainStatus.servers,
+    assertThat(domainStatus.getServers(),
         contains(adminServer, standAloneServerA, cluster1Server1, cluster1Server2, cluster2Server1));
   }
 
   @Test
   public void verifyThat_setServers_serverSortedInExpectedOrdering() {
-    ServerStatus cluster1Server1 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server1");
-    ServerStatus cluster1Server2 = new ServerStatus().withClusterName("cluster-1").withServerName("cluster1-server2");
-    ServerStatus cluster2Server1 = new ServerStatus().withClusterName("cluster-2").withServerName("cluster2-server1");
-    ServerStatus adminServer = new ServerStatus().withServerName("admin-server").withIsAdminServer(true);
-    ServerStatus standAloneServerA = new ServerStatus().withServerName("a");
+    ServerStatus cluster1Server1 = createStatus().withClusterName("cluster-1").withServerName("cluster1-server1");
+    ServerStatus cluster1Server2 = createStatus().withClusterName("cluster-1").withServerName("cluster1-server2");
+    ServerStatus cluster2Server1 = createStatus().withClusterName("cluster-2").withServerName("cluster2-server1");
+    ServerStatus adminServer = createStatus().withServerName("admin-server").withIsAdminServer(true);
+    ServerStatus standAloneServerA = createStatus().withServerName("a");
 
     domainStatus.setServers(Arrays.asList(cluster1Server1,
         cluster2Server1, cluster1Server2, standAloneServerA, adminServer));
 
-    assertThat(domainStatus.servers,
+    assertThat(domainStatus.getServers(),
         contains(adminServer, standAloneServerA, cluster1Server1, cluster1Server2, cluster2Server1));
+  }
+
+  private ServerStatus createStatus() {
+    return new ServerStatus().withState("a");
+  }
+
+  @Test
+  public void whenMatchingServersExist_setServersUpdatesState() {
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("1").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("2").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("3").withState("state1"));
+    
+    domainStatus.setServers(Arrays.asList(
+          new ServerStatus().withClusterName("1").withServerName("1").withState("state1"),
+          new ServerStatus().withClusterName("1").withServerName("2").withState("state1"),
+          new ServerStatus().withClusterName("1").withServerName("3").withState("state2")
+    ));
+
+    assertThat(getServer("1", "1").getState(), equalTo("state1"));
+    assertThat(getServer("1", "2").getState(), equalTo("state1"));
+    assertThat(getServer("1", "3").getState(), equalTo("state2"));
+  }
+
+  @Test
+  public void whenSetServerIncludesServerWithoutStateAndNoExistingState_defaultToSHUTDOWN() {
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("1").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("2").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("3").withState("state1"));
+
+    domainStatus.setServers(Arrays.asList(
+          new ServerStatus().withClusterName("1").withServerName("1").withState("state1"),
+          new ServerStatus().withClusterName("1").withServerName("2").withState("state1"),
+          new ServerStatus().withClusterName("1").withServerName("3").withState("state2"),
+          new ServerStatus().withClusterName("2").withServerName("1")
+    ));
+
+    assertThat(getServer("2", "1").getState(), equalTo(SHUTDOWN_STATE));
+  }
+
+  @Test
+  public void whenSetServerIncludesServerWithoutStateAndHasExistingState_preserveIt() {
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("1").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("2").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("3").withState("state1"));
+
+    domainStatus.setServers(Arrays.asList(
+          new ServerStatus().withClusterName("1").withServerName("1").withState("state1"),
+          new ServerStatus().withClusterName("1").withServerName("2").withState("state1"),
+          new ServerStatus().withClusterName("1").withServerName("3")
+    ));
+
+    assertThat(getServer("1", "3").getState(), equalTo("state1"));
+  }
+
+  private ServerStatus getServer(String clusterName, String serverName) {
+    return domainStatus.getServers()
+          .stream()
+          .filter(s -> s.getClusterName().equals(clusterName))
+          .filter(s -> s.getServerName().equals(serverName))
+          .findFirst()
+          .orElse(null);
   }
 
   @Test
@@ -303,7 +365,7 @@ public class DomainStatusTest {
 
     domainStatus.addCluster(cluster10).addCluster(cluster1).addCluster(cluster2);
 
-    assertThat(domainStatus.clusters, contains(cluster1, cluster2, cluster10));
+    assertThat(domainStatus.getClusters(), contains(cluster1, cluster2, cluster10));
   }
 
   @Test
@@ -314,9 +376,7 @@ public class DomainStatusTest {
 
     domainStatus.setClusters(Arrays.asList(cluster10, cluster1, cluster2));
 
-    List<ClusterStatus> clusterStatuses = domainStatus.clusters;
-
-    assertThat(clusterStatuses, contains(cluster1, cluster2, cluster10));
+    assertThat(domainStatus.getClusters(), contains(cluster1, cluster2, cluster10));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.weblogic.domain.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import com.meterware.simplestub.Memento;
 import oracle.kubernetes.utils.SystemClockTestSupport;
@@ -292,12 +293,12 @@ public class DomainStatusTest {
     domainStatus.setServers(Arrays.asList(
           new ServerStatus().withClusterName("1").withServerName("1").withState("state1"),
           new ServerStatus().withClusterName("1").withServerName("2").withState("state1"),
-          new ServerStatus().withClusterName("1").withServerName("3").withState("state2")
+          new ServerStatus().withServerName("admin").withIsAdminServer(true).withState("state2")
     ));
 
     assertThat(getServer("1", "1").getState(), equalTo("state1"));
     assertThat(getServer("1", "2").getState(), equalTo("state1"));
-    assertThat(getServer("1", "3").getState(), equalTo("state2"));
+    assertThat(getServer(null, "admin").getState(), equalTo("state2"));
   }
 
   @Test
@@ -334,8 +335,8 @@ public class DomainStatusTest {
   private ServerStatus getServer(String clusterName, String serverName) {
     return domainStatus.getServers()
           .stream()
-          .filter(s -> s.getClusterName().equals(clusterName))
-          .filter(s -> s.getServerName().equals(serverName))
+          .filter(s -> Objects.equals(clusterName, s.getClusterName()))
+          .filter(s -> Objects.equals(serverName, s.getServerName()))
           .findFirst()
           .orElse(null);
   }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ServerStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ServerStatusTest.java
@@ -135,4 +135,12 @@ public class ServerStatusTest {
         cluster1ServerA.compareTo(adminServer), greaterThan(0));
   }
 
+  // We use the volatile adminServer flag to control sorting, but it is not part of the JSON schema of the status,
+  // therefore it cannot figure in the equals() test, which is used to decide whether we need to update the status.
+  @Test
+  public void equalsMethodsIgnoresIsAdminServer() {
+    assertThat(
+          new ServerStatus().withClusterName("1").withServerName("1"),
+          equalTo(new ServerStatus().withClusterName("1").withServerName("1").withIsAdminServer(true)));
+  }
 }


### PR DESCRIPTION
This address two issues that caused the operator to send status updates repeatedly:

1. Our server status reader sometimes fails to get the status for a server. The code was defaulting to SHUTDOWN, meaning that we would intermittently change the state of a server to SHUTDOWN and then back to the real value. The code now defaults to the previous state of a server, if known.
2. The ServerStatus object has a volatile field called `isAdminServer` used for sorting to ensure that the admin server is listed first in the domain status; unfortunately, it was also included in the equals() method, meaning that it always looked as though the status had changed and needed to be updated. Since the field is volatile, that did nothing, so we updated the status about once a second. It has now been removed from equals() and hashCode().