### PR TITLE
retry for app deployment and other fixes

### DIFF
--- a/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/BaseTest.java
@@ -608,12 +608,13 @@ public class BaseTest {
                 + result.stdout());
       }
 
+      int retriesForDeployment = 10;
       domain.deployWebAppViaWlst(
           TESTWEBAPP,
           getProjectRoot() + "/src/integration-tests/apps/testwebapp.war",
           appLocationInPod,
           getUsername(),
-          getPassword());
+          getPassword(), retriesForDeployment);
       domain.callWebAppAndVerifyLoadBalancing(TESTWEBAPP, verifyLoadBalancing);
 
       /* The below check is done for domain-home-in-image domains, it needs 12.2.1.3 patched image
@@ -824,12 +825,13 @@ public class BaseTest {
     TestUtils.createRbacPoliciesForWldfScaling();
 
     // deploy opensessionapp
+    int retriesForDeployment = 10;
     domain.deployWebAppViaWlst(
         "opensessionapp",
         getProjectRoot() + "/src/integration-tests/apps/opensessionapp.war",
         appLocationInPod,
         getUsername(),
-        getPassword());
+        getPassword(), retriesForDeployment);
 
     TestUtils.createWldfModule(
         adminPodName, domainNS, ((Integer) domainMap.get("t3ChannelPort")).intValue());

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItDomainInImage.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItDomainInImage.java
@@ -209,7 +209,6 @@ public class ItDomainInImage extends BaseTest {
       domainMap.put("createDomainFilesDir", "wdt");
       // set cluster size based on the config in domain model yaml
       domainMap.put("configuredManagedServerCount", 3);
-      domainMap.put("initialManagedServerReplicas", 3);
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
       domain.enablePrecreateService();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItDomainInImage.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItDomainInImage.java
@@ -207,6 +207,9 @@ public class ItDomainInImage extends BaseTest {
           BaseTest.getProjectRoot()
               + "/integration-tests/src/test/resources/wdt/config.cluster.topology.yaml");
       domainMap.put("createDomainFilesDir", "wdt");
+      // set cluster size based on the config in domain model yaml
+      domainMap.put("configuredManagedServerCount", 3);
+      domainMap.put("initialManagedServerReplicas", 3);
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
       domain.enablePrecreateService();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItDomainInImage.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItDomainInImage.java
@@ -112,6 +112,7 @@ public class ItDomainInImage extends BaseTest {
       domainMap.remove("clusterType");
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
+      domain.enablePrecreateService();
       testBasicUseCases(domain, true);
       testClusterScaling(operator1, domain, false);
       testCompletedSuccessfully = true;
@@ -157,6 +158,7 @@ public class ItDomainInImage extends BaseTest {
 
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
+      domain.enablePrecreateService();
       List<ExecResult> execResultList = domain.verifySslListeners();
       Assert.assertTrue(execResultList.size() > 0);
       for (ExecResult execResult : execResultList) {
@@ -207,7 +209,7 @@ public class ItDomainInImage extends BaseTest {
       domainMap.put("createDomainFilesDir", "wdt");
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-
+      domain.enablePrecreateService();
       testBasicUseCases(domain, false);
       testClusterScaling(operator1, domain, true);
       testCompletedSuccessfully = true;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItManagedCoherence.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItManagedCoherence.java
@@ -242,18 +242,24 @@ public class ItManagedCoherence extends BaseTest {
     // The above command only tests that the pod from the 1st cluster is Running (1/1)
     // So, checking the MS pod of the other cluster individually here.
     // When(If) we change the utils to handle 2 clusters, this can be removed.
-    TestUtils.checkPodReady(domainUid + "-new-managed-server1", domainNS1);
-    TestUtils.checkPodReady(domainUid + "-new-managed-server2", domainNS1);
+    String cluster2PodName1 = domainUid + "-new-managed-server1";
+    String cluster2PodName2 = domainUid + "-new-managed-server2";
+    int retriesToResolveServiceName = 15;
 
-    String[] pods = {
-      domainUid + "-" + domain.getAdminServerName(),
-      domainUid + "-managed-server",
-      domainUid + "-managed-server1",
-      domainUid + "-managed-server2",
-      domainUid + "-new-managed-server1",
-      domainUid + "-new-managed-server2",
-    };
-    
+    //Check managed servers are ready
+    TestUtils.checkPodReady(cluster2PodName1, domainNS1);
+    TestUtils.checkPodReady(cluster2PodName2, domainNS1);
+
+    //check services are created
+    TestUtils.checkServiceCreated(cluster2PodName1, domainNS1);
+    TestUtils.checkServiceCreated(cluster2PodName2, domainNS1);
+
+    //resolve managed server service names from admin pod
+    TestUtils.resolveServiceName(cluster2PodName1,
+            domainUid + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+    TestUtils.resolveServiceName(cluster2PodName2,
+        domainUid + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+
     LoggerHelper.getLocal().log(Level.INFO, " Printing the pods in the doamin");
     ExecResult result  = ExecCommand.exec("kubectl get pods -n " + domain.getDomainNs() + " -o wide");
     LoggerHelper.getLocal().log(Level.INFO, "stdout = " + result.stdout()

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItMonitoringExporter.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItMonitoringExporter.java
@@ -286,7 +286,7 @@ public class ItMonitoringExporter extends BaseTest {
         "" + domainMap.get("namespace"),
         " -- mkdir -p " + appLocationInPod);
     domain.deployWebAppViaWlst(
-        "wls-exporter", exporterAppPath, appLocationInPod, getUsername(), getPassword(), true);
+        "wls-exporter", exporterAppPath, appLocationInPod, getUsername(), getPassword(), true, 5);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItMultipleClusters.java
@@ -44,6 +44,7 @@ public class ItMultipleClusters extends BaseTest {
   private static String testClassName;
   private static String domainNS1;
   private static StringBuffer namespaceList;
+  private int retriesToResolveServiceName = 15;
 
   /**
    * This method gets called only once before any of the test methods are executed. It does the
@@ -142,7 +143,7 @@ public class ItMultipleClusters extends BaseTest {
               + TWO_CONFIGURED_CLUSTER_SCRIPT);
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-      String[] pods = {
+      /* String[] pods = {
           DOMAINUID + "-" + domain.getAdminServerName(),
           DOMAINUID + "-managed-server",
           DOMAINUID + "-managed-server1",
@@ -150,7 +151,21 @@ public class ItMultipleClusters extends BaseTest {
           DOMAINUID + "-new-managed-server1",
           DOMAINUID + "-new-managed-server2",
       };
-      verifyServersStatus(domain, pods);
+      verifyServersStatus(domain, pods); */
+      String cluster2PodName1 = DOMAINUID + "-new-managed-server1";
+      String cluster2PodName2 = DOMAINUID + "-new-managed-server2";
+
+      TestUtils.checkPodReady(cluster2PodName1, domainNS1);
+      TestUtils.checkPodReady(cluster2PodName2, domainNS1);
+
+      TestUtils.checkServiceCreated(cluster2PodName1, domainNS1);
+      TestUtils.checkServiceCreated(cluster2PodName2, domainNS1);
+
+      TestUtils.resolveServiceName(cluster2PodName1,
+          DOMAINUID + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+      TestUtils.resolveServiceName(cluster2PodName2,
+          DOMAINUID + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+
       testBasicUseCases(domain, false);
       domain.testWlsLivenessProbe();
       testCompletedSuccessfully = true;
@@ -187,7 +202,7 @@ public class ItMultipleClusters extends BaseTest {
           "integration-tests/src/test/resources/domain-home-on-pv/" + TWO_MIXED_CLUSTER_SCRIPT);
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-      String[] pods = {
+      /* String[] pods = {
           domainuid + "-" + domain.getAdminServerName(),
           domainuid + "-managed-server",
           domainuid + "-managed-server1",
@@ -195,7 +210,21 @@ public class ItMultipleClusters extends BaseTest {
           domainuid + "-new-managed-server1",
           domainuid + "-new-managed-server2",
       };
-      verifyServersStatus(domain, pods);
+      verifyServersStatus(domain, pods); */
+
+      String cluster2PodName1 = DOMAINUID + "-new-managed-server1";
+      String cluster2PodName2 = DOMAINUID + "-new-managed-server2";
+
+      TestUtils.checkPodReady(cluster2PodName1, domainNS1);
+      TestUtils.checkPodReady(cluster2PodName2, domainNS1);
+
+      TestUtils.checkServiceCreated(cluster2PodName1, domainNS1);
+      TestUtils.checkServiceCreated(cluster2PodName2, domainNS1);
+
+      TestUtils.resolveServiceName(cluster2PodName1,
+          DOMAINUID + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+      TestUtils.resolveServiceName(cluster2PodName2,
+          DOMAINUID + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
 
       testBasicUseCases(domain, false);
       domain.testWlsLivenessProbe();
@@ -217,7 +246,7 @@ public class ItMultipleClusters extends BaseTest {
   @Test
   public void testCreateDomainTwoClusterWdtInImage() throws Exception {
     Assumptions.assumeTrue(FULLTEST);
-    String domainuid = "twoclusterdomainwdt";
+    String domainUid = "twoclusterdomainwdt";
     String testMethodName = new Object() {
     }.getClass().getEnclosingMethod().getName();
     logTestBegin(testMethodName);
@@ -227,7 +256,7 @@ public class ItMultipleClusters extends BaseTest {
     try {
       Map<String, Object> domainMap =
           createDomainInImageMap(getNewSuffixCount(), true, testClassName);
-      domainMap.put("domainUID", domainuid);
+      domainMap.put("domainUID", domainUid);
       domainMap.put("customDomainTemplate", customDomainTemplate);
       domainMap.put("namespace", domainNS1);
       domainMap.put(
@@ -236,14 +265,28 @@ public class ItMultipleClusters extends BaseTest {
               + "/integration-tests/src/test/resources/multipleclusters/wdtmultipledynclusters.yml");
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-      String[] pods = {
-          domainuid + "-" + domain.getAdminServerName(),
-          domainuid + "-managed-server1",
-          domainuid + "-managed-server2",
-          domainuid + "-managed-server-21",
-          domainuid + "-managed-server-22",
+      /* String[] pods = {
+          domainUid + "-" + domain.getAdminServerName(),
+          domainUid + "-managed-server1",
+          domainUid + "-managed-server2",
+          domainUid + "-managed-server-21",
+          domainUid + "-managed-server-22",
       };
-      verifyServersStatus(domain, pods);
+      verifyServersStatus(domain, pods); */
+      String cluster2PodName1 = domainUid + "-managed-server-21";
+      String cluster2PodName2 = domainUid + "-managed-server-22";
+
+      TestUtils.checkPodReady(cluster2PodName1, domainNS1);
+      TestUtils.checkPodReady(cluster2PodName2, domainNS1);
+
+      TestUtils.checkServiceCreated(cluster2PodName1, domainNS1);
+      TestUtils.checkServiceCreated(cluster2PodName2, domainNS1);
+
+      TestUtils.resolveServiceName(cluster2PodName1,
+          domainUid + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+      TestUtils.resolveServiceName(cluster2PodName2,
+          domainUid + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+
       testBasicUseCases(domain, false);
       domain.testWlsLivenessProbe();
       testCompletedSuccessfully = true;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItMultipleClusters.java
@@ -143,15 +143,6 @@ public class ItMultipleClusters extends BaseTest {
               + TWO_CONFIGURED_CLUSTER_SCRIPT);
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-      /* String[] pods = {
-          DOMAINUID + "-" + domain.getAdminServerName(),
-          DOMAINUID + "-managed-server",
-          DOMAINUID + "-managed-server1",
-          DOMAINUID + "-managed-server2",
-          DOMAINUID + "-new-managed-server1",
-          DOMAINUID + "-new-managed-server2",
-      };
-      verifyServersStatus(domain, pods); */
       String cluster2PodName1 = DOMAINUID + "-new-managed-server1";
       String cluster2PodName2 = DOMAINUID + "-new-managed-server2";
 
@@ -202,15 +193,6 @@ public class ItMultipleClusters extends BaseTest {
           "integration-tests/src/test/resources/domain-home-on-pv/" + TWO_MIXED_CLUSTER_SCRIPT);
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-      /* String[] pods = {
-          domainuid + "-" + domain.getAdminServerName(),
-          domainuid + "-managed-server",
-          domainuid + "-managed-server1",
-          domainuid + "-managed-server2",
-          domainuid + "-new-managed-server1",
-          domainuid + "-new-managed-server2",
-      };
-      verifyServersStatus(domain, pods); */
 
       String cluster2PodName1 = domainuid + "-new-managed-server1";
       String cluster2PodName2 = domainuid + "-new-managed-server2";
@@ -265,14 +247,7 @@ public class ItMultipleClusters extends BaseTest {
               + "/integration-tests/src/test/resources/multipleclusters/wdtmultipledynclusters.yml");
       domain = TestUtils.createDomain(domainMap);
       domain.verifyDomainCreated();
-      /* String[] pods = {
-          domainUid + "-" + domain.getAdminServerName(),
-          domainUid + "-managed-server1",
-          domainUid + "-managed-server2",
-          domainUid + "-managed-server-21",
-          domainUid + "-managed-server-22",
-      };
-      verifyServersStatus(domain, pods); */
+
       String cluster2PodName1 = domainUid + "-managed-server-21";
       String cluster2PodName2 = domainUid + "-managed-server-22";
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItMultipleClusters.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItMultipleClusters.java
@@ -212,8 +212,8 @@ public class ItMultipleClusters extends BaseTest {
       };
       verifyServersStatus(domain, pods); */
 
-      String cluster2PodName1 = DOMAINUID + "-new-managed-server1";
-      String cluster2PodName2 = DOMAINUID + "-new-managed-server2";
+      String cluster2PodName1 = domainuid + "-new-managed-server1";
+      String cluster2PodName2 = domainuid + "-new-managed-server2";
 
       TestUtils.checkPodReady(cluster2PodName1, domainNS1);
       TestUtils.checkPodReady(cluster2PodName2, domainNS1);
@@ -222,9 +222,9 @@ public class ItMultipleClusters extends BaseTest {
       TestUtils.checkServiceCreated(cluster2PodName2, domainNS1);
 
       TestUtils.resolveServiceName(cluster2PodName1,
-          DOMAINUID + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+          domainuid + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
       TestUtils.resolveServiceName(cluster2PodName2,
-          DOMAINUID + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
+          domainuid + "-" + domain.getAdminServerName(), domainNS1, retriesToResolveServiceName);
 
       testBasicUseCases(domain, false);
       domain.testWlsLivenessProbe();

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItUsabilityOperatorHelmChart.java
@@ -653,7 +653,9 @@ public class ItUsabilityOperatorHelmChart extends BaseTest {
       LoggerHelper.getLocal().log(Level.INFO, "Deleting operator to check that domain functionality is not effected");
       operator.destroy();
       operator = null;
-      domain.testWlsLivenessProbe();
+      //domain.testWlsLivenessProbe();
+      //Check domain is still up and running
+      domain.verifyDomainCreated();
       testCompletedSuccessfully = true;
     } finally {
       if (domain != null) {

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/ItUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/ItUsabilityOperatorHelmChart.java
@@ -653,7 +653,6 @@ public class ItUsabilityOperatorHelmChart extends BaseTest {
       LoggerHelper.getLocal().log(Level.INFO, "Deleting operator to check that domain functionality is not effected");
       operator.destroy();
       operator = null;
-      //domain.testWlsLivenessProbe();
       //Check domain is still up and running
       domain.verifyDomainCreated();
       testCompletedSuccessfully = true;

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -674,6 +674,7 @@ public class Domain {
    * @param webappLocation webappLocation
    * @param username       username
    * @param password       password
+   * @param retriesForDeployment number of retries to deploy the application if it fails
    * @throws Exception if deployment failed
    */
   public void deployWebAppViaWlst(
@@ -681,9 +682,10 @@ public class Domain {
       String webappLocation,
       String appLocationInPod,
       String username,
-      String password)
+      String password,
+      int retriesForDeployment)
       throws Exception {
-    deployWebAppViaWlst(webappName, webappLocation, appLocationInPod, username, password, false);
+    deployWebAppViaWlst(webappName, webappLocation, appLocationInPod, username, password, false, retriesForDeployment);
   }
 
   /**
@@ -695,6 +697,7 @@ public class Domain {
    * @param username             username
    * @param password             password
    * @param useAdminPortToDeploy useAdminPortToDeploy
+   * @param retriesForDeployment number of retries to deploy the application if it fails
    * @throws Exception If deployment failed
    */
   public void deployWebAppViaWlst(
@@ -703,7 +706,8 @@ public class Domain {
       String appLocationInPod,
       String username,
       String password,
-      boolean useAdminPortToDeploy)
+      boolean useAdminPortToDeploy,
+      int retriesForDeployment)
       throws Exception {
     String adminPod = domainUid + "-" + adminServerName;
 
@@ -740,7 +744,7 @@ public class Domain {
     };
 
     TestUtils.callShellScriptByExecToPod(
-        adminPod, domainNS, appLocationInPod, "callpyscript.sh", args);
+        adminPod, domainNS, appLocationInPod, "callpyscript.sh", args, retriesForDeployment);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/Domain.java
@@ -242,9 +242,10 @@ public class Domain {
    */
   public void verifyServicesCreated(boolean precreateService, int maxIterations) throws Exception {
     // check admin service
+    String adminServiceName = domainUid + "-" + adminServerName;
     LoggerHelper.getLocal().log(Level.INFO,
-        "Checking if admin service(" + domainUid + "-" + adminServerName + ") is created");
-    TestUtils.checkServiceCreated(domainUid + "-" + adminServerName, domainNS, maxIterations);
+        "Checking if admin service(" + adminServiceName + ") is created");
+    TestUtils.checkServiceCreated(adminServiceName, domainNS, maxIterations);
 
     if (exposeAdminT3Channel) {
       LoggerHelper.getLocal().log(Level.INFO,
@@ -253,9 +254,9 @@ public class Domain {
               + "-"
               + adminServerName
               + "-external) is created");
-      TestUtils.checkServiceCreated(domainUid + "-" + adminServerName + "-external", domainNS, maxIterations);
+      TestUtils.checkServiceCreated(adminServiceName + "-external", domainNS, maxIterations);
     }
-
+    int retriesToResolveServiceName = 15;
     if (!serverStartPolicy.equals("ADMIN_ONLY")) {
       // check managed server services
       for (int i = 1;
@@ -269,6 +270,9 @@ public class Domain {
                 + i
                 + ") is created");
         TestUtils.checkServiceCreated(domainUid + "-" + managedServerNameBase + i, domainNS, maxIterations);
+        // using adminServiceName for adminPodName as they both are same
+        TestUtils.resolveServiceName(domainUid + "-" + managedServerNameBase + i,
+            adminServiceName, domainNS, retriesToResolveServiceName);
       }
     }
   }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/LoadBalancer.java
@@ -138,7 +138,7 @@ public class LoadBalancer {
     StringBuffer cmd = new StringBuffer("helm upgrade ");
     cmd.append(" traefik-operator")
        .append(" stable/traefik ")
-       .append(" --debug ")
+       //.append(" --debug ")
        .append("--namespace traefik ")
        .append("--reuse-values ")
        .append("--set ")
@@ -252,7 +252,7 @@ public class LoadBalancer {
     StringBuffer cmd = new StringBuffer("helm upgrade ");
     cmd.append(" voyager-operator")
         .append(" appscode/voyager ")
-        .append("--debug ")
+        //.append("--debug ")
         .append("--namespace voyager ")
         .append("--reuse-values ")
         .append("--set ")

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -1440,6 +1440,7 @@ public class TestUtils {
         }
       } else {
         LoggerHelper.getLocal().log(Level.INFO, "Application deployed successfully, stdout = " + result.stdout());
+        break;
       }
     }
 

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -1401,7 +1401,27 @@ public class TestUtils {
    * @throws Exception exception
    */
   public static void callShellScriptByExecToPod(
-      String podName, String domainNS, String scriptsLocInPod, String shScriptName, String[] args)
+      String podName, String domainNS, String scriptsLocInPod, String shScriptName,
+      String[] args)
+      throws Exception {
+    callShellScriptByExecToPod(
+        podName, domainNS, scriptsLocInPod, shScriptName,args, 1);
+  }
+
+  /**
+   * exec into the pod and call the shell script with given arguments.
+   *
+   * @param podName         pod name
+   * @param domainNS        namespace
+   * @param scriptsLocInPod script location
+   * @param shScriptName    script name
+   * @param args            script arguments
+   * @param retriesToCallScript number of retries to execute the script if it fails
+   * @throws Exception exception
+   */
+  public static void callShellScriptByExecToPod(
+      String podName, String domainNS, String scriptsLocInPod, String shScriptName,
+      String[] args, int retriesToCallScript)
       throws Exception {
     StringBuffer cmdKubectlSh = new StringBuffer("kubectl -n ");
     cmdKubectlSh
@@ -1418,15 +1438,12 @@ public class TestUtils {
         .append(String.join(" ", args).toString())
         .append("'");
 
-    // LoggerHelper.getLocal().log(Level.INFO, "Command to call kubectl sh file " + cmdKubectlSh);
-    // TestUtils.execOrAbortProcess(cmdKubectlSh.toString(), true);
-    int numberOfRetries = 5;
-    for (int i = 1; i <= numberOfRetries; i++) {
+    for (int i = 1; i <= retriesToCallScript; i++) {
       LoggerHelper.getLocal().log(Level.INFO, "Iteration " + i
-          + "/" + numberOfRetries + ", Command to call kubectl sh file " + cmdKubectlSh);
+          + "/" + retriesToCallScript + ", Command to call kubectl sh file " + cmdKubectlSh);
       ExecResult result = ExecCommand.exec(cmdKubectlSh.toString());
       if (result.exitValue() != 0) {
-        if (i == numberOfRetries) {
+        if (i == retriesToCallScript) {
           new RuntimeException("FAILURE: Command "
               + cmdKubectlSh
               + " failed with stderr = "
@@ -1435,11 +1452,11 @@ public class TestUtils {
               + result.stdout());
         } else {
           LoggerHelper.getLocal().log(Level.INFO, "Command failed with stdout = "
-              + result.stdout() + " stderr = " + result.stderr() + ", retrying deploy");
+              + result.stdout() + " stderr = " + result.stderr() + ", retrying");
           Thread.sleep(10 * 1000);
         }
       } else {
-        LoggerHelper.getLocal().log(Level.INFO, "Application deployed successfully, stdout = " + result.stdout());
+        LoggerHelper.getLocal().log(Level.INFO, "Script invoked successfully, stdout = " + result.stdout());
         break;
       }
     }

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -1418,8 +1418,31 @@ public class TestUtils {
         .append(String.join(" ", args).toString())
         .append("'");
 
-    LoggerHelper.getLocal().log(Level.INFO, "Command to call kubectl sh file " + cmdKubectlSh);
-    TestUtils.execOrAbortProcess(cmdKubectlSh.toString(), true);
+    // LoggerHelper.getLocal().log(Level.INFO, "Command to call kubectl sh file " + cmdKubectlSh);
+    // TestUtils.execOrAbortProcess(cmdKubectlSh.toString(), true);
+    int numberOfRetries = 5;
+    for (int i = 1; i <= numberOfRetries; i++) {
+      LoggerHelper.getLocal().log(Level.INFO, "Iteration " + i
+          + "/" + numberOfRetries + ", Command to call kubectl sh file " + cmdKubectlSh);
+      ExecResult result = ExecCommand.exec(cmdKubectlSh.toString());
+      if (result.exitValue() != 0) {
+        if (i == numberOfRetries) {
+          new RuntimeException("FAILURE: Command "
+              + cmdKubectlSh
+              + " failed with stderr = "
+              + result.stderr()
+              + " \n stdout = "
+              + result.stdout());
+        } else {
+          LoggerHelper.getLocal().log(Level.INFO, "Command failed with stdout = "
+              + result.stdout() + " stderr = " + result.stderr() + ", retrying deploy");
+          Thread.sleep(10 * 1000);
+        }
+      } else {
+        LoggerHelper.getLocal().log(Level.INFO, "Application deployed successfully, stdout = " + result.stdout());
+      }
+    }
+
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/TestUtils.java
@@ -229,7 +229,7 @@ public class TestUtils {
   }
 
   /**
-   * Resole a servive name inside a pod.
+   * Resolve a servive name inside a pod.
    * @param serviceName service name to resolve
    * @param podName name of the pod
    * @param namespace namespace of the pod

--- a/integration-tests/src/test/resources/deploywebapp.py
+++ b/integration-tests/src/test/resources/deploywebapp.py
@@ -12,7 +12,7 @@ domainRuntime()
 state(clusterName,'Cluster')
 
 #deploy(sys.argv[4],sys.argv[5],sys.argv[6],upload='false',remote='false')
-deploy(appName=appName, path=appPath, targets=clusterName, upload='false', remote='false')
+deploy(appName=appName, path=appPath, targets=clusterName, upload='false', remote='false', timeout=600000)
 
 #cd ('AppDeployments')
 #myapps=cmo.getAppDeployments()

--- a/integration-tests/src/test/resources/deploywebapp.py
+++ b/integration-tests/src/test/resources/deploywebapp.py
@@ -1,5 +1,11 @@
 # Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+import time as systime
+
+# to give enough time for the DNS entries to be updated
+systime.sleep(15)
+
 connect(sys.argv[1],sys.argv[2],sys.argv[3])
 
 appName=sys.argv[4]
@@ -11,19 +17,4 @@ print 'Checking the server status on the Cluster[%s] ' %(clusterName)
 domainRuntime()
 state(clusterName,'Cluster')
 
-#deploy(sys.argv[4],sys.argv[5],sys.argv[6],upload='false',remote='false')
-deploy(appName=appName, path=appPath, targets=clusterName, upload='false', remote='false', timeout=600000)
-
-#cd ('AppDeployments')
-#myapps=cmo.getAppDeployments()
- 
-#for appName in myapps:
-#       domainConfig()
-#       cd ('/AppDeployments/'+appName.getName()+'/Targets')
-#       mytargets = ls(returnMap='true')
-#       domainRuntime()
-#       cd('AppRuntimeStateRuntime')
-#       cd('AppRuntimeStateRuntime')
-#       for targetinst in mytargets:
-#             curstate4=cmo.getCurrentState(appName.getName(),targetinst)
-#             print '-----------', curstate4, '-----------', appName.getName()
+deploy(appName=appName, path=appPath, targets=clusterName, upload='false', remote='false')

--- a/integration-tests/src/test/resources/deploywebapp.py
+++ b/integration-tests/src/test/resources/deploywebapp.py
@@ -1,11 +1,18 @@
 # Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-import time as systime
-
 connect(sys.argv[1],sys.argv[2],sys.argv[3])
-deploy(sys.argv[4],sys.argv[5],sys.argv[6],upload='false',remote='false')
-#systime.sleep(15)
+
+appName=sys.argv[4]
+appPath=sys.argv[5]
+clusterName=sys.argv[6]
+
+print 'Deploying application[%s] to the Cluster[%s] located @ [%s] ' %(appName,clusterName,appPath)
+print 'Checking the server status on the Cluster[%s] ' %(clusterName)
+domainRuntime()
+state(clusterName,'Cluster')
+
+#deploy(sys.argv[4],sys.argv[5],sys.argv[6],upload='false',remote='false')
+deploy(appName=appName, path=appPath, targets=clusterName, upload='false', remote='false')
 
 #cd ('AppDeployments')
 #myapps=cmo.getAppDeployments()

--- a/integration-tests/src/test/resources/resolveServiceName.py
+++ b/integration-tests/src/test/resources/resolveServiceName.py
@@ -1,0 +1,7 @@
+import socket
+import sys
+
+name = sys.argv[1]
+print 'Resolving Server Service Name for ' + name
+ipAddress = socket.gethostbyname(name)
+print('IP address of host name ' + name + ' is: ' + ipAddress)

--- a/integration-tests/src/test/resources/statedump.sh
+++ b/integration-tests/src/test/resources/statedump.sh
@@ -75,12 +75,6 @@ function state_dump {
     done
   done
 
-  echo "Get events to events.NAMESPACE in ${DUMP_DIR}"
-  for namespace in $namespaces; do
-    local eventsfile=${DUMP_DIR}/events.${namespace}
-    $kubectlcmd get events -n $namespace --sort-by=.metadata.creationTimestamp -o yaml > $eventsfile
-  done
-
   mkdir -p $ARCHIVE_DIR || fail Could not archive, could not create target directory \'$ARCHIVE_DIR\'.
   
   # Get various k8s resource describes and redirect/copy to files 

--- a/integration-tests/src/test/resources/statedump.sh
+++ b/integration-tests/src/test/resources/statedump.sh
@@ -75,6 +75,12 @@ function state_dump {
     done
   done
 
+  echo "Get events to events.NAMESPACE in ${DUMP_DIR}"
+  for namespace in $namespaces; do
+    local eventsfile=${DUMP_DIR}/events.${namespace}
+    $kubectlcmd get events -n $namespace --sort-by=.metadata.creationTimestamp > $eventsfile
+  done
+
   mkdir -p $ARCHIVE_DIR || fail Could not archive, could not create target directory \'$ARCHIVE_DIR\'.
   
   # Get various k8s resource describes and redirect/copy to files 

--- a/integration-tests/src/test/resources/statedump.sh
+++ b/integration-tests/src/test/resources/statedump.sh
@@ -78,7 +78,7 @@ function state_dump {
   echo "Get events to events.NAMESPACE in ${DUMP_DIR}"
   for namespace in $namespaces; do
     local eventsfile=${DUMP_DIR}/events.${namespace}
-    $kubectlcmd get events -n $namespace --sort-by=.metadata.creationTimestamp > $eventsfile
+    $kubectlcmd get events -n $namespace --sort-by=.metadata.creationTimestamp -o yaml > $eventsfile
   done
 
   mkdir -p $ARCHIVE_DIR || fail Could not archive, could not create target directory \'$ARCHIVE_DIR\'.


### PR DESCRIPTION
1. add checks to resolve the managed server service names from admin pod
2. print cluster status in py script before deploy
3. retry for app deployment
4. fixed managed coherence and multiple cluster tests for pods ready check and services created check.

With all these changes, I see good results on cluster-10. On cluster-1(quicktest) there are still ~15 failures on this branch vs ~30 failures on develop branch.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-quicktest/1464/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-quicktest/1460/

Only two failures on cluster-10 - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-quicktest-10/74/
