### PR TITLE
WIP: backport java_home fix to version 2.4.0

### DIFF
--- a/kubernetes/samples/scripts/create-soa-domain/domain-home-on-pv/wlst/create-domain-script.sh
+++ b/kubernetes/samples/scripts/create-soa-domain/domain-home-on-pv/wlst/create-domain-script.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-# Copyright (c) 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 export DOMAIN_HOME=${DOMAIN_HOME_DIR}
 
 # Create the domain
+if [ -z "${JAVA_HOME}" ]; then
+  JAVA_HOME=/usr/java/latest
+fi
 wlst.sh -skipWLSModuleScanning \
         ${CREATE_DOMAIN_SCRIPT_DIR}/createSOADomain.py \
         -oh /u01/oracle \
-        -jh /usr/java/latest \
+        -jh ${JAVA_HOME} \
         -parent ${DOMAIN_HOME}/.. \
         -name ${CUSTOM_DOMAIN_NAME} \
         -user `cat /weblogic-operator/secrets/username` \


### PR DESCRIPTION
Hi @markxnelson @rjeberhard,

This pull request is to back-port the java_home fix to version 2.4.0 branch which the early access customers are using for SOA deployment.
The issue is that, in latest fmw infra images the java home is changed to different location and set as JAVA_HOME. To address this for SOA deployment scripts we need this fix.

Kindly review and approve this.
Also please add @rdas0405  and @vivek-sam  to this PR as reviewers.
 
Thanks
Samba