### PR TITLE
Not ready for review: Adding assertions for default and t3channel node port verification

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
@@ -321,7 +321,8 @@ class ItMiiConfigMap implements LoggedTest {
       checkServiceCreated(managedServerPrefix + i, domainNamespace);
     }
 
-    int adminServiceNodePort = getAdminServiceNodePort(adminServerPodName + "-external", null, domainNamespace);
+    int adminServiceNodePort = getAdminServiceNodePort(adminServerPodName + "-external",
+        "default",null, domainNamespace);
     oracle.weblogic.kubernetes.utils.ExecResult result = null;
     try {
       checkJdbc = new StringBuffer("status=$(curl --user weblogic:welcome1 ");

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
@@ -391,7 +391,8 @@ class ItMiiConfigMapOverride implements LoggedTest {
     }
 
     oracle.weblogic.kubernetes.utils.ExecResult result = null;
-    int adminServiceNodePort = getAdminServiceNodePort(adminServerPodName + "-external", null, domainNamespace);
+    int adminServiceNodePort = getAdminServiceNodePort(adminServerPodName + "-external",
+        "default", null, domainNamespace);
     checkJdbc = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
     checkJdbc.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
           .append("/management/wls/latest/datasources/id/TestDataSource/")

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -304,7 +304,7 @@ class ItMiiDomain implements LoggedTest {
 
   }
 
-  //@Test
+  @Test
   @Order(2)
   @DisplayName("Create a second domain with the image from the the first test")
   @Slow
@@ -402,7 +402,7 @@ class ItMiiDomain implements LoggedTest {
     }
   }
 
-  //@Test
+  @Test
   @Order(3)
   @DisplayName("Create a domain with same domainUid as first domain but in a new namespace")
   @Slow

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -15,6 +15,8 @@ public interface TestConstants {
   // domain constants
   public static final String DOMAIN_VERSION = "v7";
   public static final String DOMAIN_API_VERSION = "weblogic.oracle/" + DOMAIN_VERSION;
+  public static final String ADMIN_USERNAME = "weblogic";
+  public static final String ADMIN_PASSWORD = "welcome1";
 
   // operator constants
   public static final String OPERATOR_RELEASE_NAME = "weblogic-operator";

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -464,18 +464,20 @@ public class TestActions {
   }
 
   /**
-   * Returns NodePort of a admin service.
+   * Returns the channel NodePort of a admin service.
    *
    * @param serviceName name of admin service
+   * @param channelName name of the channel, value can be default,T3Channel
    * @param label the key value pair with which the service is decorated with
    * @param namespace namespace in which to check for the service
    * @return AdminNodePort of the Kubernetes service if exits else -1
    */
   public static int getAdminServiceNodePort(
       String serviceName,
+      String channelName,
       Map<String, String> label,
       String namespace) {
-    return Service.getAdminServiceNodePortString(serviceName, label, namespace);
+    return Service.getAdminServiceNodePortString(serviceName, channelName, label, namespace);
   }
 
   // ------------------------ service account  --------------------------

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Service.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Service.java
@@ -58,21 +58,23 @@ public class Service {
   }
 
   /**
-   * Returns NodePort of admin service.
+   * Returns channel NodePort of admin service.
    *
    * @param serviceName name of admin server service
+   * @param channelName name of the channel
    * @param label key value pair with which the service is decorated with
-   * @param namespace the namespace in which to check for the service
+    * @param namespace the namespace in which to check for the service
    * @return AdminNodePort of the Kubernetes service if exits else -1
    */
   public static int getAdminServiceNodePortString(
       String serviceName,
+      String channelName,
       Map<String, String> label,
       String namespace) {
 
     int adminNodePort = -1;
     try {
-      adminNodePort = Kubernetes.getAdminServiceNodePort(serviceName, label, namespace);
+      adminNodePort = Kubernetes.getAdminServiceNodePort(serviceName, channelName, label, namespace);
     } catch (ApiException apex) {
       logger.severe(apex.getResponseBody());
       return -1;

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Service.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Service.java
@@ -58,12 +58,12 @@ public class Service {
   }
 
   /**
-   * Returns channel NodePort of admin service.
+   * Returns the channel NodePort of admin service.
    *
    * @param serviceName name of admin server service
    * @param channelName name of the channel
    * @param label key value pair with which the service is decorated with
-    * @param namespace the namespace in which to check for the service
+   * @param namespace the namespace in which to check for the service
    * @return AdminNodePort of the Kubernetes service if exits else -1
    */
   public static int getAdminServiceNodePortString(

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1540,16 +1540,18 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Returns NodePort of a admin server service.
+   * Returns NodePort of a admin server service channel.
    *
    * @param serviceName name of admin server service
+   * @param channelName name of the channel, values can be default/T3Channel
    * @param label key value pair with which the service is decorated with
    * @param namespace namespace in which to check for the service
-   * @return AdminNodePort of the Kubernetes service if exists else -1
+   * @return node port of the channel for Kubernetes service if exists else -1
    * @throws ApiException when there is error in querying the cluster
    */
   public static int getAdminServiceNodePort(
       String serviceName,
+      String channelName,
       Map<String, String> label,
       String namespace) throws ApiException {
 
@@ -1566,12 +1568,12 @@ public class Kubernetes implements LoggedTest {
     }
 
     for (int i = 0; i < portList.size(); i++) {
-      if (portList.get(i).getName().equals("default")) {
-        logger.info(portList.get(i).toString());
+      if (portList.get(i).getName().equals(channelName)) {
+        logger.info("NodePort for Channel:{0} is {1}", channelName, portList.get(i).toString());
         return portList.get(i).getNodePort().intValue();
       }
     }
-    // return -1 if there is no Port with name default
+    // return -1 if there is no Port for the channel
     return -1;
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1540,7 +1540,7 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
-   * Returns NodePort of a admin server service channel.
+   * Returns the NodePort of a admin server service channel.
    *
    * @param serviceName name of admin server service
    * @param channelName name of the channel, values can be default/T3Channel
@@ -1569,7 +1569,7 @@ public class Kubernetes implements LoggedTest {
 
     for (int i = 0; i < portList.size(); i++) {
       if (portList.get(i).getName().equals(channelName)) {
-        logger.info("NodePort for Channel:{0} is {1}", channelName, portList.get(i).toString());
+        logger.info("NodePort for Channel:{0} is {1}", channelName, portList.get(i).getNodePort().intValue());
         return portList.get(i).getNodePort().intValue();
       }
     }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -174,7 +174,7 @@ public class TestAssertions {
   }
 
   /**
-   * Verify admin default/t3channel node port is accessible.
+   * Verify admin node port(default/t3channel) is accessible.
    *
    * @param nodePort admin default or t3 channel node port
    * @param adminUser admin user name to access the REST url

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -174,25 +174,15 @@ public class TestAssertions {
   }
 
   /**
-   * Check if a adminserver T3 channel is accessible.
+   * Verify admin default/t3channel node port is accessible.
    *
-   * @param domainUid id of the domain in which admin server pod is running
-   * @param namespace in which the WebLogic server pod exists
-   * @return true if the admin T3 channel is accessible otherwise false
+   * @param nodePort admin default or t3 channel node port
+   * @param adminUser admin user name to access the REST url
+   * @param adminPassword admin password to access the REST url
+   * @return true if admin REST url is accessible using node port
    */
-  public static boolean adminT3ChannelAccessible(String domainUid, String namespace) {
-    return Domain.adminT3ChannelAccessible(domainUid, namespace);
-  }
-
-  /**
-   * Check if a admin server pod admin node port is accessible.
-   *
-   * @param domainUid domainUID id of the domain in which admin server pod is running
-   * @param namespace in which the WebLogic server pod exists
-   * @return true if the admin node port is accessible otherwise false
-   */
-  public static boolean adminNodePortAccessible(String domainUid, String namespace) {
-    return Domain.adminNodePortAccessible(domainUid, namespace);
+  public static boolean adminNodePortAccessible(int nodePort, String adminUser, String adminPassword) {
+    return Domain.adminNodePortAccessible(nodePort, adminUser, adminPassword);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -89,7 +89,8 @@ public class Domain {
   }
 
   /**
-   * Get the default node port of admin service and access the REST endpoint using node port.
+   * Verify admin node port(default/t3channel) is working by accessing REST endpoint using
+   * the node port.
    *
    * @param nodePort admin default/t3channel node port
    * @param username admin user name to access the REST url


### PR DESCRIPTION
Adding assertions for default and t3channel node port verification for adminservice

Jenkins run is clean on both cluster-10 and on kind cluster,

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/84/

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests-10/94/


Please wait to review this PR. See my comment on Sankar's PR - https://github.com/oracle/weblogic-kubernetes-operator/pull/1648#discussion_r425770296. If that is done, this PR is not needed.