### PR TITLE
convert ItUsabilityOperatorHelmChart to JUnit5

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItScaleMiiDomainNginx.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItScaleMiiDomainNginx.java
@@ -3,23 +3,13 @@
 
 package oracle.weblogic.kubernetes;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import com.google.gson.JsonObject;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretReference;
-import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import oracle.weblogic.domain.AdminServer;
 import oracle.weblogic.domain.Cluster;
 import oracle.weblogic.domain.Configuration;
@@ -27,84 +17,45 @@ import oracle.weblogic.domain.Domain;
 import oracle.weblogic.domain.DomainSpec;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
-import oracle.weblogic.kubernetes.actions.impl.NginxParams;
-import oracle.weblogic.kubernetes.actions.impl.OperatorParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
-import oracle.weblogic.kubernetes.annotations.tags.MustNotRunInParallel;
-import oracle.weblogic.kubernetes.annotations.tags.Slow;
 import oracle.weblogic.kubernetes.extensions.LoggedTest;
-import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static oracle.weblogic.kubernetes.TestConstants.GOOGLE_REPO_URL;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
-import static oracle.weblogic.kubernetes.TestConstants.NGINX_CHART_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.NGINX_RELEASE_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
-import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.REPO_DUMMY_VALUE;
-import static oracle.weblogic.kubernetes.TestConstants.REPO_EMAIL;
-import static oracle.weblogic.kubernetes.TestConstants.REPO_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.REPO_PASSWORD;
-import static oracle.weblogic.kubernetes.TestConstants.REPO_REGISTRY;
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.REPO_SECRET_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.REPO_USERNAME;
-import static oracle.weblogic.kubernetes.TestConstants.STABLE_REPO_NAME;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.ARCHIVE_DIR;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.WDT_VERSION;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.WIT_BUILD_DIR;
-import static oracle.weblogic.kubernetes.actions.TestActions.buildAppArchive;
-import static oracle.weblogic.kubernetes.actions.TestActions.createDockerConfigJson;
-import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
-import static oracle.weblogic.kubernetes.actions.TestActions.createIngress;
-import static oracle.weblogic.kubernetes.actions.TestActions.createMiiImage;
-import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
-import static oracle.weblogic.kubernetes.actions.TestActions.createServiceAccount;
-import static oracle.weblogic.kubernetes.actions.TestActions.defaultAppParams;
-import static oracle.weblogic.kubernetes.actions.TestActions.defaultWitParams;
-import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
-import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
-import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
-import static oracle.weblogic.kubernetes.actions.TestActions.installNginx;
-import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
-import static oracle.weblogic.kubernetes.actions.TestActions.listIngresses;
-import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
+import static oracle.weblogic.kubernetes.TestConstants.WLS_DOMAIN_TYPE;
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallNginx;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.isNginxReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podExists;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChangedDuringScalingCluster;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceExists;
-import static oracle.weblogic.kubernetes.utils.FileUtils.checkDirectory;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkPodCreated;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkServiceCreated;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createDockerRegistrySecret;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createIngressForDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createMiiImageAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.dockerLoginAndPushImageToRegistry;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.installAndVerifyNginx;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.scaleAndVerifyCluster;
 import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndCheckForServerNameInResponse;
 import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.with;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verify the model in image domain with multiple clusters can be scaled up and down.
- * Also verify the sample application can be accessed via NGINX.
+ * Also verify the sample application can be accessed via NGINX ingress controller.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("Verify scaling multiple clusters domain and the sample application can be accessed via NGINX")
@@ -114,46 +65,35 @@ class ItScaleMiiDomainNginx implements LoggedTest {
   // mii constants
   private static final String WDT_MODEL_FILE = "model-multiclusterdomain-sampleapp-wls.yaml";
   private static final String MII_IMAGE_NAME = "mii-image";
-  private static final String APP_NAME = "sample-app";
 
   // domain constants
-  private static final String DOMAIN_VERSION = "v7";
-  private static final String API_VERSION = "weblogic.oracle/" + DOMAIN_VERSION;
+  private static final String domainUid = "domain1";
   private static final int NUMBER_OF_CLUSTERS = 2;
   private static final String CLUSTER_NAME_PREFIX = "cluster-";
   private static final int MANAGED_SERVER_PORT = 8001;
+  private static final int replicaCount = 2;
 
-  private static String opNamespace = null;
   private static String domainNamespace = null;
-  private static ConditionFactory withStandardRetryPolicy = null;
-  private static String dockerConfigJson = "";
   private static HelmParams nginxHelmParams = null;
-  private static String nginxNamespace = null;
   private static int nodeportshttp = 0;
-  private static int nodeportshttps = 0;
+  private static List<String> ingressHostList = null;
 
-  private final int replicaCount = 2;
-  private final String managedServerNameBase = "-managed-server";
-  private final String domainUid = "domain1";
   private String curlCmd = null;
 
   /**
-   * Install operator and NGINX.
+   * Install operator and NGINX. Create model in image domain with multiple clusters.
+   * Create ingress for the domain.
    *
    * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
    *                   JUnit engine parameter resolution mechanism
    */
   @BeforeAll
   public static void initAll(@Namespaces(3) List<String> namespaces) {
-    // create standard, reusable retry/backoff policy
-    withStandardRetryPolicy = with().pollDelay(2, SECONDS)
-        .and().with().pollInterval(10, SECONDS)
-        .atMost(5, MINUTES).await();
 
     // get a unique operator namespace
     logger.info("Get a unique namespace for operator");
     assertNotNull(namespaces.get(0), "Namespace list is null");
-    opNamespace = namespaces.get(0);
+    String opNamespace = namespaces.get(0);
 
     // get a unique domain namespace
     logger.info("Get a unique namespace for WebLogic domain");
@@ -163,82 +103,116 @@ class ItScaleMiiDomainNginx implements LoggedTest {
     // get a unique NGINX namespace
     logger.info("Get a unique namespace for NGINX");
     assertNotNull(namespaces.get(2), "Namespace list is null");
-    nginxNamespace = namespaces.get(2);
+    String nginxNamespace = namespaces.get(2);
 
     // install and verify operator
-    installAndVerifyOperator();
+    installAndVerifyOperator(opNamespace, domainNamespace);
 
     // get a free node port for NGINX
     nodeportshttp = getNextFreePort(30305, 30405);
-    nodeportshttps = getNextFreePort(30443, 30543);
+    int nodeportshttps = getNextFreePort(30443, 30543);
 
     // install and verify NGINX
-    installAndVerifyNginx();
+    nginxHelmParams = installAndVerifyNginx(nginxNamespace, nodeportshttp, nodeportshttps);
+
+    // create model in image domain with multiple clusters
+    createMiiDomainWithMultiClusters();
+
+    // create ingress using host based routing
+    List<String> clusterNames = new ArrayList<>();
+    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
+      clusterNames.add(CLUSTER_NAME_PREFIX + i);
+    }
+    logger.info("Creating ingress for domain {0} in namespace {1}", domainUid, domainNamespace);
+    ingressHostList = createIngressForDomainAndVerify(domainUid, domainNamespace, MANAGED_SERVER_PORT, clusterNames);
   }
 
   @Test
-  @Order(1)
-  @DisplayName("Create model in image domain with multiple clusters")
-  @Slow
-  @MustNotRunInParallel
-  public void testCreateMiiDomainWithMultiClusters() {
+  @DisplayName("Verify the application can be accessed through NGINX for each cluster in the domain")
+  public void testAppAccessThroughIngressController() {
+
+    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
+      String clusterName = CLUSTER_NAME_PREFIX + i;
+
+      List<String> managedServerListBeforeScale =
+          listManagedServersBeforeScale(clusterName, replicaCount);
+
+      // check that NGINX can access the sample apps from all managed servers in the cluster of the domain
+      curlCmd = generateCurlCmd(clusterName);
+      assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, managedServerListBeforeScale, 50))
+          .as("Verify NGINX can access the sample app from all managed servers in the domain")
+          .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
+          .isTrue();
+    }
+  }
+
+  @Test
+  @DisplayName("Verify scale each cluster of the domain in domain namespace")
+  public void testScaleClusters() {
+
+    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
+
+      String clusterName = CLUSTER_NAME_PREFIX + i;
+      int numberOfServers = 2 * i - 1;
+
+      // scale cluster-1 to 1 server and cluster-2 to 3 servers
+      logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers.",
+          clusterName, domainUid, domainNamespace, numberOfServers);
+      curlCmd = generateCurlCmd(clusterName);
+      List<String> managedServersBeforeScale = listManagedServersBeforeScale(clusterName, replicaCount);
+      scaleAndVerifyCluster(clusterName, domainUid, domainNamespace, replicaCount, numberOfServers,
+          curlCmd, managedServersBeforeScale);
+
+      // then scale cluster-1 and cluster-2 to 0 server
+      managedServersBeforeScale = listManagedServersBeforeScale(clusterName, numberOfServers);
+      scaleAndVerifyCluster(clusterName, domainUid, domainNamespace, numberOfServers, 0,
+          curlCmd, managedServersBeforeScale);
+    }
+  }
+
+  /**
+   * TODO: remove this after Sankar's PR is merged
+   * The cleanup framework does not uninstall NGINX release. Do it here for now.
+   */
+  @AfterAll
+  public void tearDownAll() {
+    // uninstall NGINX release
+    if (nginxHelmParams != null) {
+      assertThat(uninstallNginx(nginxHelmParams))
+          .as("Test uninstallNginx returns true")
+          .withFailMessage("uninstallNginx() did not return true")
+          .isTrue();
+    }
+  }
+
+  /**
+   * Create model in image domain with multiple clusters.
+   */
+  private static void createMiiDomainWithMultiClusters() {
 
     // admin/managed server name here should match with model yaml in WDT_MODEL_FILE
-    final String adminServerPodName = domainUid + "-admin-server";
+    final String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
 
     // create image with model files
     logger.info("Creating image with model file and verify");
-    String miiImage = createImageAndVerify();
+    String miiImage = createMiiImageAndVerify(MII_IMAGE_NAME, WDT_MODEL_FILE, MII_BASIC_APP_NAME);
 
-    // docker login, if necessary
-    if (!REPO_USERNAME.equals(REPO_DUMMY_VALUE)) {
-      logger.info("docker login");
-      assertTrue(dockerLogin(REPO_REGISTRY, REPO_USERNAME, REPO_PASSWORD), "docker login failed");
-    }
+    // docker login and push image to docker registry if necessary
+    dockerLoginAndPushImageToRegistry(miiImage);
 
-    // push image, if necessary
-    if (!REPO_NAME.isEmpty()) {
-      logger.info("docker push image {0} to {1}", miiImage, REPO_NAME);
-      assertTrue(dockerPush(miiImage), String.format("docker push failed for image %s", miiImage));
-    }
-
-    // Create the V1Secret configuration
-    V1Secret repoSecret = new V1Secret()
-        .metadata(new V1ObjectMeta()
-            .name(REPO_SECRET_NAME)
-            .namespace(domainNamespace))
-        .type("kubernetes.io/dockerconfigjson")
-        .putDataItem(".dockerconfigjson", dockerConfigJson.getBytes());
-
-    boolean secretCreated = assertDoesNotThrow(() -> createSecret(repoSecret),
-        String.format("createSecret failed for %s", REPO_SECRET_NAME));
-    assertTrue(secretCreated, String.format("createSecret failed while creating secret %s", REPO_SECRET_NAME));
+    // create docker registry secret to pull the image from registry
+    logger.info("Creating docker registry secret in namespace {0}", domainNamespace);
+    createDockerRegistrySecret(domainNamespace);
 
     // create secret for admin credentials
     logger.info("Creating secret for admin credentials");
     String adminSecretName = "weblogic-credentials";
-    Map<String, String> adminSecretMap = new HashMap<>();
-    adminSecretMap.put("username", "weblogic");
-    adminSecretMap.put("password", "welcome1");
-    secretCreated = assertDoesNotThrow(() -> createSecret(new V1Secret()
-        .metadata(new V1ObjectMeta()
-            .name(adminSecretName)
-            .namespace(domainNamespace))
-        .stringData(adminSecretMap)), "Create secret failed with ApiException");
-    assertTrue(secretCreated, String.format("create secret failed for %s", adminSecretName));
+    createSecretWithUsernamePassword(adminSecretName, domainNamespace, "weblogic", "welcome1");
 
     // create encryption secret
     logger.info("Creating encryption secret");
     String encryptionSecretName = "encryptionsecret";
-    Map<String, String> encryptionSecretMap = new HashMap<>();
-    encryptionSecretMap.put("username", "weblogicenc");
-    encryptionSecretMap.put("password", "weblogicenc");
-    secretCreated = assertDoesNotThrow(() -> createSecret(new V1Secret()
-        .metadata(new V1ObjectMeta()
-            .name(encryptionSecretName)
-            .namespace(domainNamespace))
-        .stringData(encryptionSecretMap)), "Create secret failed with ApiException");
-    assertTrue(secretCreated, String.format("create secret failed for %s", encryptionSecretName));
+    createSecretWithUsernamePassword(encryptionSecretName, domainNamespace, "weblogicenc", "weblogicenc");
 
     // construct the cluster list used for domain custom resource
     List<Cluster> clusterList = new ArrayList<>();
@@ -251,7 +225,7 @@ class ItScaleMiiDomainNginx implements LoggedTest {
 
     // create the domain CR
     Domain domain = new Domain()
-        .apiVersion(API_VERSION)
+        .apiVersion(DOMAIN_API_VERSION)
         .kind("Domain")
         .metadata(new V1ObjectMeta()
             .name(domainUid)
@@ -279,531 +253,50 @@ class ItScaleMiiDomainNginx implements LoggedTest {
             .clusters(clusterList)
             .configuration(new Configuration()
                 .model(new Model()
-                    .domainType("WLS")
+                    .domainType(WLS_DOMAIN_TYPE)
                     .runtimeEncryptionSecret(encryptionSecretName))));
 
-    logger.info("Creating domain custom resource for domainUid {0} in namespace {1}",
-        domainUid, domainNamespace);
-    assertTrue(assertDoesNotThrow(() -> createDomainCustomResource(domain),
-        String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
-            domainUid, domainNamespace)),
-        String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
-            domainUid, domainNamespace));
-
-    // wait for the domain to exist
-    logger.info("Checking for domain custom resource existence in namespace {0}", domainNamespace);
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for domain {0} to be created in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                domainUid,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(domainExists(domainUid, DOMAIN_VERSION, domainNamespace));
+    // create model in image domain
+    logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",
+        domainUid, domainNamespace, miiImage);
+    createDomainAndVerify(domain, domainNamespace);
 
     // check admin server pod was created
     logger.info("Checking that admin server pod {0} was created in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkPodCreated(adminServerPodName);
+    checkPodCreated(adminServerPodName, domainUid, domainNamespace);
 
     // check admin server pod is ready
     logger.info("Checking that admin server pod {0} is ready in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkPodReady(adminServerPodName);
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
 
-    // check admin service is created
+    // check admin service was created
     logger.info("Checking that admin service {0} was created in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkServiceCreated(adminServerPodName);
+    checkServiceCreated(adminServerPodName, domainNamespace);
 
     // check the readiness for the managed servers in each cluster
     for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
       for (int j = 1; j <= replicaCount; j++) {
         String managedServerPodName =
-            domainUid + "-" + CLUSTER_NAME_PREFIX + i + managedServerNameBase + j;
+            domainUid + "-" + CLUSTER_NAME_PREFIX + i + "-" + MANAGED_SERVER_NAME_BASE + j;
 
         // check managed server pod was created
         logger.info("Checking that managed server pod {0} was created in namespace {1}",
             managedServerPodName, domainNamespace);
-        checkPodCreated(managedServerPodName);
+        checkPodCreated(managedServerPodName, domainUid, domainNamespace);
 
         // check managed server pod is ready
         logger.info("Checking that managed server pod {0} is ready in namespace {1}",
             managedServerPodName, domainNamespace);
-        checkPodReady(managedServerPodName);
+        checkPodReady(managedServerPodName, domainUid, domainNamespace);
 
         // check managed server service was created
         logger.info("Checking that managed server service {0} was created in namespace {1}",
             managedServerPodName, domainNamespace);
-        checkServiceCreated(managedServerPodName);
+        checkServiceCreated(managedServerPodName, domainNamespace);
       }
-    }
-  }
-
-  @Test
-  @Order(2)
-  @DisplayName("Create an ingress for each cluster of the WebLogic domain in the specified domain namespace")
-  public void testCreateIngress() {
-
-    // create an ingress for each cluster of the domain in the domain namespace
-    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
-
-      String clusterName = CLUSTER_NAME_PREFIX + i;
-      String ingressName = domainUid + "-" + clusterName + "-nginx";
-
-      logger.info("Creating ingress {0} for cluster {1} of domain {2} in namespace {3}",
-          ingressName, clusterName, domainUid, domainNamespace);
-      assertThat(createIngress(ingressName, domainNamespace, domainUid, clusterName,
-          MANAGED_SERVER_PORT, domainUid + "." + clusterName + ".test"))
-          .as("Test ingress creation succeeds", ingressName)
-          .withFailMessage("Ingress creation failed for cluster {0} of domain {1} in namespace {2}",
-              clusterName, domainUid, domainNamespace)
-          .isTrue();
-
-      // check that the ingress was found in the domain namespace
-      assertThat(assertDoesNotThrow(() -> listIngresses(domainNamespace)))
-          .as("Test ingress {0} was found in namespace {1}", ingressName, domainNamespace)
-          .withFailMessage("Ingress {0} was not found in namespace {1}", ingressName, domainNamespace)
-          .contains(ingressName);
-
-      logger.info("Ingress {0} for cluster {1} of domain {2} was found in namespace {3}",
-          ingressName, clusterName, domainUid, domainNamespace);
-    }
-  }
-
-  @Test
-  @Order(3)
-  @DisplayName("Verify the application can be accessed through the ingress controller for each cluster in the domain")
-  public void testAppAccessThroughIngressController() {
-
-    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
-      String clusterName = CLUSTER_NAME_PREFIX + i;
-
-      List<String> managedServerListBeforeScale =
-          listManagedServersBeforeScale(clusterName, replicaCount);
-
-      // check that NGINX can access the sample apps from all managed servers in the cluster of the domain
-      curlCmd = generateCurlCmd(clusterName);
-      assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, managedServerListBeforeScale, 50))
-          .as("Verify NGINX can access the sample app from all managed servers in the domain")
-          .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
-          .isTrue();
-    }
-  }
-
-  @Test
-  @Order(4)
-  @DisplayName("Verify scale each cluster of the domain in domain namespace")
-  public void testScaleClusters() {
-
-    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
-
-      String clusterName = CLUSTER_NAME_PREFIX + i;
-      int numberOfServers = 2 * i - 1;
-
-      // scale cluster-1 to 1 server and cluster-2 to 3 servers
-      logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers.",
-          clusterName, domainUid, domainNamespace, numberOfServers);
-      scaleAndVerifyCluster(clusterName, replicaCount, numberOfServers);
-
-      // then scale cluster-1 and cluster-2 to 0 server
-      scaleAndVerifyCluster(clusterName, numberOfServers, 0);
-    }
-  }
-
-  /**
-   * TODO: remove this after Sankar's PR is merged
-   * The cleanup framework does not uninstall NGINX release. Do it here for now.
-   */
-  @AfterAll
-  public void tearDownAll() {
-    // uninstall NGINX release
-    if (nginxHelmParams != null) {
-      assertThat(uninstallNginx(nginxHelmParams))
-          .as("Test uninstallNginx returns true")
-          .withFailMessage("uninstallNginx() did not return true")
-          .isTrue();
-    }
-  }
-
-  /**
-   * Install WebLogic operator and wait until the operator pod is ready.
-   */
-  private static void installAndVerifyOperator() {
-
-    // Create a service account for the unique opNamespace
-    logger.info("Creating service account");
-    String serviceAccountName = opNamespace + "-sa";
-    assertDoesNotThrow(() -> createServiceAccount(new V1ServiceAccount()
-        .metadata(new V1ObjectMeta()
-                .namespace(opNamespace)
-                .name(serviceAccountName))));
-    logger.info("Created service account: {0}", serviceAccountName);
-
-    // get operator image name
-    String operatorImage = getOperatorImageName();
-    assertFalse(operatorImage.isEmpty(), "operator image name can not be empty");
-    logger.info("Got operator image name {0}", operatorImage);
-
-    // Create docker registry secret in the operator namespace to pull the image from repository
-    logger.info("Creating docker registry secret in namespace {0}", opNamespace);
-    JsonObject dockerConfigJsonObject = createDockerConfigJson(
-        REPO_USERNAME, REPO_PASSWORD, REPO_EMAIL, REPO_REGISTRY);
-    dockerConfigJson = dockerConfigJsonObject.toString();
-
-    // Create the V1Secret configuration
-    V1Secret repoSecret = new V1Secret()
-        .metadata(new V1ObjectMeta()
-            .name(REPO_SECRET_NAME)
-            .namespace(opNamespace))
-        .type("kubernetes.io/dockerconfigjson")
-        .putDataItem(".dockerconfigjson", dockerConfigJson.getBytes());
-
-    boolean secretCreated = assertDoesNotThrow(() -> createSecret(repoSecret),
-        String.format("createSecret failed for %s", REPO_SECRET_NAME));
-    assertTrue(secretCreated, String.format("createSecret failed while creating secret %s in namespace %s",
-        REPO_SECRET_NAME, opNamespace));
-
-    // map with secret
-    Map<String, Object> secretNameMap = new HashMap<>();
-    secretNameMap.put("name", REPO_SECRET_NAME);
-
-    // Helm install parameters
-    HelmParams opHelmParams = new HelmParams()
-        .releaseName(OPERATOR_RELEASE_NAME)
-        .namespace(opNamespace)
-        .chartDir(OPERATOR_CHART_DIR);
-
-    // operator chart values to override
-    OperatorParams opParams = new OperatorParams()
-        .helmParams(opHelmParams)
-        .image(operatorImage)
-        .imagePullSecrets(secretNameMap)
-        .domainNamespaces(Arrays.asList(domainNamespace))
-        .serviceAccount(serviceAccountName);
-
-    // install operator
-    logger.info("Installing operator in namespace {0}", opNamespace);
-    assertTrue(installOperator(opParams),
-        String.format("Failed to install operator in namespace %s", opNamespace));
-    logger.info("Operator installed in namespace {0}", opNamespace);
-
-    // list Helm releases matching operator release name in operator namespace
-    logger.info("Checking operator release {0} status in namespace {1}",
-        OPERATOR_RELEASE_NAME, opNamespace);
-    assertTrue(isHelmReleaseDeployed(OPERATOR_RELEASE_NAME, opNamespace),
-        String.format("Operator release %s is not in deployed status in namespace %s",
-            OPERATOR_RELEASE_NAME, opNamespace));
-    logger.info("Operator release {0} status is deployed in namespace {1}",
-        OPERATOR_RELEASE_NAME, opNamespace);
-
-    // check operator is running
-    logger.info("Checking that operator pod is running in namespace {0}", opNamespace);
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for operator to be running in namespace {0} "
-                    + "(elapsed time {1}ms, remaining time {2}ms)",
-                opNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(operatorIsReady(opNamespace));
-  }
-
-  /**
-   * Install NGINX and wait until the NGINX pod is ready.
-   */
-  private static void installAndVerifyNginx() {
-
-    // Helm install parameters
-    nginxHelmParams = new HelmParams()
-        .releaseName(NGINX_RELEASE_NAME)
-        .namespace(nginxNamespace)
-        .repoUrl(GOOGLE_REPO_URL)
-        .repoName(STABLE_REPO_NAME)
-        .chartName(NGINX_CHART_NAME);
-
-    // NGINX chart values to override
-    NginxParams nginxParams = new NginxParams()
-        .helmParams(nginxHelmParams)
-        .nodePortsHttp(nodeportshttp)
-        .nodePortsHttps(nodeportshttps);
-
-    // install NGINX
-    assertThat(installNginx(nginxParams))
-        .as("Test installing NGINX succeeds")
-        .withFailMessage("NGINX installation is failed")
-        .isTrue();
-
-    // verify that NGINX is installed
-    logger.info("Checking NGINX release {0} status in namespace {1}",
-        NGINX_RELEASE_NAME, nginxNamespace);
-    assertTrue(isHelmReleaseDeployed(NGINX_RELEASE_NAME, nginxNamespace),
-        String.format("NGINX release %s is not in deployed status in namespace %s",
-            NGINX_RELEASE_NAME, nginxNamespace));
-    logger.info("NGINX release {0} status is deployed in namespace {1}",
-        NGINX_RELEASE_NAME, nginxNamespace);
-
-    // wait until the NGINX pod is ready.
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info(
-                "Waiting for NGINX to be ready in namespace {0} (elapsed time {1}ms, remaining time {2}ms)",
-                nginxNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(isNginxReady(nginxNamespace));
-  }
-
-  /**
-   * Create a Docker image for model in image.
-   *
-   * @return image name with tag
-   */
-  private String createImageAndVerify() {
-
-    // create unique image name with date
-    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-    Date date = new Date();
-    final String imageTag = dateFormat.format(date) + "-" + System.currentTimeMillis();
-    // Add repository name in image name for Jenkins runs
-    final String imageName = REPO_NAME + MII_IMAGE_NAME;
-    final String image = imageName + ":" + imageTag;
-
-    // build the model file list
-    final List<String> modelList = Collections.singletonList(MODEL_DIR + "/" + WDT_MODEL_FILE);
-
-    // build an application archive using what is in resources/apps/APP_NAME
-    assertTrue(buildAppArchive(defaultAppParams()
-        .srcDir(APP_NAME)), String.format("Failed to create app archive for %s", APP_NAME));
-
-    // build the archive list
-    String zipFile = String.format("%s/%s.zip", ARCHIVE_DIR, APP_NAME);
-    final List<String> archiveList = Collections.singletonList(zipFile);
-
-    // Set additional environment variables for WIT
-    checkDirectory(WIT_BUILD_DIR);
-    Map<String, String> env = new HashMap<>();
-    env.put("WLSIMG_BLDDIR", WIT_BUILD_DIR);
-
-    // For k8s 1.16 support and as of May 6, 2020, we presently need a different JDK for these
-    // tests and for image tool. This is expected to no longer be necessary once JDK 11.0.8 or
-    // the next JDK 14 versions are released.
-    String witJavaHome = System.getenv("WIT_JAVA_HOME");
-    if (witJavaHome != null) {
-      env.put("JAVA_HOME", witJavaHome);
-    }
-
-    // build an image using WebLogic Image Tool
-    logger.info("Creating image {0} using model directory {1}", image, MODEL_DIR);
-    boolean result = createMiiImage(
-        defaultWitParams()
-            .modelImageName(imageName)
-            .modelImageTag(imageTag)
-            .modelFiles(modelList)
-            .modelArchiveFiles(archiveList)
-            .wdtVersion(WDT_VERSION)
-            .env(env)
-            .redirect(true));
-
-    assertTrue(result, String.format("Failed to create the image %s using WebLogic Image Tool", image));
-
-    // Check image exists using docker images | grep image tag.
-    assertTrue(doesImageExist(imageTag),
-        String.format("Image %s does not exist", image));
-
-    return image;
-  }
-
-  /**
-   * Check pod is created.
-   *
-   * @param podName pod name to check
-   */
-  private void checkPodCreated(String podName) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be created in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> podExists(podName, domainUid, domainNamespace),
-            String.format("podExists failed with ApiException for %s in namespace in %s",
-                podName, domainNamespace)));
-
-  }
-
-  /**
-   * Check pod is ready.
-   *
-   * @param podName pod name to check
-   */
-  private void checkPodReady(String podName) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be ready in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> podReady(podName, domainUid, domainNamespace),
-            String.format(
-                "pod %s is not ready in namespace %s", podName, domainNamespace)));
-
-  }
-
-  /**
-   * Check service is created.
-   *
-   * @param serviceName service name to check
-   */
-  private void checkServiceCreated(String serviceName) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for service {0} to be created in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                serviceName,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> serviceExists(serviceName, null, domainNamespace),
-            String.format(
-                "Service %s is not ready in namespace %s", serviceName, domainNamespace)));
-
-  }
-
-  /**
-   * Check pod was deleted.
-   *
-   * @param podName pod name to check
-   */
-  private void checkPodDeleted(String podName) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be deleted in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> podDoesNotExist(podName, null, domainNamespace),
-            String.format("Pod %s still exists in namespace %s", podName, domainNamespace)));
-  }
-
-  /** Scale the WebLogic cluster to specified number of servers.
-   *  And verify the sample app can be accessed through NGINX.
-   *
-   * @param clusterName the WebLogic cluster name in the domain to be scaled
-   * @param replicasBeforeScale the replicas of the WebLogic cluster before the scale
-   * @param replicasAfterScale the replicas of the WebLogic cluster after the scale
-   */
-  private void scaleAndVerifyCluster(String clusterName,
-                                     int replicasBeforeScale,
-                                     int replicasAfterScale) {
-
-    String manageServerPodNamePrefix = domainUid + "-" + clusterName + managedServerNameBase;
-
-    // get the original managed server pod creation timestamp before scale
-    List<String> listOfPodCreationTimestamp = new ArrayList<>();
-    for (int i = 1; i <= replicasBeforeScale; i++) {
-      String managedServerPodName = manageServerPodNamePrefix + i;
-      String originalCreationTimestamp =
-          assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
-              String.format("getPodCreationTimestamp failed with ApiException for pod {0} in namespace {1}",
-                  managedServerPodName, domainNamespace));
-      listOfPodCreationTimestamp.add(originalCreationTimestamp);
-    }
-
-    // scale the cluster in the domain
-    logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers",
-        clusterName, domainUid, domainNamespace, replicasAfterScale);
-    assertThat(assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, replicasAfterScale)))
-        .as("Verify scaling cluster {0} of domain {1} in namespace {2} succeeds",
-            clusterName, domainUid, domainNamespace)
-        .withFailMessage("Scaling cluster failed")
-        .isTrue();
-
-    // generate a curl command to access the sample app through the ingress controller
-    curlCmd = generateCurlCmd(clusterName);
-
-    // generate the expected server list which should be in the sample app response string
-    List<String> expectedServerNames =
-        listManagedServersBeforeScale(clusterName, replicasBeforeScale);
-    logger.info("expected server name list which should be in the sample app response: {0} before scale",
-        expectedServerNames);
-
-    if (replicasBeforeScale <= replicasAfterScale) {
-
-      // scale up
-      // check that the original managed server pod state is not changed during scaling the cluster
-      for (int i = 1; i <= replicasBeforeScale; i++) {
-        String manageServerPodName = manageServerPodNamePrefix + i;
-
-        // check the original managed server pod state is not changed
-        logger.info("Checking that the state of manged server pod {0} is not changed in namespace {1}",
-            manageServerPodName, domainNamespace);
-        podStateNotChangedDuringScalingCluster(manageServerPodName, domainUid, domainNamespace,
-            listOfPodCreationTimestamp.get(i - 1));
-      }
-
-      // check that NGINX can access the sample apps from the original managed servers in the domain
-      logger.info("Checking that NGINX can access the sample app from the original managed servers in the domain "
-                  + "while the domain is scaling up.");
-      assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, expectedServerNames, 50))
-          .as("Verify NGINX can access the sample app from the original managed servers in the domain")
-          .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
-          .isTrue();
-
-      // check that new managed server pods were created and wait for them to be ready
-      for (int i = replicasBeforeScale + 1; i <= replicasAfterScale; i++) {
-        String manageServerPodName = manageServerPodNamePrefix + i;
-
-        // check new managed server pod was created
-        logger.info("Checking that the new managed server pod {0} was created in namespace {1}",
-            manageServerPodName, domainNamespace);
-        checkPodCreated(manageServerPodName);
-
-        // check new managed server pod is ready
-        logger.info("Checking that the new managed server pod {0} is ready in namespace {1}",
-            manageServerPodName, domainNamespace);
-        checkPodReady(manageServerPodName);
-
-        // check new managed server service was created
-        logger.info("Checking that the new managed server service {0} was created in namespace {1}",
-            manageServerPodName, domainNamespace);
-        checkServiceCreated(manageServerPodName);
-
-        // add the new managed server to the list
-        expectedServerNames.add(clusterName + managedServerNameBase + i);
-      }
-
-      // check that NGINX can access the sample apps from new and original managed servers
-      logger.info("Checking that NGINX can access the sample app from the new and original managed servers "
-          + "in the domain after the cluster is scaled up.");
-      assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, expectedServerNames, 50))
-          .as("Verify NGINX can access the sample app from all managed servers in the domain")
-          .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
-          .isTrue();
-    } else {
-      // scale down
-      // wait and check the pods are deleted
-      for (int i = replicasBeforeScale; i > replicasAfterScale; i--) {
-        logger.info("Checking that managed server pod {0} was deleted from namespace {1}",
-            manageServerPodNamePrefix + i, domainNamespace);
-        checkPodDeleted(manageServerPodNamePrefix + i);
-        expectedServerNames.remove(clusterName + managedServerNameBase + i);
-      }
-
-      // check that NGINX can access the app from the remaining managed servers in the domain
-      logger.info("Checking that NGINX can access the sample app from the remaining managed servers in the domain "
-          + "after the cluster is scaled down.");
-      assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, expectedServerNames, 50))
-          .as("Verify NGINX can access the sample app from the remaining managed server in the domain")
-          .withFailMessage("NGINX can not access the sample app from the remaining managed server")
-          .isTrue();
     }
   }
 
@@ -814,8 +307,16 @@ class ItScaleMiiDomainNginx implements LoggedTest {
    * @return curl command string
    */
   private String generateCurlCmd(String clusterName) {
+    int index = 0;
+    for (int i = 0; i < ingressHostList.size(); i++) {
+      if (ingressHostList.get(i).contains(clusterName)) {
+        index = i;
+        break;
+      }
+    }
+
     return String.format("curl --silent --show-error --noproxy '*' -H 'host: %s' http://%s:%s/sample-war/index.jsp",
-        domainUid + "." + clusterName + ".test", K8S_NODEPORT_HOST, nodeportshttp);
+        ingressHostList.get(index), K8S_NODEPORT_HOST, nodeportshttp);
   }
 
   /**
@@ -828,7 +329,7 @@ class ItScaleMiiDomainNginx implements LoggedTest {
   private List<String> listManagedServersBeforeScale(String clusterName, int replicasBeforeScale) {
     List<String> managedServerNames = new ArrayList<>();
     for (int i = 1; i <= replicasBeforeScale; i++) {
-      managedServerNames.add(clusterName + managedServerNameBase + i);
+      managedServerNames.add(clusterName + "-" + MANAGED_SERVER_NAME_BASE + i);
     }
 
     return managedServerNames;

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItUsabilityOperatorHelmChart.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItUsabilityOperatorHelmChart.java
@@ -1,0 +1,352 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1SecretReference;
+import oracle.weblogic.domain.AdminServer;
+import oracle.weblogic.domain.Cluster;
+import oracle.weblogic.domain.Configuration;
+import oracle.weblogic.domain.Domain;
+import oracle.weblogic.domain.DomainSpec;
+import oracle.weblogic.domain.Model;
+import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
+import oracle.weblogic.kubernetes.annotations.IntegrationTest;
+import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.annotations.tags.MustNotRunInParallel;
+import oracle.weblogic.kubernetes.annotations.tags.Slow;
+import oracle.weblogic.kubernetes.extensions.LoggedTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_SERVICE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.WLS_DOMAIN_TYPE;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
+import static oracle.weblogic.kubernetes.actions.TestActions.uninstallNginx;
+import static oracle.weblogic.kubernetes.actions.TestActions.uninstallOperator;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChanged;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkPodCreated;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkPodDeleted;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkServiceCreated;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.checkServiceDeleted;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createDockerRegistrySecret;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createIngressForDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.dockerLoginAndPushImageToRegistry;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.installAndVerifyNginx;
+import static oracle.weblogic.kubernetes.utils.CommonUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndCheckForServerNameInResponse;
+import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Simple JUnit test file used for testing operator usability.
+ * Use Helm chart to install operator(s)
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Test operator usability using Helm chart installation")
+@IntegrationTest
+class ItUsabilityOperatorHelmChart implements LoggedTest {
+
+  private static String opNamespace = null;
+  private static String domainNamespace = null;
+  private static HelmParams nginxHelmParams = null;
+  private static int nodeportshttp = 0;
+
+  // domain constants
+  private final String domainUid = "domain1";
+  private final String clusterName = "cluster-1";
+  private final int managedServerPort = 8001;
+  private final int replicaCount = 2;
+  private final String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+  private final String managedServerPrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
+
+  // ingress host list
+  private List<String> ingressHostList;
+
+  /**
+   * Get namespaces for operator, domain1 and NGINX.
+   * Install and verify NGINX.
+   *
+   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
+   *                   JUnit engine parameter resolution mechanism
+   */
+  @BeforeAll
+  public static void initAll(@Namespaces(3) List<String> namespaces) {
+
+    // get a unique operator namespace
+    logger.info("Getting a unique namespace for operator");
+    assertNotNull(namespaces.get(0), "Namespace list is null");
+    opNamespace = namespaces.get(0);
+
+    // get a unique domain namespace
+    logger.info("Getting a unique namespace for WebLogic domain");
+    assertNotNull(namespaces.get(1), "Namespace list is null");
+    domainNamespace = namespaces.get(1);
+
+    // get a unique NGINX namespace
+    logger.info("Getting a unique namespace for NGINX");
+    assertNotNull(namespaces.get(2), "Namespace list is null");
+    String nginxNamespace = namespaces.get(2);
+
+    // get a free node port for NGINX
+    nodeportshttp = getNextFreePort(30305, 30405);
+    int nodeportshttps = getNextFreePort(30443, 30543);
+
+    // install and verify NGINX
+    logger.info("Installing and verifying NGINX");
+    nginxHelmParams = installAndVerifyNginx(nginxNamespace, nodeportshttp, nodeportshttps);
+  }
+
+  /**
+   * Create operator and verify it is deployed successfully.
+   * Create a custom domain resource and verify all server pods in the domain were created and ready.
+   * Verify NGINX can access the sample app from all managed servers in the domain.
+   * Delete operator.
+   * Verify the states of all server pods in the domain were not changed.
+   * Verify NGINX can access the sample app from all managed servers in the domain after the operator was deleted.
+   * Test fails if the state of any pod in the domain was changed or NGINX can not access the sample app from
+   * all managed servers in the absence of operator.
+   */
+  @Test
+  @DisplayName("Create operator and domain, then delete operator and verify the domain is still running")
+  @Slow
+  @MustNotRunInParallel
+  public void testDeleteOperatorButNotDomain() {
+    // install and verify operator
+    logger.info("Installing and verifying operator");
+    HelmParams opHelmParams = installAndVerifyOperator(opNamespace, domainNamespace);
+
+    // create and verify the domain
+    logger.info("Creating and verifying model in image domain");
+    createAndVerifyMiiDomain();
+
+    // get the admin server pod original creation timestamp
+    logger.info("Getting admin server pod original creation timestamp");
+    String adminPodOriginalTimestamp =
+        assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
+            String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
+                adminServerPodName, domainNamespace));
+
+    // get the managed server pod original creation timestamp
+    logger.info("Getting managed server pods original creation timestamp");
+    List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
+    for (int i = 1; i <= replicaCount; i++) {
+      final String managedServerPodName = managedServerPrefix + i;
+      managedServerPodOriginalTimestampList.add(
+          assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
+              String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
+                  managedServerPodName, domainNamespace)));
+    }
+
+    // create ingress for the domain
+    logger.info("Creating ingress for domain {0} in namespace {1}", domainUid, domainNamespace);
+    ingressHostList =
+        createIngressForDomainAndVerify(domainUid, domainNamespace, managedServerPort, Arrays.asList(clusterName));
+
+    // verify the sample apps for the domain
+    logger.info("Checking that the sample app can be accessed from all managed servers through NGINX");
+    verifySampleAppAccessThroughNginx();
+
+    // delete operator
+    logger.info("Uninstalling operator");
+    uninstallOperator(opHelmParams);
+
+    // verify the operator pod was deleted
+    logger.info("Checking that operator pod was deleted");
+    checkPodDeleted("weblogic-operator-", null, opNamespace);
+
+    // verify the operator service was deleted
+    logger.info("Checking that operator service was deleted");
+    checkServiceDeleted(OPERATOR_SERVICE_NAME, opNamespace);
+
+    // check that the state of admin server pod in the domain was not changed
+    logger.info("Checking that the admin server pod state was not changed after the operator was deleted");
+    assertThat(podStateNotChanged(adminServerPodName, domainUid, domainNamespace, adminPodOriginalTimestamp))
+        .as("Test state of pod {0} was not changed in namespace {1}", adminServerPodName, domainNamespace)
+        .withFailMessage("State of pod {0} was changed in namespace {1}",
+            adminServerPodName, domainNamespace)
+        .isTrue();
+
+    // check that the states of managed server pods in the domain were not changed
+    logger.info("Checking that the managed server pod state was not changed after the operator was deleted");
+    for (int i = 1; i <= replicaCount; i++) {
+      String managedServerPodName = managedServerPrefix + i;
+      assertThat(podStateNotChanged(managedServerPodName, domainUid, domainNamespace,
+              managedServerPodOriginalTimestampList.get(i - 1)))
+          .as("Test state of pod {0} was not changed in namespace {1}", managedServerPodName, domainNamespace)
+          .withFailMessage("State of pod {0} was changed in namespace {1}",
+              managedServerPodName, domainNamespace)
+          .isTrue();
+    }
+
+    // verify the sample app in the domain is still accessible from all managed servers through NGINX
+    logger.info("Checking that the sample app can be accessed from all managed servers through NGINX "
+        + "after the operator was deleted");
+    verifySampleAppAccessThroughNginx();
+  }
+
+  /**
+   * TODO: remove this after Sankar's PR is merged
+   * The cleanup framework does not uninstall NGINX release. Do it here for now.
+   */
+  @AfterAll
+  public void tearDownAll() {
+    // uninstall NGINX release
+    if (nginxHelmParams != null) {
+      assertThat(uninstallNginx(nginxHelmParams))
+          .as("Test uninstallNginx returns true")
+          .withFailMessage("uninstallNginx() did not return true")
+          .isTrue();
+    }
+  }
+
+  /**
+   * Create a model in image domain and verify the domain pods are ready.
+   */
+  private void createAndVerifyMiiDomain() {
+
+    // get the pre-built image created by IntegrationTestWatcher
+    String miiImage = MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;
+
+    // docker login and push image to docker registry if necessary
+    dockerLoginAndPushImageToRegistry(miiImage);
+
+    // create docker registry secret to pull the image from registry
+    logger.info("Creating docker registry secret in namespace {0}", domainNamespace);
+    createDockerRegistrySecret(domainNamespace);
+
+    // create secret for admin credentials
+    logger.info("Creating secret for admin credentials");
+    String adminSecretName = "weblogic-credentials";
+    createSecretWithUsernamePassword(adminSecretName, domainNamespace, "weblogic", "welcome1");
+
+    // create encryption secret
+    logger.info("Creating encryption secret");
+    String encryptionSecretName = "encryptionsecret";
+    createSecretWithUsernamePassword(encryptionSecretName, domainNamespace, "weblogicenc", "weblogicenc");
+
+    // construct a list of oracle.weblogic.domain.Cluster objects to be used in the domain custom resource
+    List<Cluster> clusters = new ArrayList<>();
+    clusters.add(new Cluster()
+        .clusterName(clusterName)
+        .replicas(replicaCount)
+        .serverStartState("RUNNING"));
+
+    // create the domain CR
+    Domain domain = new Domain()
+        .apiVersion(DOMAIN_API_VERSION)
+        .kind("Domain")
+        .metadata(new V1ObjectMeta()
+            .name(domainUid)
+            .namespace(domainNamespace))
+        .spec(new DomainSpec()
+            .domainUid(domainUid)
+            .domainHomeSourceType("FromModel")
+            .image(miiImage)
+            .addImagePullSecretsItem(new V1LocalObjectReference()
+                .name(REPO_SECRET_NAME))
+            .webLogicCredentialsSecret(new V1SecretReference()
+                .name(adminSecretName)
+                .namespace(domainNamespace))
+            .includeServerOutInPodLog(true)
+            .serverStartPolicy("IF_NEEDED")
+            .serverPod(new ServerPod()
+                .addEnvItem(new V1EnvVar()
+                    .name("JAVA_OPTIONS")
+                    .value("-Dweblogic.StdoutDebugEnabled=false"))
+                .addEnvItem(new V1EnvVar()
+                    .name("USER_MEM_ARGS")
+                    .value("-Djava.security.egd=file:/dev/./urandom ")))
+            .adminServer(new AdminServer()
+                .serverStartState("RUNNING"))
+            .clusters(clusters)
+            .configuration(new Configuration()
+                .model(new Model()
+                    .domainType(WLS_DOMAIN_TYPE)
+                    .runtimeEncryptionSecret(encryptionSecretName))));
+
+    // create model in image domain
+    logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",
+        domainUid, domainNamespace, miiImage);
+    createDomainAndVerify(domain, domainNamespace);
+
+    // check that admin server pod was created in the domain
+    logger.info("Checking that admin server pod {0} was created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkPodCreated(adminServerPodName, domainUid, domainNamespace);
+
+    // check that admin server pod is ready
+    logger.info("Checking that admin server pod {0} is ready in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
+
+    // check that admin service was created in the domain
+    logger.info("Checking that admin service {0} was created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkServiceCreated(adminServerPodName, domainNamespace);
+
+    // check for managed server pods existence in the domain
+    for (int i = 1; i <= replicaCount; i++) {
+      String managedServerPodName = managedServerPrefix + i;
+
+      // check that the managed server pod was created
+      logger.info("Checking that managed server pod {0} was created in namespace {1}",
+          managedServerPodName, domainNamespace);
+      checkPodCreated(managedServerPodName, domainUid, domainNamespace);
+
+      // check that the managed server pod is ready
+      logger.info("Checking that managed server pod {0} is ready in namespace {1}",
+          managedServerPodName, domainNamespace);
+      checkPodReady(managedServerPodName, domainUid, domainNamespace);
+
+      // check that the managed server service was created
+      logger.info("Checking that managed server service {0} was created in namespace {1}",
+          managedServerPodName, domainNamespace);
+      checkServiceCreated(managedServerPodName, domainNamespace);
+    }
+  }
+
+  /**
+   * Verify the sample app can be accessed from all managed servers in the domain through NGINX.
+   */
+  private void verifySampleAppAccessThroughNginx() {
+
+    List<String> managedServerNames = new ArrayList<>();
+    for (int i = 1; i <= replicaCount; i++) {
+      managedServerNames.add(MANAGED_SERVER_NAME_BASE + i);
+    }
+
+    // check that NGINX can access the sample apps from all managed servers in the domain
+    String curlCmd =
+        String.format("curl --silent --show-error --noproxy '*' -H 'host: %s' http://%s:%s/sample-war/index.jsp",
+            ingressHostList.get(0), K8S_NODEPORT_HOST, nodeportshttp);
+    assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, managedServerNames, 50))
+        .as("Verify NGINX can access the sample app from all managed servers in the domain")
+        .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
+        .isTrue();
+  }
+}

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -15,6 +15,9 @@ public interface TestConstants {
   // domain constants
   public static final String DOMAIN_VERSION = "v7";
   public static final String DOMAIN_API_VERSION = "weblogic.oracle/" + DOMAIN_VERSION;
+  public static final String ADMIN_SERVER_NAME_BASE = "admin-server";
+  public static final String MANAGED_SERVER_NAME_BASE = "managed-server";
+  public static final String WLS_DOMAIN_TYPE = "WLS";
 
   // operator constants
   public static final String OPERATOR_RELEASE_NAME = "weblogic-operator";
@@ -24,6 +27,7 @@ public interface TestConstants {
       "oracle/weblogic-kubernetes-operator";
   public static final String OPERATOR_DOCKER_BUILD_SCRIPT =
       "../buildDockerImage.sh";
+  public static final String OPERATOR_SERVICE_NAME = "internal-weblogic-operator-svc";
   public static final String REPO_DUMMY_VALUE = "dummy";
   public static final String REPO_SECRET_NAME = "ocir-secret";
   public static final String REPO_REGISTRY = Optional.ofNullable(System.getenv("REPO_REGISTRY"))
@@ -63,5 +67,4 @@ public interface TestConstants {
   public static final String MII_BASIC_IMAGE_NAME = REPO_NAME + "mii-basic-image";
   public static final String MII_BASIC_IMAGE_TAG = TestUtils.getDateAndTimeStamp();
   public static final String MII_BASIC_APP_NAME = "sample-app";
-
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -217,14 +217,12 @@ public class TestActions {
    * @param ingressName the name of the ingress to be created
    * @param domainNamespace the WebLogic domain namespace in which to create the ingress
    * @param domainUid WebLogic domainUid which is backend to the ingress
-   * @param managedServerPort the port number of the WebLogic domain managed servers
-   * @param clusterNames list of the WebLogic domain cluster names in the domain
+   * @param clusterNameMsPortMap the map with key as cluster name and value as managed server port of the cluster
    * @return list of ingress hosts or null if got ApiException when calling Kubernetes client API to create ingress
    */
   public static List<String> createIngress(String ingressName, String domainNamespace, String domainUid,
-                                      int managedServerPort, List<String> clusterNames) {
-    return Nginx.createIngress(ingressName, domainNamespace, domainUid,
-                               managedServerPort, clusterNames);
+                                           Map<String, Integer> clusterNameMsPortMap) {
+    return Nginx.createIngress(ingressName, domainNamespace, domainUid, clusterNameMsPortMap);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -212,19 +212,19 @@ public class TestActions {
 
   /**
    * Create an ingress for the WebLogic domain with domainUid in the specified domain namespace.
+   * The ingress host is set to 'domainUid.clusterName.test'.
    *
    * @param ingressName the name of the ingress to be created
    * @param domainNamespace the WebLogic domain namespace in which to create the ingress
    * @param domainUid WebLogic domainUid which is backend to the ingress
-   * @param clusterName the name of the WebLogic domain cluster in the domain
    * @param managedServerPort the port number of the WebLogic domain managed servers
-   * @param ingressHostname the host name used by the ingress for the host name based routing
-   * @return true on success, false otherwise
+   * @param clusterNames list of the WebLogic domain cluster names in the domain
+   * @return list of ingress hosts or null if got ApiException when calling Kubernetes client API to create ingress
    */
-  public static boolean createIngress(String ingressName, String domainNamespace, String domainUid,
-                                      String clusterName, int managedServerPort, String ingressHostname) {
-    return Nginx.createIngress(ingressName, domainNamespace, domainUid, clusterName,
-                               managedServerPort, ingressHostname);
+  public static List<String> createIngress(String ingressName, String domainNamespace, String domainUid,
+                                      int managedServerPort, List<String> clusterNames) {
+    return Nginx.createIngress(ingressName, domainNamespace, domainUid,
+                               managedServerPort, clusterNames);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
@@ -6,6 +6,7 @@ package oracle.weblogic.kubernetes.actions.impl;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.ApiException;
@@ -70,15 +71,13 @@ public class Nginx {
    * @param ingressName name of the ingress to be created
    * @param domainNamespace the WebLogic domain namespace in which the ingress will be created
    * @param domainUid the WebLogic domainUid which is backend to the ingress
-   * @param managedServerPort the port number of the WebLogic domain managed servers
-   * @param clusterNames list of the WebLogic domain cluster names in the domain
+   * @param clusterNameMsPortMap the map with key as cluster name and value as managed server port of the cluster
    * @return list of ingress hosts or null if got ApiException when calling Kubernetes client API to create ingress
    */
   public static List<String> createIngress(String ingressName,
                                       String domainNamespace,
                                       String domainUid,
-                                      int managedServerPort,
-                                      List<String> clusterNames) {
+                                      Map<String, Integer> clusterNameMsPortMap) {
 
     // set the annotation for kubernetes.io/ingress.class to "nginx"
     HashMap<String, String> annotation = new HashMap<>();
@@ -86,7 +85,7 @@ public class Nginx {
 
     List<String> ingressHostList = new ArrayList<>();
     ArrayList<ExtensionsV1beta1IngressRule> ingressRules = new ArrayList<>();
-    for (String clusterName : clusterNames) {
+    clusterNameMsPortMap.forEach((clusterName, managedServerPort) -> {
       // set the http ingress paths
       ExtensionsV1beta1HTTPIngressPath httpIngressPath = new ExtensionsV1beta1HTTPIngressPath()
           .path(null)
@@ -106,7 +105,7 @@ public class Nginx {
 
       ingressRules.add(ingressRule);
       ingressHostList.add(ingressHost);
-    }
+    });
 
     // set the ingress
     ExtensionsV1beta1Ingress ingress = new ExtensionsV1beta1Ingress()

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
@@ -65,63 +65,68 @@ public class Nginx {
 
   /**
    * Create an ingress for the WebLogic domain with domainUid in the specified domain namespace.
+   * The ingress host is set to 'domainUid.clusterName.test'.
    *
    * @param ingressName name of the ingress to be created
    * @param domainNamespace the WebLogic domain namespace in which the ingress will be created
    * @param domainUid the WebLogic domainUid which is backend to the ingress
-   * @param clusterName the name of the WebLogic domain cluster
    * @param managedServerPort the port number of the WebLogic domain managed servers
-   * @param ingressHostname the hostname used by the ingress for the host name based routing
-   * @return true on success, false otherwise
+   * @param clusterNames list of the WebLogic domain cluster names in the domain
+   * @return list of ingress hosts or null if got ApiException when calling Kubernetes client API to create ingress
    */
-  public static boolean createIngress(String ingressName,
+  public static List<String> createIngress(String ingressName,
                                       String domainNamespace,
                                       String domainUid,
-                                      String clusterName,
                                       int managedServerPort,
-                                      String ingressHostname) {
+                                      List<String> clusterNames) {
 
     // set the annotation for kubernetes.io/ingress.class to "nginx"
     HashMap<String, String> annotation = new HashMap<>();
     annotation.put("kubernetes.io/ingress.class", INGRESS_NGINX_CLASS);
 
-    // set the http ingress paths
-    ExtensionsV1beta1HTTPIngressPath httpIngressPath = new ExtensionsV1beta1HTTPIngressPath()
-        .path(null)
-        .backend(new ExtensionsV1beta1IngressBackend()
-                .serviceName(domainUid + "-cluster-" + clusterName.toLowerCase().replace("_", "-"))
-                .servicePort(new IntOrString(managedServerPort))
-        );
-    ArrayList<ExtensionsV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
-    httpIngressPaths.add(httpIngressPath);
-
-    // set the ingress rule
-    ExtensionsV1beta1IngressRule ingressRule = new ExtensionsV1beta1IngressRule()
-        .host(ingressHostname)
-        .http(new ExtensionsV1beta1HTTPIngressRuleValue()
-              .paths(httpIngressPaths));
+    List<String> ingressHostList = new ArrayList<>();
     ArrayList<ExtensionsV1beta1IngressRule> ingressRules = new ArrayList<>();
-    ingressRules.add(ingressRule);
+    for (String clusterName : clusterNames) {
+      // set the http ingress paths
+      ExtensionsV1beta1HTTPIngressPath httpIngressPath = new ExtensionsV1beta1HTTPIngressPath()
+          .path(null)
+          .backend(new ExtensionsV1beta1IngressBackend()
+              .serviceName(domainUid + "-cluster-" + clusterName.toLowerCase().replace("_", "-"))
+              .servicePort(new IntOrString(managedServerPort))
+          );
+      ArrayList<ExtensionsV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
+      httpIngressPaths.add(httpIngressPath);
+
+      // set the ingress rule
+      String ingressHost = domainUid + "." + clusterName + ".test";
+      ExtensionsV1beta1IngressRule ingressRule = new ExtensionsV1beta1IngressRule()
+          .host(ingressHost)
+          .http(new ExtensionsV1beta1HTTPIngressRuleValue()
+              .paths(httpIngressPaths));
+
+      ingressRules.add(ingressRule);
+      ingressHostList.add(ingressHost);
+    }
 
     // set the ingress
     ExtensionsV1beta1Ingress ingress = new ExtensionsV1beta1Ingress()
         .apiVersion(INGRESS_API_VERSION)
         .kind(INGRESS_KIND)
         .metadata(new V1ObjectMeta()
-                  .name(ingressName)
-                  .namespace(domainNamespace)
-                  .annotations(annotation))
+            .name(ingressName)
+            .namespace(domainNamespace)
+            .annotations(annotation))
         .spec(new ExtensionsV1beta1IngressSpec()
-              .rules(ingressRules));
+            .rules(ingressRules));
 
     // create the ingress
     try {
       Kubernetes.createIngress(domainNamespace, ingress);
     } catch (ApiException apex) {
       logger.severe("got ApiException while calling createIngress: {0}", apex.getResponseBody());
-      return false;
+      return null;
     }
-    return true;
+    return ingressHostList;
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -467,13 +467,12 @@ public class Kubernetes implements LoggedTest {
   public static String getPodCreationTimestamp(String namespace, String labelSelector, String podName)
       throws ApiException {
     DateTimeFormatter dtf = DateTimeFormat.forPattern("HHmmss");
-    // DateTimeFormatter dtf = DateTimeFormat.forPattern("YYYYMMDDHHmmss");
+
     V1Pod pod = getPod(namespace, labelSelector, podName);
-    if (pod != null) {
-      // return pod.getMetadata().getCreationTimestamp().toString();
+    if (pod != null && pod.getMetadata() != null) {
       return dtf.print(pod.getMetadata().getCreationTimestamp());
     } else {
-      logger.info("getPodCreationTimestamp(): Pod doesn't exist");
+      logger.info("Pod doesn't exist or pod metadata is null");
       return null;
     }
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -56,10 +56,8 @@ public class TestAssertions {
    * @param namespace in which the operator REST service exists
    * @return true if REST service is running otherwise false
    */
-  public static Callable<Boolean> operatorRestServiceRunning(String namespace) throws ApiException {
-    return () -> {
-      return Operator.doesExternalRestServiceExists(namespace);
-    };
+  public static Callable<Boolean> operatorRestServiceRunning(String namespace) {
+    return () -> Operator.doesExternalRestServiceExists(namespace);
   }
 
   /**
@@ -82,10 +80,8 @@ public class TestAssertions {
    * @param namespace in which the pod exists
    * @return true if the pod exists in the namespace otherwise false
    */
-  public static Callable<Boolean> podExists(String podName, String domainUid, String namespace) throws ApiException {
-    return () -> {
-      return Kubernetes.doesPodExist(namespace, domainUid, podName);
-    };
+  public static Callable<Boolean> podExists(String podName, String domainUid, String namespace) {
+    return () -> Kubernetes.doesPodExist(namespace, domainUid, podName);
   }
 
   /**
@@ -95,13 +91,9 @@ public class TestAssertions {
    * @param domainUid Uid of WebLogic domain
    * @param namespace namespace in which to check for the pod
    * @return true if the pod does not exist in the namespace otherwise false
-   * @throws ApiException when cluster query fails
    */
-  public static Callable<Boolean> podDoesNotExist(String podName, String domainUid, String namespace)
-      throws ApiException {
-    return () -> {
-      return !Kubernetes.doesPodExist(namespace, domainUid, podName);
-    };
+  public static Callable<Boolean> podDoesNotExist(String podName, String domainUid, String namespace) {
+    return () -> !Kubernetes.doesPodExist(namespace, domainUid, podName);
   }
 
   /**
@@ -111,12 +103,9 @@ public class TestAssertions {
    * @param domainUid WebLogic domain uid in which the pod belongs
    * @param namespace in which the pod is running
    * @return true if the pod is running otherwise false
-   * @throws ApiException when Kubernetes cluster query fails to get pod
    */
-  public static Callable<Boolean> podReady(String podName, String domainUid, String namespace) throws ApiException {
-    return () -> {
-      return Kubernetes.isPodReady(namespace, domainUid, podName);
-    };
+  public static Callable<Boolean> podReady(String podName, String domainUid, String namespace) {
+    return () -> Kubernetes.isPodReady(namespace, domainUid, podName);
   }
 
   /**
@@ -128,9 +117,7 @@ public class TestAssertions {
    * @return true if the pod is terminating otherwise false
    */
   public static Callable<Boolean> podTerminating(String podName, String domainUid, String namespace) {
-    return () -> {
-      return Kubernetes.isPodTerminating(namespace, domainUid, podName);
-    };
+    return () -> Kubernetes.isPodTerminating(namespace, domainUid, podName);
   }
 
   /**
@@ -140,16 +127,23 @@ public class TestAssertions {
    * @param label       a Map of key value pairs the service is decorated with
    * @param namespace   in which the service is running
    * @return true if the service exists otherwise false
-   * @throws ApiException when query fails
    */
-  public static Callable<Boolean> serviceExists(
-      String serviceName,
-      Map<String, String> label,
-      String namespace
-  ) throws ApiException {
-    return () -> {
-      return Kubernetes.doesServiceExist(serviceName, label, namespace);
-    };
+  public static Callable<Boolean> serviceExists(String serviceName, Map<String, String> label, String namespace) {
+    return () -> Kubernetes.doesServiceExist(serviceName, label, namespace);
+  }
+
+  /**
+   * Check a service does not exist in the specified namespace.
+   *
+   * @param serviceName the name of the service to check for
+   * @param label       a Map of key value pairs the service is decorated with
+   * @param namespace   in which to check whether the service exists
+   * @return true if the service does not exist, false otherwise
+   */
+  public static Callable<Boolean> serviceDoesNotExist(String serviceName,
+                                                      Map<String, String> label,
+                                                      String namespace) {
+    return () -> !Kubernetes.doesServiceExist(serviceName, label, namespace);
   }
 
   /**
@@ -246,20 +240,18 @@ public class TestAssertions {
     };
   }
 
-  /*
-   * Verify the original managed server pod state is not changed during scaling the cluster.
-   * 
-   * @param podName the name of managed server pod to check
-   * @param domainUid the domain uid of the domain in which the managed server pod exists
+  /**
+   * Verify the pod state is not changed.
+   * @param podName the name of the pod to check
+   * @param domainUid the domain in which the pod exists
    * @param domainNamespace the domain namespace in which the domain exists
-   * @param podCreationTimestampBeforeScale the managed server pod creation time stamp before the scale
-   * @return true if the managed server pod state is not change during scaling the cluster, false otherwise
+   * @param podOriginalCreationTimestamp the pod original creation timestamp
+   * @return true if the pod state is not changed, false otherwise
    */
-  public static boolean podStateNotChangedDuringScalingCluster(String podName,
-                                                               String domainUid,
-                                                               String domainNamespace,
-                                                               String podCreationTimestampBeforeScale) {
-    return Domain.podStateNotChangedDuringScalingCluster(podName, domainUid, domainNamespace,
-        podCreationTimestampBeforeScale);
+  public static boolean podStateNotChanged(String podName,
+                                           String domainUid,
+                                           String domainNamespace,
+                                           String podOriginalCreationTimestamp) {
+    return Domain.podStateNotChanged(podName, domainUid, domainNamespace, podOriginalCreationTimestamp);
   }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -10,16 +10,12 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.ApiextensionsV1beta1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
-import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1beta1CustomResourceDefinition;
 import io.kubernetes.client.util.ClientBuilder;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
-import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.doesPodExist;
-import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.doesServiceExist;
-import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.getPod;
+import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.doesPodNotExist;
 import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isPodReady;
+import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isPodRestarted;
 import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -94,62 +90,44 @@ public class Domain {
   }
 
   /**
-   * Verify the original managed server pod state is not changed during scaling the cluster.
-   * @param podName the name of the managed server pod to check
-   * @param domainUid the domain uid of the domain in which the managed server pod exists
+   * Verify the pod state is not changed.
+   * @param podName the name of the pod to check
+   * @param domainUid the domain in which the pod exists
    * @param domainNamespace the domain namespace in which the domain exists
-   * @param podCreationTimestampBeforeScale the managed server pod creation time stamp before the scale
-   * @return true if the managed server pod state is not change during scaling the cluster, false otherwise
+   * @param podOriginalCreationTimestamp the pod original creation timestamp
+   * @return true if the pod state is not changed, false otherwise
    */
-  public static boolean podStateNotChangedDuringScalingCluster(String podName,
-                                                               String domainUid,
-                                                               String domainNamespace,
-                                                               String podCreationTimestampBeforeScale) {
+  public static boolean podStateNotChanged(String podName,
+                                           String domainUid,
+                                           String domainNamespace,
+                                           String podOriginalCreationTimestamp) {
 
-    // check that the original managed server pod still exists
-    logger.info("Checking that the managed server pod {0} still exists in namespace {1}",
-        podName, domainNamespace);
-    assertTrue(assertDoesNotThrow(() -> doesPodExist(domainNamespace, domainUid, podName),
+    // if pod does not exist, return false
+    if (assertDoesNotThrow(() -> doesPodNotExist(domainNamespace, domainUid, podName),
         String.format("podExists failed with ApiException for pod %s in namespace %s",
-            podName, domainNamespace)),
-        String.format("pod %s does not exist in namespace %s", podName, domainNamespace));
-
-    // check that the original managed server pod is in ready state
-    logger.info("Checking that the managed server pod {0} is in ready state in namespace {1}",
-        podName, domainNamespace);
-    assertTrue(assertDoesNotThrow(() -> isPodReady(domainNamespace, domainUid, podName),
-        String.format(
-            "isPodReady failed with ApiException for pod %s in namespace %s", podName, domainNamespace)),
-        String.format("pod %s is not ready in namespace %s", podName, domainNamespace));
-
-    // check that the original managed server service still exists
-    logger.info("Checking that the managed server service {0} still exists in namespace {1}",
-        podName, domainNamespace);
-    assertTrue(assertDoesNotThrow(() -> doesServiceExist(podName, null, domainNamespace),
-        String.format("doesServiceExist failed with ApiException for pod %s in namespace %s",
-            podName, domainNamespace)),
-        String.format("service %s does not exist in namespace %s", podName, domainNamespace));
-
-    // check the pod timestamp of pod is the same as before
-    logger.info("Checking that the managed server pod creation timestamp is not changed");
-    String podCreationTimeStampDuringScale;
-    DateTimeFormatter dtf = DateTimeFormat.forPattern("HHmmss");
-    V1Pod pod =
-        assertDoesNotThrow(() -> getPod(domainNamespace, "", podName),
-            String.format("getPod failed with ApiException for pod %s in namespace %s",
-                podName, domainNamespace));
-    if (pod != null && pod.getMetadata() != null) {
-      podCreationTimeStampDuringScale = dtf.print(pod.getMetadata().getCreationTimestamp());
-    } else {
-      logger.info("Pod doesn't exist or pod metadata is null");
+            podName, domainNamespace))) {
+      logger.info("pod {0} does not exist in namespace {1}", podName, domainNamespace);
       return false;
     }
 
-    if (Long.parseLong(podCreationTimestampBeforeScale) != Long.parseLong(podCreationTimeStampDuringScale)) {
-      logger.info("The creation timestamp of managed server pod {0} is changed from {1} to {2}",
-          podName, podCreationTimestampBeforeScale, podCreationTimeStampDuringScale);
+    // if the pod is not in ready state, return false
+    logger.info("Checking that pod {0} is ready in namespace {1}", podName, domainNamespace);
+    if (!assertDoesNotThrow(() -> isPodReady(domainNamespace, domainUid, podName),
+        String.format("isPodReady failed with ApiException for pod %s in namespace %s", podName, domainNamespace))) {
+      logger.info("pod {0} is not ready in namespace {1}", podName, domainNamespace);
       return false;
     }
+
+    // if the pod was restarted, return false
+    logger.info("Checking that pod {0} is not restarted in namespace {1}", podName, domainNamespace);
+    if (assertDoesNotThrow(() ->
+        isPodRestarted(podName, domainUid, domainNamespace, podOriginalCreationTimestamp),
+        String.format("isPodRestarted failed with ApiException for pod %s in namespace %s",
+            podName, domainNamespace))) {
+      logger.info("pod {0} is restarted in namespace {1}", podName, domainNamespace);
+      return false;
+    }
+
     return true;
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -413,7 +413,7 @@ public class Kubernetes {
    * @throws ApiException when query fails
    */
   public static boolean isPodRestarted(
-      String podName, String domainUid, 
+      String podName, String domainUid,
       String namespace, String timestamp) throws ApiException {
     boolean podRestarted = false;
     String labelSelector = null;

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonUtils.java
@@ -1,0 +1,655 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.utils;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1ServiceAccount;
+import oracle.weblogic.domain.Domain;
+import oracle.weblogic.kubernetes.actions.impl.NginxParams;
+import oracle.weblogic.kubernetes.actions.impl.OperatorParams;
+import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
+import org.awaitility.core.ConditionFactory;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.GOOGLE_REPO_URL;
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.NGINX_CHART_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.NGINX_RELEASE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
+import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_DUMMY_VALUE;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_EMAIL;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_PASSWORD;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_REGISTRY;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_USERNAME;
+import static oracle.weblogic.kubernetes.TestConstants.STABLE_REPO_NAME;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.ARCHIVE_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WDT_VERSION;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WIT_BUILD_DIR;
+import static oracle.weblogic.kubernetes.actions.TestActions.buildAppArchive;
+import static oracle.weblogic.kubernetes.actions.TestActions.createDockerConfigJson;
+import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.createIngress;
+import static oracle.weblogic.kubernetes.actions.TestActions.createMiiImage;
+import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
+import static oracle.weblogic.kubernetes.actions.TestActions.createServiceAccount;
+import static oracle.weblogic.kubernetes.actions.TestActions.defaultAppParams;
+import static oracle.weblogic.kubernetes.actions.TestActions.defaultWitParams;
+import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
+import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
+import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
+import static oracle.weblogic.kubernetes.actions.TestActions.installNginx;
+import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
+import static oracle.weblogic.kubernetes.actions.TestActions.listIngresses;
+import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.isNginxReady;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podExists;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChanged;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceDoesNotExist;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceExists;
+import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
+import static oracle.weblogic.kubernetes.utils.FileUtils.checkDirectory;
+import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndCheckForServerNameInResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.with;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The common utility class for tests.
+ */
+public class CommonUtils {
+
+  private static ConditionFactory withStandardRetryPolicy =
+      with().pollDelay(2, SECONDS)
+          .and().with().pollInterval(10, SECONDS)
+          .atMost(5, MINUTES).await();
+
+  /**
+   * Install WebLogic operator and wait up to 5 minutes until the operator pod is ready.
+   *
+   * @param opNamespace the operator namespace in which the operator will be installed
+   * @param domainNamespace the list of the domain namespaces which will be managed by the operator
+   * @return the operator Helm installation parameters
+   */
+  public static HelmParams installAndVerifyOperator(String opNamespace,
+                                                    String... domainNamespace) {
+
+    // Create a service account for the unique opNamespace
+    logger.info("Creating service account");
+    String serviceAccountName = opNamespace + "-sa";
+    assertDoesNotThrow(() -> createServiceAccount(new V1ServiceAccount()
+        .metadata(new V1ObjectMeta()
+            .namespace(opNamespace)
+            .name(serviceAccountName))));
+    logger.info("Created service account: {0}", serviceAccountName);
+
+    // get operator image name
+    String operatorImage = getOperatorImageName();
+    assertFalse(operatorImage.isEmpty(), "operator image name can not be empty");
+    logger.info("operator image name {0}", operatorImage);
+
+    // Create Docker registry secret in the operator namespace to pull the image from repository
+    logger.info("Creating Docker registry secret in namespace {0}", opNamespace);
+    createDockerRegistrySecret(opNamespace);
+
+    // map with secret
+    Map<String, Object> secretNameMap = new HashMap<>();
+    secretNameMap.put("name", REPO_SECRET_NAME);
+
+    // Helm install parameters
+    HelmParams opHelmParams = new HelmParams()
+        .releaseName(OPERATOR_RELEASE_NAME)
+        .namespace(opNamespace)
+        .chartDir(OPERATOR_CHART_DIR);
+
+    // operator chart values to override
+    OperatorParams opParams = new OperatorParams()
+        .helmParams(opHelmParams)
+        .image(operatorImage)
+        .imagePullSecrets(secretNameMap)
+        .domainNamespaces(Arrays.asList(domainNamespace))
+        .serviceAccount(serviceAccountName);
+
+    // install operator
+    logger.info("Installing operator in namespace {0}", opNamespace);
+    assertTrue(installOperator(opParams),
+        String.format("Failed to install operator in namespace %s", opNamespace));
+    logger.info("Operator installed in namespace {0}", opNamespace);
+
+    // list Helm releases matching operator release name in operator namespace
+    logger.info("Checking operator release {0} status in namespace {1}",
+        OPERATOR_RELEASE_NAME, opNamespace);
+    assertTrue(isHelmReleaseDeployed(OPERATOR_RELEASE_NAME, opNamespace),
+        String.format("Operator release %s is not in deployed status in namespace %s",
+            OPERATOR_RELEASE_NAME, opNamespace));
+    logger.info("Operator release {0} status is deployed in namespace {1}",
+        OPERATOR_RELEASE_NAME, opNamespace);
+
+    // wait for the operator is ready
+    logger.info("Wait for the operator pod is ready in namespace {0}", opNamespace);
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for operator to be running in namespace {0} "
+                    + "(elapsed time {1}ms, remaining time {2}ms)",
+                opNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> operatorIsReady(opNamespace),
+            "operatorIsReady failed with ApiException"));
+
+    return opHelmParams;
+  }
+
+  /**
+   * Install NGINX and wait up to 5 minutes until the NGINX pod is ready.
+   *
+   * @param nginxNamespace the namespace in which the NGINX will be installed
+   * @param nodeportshttp the http nodeport of NGINX
+   * @param nodeportshttps the https nodeport of NGINX
+   * @return the NGINX Helm installation parameters
+   */
+  public static HelmParams installAndVerifyNginx(String nginxNamespace,
+                                                 int nodeportshttp,
+                                                 int nodeportshttps) {
+
+    // Helm install parameters
+    HelmParams nginxHelmParams = new HelmParams()
+        .releaseName(NGINX_RELEASE_NAME)
+        .namespace(nginxNamespace)
+        .repoUrl(GOOGLE_REPO_URL)
+        .repoName(STABLE_REPO_NAME)
+        .chartName(NGINX_CHART_NAME);
+
+    // NGINX chart values to override
+    NginxParams nginxParams = new NginxParams()
+        .helmParams(nginxHelmParams)
+        .nodePortsHttp(nodeportshttp)
+        .nodePortsHttps(nodeportshttps);
+
+    // install NGINX
+    assertThat(installNginx(nginxParams))
+        .as("Test NGINX installation succeeds")
+        .withFailMessage("NGINX installation is failed")
+        .isTrue();
+
+    // verify that NGINX is installed
+    logger.info("Checking NGINX release {0} status in namespace {1}",
+        NGINX_RELEASE_NAME, nginxNamespace);
+    assertTrue(isHelmReleaseDeployed(NGINX_RELEASE_NAME, nginxNamespace),
+        String.format("NGINX release %s is not in deployed status in namespace %s",
+            NGINX_RELEASE_NAME, nginxNamespace));
+    logger.info("NGINX release {0} status is deployed in namespace {1}",
+        NGINX_RELEASE_NAME, nginxNamespace);
+
+    // wait until the NGINX pod is ready.
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info(
+                "Waiting for NGINX to be ready in namespace {0} (elapsed time {1}ms, remaining time {2}ms)",
+                nginxNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> isNginxReady(nginxNamespace), "isNginxReady failed with ApiException"));
+
+    return nginxHelmParams;
+  }
+
+  /**
+   * Create a domain in the specified namespace and wait up to 5 minutes until the domain exists.
+   *
+   * @param domain the oracle.weblogic.domain.Domain object to create domain custom resource
+   * @param domainNamespace namespace in which the domain will be created
+   */
+  public static void createDomainAndVerify(Domain domain, String domainNamespace) {
+
+    // create the domain CR
+    assertNotNull(domain, "domain is null");
+    assertNotNull(domain.getSpec(), "domain spec is null");
+    String domainUid = domain.getSpec().getDomainUid();
+
+    logger.info("Creating domain custom resource for domainUid {0} in namespace {1}",
+        domainUid, domainNamespace);
+    assertTrue(assertDoesNotThrow(() -> createDomainCustomResource(domain),
+        String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
+            domainUid, domainNamespace)),
+        String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
+            domainUid, domainNamespace));
+
+    // wait for the domain to exist
+    logger.info("Checking for domain custom resource in namespace {0}", domainNamespace);
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for domain {0} to be created in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                domainUid,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(domainExists(domainUid, DOMAIN_VERSION, domainNamespace));
+  }
+
+  /**
+   * Create an ingress for the domain with domainUid in the specified namespace.
+   *
+   * @param domainUid WebLogic domainUid which is backend to the ingress to be created
+   * @param domainNamespace WebLogic domain namespace in which the domain exists
+   * @param managedServerPort port number of WebLogic domain managed servers
+   * @param clusterNames list of the WebLogic domain cluster names in the domain
+   * @return list of ingress hosts
+   */
+  public static List<String> createIngressForDomainAndVerify(String domainUid,
+                                                             String domainNamespace,
+                                                             int managedServerPort,
+                                                             List<String> clusterNames) {
+
+    // create an ingress in domain namespace
+    String ingressName = domainUid + "-nginx";
+    List<String> ingressHostList =
+        createIngress(ingressName, domainNamespace, domainUid, managedServerPort, clusterNames);
+
+    assertNotNull(ingressHostList,
+        String.format("Ingress creation failed for domain %s in namespace %s", domainUid, domainNamespace));
+
+    // check the ingress was found in the domain namespace
+    assertThat(assertDoesNotThrow(() -> listIngresses(domainNamespace)))
+        .as("Test ingress {0} was found in namespace {1}", ingressName, domainNamespace)
+        .withFailMessage("Ingress {0} was not found in namespace {1}", ingressName, domainNamespace)
+        .contains(ingressName);
+
+    logger.info("ingress {0} for domain {1} was created in namespace {2}",
+        ingressName, domainUid, domainNamespace);
+
+    return ingressHostList;
+  }
+
+  /**
+   * Check pod is created.
+   *
+   * @param podName pod name to check
+   * @param domainUid the domain in which the pod exists
+   * @param domainNamespace the domain namespace in which the domain exists
+   */
+  public static void checkPodCreated(String podName, String domainUid, String domainNamespace) {
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for pod {0} to be created in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                podName,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> podExists(podName, domainUid, domainNamespace),
+            String.format("podExists failed with ApiException for pod %s in namespace %s",
+                podName, domainNamespace)));
+  }
+
+  /**
+   * Check pod is ready.
+   *
+   * @param podName pod name to check
+   * @param domainUid the domain in which the pod exists
+   * @param domainNamespace the domain namespace in which the domain exists
+   */
+  public static void checkPodReady(String podName, String domainUid, String domainNamespace) {
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for pod {0} to be ready in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                podName,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> podReady(podName, domainUid, domainNamespace),
+            String.format("podReady failed with ApiException for pod %s in namespace %s",
+               podName, domainNamespace)));
+  }
+
+  /**
+   * Check service is created.
+   *
+   * @param serviceName service name to check
+   * @param domainNamespace the domain namespace in which the service exists
+   */
+  public static void checkServiceCreated(String serviceName, String domainNamespace) {
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for service {0} to be created in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                serviceName,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> serviceExists(serviceName, null, domainNamespace),
+            String.format("serviceExists failed with ApiException for service %s in namespace %s",
+                serviceName, domainNamespace)));
+  }
+
+  /**
+   * Check pod was deleted.
+   *
+   * @param podName pod name to check
+   * @param domainUid the domain uid in which the pod exists
+   * @param domainNamespace the domain namespace in which the domain exists
+   */
+  public static void checkPodDeleted(String podName, String domainUid, String domainNamespace) {
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for pod {0} to be deleted in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                podName,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> podDoesNotExist(podName, domainUid, domainNamespace),
+            String.format("podDoesNotExist failed with ApiException for pod %s in namespace %s",
+                podName, domainNamespace)));
+  }
+
+  /**
+   * Check service was deleted.
+   *
+   * @param serviceName service name to check
+   * @param domainNamespace the namespace in which to check whether the service was deleted
+   */
+  public static void checkServiceDeleted(String serviceName, String domainNamespace) {
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for service {0} to be deleted in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                serviceName,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> serviceDoesNotExist(serviceName, null, domainNamespace),
+            String.format("serviceDoesNotExist failed with ApiException for service %s in namespace %s",
+                serviceName, domainNamespace)));
+  }
+
+  /**
+   * Create a Docker image for model in image domain.
+   *
+   * @param imageNameBase the base image name used in local or to construct the image name in repository
+   * @param wdtModelFile the WDT model file used to build the Docker image
+   * @param appName the sample application name used to build sample app ear file in WDT model file
+   * @return image name with tag
+   */
+  public static  String createMiiImageAndVerify(String imageNameBase,
+                                                String wdtModelFile,
+                                                String appName) {
+
+    // create unique image name with date
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    Date date = new Date();
+    final String imageTag = dateFormat.format(date) + "-" + System.currentTimeMillis();
+    // Add repository name in image name for Jenkins runs
+    final String imageName = REPO_NAME + imageNameBase;
+    final String image = imageName + ":" + imageTag;
+
+    // build the model file list
+    final List<String> modelList = Collections.singletonList(MODEL_DIR + "/" + wdtModelFile);
+
+    // build an application archive using what is in resources/apps/APP_NAME
+    assertTrue(buildAppArchive(defaultAppParams()
+        .srcDir(appName)), String.format("Failed to create app archive for %s", appName));
+
+    // build the archive list
+    String zipFile = String.format("%s/%s.zip", ARCHIVE_DIR, appName);
+    final List<String> archiveList = Collections.singletonList(zipFile);
+
+    // Set additional environment variables for WIT
+    checkDirectory(WIT_BUILD_DIR);
+    Map<String, String> env = new HashMap<>();
+    env.put("WLSIMG_BLDDIR", WIT_BUILD_DIR);
+
+    // For k8s 1.16 support and as of May 6, 2020, we presently need a different JDK for these
+    // tests and for image tool. This is expected to no longer be necessary once JDK 11.0.8 or
+    // the next JDK 14 versions are released.
+    String witJavaHome = System.getenv("WIT_JAVA_HOME");
+    if (witJavaHome != null) {
+      env.put("JAVA_HOME", witJavaHome);
+    }
+
+    // build an image using WebLogic Image Tool
+    logger.info("Creating image {0} using model directory {1}", image, MODEL_DIR);
+    boolean result = createMiiImage(
+        defaultWitParams()
+            .modelImageName(imageName)
+            .modelImageTag(imageTag)
+            .modelFiles(modelList)
+            .modelArchiveFiles(archiveList)
+            .wdtVersion(WDT_VERSION)
+            .env(env)
+            .redirect(true));
+
+    assertTrue(result, String.format("Failed to create the image %s using WebLogic Image Tool", image));
+
+    // Check image exists using docker images | grep image tag.
+    assertTrue(doesImageExist(imageTag),
+        String.format("Image %s does not exist", image));
+
+    return image;
+  }
+
+  /**
+   * Create a Docker registry secret in the specified namespace.
+   *
+   * @param namespace the namespace in which the secret will be created
+   */
+  public static void createDockerRegistrySecret(String namespace) {
+
+    // Create Docker registry secret in the namespace to pull the image from repository
+    JsonObject dockerConfigJsonObject = createDockerConfigJson(
+        REPO_USERNAME, REPO_PASSWORD, REPO_EMAIL, REPO_REGISTRY);
+    String dockerConfigJson = dockerConfigJsonObject.toString();
+
+    // Create the V1Secret configuration
+    V1Secret repoSecret = new V1Secret()
+        .metadata(new V1ObjectMeta()
+            .name(REPO_SECRET_NAME)
+            .namespace(namespace))
+        .type("kubernetes.io/dockerconfigjson")
+        .putDataItem(".dockerconfigjson", dockerConfigJson.getBytes());
+
+    boolean secretCreated = assertDoesNotThrow(() -> createSecret(repoSecret),
+        String.format("createSecret failed for %s", REPO_SECRET_NAME));
+    assertTrue(secretCreated, String.format("createSecret failed while creating secret %s in namespace %s",
+        REPO_SECRET_NAME, namespace));
+  }
+
+  /**
+   * Docker login and push the image to Docker registry.
+   *
+   * @param dockerImage the Docker image to push to registry
+   */
+  public static void dockerLoginAndPushImageToRegistry(String dockerImage) {
+    // docker login, if necessary
+    if (!REPO_USERNAME.equals(REPO_DUMMY_VALUE)) {
+      logger.info("docker login");
+      assertTrue(dockerLogin(REPO_REGISTRY, REPO_USERNAME, REPO_PASSWORD), "docker login failed");
+    }
+
+    // push image, if necessary
+    if (!REPO_NAME.isEmpty()) {
+      logger.info("docker push image {0} to {1}", dockerImage, REPO_NAME);
+      assertTrue(dockerPush(dockerImage), String.format("docker push failed for image %s", dockerImage));
+    }
+  }
+
+  /**
+   * Create a secret with username and password in the specified namespace.
+   *
+   * @param secretName secret name to create
+   * @param namespace namespace in which the secret will be created
+   * @param username username in the secret
+   * @param password passowrd in the secret
+   */
+  public static void createSecretWithUsernamePassword(String secretName,
+                                                      String namespace,
+                                                      String username,
+                                                      String password) {
+    Map<String, String> secretMap = new HashMap<>();
+    secretMap.put("username", username);
+    secretMap.put("password", password);
+
+    boolean secretCreated = assertDoesNotThrow(() -> createSecret(new V1Secret()
+        .metadata(new V1ObjectMeta()
+            .name(secretName)
+            .namespace(namespace))
+        .stringData(secretMap)), "Create secret failed with ApiException");
+    assertTrue(secretCreated, String.format("create secret failed for %s", secretName));
+  }
+
+  /** Scale the WebLogic cluster to specified number of servers.
+   *  And verify the sample app can be accessed through NGINX.
+   *
+   * @param clusterName the WebLogic cluster name in the domain to be scaled
+   * @param domainUid the domain to which the cluster belongs
+   * @param domainNamespace the domain namespace in which the domain exists
+   * @param replicasBeforeScale the replicas of the WebLogic cluster before the scale
+   * @param replicasAfterScale the replicas of the WebLogic cluster after the scale
+   * @param curlCmd the curl command to verify ingress controller can access the sample apps from all managed servers
+   *                in the cluster, if curlCmd is null, the method will not verify the accessibility of the sample app
+   *                through ingress controller
+   * @param expectedServerNames list of managed servers in the cluster before scale, if curlCmd is null,
+   *                            set expectedServerNames to null too
+   */
+  public static void scaleAndVerifyCluster(String clusterName,
+                                           String domainUid,
+                                           String domainNamespace,
+                                           int replicasBeforeScale,
+                                           int replicasAfterScale,
+                                           String curlCmd,
+                                           List<String> expectedServerNames) {
+
+    String manageServerPodNamePrefix = domainUid + "-" + clusterName + "-" + MANAGED_SERVER_NAME_BASE;
+
+    // get the original managed server pod creation timestamp before scale
+    List<String> listOfPodCreationTimestamp = new ArrayList<>();
+    for (int i = 1; i <= replicasBeforeScale; i++) {
+      String managedServerPodName = manageServerPodNamePrefix + i;
+      String originalCreationTimestamp =
+          assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
+              String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
+                  managedServerPodName, domainNamespace));
+      listOfPodCreationTimestamp.add(originalCreationTimestamp);
+    }
+
+    // scale the cluster in the domain
+    logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers",
+        clusterName, domainUid, domainNamespace, replicasAfterScale);
+    assertThat(assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, replicasAfterScale)))
+        .as("Verify scaling cluster {0} of domain {1} in namespace {2} succeeds",
+            clusterName, domainUid, domainNamespace)
+        .withFailMessage("Scaling cluster failed")
+        .isTrue();
+
+    if (replicasBeforeScale <= replicasAfterScale) {
+
+      // scale up
+      // check that the original managed server pod state is not changed during scaling the cluster
+      for (int i = 1; i <= replicasBeforeScale; i++) {
+        String manageServerPodName = manageServerPodNamePrefix + i;
+
+        // check the original managed server pod state is not changed
+        logger.info("Checking that the state of manged server pod {0} is not changed in namespace {1}",
+            manageServerPodName, domainNamespace);
+        podStateNotChanged(manageServerPodName, domainUid, domainNamespace, listOfPodCreationTimestamp.get(i - 1));
+      }
+
+      if (curlCmd != null && expectedServerNames != null) {
+        // check that NGINX can access the sample apps from the original managed servers in the domain
+        logger.info("Checking that NGINX can access the sample app from the original managed servers in the domain "
+            + "while the domain is scaling up.");
+        logger.info("expected server name list which should be in the sample app response: {0} before scale",
+            expectedServerNames);
+
+        assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, expectedServerNames, 50))
+            .as("Verify NGINX can access the sample app from the original managed servers in the domain")
+            .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
+            .isTrue();
+      }
+
+      // check that new managed server pods were created and wait for them to be ready
+      for (int i = replicasBeforeScale + 1; i <= replicasAfterScale; i++) {
+        String manageServerPodName = manageServerPodNamePrefix + i;
+
+        // check new managed server pod was created
+        logger.info("Checking that the new managed server pod {0} was created in namespace {1}",
+            manageServerPodName, domainNamespace);
+        checkPodCreated(manageServerPodName, domainUid, domainNamespace);
+
+        // check new managed server pod is ready
+        logger.info("Checking that the new managed server pod {0} is ready in namespace {1}",
+            manageServerPodName, domainNamespace);
+        checkPodReady(manageServerPodName, domainUid, domainNamespace);
+
+        // check new managed server service was created
+        logger.info("Checking that the new managed server service {0} was created in namespace {1}",
+            manageServerPodName, domainNamespace);
+        checkServiceCreated(manageServerPodName, domainNamespace);
+
+        if (expectedServerNames != null) {
+          // add the new managed server to the list
+          expectedServerNames.add(clusterName + "-" + MANAGED_SERVER_NAME_BASE + i);
+        }
+      }
+
+      if (curlCmd != null && expectedServerNames != null) {
+        // check that NGINX can access the sample apps from new and original managed servers
+        logger.info("Checking that NGINX can access the sample app from the new and original managed servers "
+            + "in the domain after the cluster is scaled up.");
+        assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, expectedServerNames, 50))
+            .as("Verify NGINX can access the sample app from all managed servers in the domain")
+            .withFailMessage("NGINX can not access the sample app from one or more of the managed servers")
+            .isTrue();
+      }
+    } else {
+      // scale down
+      // wait and check the pods are deleted
+      for (int i = replicasBeforeScale; i > replicasAfterScale; i--) {
+        logger.info("Checking that managed server pod {0} was deleted from namespace {1}",
+            manageServerPodNamePrefix + i, domainNamespace);
+        checkPodDeleted(manageServerPodNamePrefix + i, domainUid, domainNamespace);
+        expectedServerNames.remove(clusterName + "-" + MANAGED_SERVER_NAME_BASE + i);
+      }
+
+      if (curlCmd != null && expectedServerNames != null) {
+        // check that NGINX can access the app from the remaining managed servers in the domain
+        logger.info("Checking that NGINX can access the sample app from the remaining managed servers in the domain "
+            + "after the cluster is scaled down.");
+        assertThat(callWebAppAndCheckForServerNameInResponse(curlCmd, expectedServerNames, 50))
+            .as("Verify NGINX can access the sample app from the remaining managed server in the domain")
+            .withFailMessage("NGINX can not access the sample app from the remaining managed server")
+            .isTrue();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Convert ItUsabilityOperatorHelmChart#testDeleteOperatorButNotDomain to JUnit5 test framework.
Move commonly used test methods to CommonUtils.java.
Since I keep getting Jenkins run failure in PR 1647, I will create a new PR and close 1647.
Possible reason for the Jenkins failure is my branch name was too long. 

The Jenkins error in PR 1647:
Running as SYSTEM
[EnvInject] - Loading node environment variables.
Building on master in workspace /var/lib/jenkins/workspace/weblogic-kubernetes-operator-model-in-image-tests
No credentials specified
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/oracle/weblogic-kubernetes-operator # timeout=10
Cleaning workspace
 > git rev-parse --verify HEAD # timeout=10
Resetting working tree
 > git reset --hard # timeout=10
 > git clean -fdx # timeout=10
Fetching upstream changes from https://github.com/oracle/weblogic-kubernetes-operator
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/oracle/weblogic-kubernetes-operator +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse origin/convertItUsabilityOperatorHelm​Chart^{commit} # timeout=10
 > git rev-parse convertItUsabilityOperatorHelm​Chart^{commit} # timeout=10
ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.
Strings match run condition: string 1=[convertItUsabilityOperatorHelm​Chart], string 2=[mii-new-integration-tests]
Run condition [Strings match] preventing perform for step [[Editable Email Notification, Slack Notifications]]
Archiving artifacts
Recording test results
ERROR: Step ‘Publish JUnit test result report’ failed: No test report files were found. Configuration error?
Finished: FAILURE