### PR TITLE
Add config/dynamic cluster to MiiDomain

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
@@ -321,21 +321,33 @@ class ItMiiAddCluster implements LoggedTest {
         String.format("Can't create ConfigMap %s", configMapName));
     assertTrue(cmCreated, String.format("createConfigMap failed while creating ConfigMap %s", configMapName));
      
+    // get the creation time of the admin server pod before patching
     String adminPodCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
-            String.format("Couldn't get PodCreationTime for pod %s", adminServerPodName));
-    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns null");
-    logger.info("AdminPodCreationTime {0} ", adminPodCreationTime);
+            String.format("Can not find PodCreationTime for pod %s", adminServerPodName));
+    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns NULL");
+    logger.info("Domain {0} in namespace {1}, admin server pod {2} creationTimestamp before patching is {3}",
+        domainUid,
+        domainNamespace,
+        adminServerPodName,
+        adminPodCreationTime);
 
+    // get the creation time of the managed server pods before patching
     List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
-    for (int i = 1; i <= replicaCount; i++) {
-      final String managedServerPodName = managedServerPrefix + i;
-      managedServerPodOriginalTimestampList.add(
-          assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
-              String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
-                  managedServerPodName, domainNamespace)));
-    }
-
+    assertDoesNotThrow(
+        () -> { 
+          for (int i = 1; i <= replicaCount; i++) {
+            String managedServerPodName = managedServerPrefix + i;
+            String creationTime = getPodCreationTimestamp(domainNamespace,"", managedServerPodName);
+            managedServerPodOriginalTimestampList.add(creationTime);
+            logger.info("Domain {0} in namespace {1}, managed server pod {2} creationTimestamp before patching is {3}",
+                domainUid,
+                domainNamespace,
+                managedServerPodName,
+                creationTime);
+          } 
+        },
+        String.format("Failed to get creationTimestamp for managed server pods"));
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
     patchStr.append("\"op\": \"replace\",")
@@ -427,21 +439,33 @@ class ItMiiAddCluster implements LoggedTest {
         String.format("Can't create ConfigMap %s", configMapName));
     assertTrue(cmCreated, String.format("createConfigMap failed while creating ConfigMap %s", configMapName));
      
+    // get the creation time of the admin server pod before patching
     String adminPodCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
-            String.format("Couldn't get PodCreationTime for pod %s", adminServerPodName));
-    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns null");
-    logger.info("AdminPodCreationTime {0} ", adminPodCreationTime);
+            String.format("Can not find PodCreationTime for pod %s", adminServerPodName));
+    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns NULL");
+    logger.info("Domain {0} in namespace {1}, admin server pod {2} creationTimestamp before patching is {3}",
+        domainUid,
+        domainNamespace,
+        adminServerPodName,
+        adminPodCreationTime);
 
+    // get the creation time of the managed server pods before patching
     List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
-    for (int i = 1; i <= replicaCount; i++) {
-      final String managedServerPodName = managedServerPrefix + i;
-      managedServerPodOriginalTimestampList.add(
-          assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
-              String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
-                  managedServerPodName, domainNamespace)));
-    }
-
+    assertDoesNotThrow(
+        () -> { 
+          for (int i = 1; i <= replicaCount; i++) {
+            String managedServerPodName = managedServerPrefix + i;
+            String creationTime = getPodCreationTimestamp(domainNamespace,"", managedServerPodName);
+            managedServerPodOriginalTimestampList.add(creationTime);
+            logger.info("Domain {0} in namespace {1}, managed server pod {2} creationTimestamp before patching is {3}",
+                domainUid,
+                domainNamespace,
+                managedServerPodName,
+                creationTime);
+          } 
+        },
+        String.format("Failed to get creationTimestamp for managed server pods"));
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
     patchStr.append("\"op\": \"replace\",")
@@ -547,21 +571,33 @@ class ItMiiAddCluster implements LoggedTest {
         String.format("Can't create ConfigMap %s", configMapName));
     assertTrue(cmCreated, String.format("createConfigMap failed while creating ConfigMap %s", configMapName));
      
+    // get the creation time of the admin server pod before patching
     String adminPodCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
-            String.format("Couldn't get PodCreationTime for pod %s", adminServerPodName));
-    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns null");
-    logger.info("AdminPodCreationTime {0} ", adminPodCreationTime);
+            String.format("Can not find PodCreationTime for pod %s", adminServerPodName));
+    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns NULL");
+    logger.info("Domain {0} in namespace {1}, admin server pod {2} creationTimestamp before patching is {3}",
+        domainUid,
+        domainNamespace,
+        adminServerPodName,
+        adminPodCreationTime);
 
+    // get the creation time of the managed server pods before patching
     List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
-    for (int i = 1; i <= replicaCount; i++) {
-      final String managedServerPodName = managedServerPrefix + i;
-      managedServerPodOriginalTimestampList.add(
-          assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
-              String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
-                  managedServerPodName, domainNamespace)));
-    }
-
+    assertDoesNotThrow(
+        () -> { 
+          for (int i = 1; i <= replicaCount; i++) {
+            String managedServerPodName = managedServerPrefix + i;
+            String creationTime = getPodCreationTimestamp(domainNamespace,"", managedServerPodName);
+            managedServerPodOriginalTimestampList.add(creationTime);
+            logger.info("Domain {0} in namespace {1}, managed server pod {2} creationTimestamp before patching is {3}",
+                domainUid,
+                domainNamespace,
+                managedServerPodName,
+                creationTime);
+          } 
+        },
+        String.format("Failed to get creationTimestamp for managed server pods"));
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
     patchStr.append("\"op\": \"replace\",")

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -312,6 +314,7 @@ class ItMiiAddCluster implements LoggedTest {
    * Verify servers from new cluster are in running state.
    */
   @Test
+  @Order(2)
   @DisplayName("Add a dynamic cluster to model in image domain")
   @Slow
   @MustNotRunInParallel
@@ -431,6 +434,7 @@ class ItMiiAddCluster implements LoggedTest {
    * Verify servers from new cluster are in running state.
    */
   @Test
+  @Order(3)
   @DisplayName("Add a configured cluster to model in image domain")
   @Slow
   @MustNotRunInParallel
@@ -546,11 +550,11 @@ class ItMiiAddCluster implements LoggedTest {
   /**
    * Patch the domain resource with the configmap to add a cluster.
    * Update the restart version of the domain resource to 4
-   * Update the spec level replica count to zero(default) value
    * Verify rolling restart of the domain by comparing PodCreationTimestamp before and after rolling restart.
-   * Verify servers from new cluster are not in running state.
+   * Verify servers from new cluster are not in running state, because the spec level replica count to zero(default)
    */
   @Test
+  @Order(1)
   @DisplayName("Add a cluster to model in image domain with default replica count")
   @Slow
   @MustNotRunInParallel
@@ -611,19 +615,6 @@ class ItMiiAddCluster implements LoggedTest {
         "patchDomainCustomResource(configMap)  failed ");
     assertTrue(cmPatched, "patchDomainCustomResource(configMap) failed");
     
-    patchStr = new StringBuffer("[{");
-    patchStr.append(" \"op\": \"replace\",")
-        .append(" \"path\": \"/spec/replicas\",")
-        .append(" \"value\": 0")
-        .append(" }]");
-    logger.log(Level.INFO, "Replicas patch string: {0}", patchStr);
-
-    patch = new V1Patch(new String(patchStr));
-    boolean repilcaPatched = assertDoesNotThrow(() ->
-            patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
-        "patchDomainCustomResource(restartVersion)  failed ");
-    assertTrue(repilcaPatched, "patchDomainCustomResource(repilcas) failed");
-
     patchStr = new StringBuffer("[{");
     patchStr.append(" \"op\": \"replace\",")
         .append(" \"path\": \"/spec/restartVersion\",")

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
@@ -573,7 +573,7 @@ class ItMiiConfigMap implements LoggedTest {
     int adminServiceNodePort = getServiceNodePort(domainNamespace, adminServerPodName + "-external", "default");
     ExecResult result = null;
 
-    curlString = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
+    curlString = new StringBuffer("curl --user weblogic:welcome1 ");
     curlString.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
          .append("/management/wls/latest/datasources/id/")
          .append(resourcesName)

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
@@ -399,8 +399,8 @@ class ItMiiConfigMap implements LoggedTest {
       fail("CheckJms:  got unexpected exception" + ex);
     }
     logger.info("CheckJms: curl command returns {0}", result.toString());
-    assertEquals("200", result.stdout(), "JMSSystemResources configuration not found");
-    logger.info("Found the JMSSystemResources configuration");
+    assertEquals("200", result.stdout(), "JMSSystemResource configuration not found");
+    logger.info("Found the JMSSystemResource configuration");
 
     checkWldf = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
     checkWldf.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
@@ -418,8 +418,8 @@ class ItMiiConfigMap implements LoggedTest {
       fail("CheckWldf: got unexpected exception" + ex);
     }
     logger.info("CheckWldf: curl command returns {0}", result.toString());
-    assertEquals("200", result.stdout(), "WLDFSystemResources configuration not found");
-    logger.info("Found the WLDFSystemResources configuration");
+    assertEquals("200", result.stdout(), "WLDFSystemResource configuration not found");
+    logger.info("Found the WLDFSystemResource configuration");
   }
 
   // This method is needed in this test class, since the cleanup util

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
@@ -662,13 +662,13 @@ class ItMiiConfigMapOverride implements LoggedTest {
   private ExecResult checkJdbcRuntime(String resourcesName) {
     int adminServiceNodePort = getServiceNodePort(domainNamespace, adminServerPodName + "-external", "default");
     ExecResult result = null;
-
-    curlString = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
+    curlString = new StringBuffer("curl --user weblogic:welcome1 ");
     curlString.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
          .append("/management/wls/latest/datasources/id/")
          .append(resourcesName)
          .append("/")
          .append(" --silent --show-error ");
+
     logger.info("checkJdbcRuntime: curl command {0}", new String(curlString));
     try {
       result = exec(new String(curlString), true);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
@@ -90,7 +90,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("Test to update a model in image domain with a configmap")
@@ -107,12 +106,12 @@ class ItMiiConfigMapOverride implements LoggedTest {
   private static String dockerConfigJson = "";
 
   private String domainUid = "miicfgoverride";
-  private StringBuffer checkJdbc = null;
-  private StringBuffer checkJms = null;
-  private StringBuffer checkWldf = null;
+  private StringBuffer curlString = null;
   private V1Patch patch = null;
 
   private static Map<String, Object> secretNameMap;
+  final String adminServerPodName =  String.format("%s-%s", domainUid, ADMIN_SERVER_NAME_BASE);
+  final String managedServerPrefix =  String.format("%s-%s", domainUid, MANAGED_SERVER_NAME_BASE);
 
   /**
    * Install Operator.
@@ -230,8 +229,6 @@ class ItMiiConfigMapOverride implements LoggedTest {
   @Slow
   @MustNotRunInParallel
   public void testAddMiiSystemResources() {
-    final String adminServerPodName =  String.format("%s-%s", domainUid, ADMIN_SERVER_NAME_BASE);
-    final String managedServerPrefix =  String.format("%s-%s", domainUid, MANAGED_SERVER_NAME_BASE);
     final int replicaCount = 2;
 
     // Create the repo secret to pull the image
@@ -355,7 +352,7 @@ class ItMiiConfigMapOverride implements LoggedTest {
     String adminPodCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
             String.format("Can not find PodCreationTime for pod %s", adminServerPodName));
-    assertNotNull(adminPodCreationTime, "adminPodCreationTime returns NULL");
+    assertNotNull(adminPodCreationTime, "adminPodCreationTime returned null");
     logger.info("Domain {0} in namespace {1}, admin server pod {2} creationTimestamp before patching is {3}",
         domainUid,
         domainNamespace,
@@ -428,62 +425,24 @@ class ItMiiConfigMapOverride implements LoggedTest {
     }
 
     ExecResult result = null;
-    int adminServiceNodePort = getServiceNodePort(domainNamespace, adminServerPodName + "-external", "default");
-    checkJdbc = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
-    checkJdbc.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
-          .append("/management/wls/latest/datasources/id/TestDataSource/")
-          .append(" --silent --show-error ")
-          .append(" -o /dev/null")
-          .append(" -w %{http_code});")
-          .append("echo ${status}");
-    logger.info("curl command {0}", new String(checkJdbc));
-    try {
-      result = exec(new String(checkJdbc), true);
-    } catch (Exception ex) {
-      logger.info("Caught unexpected exception {0}", ex);
-      fail("Got unexpected exception" + ex);
-    }
-
-    logger.info("curl command returns {0}", result.toString());
+    result = checkSystemResourceConfiguration("JDBCSystemResources", "TestDataSource");
+    assertNotNull(result, "CheckJDBCSystemResources returned null");
+    logger.info("CheckJDBCSystemResource returned {0}", result.toString());
     assertEquals("200", result.stdout(), "DataSource configuration not found");
     logger.info("Found the DataSource configuration");
-
-    checkJms = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
-    checkJms.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
-          .append("/management/weblogic/latest/domainConfig")
-          .append("/JMSSystemResources/TestClusterJmsModule/")
-          .append(" --silent --show-error ")
-          .append(" -o /dev/null ")
-          .append(" -w %{http_code});")
-          .append("echo ${status}");
-    logger.info("CheckJms: curl command {0}", new String(checkJms));
-    try {
-      result = exec(new String(checkJms), true);
-    } catch (Exception ex) {
-      logger.info("CheckJms: caught unexpected exception {0}", ex);
-      fail("CheckJms:  got unexpected exception" + ex);
-    }
-    logger.info("CheckJms: curl command returns {0}", result.toString());
-    assertEquals("200", result.stdout(), "JMSSystemResource configuration not found");
+    
+    result = null;
+    result = checkSystemResourceConfiguration("JMSSystemResources", "TestClusterJmsModule");
+    assertNotNull(result, "CheckJMSSystemResources returned null");
+    logger.info("CheckJMSSystemResource returned {0}", result.toString());
+    assertEquals("200", result.stdout(), "JMSSystemResource not found");
     logger.info("Found the JMSSystemResource configuration");
 
-    checkWldf = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
-    checkWldf.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
-          .append("/management/weblogic/latest/domainConfig")
-          .append("/WLDFSystemResources/TestWldfModule/")
-          .append(" --silent --show-error ")
-          .append(" -o /dev/null ")
-          .append(" -w %{http_code});")
-          .append("echo ${status}");
-    logger.info("CheckWldf: curl command {0}", new String(checkWldf));
-    try {
-      result = exec(new String(checkWldf), true);
-    } catch (Exception ex) {
-      logger.info("CheckWldf: caught unexpected exception {0}", ex);
-      fail("CheckWldf: got unexpected exception" + ex);
-    }
-    logger.info("CheckWldf: curl command returns {0}", result.toString());
-    assertEquals("200", result.stdout(), "WLDFSystemResource configuration not found");
+    result = null;
+    result = checkSystemResourceConfiguration("WLDFSystemResources", "TestWldfModule");
+    assertNotNull(result, "CheckWLDFSystemResources returned null");
+    logger.info("CheckWLDFSystemResource returned {0}", result.toString());
+    assertEquals("200", result.stdout(), "WLDFSystemResource not found");
     logger.info("Found the WLDFSystemResource configuration");
 
   }
@@ -672,6 +631,52 @@ class ItMiiConfigMapOverride implements LoggedTest {
         .until(assertDoesNotThrow(() -> isPodRestarted(podName, domainUid, domNamespace, timestamp),
             String.format("podExists failed with ApiException for %s in namespace in %s",
                 podName, domNamespace)));
+  }
+
+  private ExecResult checkSystemResourceConfiguration(String resourcesType, String resourcesName) {
+
+    int adminServiceNodePort = getServiceNodePort(domainNamespace, adminServerPodName + "-external", "default");
+    ExecResult result = null;
+    curlString = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
+    curlString.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
+         .append("/management/weblogic/latest/domainConfig")
+         .append("/")
+         .append(resourcesType)
+         .append("/")
+         .append(resourcesName)
+         .append("/")
+         .append(" --silent --show-error ")
+         .append(" -o /dev/null ")
+         .append(" -w %{http_code});")
+         .append("echo ${status}");
+    logger.info("checkSystemResource: curl command {0}", new String(curlString));
+    try {
+      result = exec(new String(curlString), true);
+    } catch (Exception ex) {
+      logger.info("checkSystemResource: caught unexpected exception {0}", ex);
+      return null;
+    }
+    return result;
+  }
+
+  private ExecResult checkJdbcRuntime(String resourcesName) {
+    int adminServiceNodePort = getServiceNodePort(domainNamespace, adminServerPodName + "-external", "default");
+    ExecResult result = null;
+
+    curlString = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
+    curlString.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
+         .append("/management/wls/latest/datasources/id/")
+         .append(resourcesName)
+         .append("/")
+         .append(" --silent --show-error ");
+    logger.info("checkJdbcRuntime: curl command {0}", new String(curlString));
+    try {
+      result = exec(new String(curlString), true);
+    } catch (Exception ex) {
+      logger.info("checkJdbcRuntime: caught unexpected exception {0}", ex);
+      return null;
+    }
+    return result;
   }
 
 }

--- a/new-integration-tests/src/test/resources/wdt-models/model.jdbc.yaml
+++ b/new-integration-tests/src/test/resources/wdt-models/model.jdbc.yaml
@@ -14,9 +14,9 @@ resources:
                     RowPrefetchSize: 200
                     JNDIName: jdbc/TestDataSource
                 JDBCDriverParams:
-                    URL: 'jdbc:oracle:thin:@//xxx.xxx.x.xxx:1521/ORCLCDB'
-                    PasswordEncrypted: 'j2ee'
+                    URL: '@@SECRET:@@ENV:DOMAIN_UID@@-db-secret:url@@'
+                    PasswordEncrypted: '@@SECRET:@@ENV:DOMAIN_UID@@-db-secret:password@@'
                     DriverName: oracle.jdbc.OracleDriver
                     Properties:
                         user:
-                            Value: j2ee
+                            Value: '@@SECRET:@@ENV:DOMAIN_UID@@-db-secret:username@@'


### PR DESCRIPTION
Here is the usecase description 

(a)  Add a cluster with default spec level replica count i.e. ZERO.  Update the domainRestartVersion to trigger a rolling restart.  Make sure no server from the new cluster is in RUNNING state.

(b) Add a configured cluster to a deployed MII Domain using a sparse model file. 
(c) Add a dynamic cluster to a deployed MII Domain using a sparse model file. 

Make sure the managed servers from the new cluster are in RUNNING state after updating the domainRestartVersion and spec level replica count to a non-ZERO value

Extra Update -  Add a JMS/WLDF configuration to MiiDomain using sparse model files.  Verify the Configuration/Runtime for the JMS/WLDF system resource using REST API 

External Jenkin Run(s)   
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests-10/129/    ( I see  oracle.weblogic.kubernetes.ItDomainOnPV.testDomainOnPvUsingWlst test fails unrelated to the changes in this PR ) 

Kind Cluster  ( all passed ) 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/129