### PR TITLE
Test change domain credentials secret

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
@@ -107,11 +107,15 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
   }
   
   /**
-   * Test patching a running model-in-image domain with a new webLogicCredentialsSecret and then
-   * update the domain's restartVersion to trigger a rolling restart of the managed server pods.
-   * Verify that the WebLogic server pods are restarted by verifying that each pod's creation time,
-   * and the weblogic.domainRestartVersion label are updated.
-   * Also verify that the new credentials are valid and can access WebLogic RESTful Management Services.
+   * Test patching a running model-in-image domain with a new WebLogic credentials secret。
+   * The test performs two patching operations to the domain spec：
+   * 1） Change the domain spec's webLogicCredentialsSecret；
+   * 2） Change the domain spec's domainRestartVersion to trigger a rolling restart of the server pods。
+   * The test verifies the following：
+   * 1） the domain spec's webLogicCredentialsSecret and restartVersion are updated；
+   * 2） the server pods are recreated by checking each pod's creationTimestamp before and after patching；
+   * 3） the server pods' weblogic.domainRestartVersion label is updated；
+   * 4） the new credentials are valid and can be used to access WebLogic RESTful Management Services。
    */
   @Test
   @DisplayName("Change the WebLogic credentials")

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
@@ -265,7 +265,7 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
     String updatedVersion = assertDoesNotThrow(
         () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
         String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
-    logger.info("Current restartVersion is %s", updatedVersion);
+    logger.info("Current restartVersion is {0}", updatedVersion);
     assertTrue(updatedVersion.equals(String.valueOf(newVersion)),
         String.format("Failed to update the restartVersion of domain %s from %s to %s",
             domainResourceName,
@@ -362,7 +362,7 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
     String restartVersion = patchDomainResourceWithNewAdminSecret(domainUid, namespace, secretName);
     
     logger.info(
-        "Check that domain resource {0} in namespace {1} has been patched with new secret {3}",
+        "Check that domain resource {0} in namespace {1} has been patched with new secret {2}",
         domainUid, namespace, secretName);
     checkDomainCredentialsSecretPatched(domainUid, namespace, secretName);
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
@@ -131,7 +131,7 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
     String adminPodLastCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace,"",adminServerPodName),
         String.format("Failed to get creationTimestamp for pod %s", adminServerPodName));
-    assertNotNull(adminPodLastCreationTime, "creationTimestamp of the admin server pod is NULL");
+    assertNotNull(adminPodLastCreationTime, "creationTimestamp of the admin server pod is null");
 
     logger.info("Domain {0} in namespace {1}, admin server pod {2} creationTimestamp before patching is {3}",
         domainUid,

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
@@ -79,10 +79,9 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
   private static int replicaCount = 2;
 
   /**
-   * Perform the following initialization for all the tests in this class:
-   * 1) set up the necessary namespaces for the operator and one domain,
-   * 2) install the operator in the first namespace, and
-   * 3) create a domain in the second namespace using the pre-created basic MII image.
+   * Perform initialization for all the tests in this class.
+   * Set up the necessary namespaces, install the operator in the first namespace, and
+   * create a domain in the second namespace using the pre-created basic MII image.
    * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
    *                   JUnit engine parameter resolution mechanism
    */
@@ -112,15 +111,13 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
   }
   
   /**
-   * Test patching a running model-in-image domain with a new WebLogic credentials secret。
-   * The test performs two patching operations to the domain spec：
-   * 1） Change the domain spec's webLogicCredentialsSecret；
-   * 2） Change the domain spec's domainRestartVersion to trigger a rolling restart of the server pods。
-   * The test verifies the following：
-   * 1） the domain spec's webLogicCredentialsSecret and restartVersion are updated；
-   * 2） the server pods are recreated by checking each pod's creationTimestamp before and after patching；
-   * 3） the server pods' weblogic.domainRestartVersion label is updated；
-   * 4） the new credentials are valid and can be used to access WebLogic RESTful Management Services。
+   * Test patching a running model-in-image domain with a new WebLogic credentials secret.
+   * Perform two patching operations to the domain spec: change the webLogicCredentialsSecret to a new
+   * secret, and change the domainRestartVersion to trigger a rolling restart of the server pods.
+   * Verify that the domain spec's webLogicCredentialsSecret and restartVersion are updated,
+   * the server pods are recreated by checking each pod's creationTimestamp before and after patching,
+   * the server pods' weblogic.domainRestartVersion label is updated, and 
+   * the new credentials are valid and can be used to access WebLogic RESTful Management Services.
    */
   @Test
   @DisplayName("Change the WebLogic credentials")

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
@@ -75,8 +75,8 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
   private static ConditionFactory withStandardRetryPolicy = null;
 
   // admin/managed server name here should match with model yaml in WDT_MODEL_FILE
-  private static String adminServerPodName = domainUid + ADMIN_SERVER_NAME_BASE;
-  private static String managedServerPrefix = domainUid + MANAGED_SERVER_NAME_BASE;
+  private static String adminServerPodName = String.format("%s-%s", domainUid, ADMIN_SERVER_NAME_BASE);
+  private static String managedServerPrefix = String.format("%s-%s", domainUid, MANAGED_SERVER_NAME_BASE);
   private static int replicaCount = 2;
 
   /**
@@ -159,8 +159,10 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
     logger.info("Create a new secret for WebLogic admin credentials");
     String adminSecretName = "weblogic-credentials-new";
     assertDoesNotThrow(() -> createSecretWithUsernamePassword(
-        adminSecretName,ADMIN_USERNAME_PATCH,
-        ADMIN_PASSWORD_PATCH, domainNamespace),
+        adminSecretName,
+        domainNamespace,
+        ADMIN_USERNAME_PATCH,
+        ADMIN_PASSWORD_PATCH),
         String.format("createSecret failed for %s", adminSecretName));
 
     // patch the domain resource with the new secret and verify that the domain resource is patched.
@@ -416,7 +418,7 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
   }
   
   private static void createAndVerifyMiiDomain() {
-    // Create the repo secret to pull the image
+    logger.info("Create the repo secret {0} to pull the image", REPO_SECRET_NAME);
     assertDoesNotThrow(() -> createDockerRegistrySecret(domainNamespace),
             String.format("createSecret failed for %s", REPO_SECRET_NAME));
 
@@ -425,9 +427,9 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
     String adminSecretName = "weblogic-credentials";
     assertDoesNotThrow(() -> createSecretWithUsernamePassword(
         adminSecretName,
+        domainNamespace,
         ADMIN_USERNAME_DEFAULT,
-        ADMIN_PASSWORD_DEFAULT,
-        domainNamespace),
+        ADMIN_PASSWORD_DEFAULT),
         String.format("createSecret failed for %s", adminSecretName));
 
     // create encryption secret
@@ -435,9 +437,9 @@ class ItMiiChangeAdminCredentials implements LoggedTest {
     String encryptionSecretName = "encryptionsecret";
     assertDoesNotThrow(() -> createSecretWithUsernamePassword(
         encryptionSecretName,
+        domainNamespace,
         "weblogicenc",
-        "weblogicenc",
-        domainNamespace),
+        "weblogicenc"),
         String.format("createSecret failed for %s", encryptionSecretName));
 
     // create the domain CR

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiChangeAdminCredentials.java
@@ -1,0 +1,473 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1SecretReference;
+import oracle.weblogic.domain.AdminServer;
+import oracle.weblogic.domain.AdminService;
+import oracle.weblogic.domain.Channel;
+import oracle.weblogic.domain.Cluster;
+import oracle.weblogic.domain.Configuration;
+import oracle.weblogic.domain.Domain;
+import oracle.weblogic.domain.DomainSpec;
+import oracle.weblogic.domain.Model;
+import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.annotations.IntegrationTest;
+import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.annotations.tags.MustNotRunInParallel;
+import oracle.weblogic.kubernetes.annotations.tags.Slow;
+import oracle.weblogic.kubernetes.extensions.LoggedTest;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_PATCH;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_PATCH;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_SECRET_NAME;
+import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.credentialsValid;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainResourceAdminSecretPatched;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.isPodRestarted;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podRestartVersionUpdated;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDockerRegistrySecret;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
+import static org.awaitility.Awaitility.with;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Test to create model in image domain and verify the domain started successfully
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Test to patch the model-in-image image to change WebLogic admin credentials secret")
+@IntegrationTest
+class ItMiiChangeAdminCredentials implements LoggedTest {
+
+  private static String domainNamespace = null;
+  private static String domainUid = "domain1";
+  private static ConditionFactory withStandardRetryPolicy = null;
+
+  // admin/managed server name here should match with model yaml in WDT_MODEL_FILE
+  private static String adminServerPodName = domainUid + ADMIN_SERVER_NAME_BASE;
+  private static String managedServerPrefix = domainUid + MANAGED_SERVER_NAME_BASE;
+  private static int replicaCount = 2;
+
+  /**
+   * Initialization.
+   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
+   JUnit engine parameter resolution mechanism
+   */
+  @BeforeAll
+  public static void initAll(@Namespaces(2) List<String> namespaces) {
+    // create standard, reusable retry/backoff policy
+    withStandardRetryPolicy = with().pollDelay(2, SECONDS)
+        .and().with().pollInterval(10, SECONDS)
+        .atMost(6, MINUTES).await();
+
+    // get namespaces 
+    assertNotNull(namespaces.get(0), String.format("Namespace %s is null", namespaces.get(0)));
+    String opNamespace = namespaces.get(0);
+
+    assertNotNull(namespaces.get(1), String.format("Namespace %s is null", namespaces.get(1)));
+    domainNamespace = namespaces.get(1);
+
+    logger.info("Install an operator in namespace {0}, managing namespace {1}",
+        opNamespace, domainNamespace); 
+    installAndVerifyOperator(opNamespace, domainNamespace);
+   
+    logger.info("Create model-in-image domain {0} in namespace {1}, and wait until it comes up",
+        domainUid, domainNamespace); 
+    createAndVerifyMiiDomain();
+  }
+  
+  /**
+   * Test patching a running model-in-image domain with a new weblogicCredentialsSecret and then
+   * update the domain's restartVersion to trigger a rolling restart of the managed server pods.
+   * Verify that the WebLogic server pods are restarted by verifying that each pod's creation time,
+   * and the weblogic.domainRestartVersion label are updated.
+   */
+  @Test
+  @DisplayName("Change the WebLogic credentials")
+  @Slow
+  @MustNotRunInParallel
+  public void testChangeWebLogicCredentials() {
+    final boolean VALID = true;
+    final boolean INVALID = false;
+
+    // get the creation time of the admin server pod before patching
+    String adminPodLastCreationTime =
+        assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace,"",adminServerPodName),
+        String.format("Can not find PodCreationTime for pod %s", adminServerPodName));
+    assertNotNull(adminPodLastCreationTime, "adminPodCreationTime returns NULL");
+
+    logger.info("Domain {0} in namespace {1}, admin server pod {2} CreationTime before patching is {3}",
+        domainUid,
+        domainNamespace,
+        adminServerPodName,
+        adminPodLastCreationTime);
+    
+    List<String> msLastCreationTime = new ArrayList<String>();
+    // get the creation time of the managed server pods before patching
+    assertDoesNotThrow(
+        () -> { 
+          for (int i = 1; i <= replicaCount; i++) {
+            String managedServerPodName = managedServerPrefix + i;
+            String creationTime = getPodCreationTimestamp(domainNamespace,"", managedServerPodName);
+            msLastCreationTime.add(creationTime);
+
+            logger.info("Domain {0} in namespace {1}, managed server pod {2} CreationTime before patching is {3}",
+                domainUid,
+                domainNamespace,
+                managedServerPodName,
+                creationTime);
+          } 
+        },
+        String.format("Failed to get PodCreationTime for managed server pods"));
+    
+    logger.info("Check that before patching current credentials are in valid and new credentials are not");
+    verifyCredentials(adminServerPodName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, VALID);
+    verifyCredentials(adminServerPodName, domainNamespace, ADMIN_USERNAME_PATCH, ADMIN_PASSWORD_PATCH, INVALID);
+    
+    // create a new secret for admin credentials
+    logger.info("Create a new secret for WebLogic admin credentials");
+    String adminSecretName = "weblogic-credentials-new";
+    assertDoesNotThrow(() -> createSecretWithUsernamePassword(
+        adminSecretName,ADMIN_USERNAME_PATCH,
+        ADMIN_PASSWORD_PATCH, domainNamespace),
+        String.format("createSecret failed for %s", adminSecretName));
+
+    // patch the domain resource with the new secret and verify that the domain resource is patched.
+    logger.info("Patch domain {0} in namespace {1} with the secret {2}, and verify the result",
+        domainUid, domainNamespace, adminSecretName); 
+
+    String restartVersion = patchAndVerifyDomainResource(
+        domainUid,
+        domainNamespace,
+        adminServerPodName,
+        managedServerPrefix,
+        replicaCount,
+        adminSecretName);
+
+    logger.info("Wait for domain {0} admin server pod {1} in namespace {2} to be restarted",
+        domainUid, adminServerPodName, domainNamespace);
+    checkPodRestarted(domainUid, domainNamespace, adminServerPodName, adminPodLastCreationTime);
+    
+    // check that the admin server pod's label has been updated with the new restarVersion
+    checkPodRestartVersionUpdated(adminServerPodName, domainUid, domainNamespace, restartVersion);
+    
+    // check managed server pods are ready
+    for (int i = 1; i <= replicaCount; i++) {
+      final String podName = managedServerPrefix + i;
+      final String lastCreationTime = msLastCreationTime.get(i - 1);
+      logger.info("Wait for managed server pod {0} to be restarted in namespace {1}",
+          podName, domainNamespace);
+      checkPodRestarted(domainUid, domainNamespace, podName, lastCreationTime);
+      
+      // check that the managed server pod's label has been updated with the new restarVersion`
+      checkPodRestartVersionUpdated(podName, domainUid, domainNamespace, restartVersion);
+    }
+ 
+    // check if the new credentials are valid and the old credentials are not valid any more
+    logger.info("Check that after patching current credentials are not valid and new credentials are");
+    verifyCredentials(adminServerPodName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, INVALID);
+    verifyCredentials(adminServerPodName, domainNamespace, ADMIN_USERNAME_PATCH, ADMIN_PASSWORD_PATCH, VALID);
+    
+    logger.info("Domain {0} in namespace {1} is fully started after changing WebLogic credentials secret",
+        domainUid, domainNamespace);
+  }
+
+  /**
+   * Patch the domain resource with a new WebLogic admin credentials secret.
+   * 
+   * @param domainResourceName name of the domain resource
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @param secretName name of the new WebLogic admin credentials secret
+   * @return restartVersion new restartVersion of the domain resource
+   */
+  private String patchDomainResource(
+      String domainResourceName,
+      String namespace,
+      String secretName
+  ) {
+    String patch = String.format(
+        "[\n  {\"op\": \"replace\", \"path\": \"/spec/%s\", \"value\": \"%s\"}\n]\n",
+            "webLogicCredentialsSecret/name", secretName);
+    logger.info("About to patch the domain resource {0} in namespace {1} with:{2}\n",
+        domainResourceName, namespace, patch);
+
+    assertTrue(patchDomainCustomResource(
+            domainResourceName,
+            namespace,
+            new V1Patch(patch),
+            V1Patch.PATCH_FORMAT_JSON_PATCH),
+        String.format("Failed to patch the domain resource %s in namespace %s with %s:%s",
+            domainResourceName, namespace, "/spec/webLogicCredentialsSecret/name", secretName));
+
+    String restartVersion = assertDoesNotThrow(
+        () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
+        String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
+    int newVersion = restartVersion == null ? 1 : Integer.valueOf(restartVersion) + 1;
+    logger.info("Update restartVersion of domain {0} from {1} to {2}",
+        domainResourceName, restartVersion, newVersion);
+    patch =
+        String.format("[\n  {\"op\": \"replace\", \"path\": \"/spec/restartVersion\", \"value\": \"%s\"}\n]\n",
+            newVersion);
+    logger.info("About to patch the domain resource {0} in namespace {1} with:{2}\n",
+        domainResourceName, namespace, patch);
+
+    assertTrue(patchDomainCustomResource(
+            domainResourceName,
+            namespace,
+            new V1Patch(patch),
+            V1Patch.PATCH_FORMAT_JSON_PATCH),
+        String.format("Failed to patch the domain resource %s in namespace %s with startVersion:%s",
+              domainResourceName, namespace, newVersion));
+
+    String currentVersion = assertDoesNotThrow(
+        () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
+        String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
+    logger.info("Current restartVersion is %s", currentVersion);
+    assertTrue(currentVersion.equals(String.valueOf(newVersion)),
+        String.format("Failed to update the restartVersion of domain %s from %s to %s",
+            domainResourceName,
+            restartVersion,
+            newVersion));
+    return String.valueOf(newVersion);
+  }
+
+  private static Domain createDomainResource(
+      String domainUid, 
+      String domNamespace, 
+      String adminSecretName,
+      String repoSecretName, 
+      String encryptionSecretName, 
+      int replicaCount) {
+    // create the domain CR
+    return new Domain()
+            .apiVersion(DOMAIN_API_VERSION)
+            .kind("Domain")
+            .metadata(new V1ObjectMeta()
+                    .name(domainUid)
+                    .namespace(domNamespace))
+            .spec(new DomainSpec()
+                    .domainUid(domainUid)
+                    .domainHomeSourceType("FromModel")
+                    .image(MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG)
+                    .addImagePullSecretsItem(new V1LocalObjectReference()
+                            .name(repoSecretName))
+                    .webLogicCredentialsSecret(new V1SecretReference()
+                            .name(adminSecretName)
+                            .namespace(domNamespace))
+                    .includeServerOutInPodLog(true)
+                    .serverStartPolicy("IF_NEEDED")
+                    .serverPod(new ServerPod()
+                            .addEnvItem(new V1EnvVar()
+                                    .name("JAVA_OPTIONS")
+                                    .value("-Dweblogic.StdoutDebugEnabled=false"))
+                            .addEnvItem(new V1EnvVar()
+                                    .name("USER_MEM_ARGS")
+                                    .value("-Djava.security.egd=file:/dev/./urandom ")))
+                    .adminServer(new AdminServer()
+                            .serverStartState("RUNNING")
+                            .adminService(new AdminService()
+                                    .addChannelsItem(new Channel()
+                                            .channelName("default")
+                                            .nodePort(0))))
+                    .addClustersItem(new Cluster()
+                            .clusterName("cluster-1")
+                            .replicas(replicaCount)
+                            .serverStartState("RUNNING"))
+                    .configuration(new Configuration()
+                            .model(new Model()
+                                    .domainType("WLS")
+                                    .runtimeEncryptionSecret(encryptionSecretName))
+                        .introspectorJobActiveDeadlineSeconds(300L)));
+
+  }
+
+  private String patchAndVerifyDomainResource(
+      final String domainUid,
+      final String namespace,
+      final String adminServerPodName,
+      final String managedServerPrefix,
+      final int replicaCount,
+      final String secretName
+  ) {
+    logger.info(
+        "Patch domain resource {0} in namespace {1} to use the new secret {2}",
+        domainUid, namespace, secretName);
+
+    String restartVersion = patchDomainResource(domainUid, namespace, secretName);
+    
+    logger.info(
+        "Check that domain resource {0} in namespace {1} has been patched with new secret {3}",
+        domainUid, namespace, secretName);
+    checkDomainAdminSecretPatched(domainUid, namespace, secretName);
+
+    // check and wait for the admin server pod to be patched with the new image
+    logger.info(
+        "Check that admin server pod for domain resource {0} in namespace {1} has been patched with {2}: {3}",
+        domainUid, namespace, "/spec/WebLogicCredentialsSecret/name", secretName);
+
+    return restartVersion;
+  }
+
+  private void checkDomainAdminSecretPatched(
+      String domainUid,
+      String namespace,
+      String newValue
+  ) {
+   
+    // check if domain resource has been patched with the new secret
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for domain {0} to be patched in namespace {1} "
+            + "(elapsed time {2}ms, remaining time {3}ms)",
+            domainUid,
+            namespace,
+            condition.getElapsedTimeInMS(),
+            condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> domainResourceAdminSecretPatched(domainUid, namespace, newValue),
+            String.format(
+               "Domain %s is not patched in namespace %s with admin credentials secret %s",
+               domainUid, namespace, newValue)));
+
+  }
+  
+  private void checkPodRestarted(
+      String domainUid,
+      String domNamespace,
+      String podName,
+      String lastCreationTime
+  ) {
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for pod {0} to be restarted in namespace {1} "
+            + "(elapsed time {2}ms, remaining time {3}ms)",
+            podName,
+            domNamespace,
+            condition.getElapsedTimeInMS(),
+            condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> isPodRestarted(podName, domainUid, domNamespace, lastCreationTime),
+            String.format(
+                "pod %s has not been restarted in namespace %s", podName, domNamespace)));
+  }
+
+  private void checkPodRestartVersionUpdated(
+      String podName,
+      String domainUid,
+      String namespace,
+      String restartVersion) {
+    logger.info("Check if weblogic.domainRestartVersion of pod {0} has been updated", podName);
+    boolean restartVersionUpdated = assertDoesNotThrow(
+        () -> podRestartVersionUpdated(podName, domainUid, namespace, restartVersion),
+        String.format("Failed to get weblogic.domainRestartVersion label of pod %s in namespace %s",
+            podName, namespace));
+    assertTrue(restartVersionUpdated, 
+        String.format("Label weblogic.domainRestartVersion of pod %s in namespace %s has not been updated",
+            podName, namespace));
+  }
+  
+  private void verifyCredentials(
+      String podName,
+      String namespace,
+      String username,
+      String password,
+      boolean shouldBeValid) {
+    logger.info("Check if new WebLogic admin credentials are valid");
+    boolean connectSucceeded = assertDoesNotThrow(
+        () -> credentialsValid(K8S_NODEPORT_HOST, podName, namespace, username, password),
+        String.format("Failed to check the credentials on pod %s", podName));
+        
+    if (shouldBeValid) {
+      assertTrue(connectSucceeded, 
+          "Given credentials are invalid");
+    } else {
+      assertFalse(connectSucceeded, 
+          "Given credentials are valid when they are not expected to be"); 
+    }
+  }
+  
+  private static void createAndVerifyMiiDomain() {
+    // Create the repo secret to pull the image
+    assertDoesNotThrow(() -> createDockerRegistrySecret(domainNamespace),
+            String.format("createSecret failed for %s", REPO_SECRET_NAME));
+
+    // create secret for admin credentials
+    logger.info("Create secret for admin credentials");
+    String adminSecretName = "weblogic-credentials";
+    assertDoesNotThrow(() -> createSecretWithUsernamePassword(
+        adminSecretName,
+        ADMIN_USERNAME_DEFAULT,
+        ADMIN_PASSWORD_DEFAULT,
+        domainNamespace),
+        String.format("createSecret failed for %s", adminSecretName));
+
+    // create encryption secret
+    logger.info("Create encryption secret");
+    String encryptionSecretName = "encryptionsecret";
+    assertDoesNotThrow(() -> createSecretWithUsernamePassword(
+        encryptionSecretName,
+        "weblogicenc",
+        "weblogicenc",
+        domainNamespace),
+        String.format("createSecret failed for %s", encryptionSecretName));
+
+    // create the domain CR
+    logger.info("Create domain resource {0} object in namespace {1} and verify that it is created",
+        domainUid, domainNamespace);
+    Domain domain = createDomainResource(domainUid, domainNamespace, adminSecretName, REPO_SECRET_NAME,
+        encryptionSecretName, replicaCount);
+    createDomainAndVerify(domain, domainNamespace); 
+
+    // check admin server pod is ready
+    logger.info("Wait for admin server pod {0} to be ready in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
+
+    // check managed server pods are ready
+    for (int i = 1; i <= replicaCount; i++) {
+      logger.info("Wait for managed server pod {0} to be ready in namespace {1}",
+          managedServerPrefix + i, domainNamespace);
+      checkPodReady(managedServerPrefix + i, domainUid, domainNamespace);
+    }
+
+    logger.info("Check admin service {0} is created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkServiceExists(adminServerPodName, domainNamespace);
+
+    // check managed server services created
+    for (int i = 1; i <= replicaCount; i++) {
+      logger.info("Check managed server service {0} is created in namespace {1}",
+          managedServerPrefix + i, domainNamespace);
+      checkServiceExists(managedServerPrefix + i, domainNamespace);
+    }
+  }
+}

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -75,4 +75,10 @@ public interface TestConstants {
   public static final String MII_APP_RESPONSE_V3 = "How are you doing! You have reached server managed-server";
   public static final String READ_STATE_COMMAND = "/weblogic-operator/scripts/readState.sh";
 
+  // credentials
+  public static final String ADMIN_USERNAME_DEFAULT = "weblogic";
+  public static final String ADMIN_PASSWORD_DEFAULT = "welcome1";
+  public static final String ADMIN_USERNAME_PATCH = "weblogicnew";
+  public static final String ADMIN_PASSWORD_PATCH = "welcome1new";
+
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -693,6 +693,21 @@ public class TestActions {
   public static String getPodLog(String podName, String namespace) throws ApiException {
     return Pod.getPodLog(podName, namespace);
   }
+  
+  /**
+   * Get the weblogic.domainRestartVersion label from a given pod.
+   *
+   * @param namespace in which to check for the pod existence
+   * @param labelSelector in the format "weblogic.domainUID in (%s)"
+   * @param podName  name of the pod
+   * @return value of weblogic.domainRestartVersion label, null if unset or the pod is not available
+   * @throws ApiException when there is error in querying the cluster
+   */
+  public static String getPodRestartVersion(String namespace, String labelSelector, String podName)
+      throws ApiException {
+    return Kubernetes.getPodRestartVersion(namespace, labelSelector, podName);
+  }
+
 
   // ------------------------ where does this go  -------------------------
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Command.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Command.java
@@ -59,8 +59,12 @@ public class Command {
       }
 
       // check exitValue to determine if the command execution has failed.
-      if (params.verbose() && result.exitValue() != 0) {
-        logger.severe("The command execution failed because it returned non-zero exit value: {0}.", result);
+      if (params.verbose()) {
+        if (result.exitValue() != 0) {
+          logger.severe("The command execution failed because it returned non-zero exit value: {0}.", result);
+        } else {
+          logger.info("The command execution succeeded with result: {0}.", result);
+        }
       } 
 
       return result.exitValue() == 0;
@@ -91,8 +95,12 @@ public class Command {
       }
 
       // check exitValue to determine if the command execution has failed.
-      if (params.verbose() && result.exitValue() != 0) {
-        logger.severe("The command execution failed because it returned non-zero exit value: {0}.", result);
+      if (params.verbose()) {
+        if (result.exitValue() != 0) {
+          logger.severe("The command execution failed because it returned non-zero exit value: {0}.", result);
+        } else {
+          logger.info("The command execution succeeded with result: {0}.", result);
+        }
       } 
 
       return result.exitValue() == 0

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -479,6 +479,27 @@ public class Kubernetes implements LoggedTest {
   }
 
   /**
+   * Get the weblogic.domainRestartVersion label from a given pod.
+   *
+   * @param namespace in which to check for the pod existence
+   * @param labelSelector in the format "weblogic.domainUID in (%s)"
+   * @param podName  name of the pod
+   * @return value of weblogic.domainRestartVersion label, null if unset or the pod is not available
+   * @throws ApiException when there is error in querying the cluster
+   */
+  public static String getPodRestartVersion(String namespace, String labelSelector, String podName)
+      throws ApiException {
+    V1Pod pod = getPod(namespace, labelSelector, podName);
+    if (pod != null) {
+      // return the value of the weblogic.domainRestartVersion label
+      return pod.getMetadata().getLabels().get("weblogic.domainRestartVersion");
+    } else {
+      logger.info("getPodRestartVersion(): Pod doesn't exist");
+      return null;
+    }
+  }
+
+  /**
    * List all pods in given namespace.
    *
    * @param namespace Namespace in which to list all pods

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -310,13 +310,33 @@ public class TestAssertions {
    * @param password WebLogic admin password
    * @return true if the RESTful Management Services command succeeded
    */
-  public static boolean credentialsValid(
+  public static Callable<Boolean> credentialsValid(
       String host,
       String podName,
       String namespace,
       String username,
       String password) {
-    return Application.credentialsValid(host, podName, namespace, username, password);
+    return () -> Application.credentialsValid(host, podName, namespace, username, password);
+  }
+
+  /**
+   * Check if the given WebLogic credentials are NOT valid by using the credentials to 
+   * invoke a RESTful Management Services command.
+   *
+   * @param host hostname of the admin server pod
+   * @param podName name of the admin server pod
+   * @param namespace name of the namespace that the pod is running in
+   * @param username WebLogic admin username
+   * @param password WebLogic admin password
+   * @return true if the RESTful Management Services command failed with exitCode 401
+   */
+  public static Callable<Boolean> credentialsNotValid(
+      String host,
+      String podName,
+      String namespace,
+      String username,
+      String password) {
+    return () -> Application.credentialsNotValid(host, podName, namespace, username, password);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -102,12 +102,12 @@ public class TestAssertions {
    * @param secretName name of the secret that was used to patch the domain resource
    * @return true if the domain is patched correctly
    */
-  public static Callable<Boolean> domainResourceAdminSecretPatched(
+  public static Callable<Boolean> domainResourceCredentialsSecretPatched(
       String domainUid,
       String namespace,
       String secretName
   ) {
-    return () -> Domain.domainResourceAdminSecretPatched(domainUid, namespace, secretName);
+    return () -> Domain.domainResourceCredentialsSecretPatched(domainUid, namespace, secretName);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -316,7 +316,7 @@ public class TestAssertions {
       String namespace,
       String username,
       String password) {
-    return () -> Application.credentialsValid(host, podName, namespace, username, password);
+    return () -> Domain.credentialsValid(host, podName, namespace, username, password);
   }
 
   /**
@@ -336,7 +336,7 @@ public class TestAssertions {
       String namespace,
       String username,
       String password) {
-    return () -> Application.credentialsNotValid(host, podName, namespace, username, password);
+    return () -> Domain.credentialsNotValid(host, podName, namespace, username, password);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -80,7 +80,7 @@ public class TestAssertions {
    * @param domainUid WebLogic domain uid in which the pod belongs
    * @param namespace in which the pod is running
    * @param expectedRestartVersion restartVersion that is expected
-   * @return true if the pod has been restarted
+   * @return true if the pod's restartVersion has been updated
    */
   public static boolean podRestartVersionUpdated(
       String podName,
@@ -105,7 +105,7 @@ public class TestAssertions {
       String namespace,
       String secretName
   ) {
-    return Domain.domainResourceAdminSecretPatched(domainUid, namespace, secretName);
+    return () -> Domain.domainResourceAdminSecretPatched(domainUid, namespace, secretName);
   }
 
   /**
@@ -121,7 +121,7 @@ public class TestAssertions {
       String namespace,
       String image
   ) {
-    return Domain.domainResourceImagePatched(domainUid, namespace, image);
+    return () -> Domain.domainResourceImagePatched(domainUid, namespace, image);
   }
 
   /**
@@ -295,14 +295,15 @@ public class TestAssertions {
   }
 
   /**
-   * Check if the given WebLogic admin credentials are valid.
+   * Check if the given WebLogic credentials are valid by using the credentials to 
+   * invoke a RESTful Management Services command.
    *
-   * @param host hostname of WebLogic admin server pod
-   * @param podName name of WebLogic admin server pod
+   * @param host hostname of the admin server pod
+   * @param podName name of the admin server pod
    * @param namespace name of the namespace that the pod is running in
    * @param username WebLogic admin username
    * @param password WebLogic admin password
-   * @return true if the console can be accessed
+   * @return true if the RESTful Management Services command succeeded
    */
   public static boolean credentialsValid(
       String host,

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -74,6 +74,41 @@ public class TestAssertions {
   }
 
   /**
+   * Check if a pod's restartVersion has been updated. 
+   *
+   * @param podName   name of the pod to check
+   * @param domainUid WebLogic domain uid in which the pod belongs
+   * @param namespace in which the pod is running
+   * @param expectedRestartVersion restartVersion that is expected
+   * @return true if the pod has been restarted
+   */
+  public static boolean podRestartVersionUpdated(
+      String podName,
+      String domainUid,
+      String namespace,
+      String expectedRestartVersion
+  ) throws ApiException {
+    return Kubernetes.podRestartVersionUpdated(namespace, domainUid, podName, expectedRestartVersion);
+  }
+
+
+  /**
+   * Check if a WebLogic domain custom resource has been patched with a new WebLogic credentials secret.
+   *
+   * @param domainUid ID of the domain resource
+   * @param namespace Kubernetes namespace in which the domain custom resource object exists
+   * @param secretName name of the secret that was used to patch the domain resource
+   * @return true if the domain is patched correctly
+   */
+  public static Callable<Boolean> domainResourceAdminSecretPatched(
+      String domainUid,
+      String namespace,
+      String secretName
+  ) {
+    return Domain.domainResourceAdminSecretPatched(domainUid, namespace, secretName);
+  }
+
+  /**
    * Check if a WebLogic domain custom resource has been patched with a new image.
    *
    * @param domainUid ID of the domain resource
@@ -257,6 +292,25 @@ public class TestAssertions {
       String expectedResponse
   ) {
     return Application.appAccessibleInPodKubectl(namespace, podName, port, appPath, expectedResponse);
+  }
+
+  /**
+   * Check if the given WebLogic admin credentials are valid.
+   *
+   * @param host hostname of WebLogic admin server pod
+   * @param podName name of WebLogic admin server pod
+   * @param namespace name of the namespace that the pod is running in
+   * @param username WebLogic admin username
+   * @param password WebLogic admin password
+   * @return true if the console can be accessed
+   */
+  public static boolean credentialsValid(
+      String host,
+      String podName,
+      String namespace,
+      String username,
+      String password) {
+    return Application.credentialsValid(host, podName, namespace, username, password);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
@@ -12,11 +12,7 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.logging.LoggingFactory;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 
-import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
-import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
-import static oracle.weblogic.kubernetes.TestConstants.WLS_DEFAULT_CHANNEL_NAME;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
-import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 
 /**
  * Assertions for applications that are deployed in a domain custom resource.
@@ -123,81 +119,5 @@ public class Application {
       return false;
     }
   } 
-  
-  /**
-   * Check if the given WebLogic credentials are valid by using the credentials to 
-   * invoke a RESTful Management Services command.
-   *
-   * @param host hostname of the admin server pod
-   * @param podName name of the admin server pod
-   * @param namespace name of the namespace that the pod is running in
-   * @param username WebLogic admin username
-   * @param password WebLogic admin password
-   * @return true if the RESTful Management Services command succeeded
-   **/
-  public static boolean credentialsValid(
-      String host,
-      String podName,
-      String namespace,
-      String username,
-      String password) {
-    CommandParams params = createCommandParams(host, podName, namespace, username, password);
-    return Command.withParams(params).executeAndVerify("200");
-  }
-  
-  /**
-   * Check if the given WebLogic credentials are not valid by using the credentials to 
-   * invoke a RESTful Management Services command.
-   *
-   * @param host hostname of the admin server pod
-   * @param podName name of the admin server pod
-   * @param namespace name of the namespace that the pod is running in
-   * @param username WebLogic admin username
-   * @param password WebLogic admin password
-   * @return true if the RESTful Management Services command failed with exitCode 401
-   **/
-  public static boolean credentialsNotValid(
-      String host,
-      String podName,
-      String namespace,
-      String username,
-      String password) {
-    CommandParams params = createCommandParams(host, podName, namespace, username, password);
-    return Command.withParams(params).executeAndVerify("401");
-  }
- 
-  private static CommandParams createCommandParams(
-      String host,
-      String podName,
-      String namespace,
-      String username,
-      String password) {
-    int adminServiceNodePort = getServiceNodePort(namespace, podName + "-external", WLS_DEFAULT_CHANNEL_NAME);
 
-    if (username == null) {
-      username = ADMIN_USERNAME_DEFAULT;
-    }
-    if (password == null) {
-      password = ADMIN_PASSWORD_DEFAULT;
-    }
-
-    // create a RESTful management services command that connects to admin server using given credentials to get
-    // information about a managed server
-    StringBuffer cmdString = new StringBuffer()
-        .append("status=$(curl --user " + username + ":" + password)
-        .append(" http://" + host + ":" + adminServiceNodePort)
-        .append("/management/tenant-monitoring/servers/managed-server1")
-        .append(" --silent --show-error")
-        .append(" --noproxy '*'")
-        .append(" -o /dev/null")
-        .append(" -w %{http_code});")
-        .append(" echo ${status}");
-
-    return Command
-            .defaultCommandParams()
-            .command(cmdString.toString())
-            .saveResults(true)
-            .redirect(true)
-            .verbose(true);
-  }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
@@ -187,10 +187,11 @@ public class Application {
         .append("status=$(curl --user " + username + ":" + password)
         .append(" http://" + host + ":" + adminServiceNodePort)
         .append("/management/tenant-monitoring/servers/managed-server1")
-        .append(" --silent --show-error ")
+        .append(" --silent --show-error")
+        .append(" --noproxy '*'")
         .append(" -o /dev/null")
         .append(" -w %{http_code});")
-        .append("echo ${status}");
+        .append(" echo ${status}");
 
     return Command
             .defaultCommandParams()

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
@@ -132,7 +132,7 @@ public class Application {
    * @param namespace name of the namespace that the pod is running in
    * @param username WebLogic admin username
    * @param password WebLogic admin password
-   * @return true if the credentials are valid
+   * @return true if the RESTful Management Services command succeeded
    **/
   public static boolean credentialsValid(
       String host,

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -136,7 +136,7 @@ public class Domain {
     
     boolean domainPatched = domain.spec().webLogicCredentialsSecret().getName().equals(secretName);
     logger.info("Domain Object patched : {0}, webLogicCredentialsSecret: {1}",
-        domain, domain.getSpec().webLogicCredentialsSecret().getName());
+        domainUID, domain.getSpec().webLogicCredentialsSecret().getName());
     return domainPatched;
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -121,7 +121,7 @@ public class Domain {
    * @param secretName name of the secret that the domain resource is expected to be using
    * @return true if domain resource's webLogicCredentialsSecret matches the expected value
    */
-  public static boolean domainResourceAdminSecretPatched(
+  public static boolean domainResourceCredentialsSecretPatched(
       String domainUID,
       String namespace,
       String secretName
@@ -130,12 +130,12 @@ public class Domain {
     try {
       domain = getDomainCustomResource(domainUID, namespace);
     } catch (ApiException apex) {
-      logger.severe("Failed to obtain the domain resource object from the API server", apex);
+      logger.severe(String.format("Failed to obtain domain resource %s in namespace %s", domainUID, namespace), apex);
       return false;
     }
     
     boolean domainPatched = domain.spec().webLogicCredentialsSecret().getName().equals(secretName);
-    logger.info("Domain Object patched : {0}, webLogicCredentialsSecret: {1}",
+    logger.info("Domain {0} is patched with webLogicCredentialsSecret: {1}",
         domainUID, domain.getSpec().webLogicCredentialsSecret().getName());
     return domainPatched;
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -110,6 +110,36 @@ public class Domain {
     };
   }
 
+  /**
+   * Check if the domain resource has been patched with a new WebLogic admin credentials secret.
+   *
+   * @param domainUID identifier of the domain resource
+   * @param namespace Kubernetes namespace in which the domain exists
+   * @param secretName name of the secret that the domain resource is expected to be using
+   * @return true if domain resource's image matches the expected value
+   */
+  public static Callable<Boolean> domainResourceAdminSecretPatched(
+      String domainUID,
+      String namespace,
+      String secretName
+  ) {
+    return () -> {
+      oracle.weblogic.domain.Domain domain = null;
+      try {
+        domain = oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes
+                .getDomainCustomResource(domainUID, namespace);
+      } catch (ApiException apex) {
+        logger.severe("Failed to obtain the domain resource object from the API server", apex);
+        return false;
+      }
+      
+      boolean domainPatched = (domain.spec().webLogicCredentialsSecret().getName().equals(secretName));
+      logger.info("Domain Object patched : {0}, weblogicDomainSecret: {1}",
+          domain, domain.getSpec().webLogicCredentialsSecret());
+      return domainPatched;
+    };
+  }
+
   public static boolean adminT3ChannelAccessible(String domainUid, String namespace) {
     return true;
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -135,7 +135,7 @@ public class Domain {
       
       boolean domainPatched = (domain.spec().webLogicCredentialsSecret().getName().equals(secretName));
       logger.info("Domain Object patched : {0}, weblogicDomainSecret: {1}",
-          domain, domain.getSpec().webLogicCredentialsSecret());
+          domain, domain.getSpec().webLogicCredentialsSecret().getName());
       return domainPatched;
     };
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -27,9 +27,9 @@ import io.kubernetes.client.openapi.models.V1ServiceList;
 import io.kubernetes.client.util.ClientBuilder;
 
 import static io.kubernetes.client.util.Yaml.dump;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPodRestartVersion;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.getPod;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.getPodCreationTimestamp;
-import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.getPodRestartVersion;
 import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
 
 public class Kubernetes {


### PR DESCRIPTION
Add a new Junit5 test case to patch an existing domain resource with a new domain credentials secret that contains new credentials. 

The test performs two patches to the domain spec:
1) change the domain spec's  webLogicCredentialsSecret to a new secret
2) change the domain spec's restartVersion to trigger a rolling restart of server pods.

The test verifies the following:
1) the domain spec's webLogicCredentialsSecret and restartVersion are updated;
2) the server pods are recreated;
3) the server pods' restartVersion label is updated;
4) the new credentials are valid.
