### PR TITLE
Add new rolling re-start assertion to ItClasses

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainOnPV.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainOnPV.java
@@ -106,8 +106,8 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.jobCompleted;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -283,24 +283,24 @@ public class ItDomainOnPV implements LoggedTest {
     // check admin server pod is ready
     logger.info("Waiting for admin server pod {0} to be ready in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkPodReady(adminServerPodName);
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
 
     // check managed server pods are ready
     for (int i = 1; i <= replicaCount; i++) {
       logger.info("Wait for managed server pod {0} to be ready in namespace {1}",
           managedServerPodNamePrefix + i, domainNamespace);
-      checkPodReady(managedServerPodNamePrefix + i);
+      checkPodReady(managedServerPodNamePrefix + i, domainUid, domainNamespace);
     }
 
     logger.info("Check admin service {0} is created in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkServiceCreated(adminServerPodName);
+    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server services created
     for (int i = 1; i <= replicaCount; i++) {
       logger.info("Check managed server service {0} is created in namespace {1}",
           managedServerPodNamePrefix + i, domainNamespace);
-      checkServiceCreated(managedServerPodNamePrefix + i);
+      checkServiceExists(managedServerPodNamePrefix + i, domainNamespace);
     }
 
     logger.info("Getting node port");
@@ -670,39 +670,4 @@ public class ItDomainOnPV implements LoggedTest {
                 condition.getRemainingTimeInMS()))
         .until(operatorIsReady(opNamespace));
   }
-
-  /**
-   * Check pod is ready.
-   *
-   * @param podName pod name to check
-   */
-  private void checkPodReady(String podName) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be ready in namespace {1} "
-                + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(podReady(podName, domainUid, domainNamespace));
-  }
-
-  /**
-   * Check service is created.
-   *
-   * @param serviceName service name to check
-   */
-  private void checkServiceCreated(String serviceName) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for service {0} to be created in namespace {1} "
-                + "(elapsed time {2}ms, remaining time {3}ms)",
-                serviceName,
-                domainNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(serviceExists(serviceName, null, domainNamespace));
-  }
-
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainOnPV.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainOnPV.java
@@ -284,6 +284,9 @@ public class ItDomainOnPV implements LoggedTest {
     logger.info("Waiting for admin server pod {0} to be ready in namespace {1}",
         adminServerPodName, domainNamespace);
     checkPodReady(adminServerPodName, domainUid, domainNamespace);
+    logger.info("Check admin service {0} is created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server pods are ready
     for (int i = 1; i <= replicaCount; i++) {
@@ -291,10 +294,6 @@ public class ItDomainOnPV implements LoggedTest {
           managedServerPodNamePrefix + i, domainNamespace);
       checkPodReady(managedServerPodNamePrefix + i, domainUid, domainNamespace);
     }
-
-    logger.info("Check admin service {0} is created in namespace {1}",
-        adminServerPodName, domainNamespace);
-    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server services created
     for (int i = 1; i <= replicaCount; i++) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
@@ -262,6 +262,9 @@ class ItMiiAddCluster implements LoggedTest {
     logger.info("Wait for admin server pod {0} to be ready in namespace {1}",
         adminServerPodName, domainNamespace);
     checkPodReady(adminServerPodName, domainUid, domainNamespace);
+    logger.info("Check admin service {0} is created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server pods are ready
     for (int i = 1; i <= replicaCount; i++) {
@@ -269,10 +272,6 @@ class ItMiiAddCluster implements LoggedTest {
           managedServerPrefix + i, domainNamespace);
       checkPodReady(managedServerPrefix + i, domainUid, domainNamespace);
     }
-
-    logger.info("Check admin service {0} is created in namespace {1}",
-        adminServerPodName, domainNamespace);
-    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server services created
     for (int i = 1; i <= replicaCount; i++) {
@@ -305,7 +304,7 @@ class ItMiiAddCluster implements LoggedTest {
 
     LinkedHashMap<String, String> pods = new LinkedHashMap<>();
 
-    // get the creation time of the admin server pod before patching
+    // get the creation time of the server pods before patching
     String adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     for (int i = 1; i <= replicaCount; i++) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
@@ -74,6 +74,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageNam
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewRestartVersion;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
@@ -82,7 +83,6 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRolling
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getPodCreationTime;
-import static oracle.weblogic.kubernetes.utils.CommonTestUtils.patchDomainResourceWithNewRestartVersion;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
@@ -326,8 +326,8 @@ class ItMiiAddCluster implements LoggedTest {
         "patchDomainCustomResource(configMap)  failed ");
     assertTrue(cmPatched, "patchDomainCustomResource(configMap) failed");
 
-    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
-    logger.log(Level.INFO, "New Restart version : {0}", newRestartVesrion);
+    String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New restart version : {0}", newRestartVersion);
     
     assertTrue(assertDoesNotThrow(
         () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
@@ -403,8 +403,8 @@ class ItMiiAddCluster implements LoggedTest {
         "patchDomainCustomResource(restartVersion)  failed ");
     assertTrue(repilcaPatched, "patchDomainCustomResource(repilcas) failed");
 
-    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
-    logger.log(Level.INFO, "New Restart version : {0}", newRestartVesrion);
+    String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New restart version : {0}", newRestartVersion);
     
     // Check if the admin server pod has been restarted 
     // by comparing the PodCreationTime before and after rolling restart
@@ -485,8 +485,8 @@ class ItMiiAddCluster implements LoggedTest {
         "patchDomainCustomResource(restartVersion)  failed ");
     assertTrue(repilcaPatched, "patchDomainCustomResource(repilcas) failed");
 
-    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
-    logger.log(Level.INFO, "New Restart version : {0}", newRestartVesrion);
+    String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New restart version : {0}", newRestartVersion);
     
     assertTrue(assertDoesNotThrow(
         () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
@@ -717,14 +717,14 @@ class ItMiiAddCluster implements LoggedTest {
    * 
    * @param namespace Kubernetes namespace that the domain is hosted
    * @param podName name of the pod 
-   * @return podCreationTimestamp of the pod
+   * @return PodCreationTimestamp of the pod
    */
   private String getPodCreationTime(String namespace, String podName) {
     String podCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(namespace, "", podName),
             String.format("Couldn't get PodCreationTime for pod %s", podName));
-    assertNotNull(podCreationTime, "PodCreationTime returned null");
-    logger.info("Pod {0} PodCreationTimestamp for pod ${0} in namespace ${1} is {2}",
+    assertNotNull(podCreationTime, "Got null PodCreationTimestamp");
+    logger.info("PodCreationTimestamp for pod ${0} in namespace ${1} is {2}",
         namespace,
         podName,
         podCreationTime);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAddCluster.java
@@ -5,9 +5,9 @@ package oracle.weblogic.kubernetes;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -70,6 +70,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomR
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.createServiceAccount;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
@@ -77,11 +78,11 @@ import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.isPodRestarted;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceExists;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -302,12 +303,14 @@ class ItMiiAddCluster implements LoggedTest {
     String configMapName = "noreplicaconfigmap";
     createClusterConfigMap(configMapName, "model.config.cluster.yaml");
 
-    // get the creation time of the admin server pod before patching
-    String adminPodCreationTime = getadminPodCreationTime();
+    LinkedHashMap<String, String> pods = new LinkedHashMap<>();
 
-    // get the creation time of the managed server pods before patching
-    List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
-    managedServerPodOriginalTimestampList = getManagedServerPodTimestampList();
+    // get the creation time of the admin server pod before patching
+    String adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    pods.put(adminServerPodName, adminPodCreationTime);
+    for (int i = 1; i <= replicaCount; i++) {
+      pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace, managedServerPrefix + i));
+    }
     
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
@@ -322,30 +325,14 @@ class ItMiiAddCluster implements LoggedTest {
             patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
         "patchDomainCustomResource(configMap)  failed ");
     assertTrue(cmPatched, "patchDomainCustomResource(configMap) failed");
+
+    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New Restart version : {0}", newRestartVesrion);
     
-    patchStr = new StringBuffer("[{");
-    patchStr.append(" \"op\": \"replace\",")
-        .append(" \"path\": \"/spec/restartVersion\",")
-        .append(" \"value\": \"1\"")
-        .append(" }]");
-    logger.log(Level.INFO, "Restart version patch string: {0}", patchStr);
-
-    patch = new V1Patch(new String(patchStr));
-    boolean rvPatched = assertDoesNotThrow(() ->
-            patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
-        "patchDomainCustomResource(restartVersion)  failed ");
-    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
-
-    // Check if the admin server pod has been restarted 
-    // by comparing the PodCreationTime before and after rolling restart
-    checkPodRestarted(adminServerPodName, domainUid, domainNamespace, adminPodCreationTime);
-
-    // Check if the managed server pods have been restarted 
-    // by comparing the PodCreationTime before and after rolling restart
-    for (int i = 1; i <= replicaCount; i++) {
-      checkPodRestarted(managedServerPrefix + 1, domainUid, 
-           domainNamespace, managedServerPodOriginalTimestampList.get(i - 1));
-    }
+    assertTrue(assertDoesNotThrow(
+        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
+         "More than one pod was restarted at same time"),
+        "Rolling restart failed");
 
     // The ServerNamePrefix for the new configured cluster is config-server
     // Make sure the managed server from new cluster is not running
@@ -357,7 +344,6 @@ class ItMiiAddCluster implements LoggedTest {
     assertTrue(isServerConfigured, "Could not find new managed server configuration");
     logger.info("Found new managed server configuration");
   }
-
 
   /**
    * Create a configmap with a sparse model file to add a dynamic cluster.
@@ -381,12 +367,14 @@ class ItMiiAddCluster implements LoggedTest {
     String configMapName = "dynamicclusterconfigmap";
     createClusterConfigMap(configMapName, "model.dynamic.cluster.yaml");
 
+    LinkedHashMap<String, String> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    String adminPodCreationTime = getadminPodCreationTime();
-
+    String adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
-    List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
-    managedServerPodOriginalTimestampList = getManagedServerPodTimestampList();
+    for (int i = 1; i <= replicaCount; i++) {
+      pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace, managedServerPrefix + i));
+    }
 
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
@@ -415,29 +403,16 @@ class ItMiiAddCluster implements LoggedTest {
         "patchDomainCustomResource(restartVersion)  failed ");
     assertTrue(repilcaPatched, "patchDomainCustomResource(repilcas) failed");
 
-    patchStr = new StringBuffer("[{");
-    patchStr.append(" \"op\": \"replace\",")
-        .append(" \"path\": \"/spec/restartVersion\",")
-        .append(" \"value\": \"2\"")
-        .append(" }]");
-    logger.log(Level.INFO, "Restart version patch string: {0}", patchStr);
-
-    patch = new V1Patch(new String(patchStr));
-    boolean rvPatched = assertDoesNotThrow(() ->
-            patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
-        "patchDomainCustomResource(restartVersion)  failed ");
-    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
-
+    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New Restart version : {0}", newRestartVesrion);
+    
     // Check if the admin server pod has been restarted 
     // by comparing the PodCreationTime before and after rolling restart
-    checkPodRestarted(adminServerPodName, domainUid, domainNamespace, adminPodCreationTime);
-
-    // Check if the managed server pods have been restarted 
-    // by comparing the PodCreationTime before and after rolling restart
-    for (int i = 1; i <= replicaCount; i++) {
-      checkPodRestarted(managedServerPrefix + 1, domainUid, 
-           domainNamespace, managedServerPodOriginalTimestampList.get(i - 1));
-    }
+    
+    assertTrue(assertDoesNotThrow(
+        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
+         "More than one pod was restarted at same time"),
+        "Rolling restart failed");
 
     // The ServerNamePrefix for the new dynamic cluster is dynamic-server
     // Make sure the managed server from the new cluster is running
@@ -473,12 +448,15 @@ class ItMiiAddCluster implements LoggedTest {
     String configMapName = "configclusterconfigmap";
     createClusterConfigMap(configMapName, "model.config.cluster.yaml");
 
-    // get the creation time of the admin server pod before patching
-    String adminPodCreationTime = getadminPodCreationTime();
+    LinkedHashMap<String, String> pods = new LinkedHashMap<>();
 
+    // get the creation time of the admin server pod before patching
+    String adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     // get the creation time of the managed server pods before patching
-    List<String> managedServerPodOriginalTimestampList = new ArrayList<>();
-    managedServerPodOriginalTimestampList = getManagedServerPodTimestampList();
+    pods.put(adminServerPodName, adminPodCreationTime);
+    for (int i = 1; i <= replicaCount; i++) {
+      pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace,   managedServerPrefix + i));
+    }
 
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
@@ -507,42 +485,23 @@ class ItMiiAddCluster implements LoggedTest {
         "patchDomainCustomResource(restartVersion)  failed ");
     assertTrue(repilcaPatched, "patchDomainCustomResource(repilcas) failed");
 
-    patchStr = new StringBuffer("[{");
-    patchStr.append(" \"op\": \"replace\",")
-        .append(" \"path\": \"/spec/restartVersion\",")
-        .append(" \"value\": \"3\"")
-        .append(" }]");
-    logger.log(Level.INFO, "Restart version patch string: {0}", patchStr);
-
-    patch = new V1Patch(new String(patchStr));
-    boolean rvPatched = assertDoesNotThrow(() ->
-            patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
-        "patchDomainCustomResource(restartVersion)  failed ");
-    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
+    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New Restart version : {0}", newRestartVesrion);
+    
+    assertTrue(assertDoesNotThrow(
+        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
+         "More than one pod was restarted at same time"),
+        "Rolling restart failed");
 
     // The ServerNamePrefix for the new configured cluster is config-server
     // Make sure the managed server from the new cluster is running
-    
     String newServerPodName = domainUid + "-config-server1";
     checkPodReady(newServerPodName, domainUid, domainNamespace);
     checkServiceCreated(newServerPodName, domainNamespace);
 
-    // Check if the admin server pod has been restarted 
-    // by comparing the PodCreationTime before and after rolling restart
-    checkPodRestarted(adminServerPodName, domainUid, domainNamespace, adminPodCreationTime);
-
-    // Check if the managed server pods have been restarted 
-    // by comparing the PodCreationTime before and after rolling restart
-    
-    for (int i = 1; i <= replicaCount; i++) {
-      checkPodRestarted(managedServerPrefix + 1, domainUid, 
-           domainNamespace, managedServerPodOriginalTimestampList.get(i - 1));
-    }
-
     boolean isServerConfigured = checkManagedServerConfiguration("config-server1");
     assertTrue(isServerConfigured, "Could not find new managed server configuration");
     logger.info("Found new managed server configuration");
-
   }
 
   // This method is needed in this test class, since the cleanup util
@@ -728,22 +687,8 @@ class ItMiiAddCluster implements LoggedTest {
     }
   }
 
-  private void checkPodRestarted(String podName, String domainUid, String domNamespace, String timestamp) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be restarted in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> isPodRestarted(podName, domainUid, domNamespace, timestamp),
-            String.format("podExists failed with ApiException for %s in namespace in %s",
-                podName, domNamespace)));
-  }
-
+  // Crate a ConfigMap with a model file to add a new WebLogic cluster
   private void createClusterConfigMap(String configMapName, String modelFile) {
-
     Map<String, String> labels = new HashMap<>();
     labels.put("weblogic.domainUid", domainUid);
     String dsModelFile =  String.format("%s/%s", MODEL_DIR,modelFile);
@@ -767,37 +712,57 @@ class ItMiiAddCluster implements LoggedTest {
     assertTrue(cmCreated, String.format("createConfigMap failed while creating ConfigMap %s", configMapName));
   }     
 
-  private String getadminPodCreationTime() {
-
-    String adminPodCreationTime =
-        assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
-            String.format("Couldn't get PodCreationTime for pod %s", adminServerPodName));
-    assertNotNull(adminPodCreationTime, "adminPodCreationTime returned null");
-    logger.info("Domain {0} in namespace {1}, admin server pod {2} creationTimestamp before patching is {3}",
-        domainUid,
-        domainNamespace,
-        adminServerPodName,
-        adminPodCreationTime);
-    return adminPodCreationTime;
+  /**
+   * Get the PodCreationTimestamp of a pod in a namespace.
+   * 
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @param podName name of the pod 
+   * @return podCreationTimestamp of the pod
+   */
+  private String getPodCreationTime(String namespace, String podName) {
+    String podCreationTime =
+        assertDoesNotThrow(() -> getPodCreationTimestamp(namespace, "", podName),
+            String.format("Couldn't get PodCreationTime for pod %s", podName));
+    assertNotNull(podCreationTime, "PodCreationTime returned null");
+    logger.info("Pod {0} PodCreationTimestamp for pod ${0} in namespace ${1} is {2}",
+        namespace,
+        podName,
+        podCreationTime);
+    return podCreationTime;
   }
 
-  private List<String> getManagedServerPodTimestampList() {
-    List<String> managedServerPodTimestampList = new ArrayList<>();
-    assertDoesNotThrow(
-        () -> { 
-          for (int i = 1; i <= replicaCount; i++) {
-            String managedServerPodName = managedServerPrefix + i;
-            String creationTime = getPodCreationTimestamp(domainNamespace,"", managedServerPodName);
-            managedServerPodTimestampList.add(creationTime);
-            logger.info("Domain {0} in namespace {1}, managed server pod {2} creationTimestamp before patching is {3}",
-                domainUid,
-                domainNamespace,
-                managedServerPodName,
-                creationTime);
-          } 
-        },
-        String.format("Failed to get creationTimestamp for managed server pods"));
-    return managedServerPodTimestampList;
+  /**
+   * Patch the domain resource with a new restartVersion.
+   * 
+   * @param domainResourceName name of the domain resource
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @return restartVersion new restartVersion of the domain resource
+   */
+  private String patchDomainResourceWithNewRestartVersion(
+      String domainResourceName, String namespace) {
+    String oldVersion = assertDoesNotThrow(
+        () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
+        String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
+    int newVersion = oldVersion == null ? 1 : Integer.valueOf(oldVersion) + 1;
+    logger.info("Update domain resource {0} in namespace {1} restartVersion from {2} to {3}",
+        domainResourceName, namespace, oldVersion, newVersion);
+
+    StringBuffer patchStr = new StringBuffer("[{");
+    patchStr.append(" \"op\": \"replace\",")
+        .append(" \"path\": \"/spec/restartVersion\",")
+        .append(" \"value\": \"")
+        .append(newVersion)
+        .append("\"")
+        .append(" }]");
+
+    logger.log(Level.INFO, "Restart version patch string: {0}", patchStr);
+    V1Patch patch = new V1Patch(new String(patchStr));
+    boolean rvPatched = assertDoesNotThrow(() ->
+            patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
+        "patchDomainCustomResource(restartVersion)  failed ");
+    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
+
+    return String.valueOf(newVersion);
   }
 
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMap.java
@@ -73,9 +73,8 @@ import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podExists;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.serviceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -309,13 +308,13 @@ class ItMiiConfigMap implements LoggedTest {
     // check admin server pod exists
     logger.info("Check for admin server pod {0} existence in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkPodCreated(adminServerPodName, domainUid, domainNamespace);
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
 
     // check managed server pods exist
     for (int i = 1; i <= replicaCount; i++) {
       logger.info("Check for managed server pod {0} existence in namespace {1}",
           managedServerPrefix + i, domainNamespace);
-      checkPodCreated(managedServerPrefix + i, domainUid, domainNamespace);
+      checkPodReady(managedServerPrefix + i, domainUid, domainNamespace);
     }
 
     // check admin server pod is ready
@@ -332,13 +331,13 @@ class ItMiiConfigMap implements LoggedTest {
 
     logger.info("Check admin service {0} is created in namespace {1}",
         adminServerPodName, domainNamespace);
-    checkServiceCreated(adminServerPodName, domainNamespace);
+    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server services created
     for (int i = 1; i <= replicaCount; i++) {
       logger.info("Check managed server service {0} is created in namespace {1}",
           managedServerPrefix + i, domainNamespace);
-      checkServiceCreated(managedServerPrefix + i, domainNamespace);
+      checkServiceExists(managedServerPrefix + i, domainNamespace);
     }
 
     ExecResult result = null;
@@ -496,51 +495,6 @@ class ItMiiConfigMap implements LoggedTest {
                     domainUid, domNamespace));
     assertTrue(domCreated, String.format("Create domain custom resource failed with ApiException "
                     + "for %s in namespace %s", domainUid, domNamespace));
-  }
-
-  private void checkPodCreated(String podName, String domainUid, String domNamespace) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be created in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> podExists(podName, domainUid, domNamespace),
-            String.format("podExists failed with ApiException for %s in namespace in %s",
-                podName, domNamespace)));
-
-  }
-
-  private void checkPodReady(String podName, String domainUid, String domNamespace) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for pod {0} to be ready in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                podName,
-                domNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> podReady(podName, domainUid, domNamespace),
-            String.format(
-                "pod %s is not ready in namespace %s", podName, domNamespace)));
-
-  }
-
-  private void checkServiceCreated(String serviceName, String domNamespace) {
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for service {0} to be created in namespace {1} "
-                    + "(elapsed time {2}ms, remaining time {3}ms)",
-                serviceName,
-                domNamespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> serviceExists(serviceName, null, domNamespace),
-            String.format(
-                "Service %s is not ready in namespace %s", serviceName, domainNamespace)));
-
   }
 
   private ExecResult checkSystemResourceConfiguration(String resourcesType, String resourcesName) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
@@ -330,6 +330,9 @@ class ItMiiConfigMapOverride implements LoggedTest {
     logger.info("Wait for admin server pod {0} to be ready in namespace {1}",
         adminServerPodName, domainNamespace);
     checkPodReady(adminServerPodName, domainUid, domainNamespace);
+    logger.info("Check admin service {0} is created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server pods are ready
     for (int i = 1; i <= replicaCount; i++) {
@@ -338,9 +341,6 @@ class ItMiiConfigMapOverride implements LoggedTest {
       checkPodReady(managedServerPrefix + i, domainUid, domainNamespace);
     }
 
-    logger.info("Check admin service {0} is created in namespace {1}",
-        adminServerPodName, domainNamespace);
-    checkServiceExists(adminServerPodName, domainNamespace);
 
     // check managed server services created
     for (int i = 1; i <= replicaCount; i++) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
@@ -373,8 +373,8 @@ class ItMiiConfigMapOverride implements LoggedTest {
         "patchDomainCustomResource(configMap)  failed ");
     assertTrue(cmPatched, "patchDomainCustomResource(configMap) failed");
 
-    String newRestartVesrion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
-    logger.log(Level.INFO, "New restart version is {0}", newRestartVesrion);
+    String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
+    logger.log(Level.INFO, "New restart version is {0}", newRestartVersion);
 
     assertTrue(assertDoesNotThrow(
         () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
@@ -665,14 +665,14 @@ class ItMiiConfigMapOverride implements LoggedTest {
    * 
    * @param namespace Kubernetes namespace that the domain is hosted
    * @param podName name of the pod 
-   * @return podCreationTimestamp of the pod
+   * @return PodCreationTimestamp of the pod
    */
   private String getPodCreationTime(String namespace, String podName) {
     String podCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(namespace, "", podName),
-            String.format("Couldn't get PodCreationTime for pod %s", podName));
-    assertNotNull(podCreationTime, "PodCreationTime returned null");
-    logger.info("Pod {0} PodCreationTimestamp for pod ${0} in namespace ${1} is {2}",
+            String.format("Couldn't get PodCreationTimestamp for pod %s", podName));
+    assertNotNull(podCreationTime, "Got null PodCreationTimestamp");
+    logger.info("PodCreationTimestamp for pod ${0} in namespace ${1} is {2}",
         namespace,
         podName,
         podCreationTime);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiConfigMapOverride.java
@@ -76,6 +76,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageNam
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewRestartVersion;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isHelmReleaseDeployed;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
@@ -83,7 +84,6 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRolling
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getPodCreationTime;
-import static oracle.weblogic.kubernetes.utils.CommonTestUtils.patchDomainResourceWithNewRestartVersion;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -46,6 +46,10 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.WebLogicImageTool;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 
+import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 // this class essentially delegates to the impl classes, and "hides" all of the
 // detail impl classes - tests would only ever call methods in here, never
 // directly call the methods in the impl classes
@@ -746,6 +750,40 @@ public class TestActions {
   public static boolean deployApplication(String appName, String appLocation, String t3Url,
                                           String username, String password, String target) {
     return true;
+  }
+
+  /**
+   * Patch the domain resource with a new restartVersion.
+   * 
+   * @param domainResourceName name of the domain resource
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @return restartVersion new restartVersion of the domain resource
+   */
+  public static String patchDomainResourceWithNewRestartVersion(
+      String domainResourceName, String namespace) {
+    String oldVersion = assertDoesNotThrow(
+        () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
+        String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
+    int newVersion = oldVersion == null ? 1 : Integer.valueOf(oldVersion) + 1;
+    logger.info("Update domain resource {0} in namespace {1} restartVersion from {2} to {3}",
+        domainResourceName, namespace, oldVersion, newVersion);
+
+    StringBuffer patchStr = new StringBuffer("[{");
+    patchStr.append(" \"op\": \"replace\",")
+        .append(" \"path\": \"/spec/restartVersion\",")
+        .append(" \"value\": \"")
+        .append(newVersion)
+        .append("\"")
+        .append(" }]");
+
+    logger.info("Restart version patch string: {0}", patchStr);
+    V1Patch patch = new V1Patch(new String(patchStr));
+    boolean rvPatched = assertDoesNotThrow(() ->
+            patchDomainCustomResource(domainResourceName, namespace, patch, "application/json-patch+json"),
+        "patchDomainCustomResource(restartVersion)  failed ");
+    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
+
+    return String.valueOf(newVersion);
   }
 
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -12,8 +12,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 import com.google.gson.JsonObject;
+import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
@@ -58,11 +60,13 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createServiceAccoun
 import static oracle.weblogic.kubernetes.actions.TestActions.defaultAppParams;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
+import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
 import static oracle.weblogic.kubernetes.actions.TestActions.installNginx;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.actions.TestActions.listIngresses;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
 import static oracle.weblogic.kubernetes.actions.TestActions.upgradeOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
@@ -751,4 +755,58 @@ public class CommonTestUtils {
       }
     }
   }
+
+  /**
+   * Get the PodCreationTimestamp of a pod in a namespace.
+   * 
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @param podName name of the pod 
+   * @return PodCreationTimestamp of the pod
+   */
+  public static String getPodCreationTime(String namespace, String podName) {
+    String podCreationTime =
+        assertDoesNotThrow(() -> getPodCreationTimestamp(namespace, "", podName),
+            String.format("Couldn't get PodCreationTimestamp for pod %s", podName));
+    assertNotNull(podCreationTime, "Got null PodCreationTimestamp");
+    logger.info("PodCreationTimestamp for pod ${0} in namespace ${1} is {2}",
+        namespace,
+        podName,
+        podCreationTime);
+    return podCreationTime;
+  }
+
+  /**
+   * Patch the domain resource with a new restartVersion.
+   * 
+   * @param domainResourceName name of the domain resource
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @return restartVersion new restartVersion of the domain resource
+   */
+  public static String patchDomainResourceWithNewRestartVersion(
+      String domainResourceName, String namespace) {
+    String oldVersion = assertDoesNotThrow(
+        () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
+        String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
+    int newVersion = oldVersion == null ? 1 : Integer.valueOf(oldVersion) + 1;
+    logger.info("Update domain resource {0} in namespace {1} restartVersion from {2} to {3}",
+        domainResourceName, namespace, oldVersion, newVersion);
+
+    StringBuffer patchStr = new StringBuffer("[{");
+    patchStr.append(" \"op\": \"replace\",")
+        .append(" \"path\": \"/spec/restartVersion\",")
+        .append(" \"value\": \"")
+        .append(newVersion)
+        .append("\"")
+        .append(" }]");
+
+    logger.log(Level.INFO, "Restart version patch string: {0}", patchStr);
+    V1Patch patch = new V1Patch(new String(patchStr));
+    boolean rvPatched = assertDoesNotThrow(() ->
+            patchDomainCustomResource(domainResourceName, namespace, patch, "application/json-patch+json"),
+        "patchDomainCustomResource(restartVersion)  failed ");
+    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
+
+    return String.valueOf(newVersion);
+  }
+
 }


### PR DESCRIPTION
Add the new rolling restart assertion (verifyRollingRestartOccurred) to following ItClasses  ItMiiConfigMapOverride, ItMiiAddCluster and ItMiiChangeAdminCredentials

Added following utility method(s) to utils/CommonTestUtils.java
getPodCreationTime()

Removed local methods checkPodCreated/checkServiceCreated to replace with methods from 
utils/CommonTestUtils.java

Added a new action method patchDomainResourceWithNewRestartVersion() to restart a domain with new Restart Version.

External Jenkin Runs

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/182/  ( all passed)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests-10/181/    ( all passed ) 