### PR TITLE
fix error in WatchBuilderTest.tearDown() caused by NamespaceTest

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
@@ -156,7 +156,6 @@ public class DomainUpPlanTest {
 
   @Test
   public void whenAdminPodCreated_hasListenPort() throws NoSuchFieldException {
-    mementos.add(TuningParametersStub.install());
     mementos.add(UnitTestHash.install());
 
     WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("domain");


### PR DESCRIPTION
Fixes test failure in WatchBuilderTest on Linux that is caused by NamespaceTest having a value of domainPresenceRecheckIntervalSeconds in MainTuning that is too low. 

Example of test failure (could happen in a different test in WatchBuilderTest):             

[ERROR] whenServiceWatchSpecifiesParameters_verifyAndReturnResponse(oracle.kubernetes.operator.builders.WatchBuilderTest)  Time elapsed: 0.005 s  <<< ERROR!
io.kubernetes.client.openapi.ApiException: java.net.ConnectException: Failed to connect to localhost/127.0.0.1:45387
        at oracle.kubernetes.operator.builders.WatchBuilderTest.whenServiceWatchSpecifiesParameters_verifyAndReturnResponse(WatchBuilderTest.java:203)
Caused by: java.net.ConnectException: Failed to connect to localhost/127.0.0.1:45387
        at oracle.kubernetes.operator.builders.WatchBuilderTest.whenServiceWatchSpecifiesParameters_verifyAndReturnResponse(WatchBuilderTest.java:203)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at oracle.kubernetes.operator.builders.WatchBuilderTest.whenServiceWatchSpecifiesParameters_verifyAndReturnResponse(WatchBuilderTest.java:203)
