### PR TITLE
Intermittent status issue fix

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -314,6 +314,9 @@ public class DomainStatus {
   private ServerStatus adjust(ServerStatus server) {
     if (server.getState() == null) {
       ServerStatus oldServer = getMatchingServer(server);
+      if ((oldServer != null) && (oldServer.getHealth() == null)) {
+        return server;
+      }
       server.setState(oldServer == null ? SHUTDOWN_STATE : oldServer.getState());
     }
     return server;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -208,7 +208,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
    *
    * @return health
    */
-  public ServerHealth getHealth() {
+  ServerHealth getHealth() {
     return health;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -208,7 +208,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
    *
    * @return health
    */
-  private ServerHealth getHealth() {
+  public ServerHealth getHealth() {
     return health;
   }
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -319,15 +319,18 @@ public class DomainStatusTest {
 
   @Test
   public void whenSetServerIncludesServerWithoutStateAndHasExistingState_preserveIt() {
-    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("1").withState("state1"));
-    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("2").withState("state1"));
-    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("3").withState("state1"));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("1").withState("state1")
+        .withHealth(new ServerHealth().withOverallHealth("ok")));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("2").withState("state1")
+        .withHealth(new ServerHealth().withOverallHealth("ok")));
+    domainStatus.addServer(new ServerStatus().withClusterName("1").withServerName("3").withState("state1")
+        .withHealth(new ServerHealth().withOverallHealth("ok")));
 
     domainStatus.setServers(Arrays.asList(
-          new ServerStatus().withClusterName("1").withServerName("1").withState("state1"),
-          new ServerStatus().withClusterName("1").withServerName("2").withState("state1"),
-          new ServerStatus().withClusterName("1").withServerName("3")
-    ));
+        new ServerStatus().withClusterName("1").withServerName("1").withState("state1"),
+        new ServerStatus().withClusterName("1").withServerName("2").withState("state1"),
+        new ServerStatus().withClusterName("1").withServerName("3")
+        ));
 
     assertThat(getServer("1", "3").getState(), equalTo("state1"));
   }


### PR DESCRIPTION
Potential fix for OWLS-82442 - server state incorrectly reported as RUNNING even after server is shut-down due to scale down action. Intermittently state of old matching server is RUNNING but health is null (this could be due to race condition). This PR checks if health of old matching server is null then it doesn't update new state with state of old matching server.