### PR TITLE
scale a cluster using REST API

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItScaleMiiDomainNginx.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItScaleMiiDomainNginx.java
@@ -177,6 +177,8 @@ class ItScaleMiiDomainNginx implements LoggedTest {
           replicaCount, numberOfServers, curlCmd, managedServersBeforeScale);
 
       // then scale cluster-1 and cluster-2 to 2 servers
+      logger.info("Scaling cluster {0} of domain {1} in namespace {2} from {3} servers to {4} servers.",
+          clusterName, domainUid, domainNamespace, numberOfServers, replicaCount);
       managedServersBeforeScale = listManagedServersBeforeScale(clusterName, numberOfServers);
       scaleAndVerifyCluster(clusterName, domainUid, domainNamespace,
           domainUid + "-" + clusterName + "-" + MANAGED_SERVER_NAME_BASE,
@@ -199,15 +201,17 @@ class ItScaleMiiDomainNginx implements LoggedTest {
         numberOfServers = 3;
       }
 
-      logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers.",
-          clusterName, domainUid, domainNamespace, numberOfServers);
+      logger.info("Scaling cluster {0} of domain {1} in namespace {2} from {3} servers to {4} servers.",
+          clusterName, domainUid, domainNamespace, replicaCount, numberOfServers);
       curlCmd = generateCurlCmd(clusterName);
       List<String> managedServersBeforeScale = listManagedServersBeforeScale(clusterName, replicaCount);
-      scaleClusterAndVerifyWithRestApi(clusterName, numberOfServers, managedServersBeforeScale);
+      scaleClusterAndVerifyWithRestApi(clusterName, replicaCount, numberOfServers, managedServersBeforeScale);
 
       // then scale cluster-1 and cluster-2 to 2 servers
+      logger.info("Scaling cluster {0} of domain {1} in namespace {2} from {3} servers to {4} servers.",
+          clusterName, domainUid, domainNamespace, numberOfServers, replicaCount);
       managedServersBeforeScale = listManagedServersBeforeScale(clusterName, numberOfServers);
-      scaleClusterAndVerifyWithRestApi(clusterName, numberOfServers, managedServersBeforeScale);
+      scaleClusterAndVerifyWithRestApi(clusterName, numberOfServers, replicaCount, managedServersBeforeScale);
     }
   }
 
@@ -373,15 +377,17 @@ class ItScaleMiiDomainNginx implements LoggedTest {
    * Scale a cluster using REST API.
    *
    * @param clusterName cluster name to scale
-   * @param numberOfServers number of servers to scale to
+   * @param replicasBeforeScale number of servers in cluster before scaling
+   * @param replicasAfterScale number of serverss in cluster after scaling
    * @param managedServersBeforeScale list of managed servers in the cluster before scale
    */
   private void scaleClusterAndVerifyWithRestApi(String clusterName,
-                                                int numberOfServers,
+                                                int replicasBeforeScale,
+                                                int replicasAfterScale,
                                                 List<String> managedServersBeforeScale) {
     scaleAndVerifyCluster(clusterName, domainUid, domainNamespace,
         domainUid + "-" + clusterName + "-" + MANAGED_SERVER_NAME_BASE,
-        replicaCount, numberOfServers, true, externalRestHttpsPort, opNamespace, serviceAccountName,
+        replicasBeforeScale, replicasAfterScale, true, externalRestHttpsPort, opNamespace, serviceAccountName,
         curlCmd, managedServersBeforeScale);
   }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -106,4 +106,9 @@ public interface TestConstants {
   public static final String ADMIN_USERNAME_PATCH = "weblogicnew";
   public static final String ADMIN_PASSWORD_PATCH = "welcome1new";
 
+  // REST API
+  public static final String PROJECT_ROOT = System.getProperty("user.dir");
+  public static final String GEN_EXTERNAL_REST_IDENTITY_FILE =
+      PROJECT_ROOT + "/../kubernetes/samples/scripts/rest/generate-external-rest-identity.sh";
+  public static final String DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME = "weblogic-operator-external-rest-identity";
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -196,7 +196,7 @@ public class TestActions {
   }
 
   /**
-   * Scale the cluster of the domain in the specified namespace .
+   * Scale the cluster of the domain in the specified namespace by patching the domain resource.
    *
    * @param domainUid domainUid of the domain to be scaled
    * @param namespace name of Kubernetes namespace that the domain belongs to
@@ -211,24 +211,24 @@ public class TestActions {
   }
 
   /**
-   * Scale the cluster of the domain in the specified namespace.
+   * Scale the cluster of the domain in the specified namespace using REST API.
    *
    * @param domainUid domainUid of the domain to be scaled
    * @param clusterName name of the WebLogic cluster to be scaled in the domain
    * @param numOfServers number of servers to be scaled to
    * @param externalRestHttpsPort node port allocated for the external operator REST HTTPS interface
    * @param opNamespace namespace of WebLogic operator
-   * @param operatorServiceAccount the service account for operator
-   * @return true if patch domain custom resource succeeds, false otherwise
+   * @param opServiceAccount the service account for operator
+   * @return true if REST call succeeds, false otherwise
    */
   public static boolean scaleClusterWithRestApi(String domainUid,
                                                 String clusterName,
                                                 int numOfServers,
                                                 int externalRestHttpsPort,
                                                 String opNamespace,
-                                                String operatorServiceAccount) {
+                                                String opServiceAccount) {
     return Domain.scaleClusterWithRestApi(domainUid, clusterName, numOfServers,
-        externalRestHttpsPort, opNamespace, operatorServiceAccount);
+        externalRestHttpsPort, opNamespace, opServiceAccount);
   }
 
   // ------------------------   Ingress Controller ----------------------

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -207,6 +207,27 @@ public class TestActions {
     return Domain.scaleCluster(domainUid, namespace, clusterName, numOfServers);
   }
 
+  /**
+   * Scale the cluster of the domain in the specified namespace.
+   *
+   * @param domainUid domainUid of the domain to be scaled
+   * @param clusterName name of the WebLogic cluster to be scaled in the domain
+   * @param numOfServers number of servers to be scaled to
+   * @param externalRestHttpsPort node port allocated for the external operator REST HTTPS interface
+   * @param opNamespace namespace of WebLogic operator
+   * @param operatorServiceAccount the service account for operator
+   * @return true if patch domain custom resource succeeds, false otherwise
+   */
+  public static boolean scaleClusterWithRestApi(String domainUid,
+                                                String clusterName,
+                                                int numOfServers,
+                                                int externalRestHttpsPort,
+                                                String opNamespace,
+                                                String operatorServiceAccount) {
+    return Domain.scaleClusterWithRestApi(domainUid, clusterName, numOfServers,
+        externalRestHttpsPort, opNamespace, operatorServiceAccount);
+  }
+
   // ------------------------   Ingress Controller ----------------------
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
@@ -4,14 +4,18 @@
 package oracle.weblogic.kubernetes.actions.impl;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiException;
 import oracle.weblogic.domain.Cluster;
 import oracle.weblogic.domain.DomainList;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
+import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 
+import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
 
 public class Domain {
@@ -172,4 +176,63 @@ public class Domain {
     return Kubernetes.patchDomainCustomResource(domainUid, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH);
   }
 
+  /**
+   * Scale the cluster of the domain in the specified namespace.
+   *
+   * @param domainUid domainUid of the domain to be scaled
+   * @param clusterName name of the WebLogic cluster to be scaled in the domain
+   * @param numOfServers number of servers to be scaled to
+   * @param externalRestHttpsPort node port allocated for the external operator REST HTTPS interface
+   * @param opNamespace namespace of WebLogic operator
+   * @param operatorServiceAccount the service account for operator
+   * @return true if patch domain custom resource succeeds, false otherwise
+   */
+  public static boolean scaleClusterWithRestApi(String domainUid,
+                                                String clusterName,
+                                                int numOfServers,
+                                                int externalRestHttpsPort,
+                                                String opNamespace,
+                                                String operatorServiceAccount) {
+
+    String secretName = Secret.getSecretFromServiceAccount(opNamespace, operatorServiceAccount);
+    logger.info("Got secret {0} in operator namespace {1}", secretName, opNamespace);
+
+    String secretToken = Secret.getSecretEncodedToken(opNamespace, secretName);
+    logger.info("Got the encoded token for secret {0} in operator namespace {1}: {2}",
+        secretName, opNamespace, secretToken);
+
+    String decodedToken = new String(Base64.getDecoder().decode(secretToken));
+    logger.info("Got the decoded token for secret {0} in operator namespace {1}: {2}",
+        secretName, opNamespace, decodedToken);
+
+    // build the curl command to scale the cluster
+    String command = new StringBuffer()
+        .append("curl --noproxy '*' -v -k ")
+        .append("-H \"Authorization:Bearer ")
+        .append(decodedToken)
+        .append("\" ")
+        .append("-H Accept:application/json ")
+        .append("-H Content-Type:application/json ")
+        .append("-H X-Requested-By:MyClient ")
+        .append("-d '{\"managedServerCount\": ")
+        .append(numOfServers)
+        .append("}' ")
+        .append("-X POST https://")
+        .append(K8S_NODEPORT_HOST)
+        .append(":")
+        .append(externalRestHttpsPort)
+        .append("/operator/latest/domains/")
+        .append(domainUid)
+        .append("/clusters/")
+        .append(clusterName)
+        .append("/scale").toString();
+
+    CommandParams params = Command
+        .defaultCommandParams()
+        .command(command)
+        .saveResults(true)
+        .redirect(true);
+
+    return Command.withParams(params).execute();
+  }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
@@ -195,16 +195,30 @@ public class Domain {
                                                 String opNamespace,
                                                 String opServiceAccount) {
 
-    String secretName = Secret.getSecretFromServiceAccount(opNamespace, opServiceAccount);
-    logger.info("Got secret {0} in operator namespace {1}", secretName, opNamespace);
+    logger.info("Getting the secret of service account {0} in namespace {1}", opServiceAccount, opNamespace);
+    String secretName = Secret.getSecretOfServiceAccount(opNamespace, opServiceAccount);
+    if (secretName.isEmpty()) {
+      logger.info("Did not find secret of service account {0} in namespace {1}", opServiceAccount, opNamespace);
+      return false;
+    }
+    logger.info("Got secret {0} of service account {1} in namespace {2}",
+        secretName, opServiceAccount, opNamespace);
 
+    logger.info("Getting service account token stored in secret {0} to authenticate as service account {1}"
+        + " in namespace {2}", secretName, opServiceAccount, opNamespace);
     String secretToken = Secret.getSecretEncodedToken(opNamespace, secretName);
-    logger.info("Got the encoded token for secret {0} in operator namespace {1}: {2}",
-        secretName, opNamespace, secretToken);
+    if (secretToken.isEmpty()) {
+      logger.info("Did not get encoded token for secret {0} associated with service account {1} in namespace {2}",
+          secretName, opServiceAccount, opNamespace);
+      return false;
+    }
+    logger.info("Got encoded token for secret {0} associated with service account {1} in namespace {2}: {3}",
+        secretName, opServiceAccount, opNamespace, secretToken);
 
+    // decode the secret encoded token
     String decodedToken = new String(Base64.getDecoder().decode(secretToken));
-    logger.info("Got the decoded token for secret {0} in operator namespace {1}: {2}",
-        secretName, opNamespace, decodedToken);
+    logger.info("Got decoded token for secret {0} associated with service account {1} in namespace {2}: {3}",
+        secretName, opServiceAccount, opNamespace, decodedToken);
 
     // build the curl command to scale the cluster
     String command = new StringBuffer()

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
@@ -178,24 +178,24 @@ public class Domain {
   }
 
   /**
-   * Scale the cluster of the domain in the specified namespace.
+   * Scale the cluster of the domain in the specified namespace with REST API.
    *
    * @param domainUid domainUid of the domain to be scaled
    * @param clusterName name of the WebLogic cluster to be scaled in the domain
    * @param numOfServers number of servers to be scaled to
    * @param externalRestHttpsPort node port allocated for the external operator REST HTTPS interface
    * @param opNamespace namespace of WebLogic operator
-   * @param operatorServiceAccount the service account for operator
-   * @return true if patch domain custom resource succeeds, false otherwise
+   * @param opServiceAccount the service account for operator
+   * @return true if REST call succeeds, false otherwise
    */
   public static boolean scaleClusterWithRestApi(String domainUid,
                                                 String clusterName,
                                                 int numOfServers,
                                                 int externalRestHttpsPort,
                                                 String opNamespace,
-                                                String operatorServiceAccount) {
+                                                String opServiceAccount) {
 
-    String secretName = Secret.getSecretFromServiceAccount(opNamespace, operatorServiceAccount);
+    String secretName = Secret.getSecretFromServiceAccount(opNamespace, opServiceAccount);
     logger.info("Got secret {0} in operator namespace {1}", secretName, opNamespace);
 
     String secretToken = Secret.getSecretEncodedToken(opNamespace, secretName);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
@@ -3,8 +3,13 @@
 
 package oracle.weblogic.kubernetes.actions.impl;
 
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1SecretList;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 
 public class Secret {
@@ -29,5 +34,62 @@ public class Secret {
    */
   public static boolean delete(String name, String namespace) {
     return Kubernetes.deleteSecret(name, namespace);
+  }
+
+  /**
+   * Get a secret which name starts with the specfied string in the specified namespace.
+   * @param namespace namespace in which to get the secret
+   * @param serviceAccountName the service account name which the secret is associated with
+   * @return secret name
+   */
+  public static String getSecretFromServiceAccount(String namespace, String serviceAccountName) {
+    String secretName = "";
+    List<V1Secret> v1Secrets = new ArrayList<>();
+
+    V1SecretList secretList = Kubernetes.listSecrets(namespace);
+    if (secretList != null) {
+      v1Secrets = secretList.getItems();
+    }
+
+    for (V1Secret v1Secret : v1Secrets) {
+      if (v1Secret.getMetadata() != null) {
+        secretName = v1Secret.getMetadata().getName();
+        if (secretName != null && secretName.startsWith(serviceAccountName)) {
+          return secretName;
+        }
+      }
+    }
+
+    return secretName;
+  }
+
+  /**
+   * Get a secret encoded token in the specified namespace.
+   *
+   * @param namespace namespace in which the secret exists
+   * @param secretName secret name to get the encoded token
+   * @return the encoded token of the secret
+   */
+  public static String getSecretEncodedToken(String namespace, String secretName) {
+
+    List<V1Secret> v1Secrets = new ArrayList<>();
+
+    V1SecretList secretList = Kubernetes.listSecrets(namespace);
+    if (secretList != null) {
+      v1Secrets = secretList.getItems();
+    }
+
+    for (V1Secret v1Secret : v1Secrets) {
+      if (v1Secret.getMetadata() != null) {
+        if (v1Secret.getMetadata().getName().equals(secretName)) {
+          if (v1Secret.getData() != null) {
+            byte[] encodedToken = v1Secret.getData().get("token");
+            return Base64.getEncoder().encodeToString(encodedToken);
+          }
+        }
+      }
+    }
+
+    return null;
   }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
@@ -37,12 +37,12 @@ public class Secret {
   }
 
   /**
-   * Get a secret from a service account in the specified namespace.
+   * Get a secret of a service account in the specified namespace.
    * @param namespace namespace in which to get the secret
    * @param serviceAccountName the service account name which the secret is associated with
    * @return secret name
    */
-  public static String getSecretFromServiceAccount(String namespace, String serviceAccountName) {
+  public static String getSecretOfServiceAccount(String namespace, String serviceAccountName) {
 
     List<V1Secret> v1Secrets = new ArrayList<>();
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
@@ -37,13 +37,13 @@ public class Secret {
   }
 
   /**
-   * Get a secret which name starts with the specfied string in the specified namespace.
+   * Get a secret from a service account in the specified namespace.
    * @param namespace namespace in which to get the secret
    * @param serviceAccountName the service account name which the secret is associated with
    * @return secret name
    */
   public static String getSecretFromServiceAccount(String namespace, String serviceAccountName) {
-    String secretName = "";
+
     List<V1Secret> v1Secrets = new ArrayList<>();
 
     V1SecretList secretList = listSecrets(namespace);
@@ -52,15 +52,14 @@ public class Secret {
     }
 
     for (V1Secret v1Secret : v1Secrets) {
-      if (v1Secret.getMetadata() != null) {
-        secretName = v1Secret.getMetadata().getName();
-        if (secretName != null && secretName.startsWith(serviceAccountName)) {
-          return secretName;
+      if (v1Secret.getMetadata() != null && v1Secret.getMetadata().getName() != null) {
+        if (v1Secret.getMetadata().getName().startsWith(serviceAccountName)) {
+          return v1Secret.getMetadata().getName();
         }
       }
     }
 
-    return secretName;
+    return "";
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
-import oracle.weblogic.kubernetes.utils.CleanupUtil;
+//import oracle.weblogic.kubernetes.utils.CleanupUtil;
 import oracle.weblogic.kubernetes.utils.LoggingUtil;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -294,7 +294,7 @@ public class IntegrationTestWatcher implements
   public void afterAll(ExtensionContext context) {
     printHeader(String.format("Ending Test Suite %s", className), "+");
     logger.info("Starting cleanup after test class");
-    CleanupUtil.cleanup(namespaces);
+    //CleanupUtil.cleanup(namespaces);
   }
 
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
-//import oracle.weblogic.kubernetes.utils.CleanupUtil;
+import oracle.weblogic.kubernetes.utils.CleanupUtil;
 import oracle.weblogic.kubernetes.utils.LoggingUtil;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -294,7 +294,7 @@ public class IntegrationTestWatcher implements
   public void afterAll(ExtensionContext context) {
     printHeader(String.format("Ending Test Suite %s", className), "+");
     logger.info("Starting cleanup after test class");
-    //CleanupUtil.cleanup(namespaces);
+    CleanupUtil.cleanup(namespaces);
   }
 
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -27,6 +27,8 @@ import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import oracle.weblogic.domain.Domain;
 import oracle.weblogic.kubernetes.actions.impl.NginxParams;
 import oracle.weblogic.kubernetes.actions.impl.OperatorParams;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
+import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
 import org.awaitility.core.ConditionFactory;
@@ -35,8 +37,11 @@ import org.joda.time.DateTime;
 import static java.nio.file.Files.readString;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.GEN_EXTERNAL_REST_IDENTITY_FILE;
 import static oracle.weblogic.kubernetes.TestConstants.GOOGLE_REPO_URL;
+import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.NGINX_CHART_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.NGINX_RELEASE_NAME;
@@ -82,6 +87,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.installNginx;
 import static oracle.weblogic.kubernetes.actions.TestActions.installOperator;
 import static oracle.weblogic.kubernetes.actions.TestActions.listIngresses;
 import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
+import static oracle.weblogic.kubernetes.actions.TestActions.scaleClusterWithRestApi;
 import static oracle.weblogic.kubernetes.actions.TestActions.upgradeOperator;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
@@ -128,9 +134,27 @@ public class CommonTestUtils {
   public static HelmParams installAndVerifyOperator(String opNamespace,
                                                     String... domainNamespace) {
 
+    return installAndVerifyOperator(opNamespace, opNamespace + "-sa",false, 0, domainNamespace);
+  }
+
+  /**
+   * Install WebLogic operator and wait up to five minutes until the operator pod is ready.
+   *
+   * @param opNamespace the operator namespace in which the operator will be installed
+   * @param serviceAccountName the service account name for operator
+   * @param withRestAPI whether to use REST API
+   * @param externalRestHttpsPort the node port allocated for the external operator REST HTTPS interface
+   * @param domainNamespace the list of the domain namespaces which will be managed by the operator
+   * @return the operator Helm installation parameters
+   */
+  public static HelmParams installAndVerifyOperator(String opNamespace,
+                                                    String serviceAccountName,
+                                                    boolean withRestAPI,
+                                                    int externalRestHttpsPort,
+                                                    String... domainNamespace) {
+
     // Create a service account for the unique opNamespace
     logger.info("Creating service account");
-    String serviceAccountName = opNamespace + "-sa";
     assertDoesNotThrow(() -> createServiceAccount(new V1ServiceAccount()
         .metadata(new V1ObjectMeta()
             .namespace(opNamespace)
@@ -163,6 +187,15 @@ public class CommonTestUtils {
         .imagePullSecrets(secretNameMap)
         .domainNamespaces(Arrays.asList(domainNamespace))
         .serviceAccount(serviceAccountName);
+
+    if (withRestAPI) {
+      // create externalRestIdentitySecret
+      createExternalRestIdentitySecret(opNamespace, DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME);
+      opParams
+          .externalRestEnabled(true)
+          .externalRestHttpsPort(externalRestHttpsPort)
+          .externalRestIdentitySecret(DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME);
+    }
 
     // install operator
     logger.info("Installing operator in namespace {0}", opNamespace);
@@ -741,6 +774,42 @@ public class CommonTestUtils {
                                            String curlCmd,
                                            List<String> expectedServerNames) {
 
+    scaleAndVerifyCluster(clusterName, domainUid, domainNamespace, manageServerPodNamePrefix, replicasBeforeScale,
+        replicasAfterScale, false, 0, "", "", curlCmd, expectedServerNames);
+  }
+
+  /** Scale the WebLogic cluster to specified number of servers.
+   *  Verify the sample app can be accessed through NGINX if curlCmd is not null.
+   *
+   * @param clusterName the WebLogic cluster name in the domain to be scaled
+   * @param domainUid the domain to which the cluster belongs
+   * @param domainNamespace the namespace in which the domain exists
+   * @param manageServerPodNamePrefix managed server pod name prefix
+   * @param replicasBeforeScale the replicas of the WebLogic cluster before the scale
+   * @param replicasAfterScale the replicas of the WebLogic cluster after the scale
+   * @param withRestApi whether to use REST API to scale the cluster
+   * @param externalRestHttpsPort the node port allocated for the external operator REST HTTPS interface
+   * @param opNamespace the namespace of WebLogic operator
+   * @param opServiceAccount the service account for operator
+   * @param curlCmd the curl command to verify ingress controller can access the sample apps from all managed servers
+   *                in the cluster, if curlCmd is null, the method will not verify the accessibility of the sample app
+   *                through ingress controller
+   * @param expectedServerNames list of managed servers in the cluster before scale, if curlCmd is null,
+   *                            set expectedServerNames to null too
+   */
+  public static void scaleAndVerifyCluster(String clusterName,
+                                           String domainUid,
+                                           String domainNamespace,
+                                           String manageServerPodNamePrefix,
+                                           int replicasBeforeScale,
+                                           int replicasAfterScale,
+                                           boolean withRestApi,
+                                           int externalRestHttpsPort,
+                                           String opNamespace,
+                                           String opServiceAccount,
+                                           String curlCmd,
+                                           List<String> expectedServerNames) {
+
     // get the original managed server pod creation timestamp before scale
     List<DateTime> listOfPodCreationTimestamp = new ArrayList<>();
     for (int i = 1; i <= replicasBeforeScale; i++) {
@@ -755,12 +824,22 @@ public class CommonTestUtils {
     // scale the cluster in the domain
     logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers",
         clusterName, domainUid, domainNamespace, replicasAfterScale);
-    assertThat(assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, replicasAfterScale)))
-        .as("Verify scaling cluster {0} of domain {1} in namespace {2} succeeds",
-            clusterName, domainUid, domainNamespace)
-        .withFailMessage("Scaling cluster {0} of domain {1} in namespace {2} failed",
-            clusterName, domainUid, domainNamespace)
-        .isTrue();
+    if (withRestApi) {
+      assertThat(assertDoesNotThrow(() -> scaleClusterWithRestApi(domainUid, clusterName,
+          replicasAfterScale, externalRestHttpsPort, opNamespace, opServiceAccount)))
+          .as("Verify scaling cluster {0} of domain {1} in namespace {2} with REST API succeeds",
+              clusterName, domainUid, domainNamespace)
+          .withFailMessage("Scaling cluster {0} of domain {1} in namespace {2} with REST API failed",
+              clusterName, domainUid, domainNamespace)
+          .isTrue();
+    } else {
+      assertThat(assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, replicasAfterScale)))
+          .as("Verify scaling cluster {0} of domain {1} in namespace {2} succeeds",
+              clusterName, domainUid, domainNamespace)
+          .withFailMessage("Scaling cluster {0} of domain {1} in namespace {2} failed",
+              clusterName, domainUid, domainNamespace)
+          .isTrue();
+    }
 
     if (replicasBeforeScale <= replicasAfterScale) {
 
@@ -1023,5 +1102,35 @@ public class CommonTestUtils {
         String.format("Failed to read model file %s", dsModelFile));
 
     data.put(modelFileName, cmData);
+  }
+
+  /**
+   * Create an external REST Identity secret in the specified namespace.
+   *
+   * @param opNamespace the operator namespace in which the secret to be created
+   * @param secretName name of the secret to be created
+   * @return name of the secret
+   */
+  private static String createExternalRestIdentitySecret(String opNamespace, String secretName) {
+
+    String command = new StringBuffer()
+        .append(GEN_EXTERNAL_REST_IDENTITY_FILE)
+        .append(" -a \"DNS:")
+        .append(K8S_NODEPORT_HOST)
+        .append(",DNS:localhost,IP:127.0.0.1\"")
+        .append(" -n ")
+        .append(opNamespace)
+        .append(" -s ")
+        .append(secretName).toString();
+
+    CommandParams params = Command
+        .defaultCommandParams()
+        .command(command)
+        .saveResults(true)
+        .redirect(true);
+
+    Command.withParams(params).execute();
+    return secretName;
+
   }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -1115,19 +1115,25 @@ public class CommonTestUtils {
    */
   private static boolean createExternalRestIdentitySecret(String namespace, String secretName) {
 
-    String command = new StringBuffer()
-        .append(GEN_EXTERNAL_REST_IDENTITY_FILE)
-        .append(" -a \"DNS:")
-        .append(K8S_NODEPORT_HOST)
+    StringBuffer command = new StringBuffer()
+        .append(GEN_EXTERNAL_REST_IDENTITY_FILE);
+
+    if (Character.isDigit(K8S_NODEPORT_HOST.charAt(0))) {
+      command.append(" -a \"IP:");
+    } else {
+      command.append(" -a \"DNS:");
+    }
+
+    command.append(K8S_NODEPORT_HOST)
         .append(",DNS:localhost,IP:127.0.0.1\"")
         .append(" -n ")
         .append(namespace)
         .append(" -s ")
-        .append(secretName).toString();
+        .append(secretName);
 
     CommandParams params = Command
         .defaultCommandParams()
-        .command(command)
+        .command(command.toString())
         .saveResults(true)
         .redirect(true);
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -779,8 +779,9 @@ public class CommonTestUtils {
         replicasAfterScale, false, 0, "", "", curlCmd, expectedServerNames);
   }
 
-  /** Scale the WebLogic cluster to specified number of servers.
-   *  Verify the sample app can be accessed through NGINX if curlCmd is not null.
+  /**
+   * Scale the WebLogic cluster to specified number of servers.
+   * Verify the sample app can be accessed through NGINX if curlCmd is not null.
    *
    * @param clusterName the WebLogic cluster name in the domain to be scaled
    * @param domainUid the domain to which the cluster belongs


### PR DESCRIPTION
Add the test infrastructure support for scaling a cluster using REST API.

Jira task: https://jira.oraclecorp.com/jira/browse/OWLS-82419

Jenkins result: https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/279/
The test oracle.weblogic.kubernetes.ItSessionMigration.testSessionMigration failed on develop branch too. See https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/268/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-model-in-image-tests-10/266/