### PR TITLE
Fix image name

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
@@ -160,7 +160,7 @@ class ItMiiMultiModel implements LoggedTest {
 
     logger.info("Create an image with two model files");
     miiImageMultiModel = createMiiImageAndVerify(
-        String.format("%s-%s", MII_BASIC_IMAGE_NAME, "test-multi-model-image"),
+        String.format("%s-%s", "mii-basic-image", "test-multi-model-image"),
         Arrays.asList(
             MODEL_DIR + "/" + MII_BASIC_WDT_MODEL_FILE, 
             MODEL_DIR + "/" + modelFileName2, 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
@@ -160,7 +160,7 @@ class ItMiiMultiModel implements LoggedTest {
 
     logger.info("Create an image with two model files");
     miiImageMultiModel = createMiiImageAndVerify(
-        String.format("%s-%s", "mii-basic-image", "test-multi-model-image"),
+        "mii-test-multi-model-image",
         Arrays.asList(
             MODEL_DIR + "/" + MII_BASIC_WDT_MODEL_FILE, 
             MODEL_DIR + "/" + modelFileName2, 


### PR DESCRIPTION
Remove the REPO_NAME from the image name in ITMIIMultiModel test's BeforeAll method because the common utility method it uses, createMiiImageAndVerify(), already adds REPO_NAME. 