### PR TITLE
Set client's timeouts fr default to no timeout to forces the internal HTTP client to keep a long running connection with the server

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -132,9 +132,14 @@ public class Kubernetes implements LoggedTest {
       apiClient = Configuration.getDefaultApiClient();
       // Set timeout to 0 to forces the internal HTTP client to keep a long
       // running connection with the server to fix SSL connection closed issue
-      //apiClient.setConnectTimeout(120 * 100);
+      System.out.println("----- getConnectTimeout: " + apiClient.getConnectTimeout());
+      System.out.println("----- getWriteTimeout: " + apiClient.getWriteTimeout());
+      System.out.println("----- getReadTimeout: " + apiClient.getReadTimeout());
+      System.out.println("----- isDebugging: " + apiClient.isDebugging());
+      apiClient.setDebugging(true);
+      apiClient.setConnectTimeout(0);
       apiClient.setReadTimeout(0);
-      //apiClient.setWriteTimeout(120 * 100);
+      //apiClient.setWriteTimeout(30 * 1000);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,11 +130,11 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
-      // Set connection and read timeout to 5 minutes to forces the internal HTTP client 
+      // Set connection, write and read timeout to no-timeout to forces the internal HTTP client 
       // to keep a long running connection with the server to fix SSL connection closed issue
-      apiClient.setConnectTimeout(300 * 1000);
-      apiClient.setReadTimeout(300 * 1000);
-      //apiClient.setWriteTimeout(300 * 1000);
+      apiClient.setConnectTimeout(0);
+      apiClient.setReadTimeout(0);
+      apiClient.setWriteTimeout(0);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,10 +130,11 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
-      // Set connection timeout to 0 and read timeout to 30 seconds to forces the internal HTTP client 
+      // Set connection and read timeout to 0 to forces the internal HTTP client 
       // to keep a long running connection with the server to fix SSL connection closed issue
       apiClient.setConnectTimeout(0);
-      apiClient.setReadTimeout(30 * 1000);
+      apiClient.setReadTimeout(0);
+      apiClient.setWriteTimeout(0);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,11 +130,11 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
-      // Set connection and read timeout to 5 minutes to forces the internal HTTP client 
+      // Set connection and read timeout to 15 minutes to forces the internal HTTP client 
       // to keep a long running connection with the server to fix SSL connection closed issue
-      apiClient.setConnectTimeout(300 * 1000);
-      apiClient.setReadTimeout(300 * 1000);
-      apiClient.setWriteTimeout(300 * 1000);
+      apiClient.setConnectTimeout(900 * 1000);
+      apiClient.setReadTimeout(900 * 1000);
+      apiClient.setWriteTimeout(900 * 1000);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,11 +130,11 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
-      // Set connection and read timeout to 15 minutes to forces the internal HTTP client 
+      // Set connection and read timeout to 5 minutes to forces the internal HTTP client 
       // to keep a long running connection with the server to fix SSL connection closed issue
-      apiClient.setConnectTimeout(900 * 1000);
-      apiClient.setReadTimeout(900 * 1000);
-      apiClient.setWriteTimeout(900 * 1000);
+      apiClient.setConnectTimeout(300 * 1000);
+      apiClient.setReadTimeout(300 * 1000);
+      //apiClient.setWriteTimeout(300 * 1000);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -138,7 +138,7 @@ public class Kubernetes implements LoggedTest {
       System.out.println("----- isDebugging: " + apiClient.isDebugging());
       apiClient.setDebugging(true);
       apiClient.setConnectTimeout(0);
-      apiClient.setReadTimeout(0);
+      apiClient.setReadTimeout(30 * 1000);
       //apiClient.setWriteTimeout(30 * 1000);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,11 +130,11 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
-      // Set connection and read timeout to 0 to forces the internal HTTP client 
+      // Set connection and read timeout to 5 minutes to forces the internal HTTP client 
       // to keep a long running connection with the server to fix SSL connection closed issue
-      apiClient.setConnectTimeout(0);
-      apiClient.setReadTimeout(0);
-      apiClient.setWriteTimeout(0);
+      apiClient.setConnectTimeout(300 * 1000);
+      apiClient.setReadTimeout(300 * 1000);
+      apiClient.setWriteTimeout(300 * 1000);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,6 +130,11 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
+      // Set timeout to 0 to forces the internal HTTP client to keep a long
+      // running connection with the server to fix SSL connection closed issue
+      //apiClient.setConnectTimeout(120 * 100);
+      apiClient.setReadTimeout(0);
+      //apiClient.setWriteTimeout(120 * 100);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -130,16 +130,10 @@ public class Kubernetes implements LoggedTest {
     try {
       Configuration.setDefaultApiClient(ClientBuilder.defaultClient());
       apiClient = Configuration.getDefaultApiClient();
-      // Set timeout to 0 to forces the internal HTTP client to keep a long
-      // running connection with the server to fix SSL connection closed issue
-      System.out.println("----- getConnectTimeout: " + apiClient.getConnectTimeout());
-      System.out.println("----- getWriteTimeout: " + apiClient.getWriteTimeout());
-      System.out.println("----- getReadTimeout: " + apiClient.getReadTimeout());
-      System.out.println("----- isDebugging: " + apiClient.isDebugging());
-      apiClient.setDebugging(true);
+      // Set connection timeout to 0 and read timeout to 30 seconds to forces the internal HTTP client 
+      // to keep a long running connection with the server to fix SSL connection closed issue
       apiClient.setConnectTimeout(0);
       apiClient.setReadTimeout(30 * 1000);
-      //apiClient.setWriteTimeout(30 * 1000);
       coreV1Api = new CoreV1Api();
       customObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();

--- a/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
+++ b/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
@@ -59,6 +59,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
                        "<countattribute>" + session.getAttribute("count") + "</countattribute>");
           }
      } else {
+          out.println("<sessioncreatetime>NA</sessioncreatetime>");
+          out.println("<sessionid>NA</sessionid>");
           out.println("<primary>NA</primary>");
           out.println("<secondary>NA</secondary>");
           out.println("<countattribute>00</countattribute>");

--- a/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
+++ b/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
@@ -35,7 +35,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 %>
 <%
      if (session != null) {
-          out.clearBuffer();
           if (request.getParameter("invalidate") != null) {
                session.invalidate();
                out.println("Your session is invalidated");

--- a/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
+++ b/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
@@ -63,6 +63,4 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
           out.println("<secondary>NA</secondary>");
           out.println("<countattribute>00</countattribute>");
      }
-
-     out.println("==== buffer size after is: " + out.getRemaining());
 %>

--- a/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
+++ b/new-integration-tests/src/test/resources/apps/sessmigr-app/sessmigr-war/index.jsp
@@ -2,11 +2,12 @@
 Copyright (c) 2020, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 --%>
-<%@ page contentType="text/html; charset=utf-8" %>
+<%@ page language="java" contentType="text/html; charset=ISO-8859-1" pageEncoding="ISO-8859-1"%>
 <%@ page import="javax.servlet.http.HttpSession,
                  weblogic.servlet.internal.MembershipControllerImpl,
                  weblogic.servlet.internal.session.RSID,
-                 weblogic.servlet.spi.WebServerRegistry" %>
+                 weblogic.servlet.spi.WebServerRegistry"
+%>
 <%!
      String getPrimaryServer(String sessionId) {
           MembershipControllerImpl cluster =
@@ -33,60 +34,36 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
      }
 %>
 <%
-     HttpSession currentSession = request.getSession(true);
-
-     if (currentSession != null) {
-         if (request.getParameter("delayTime") != null) {
-               try {
-                    Integer ival = (Integer)currentSession.getAttribute("simplesession.counter");
-                    if (ival == null) {
-                         // Initialize the counter
-                         ival = new Integer(1);
-                    } else {
-                         // Increment the counter
-                         ival = new Integer(ival.intValue() + 1);
-                    }
-                    // Set the new attribute value in the session
-                    currentSession.setAttribute("simplesession.counter", ival);
-
-                    currentSession.setMaxInactiveInterval(Integer.valueOf(request.getParameter("delayTime")));
-                    out.println(
-                            "<sleep>Starting to sleep : "
-                                    + (Integer.valueOf(request.getParameter("delayTime")))
-                                    + "</sleep>");
-                    Thread.sleep(Integer.valueOf(request.getParameter("delayTime")));
-                    out.println("<sleep>Ending to sleep</sleep>");
-               } catch (Exception ex) {
-                    // just ignore
-               }
-          }
-
+     if (session != null) {
+          out.clearBuffer();
           if (request.getParameter("invalidate") != null) {
-               currentSession.invalidate();
+               session.invalidate();
                out.println("Your session is invalidated");
           } else {
                if (request.getParameter("setCounter") != null) {
-                    currentSession.setAttribute("count", Integer.valueOf(request.getParameter("setCounter")));
+                    session.setAttribute("count", Integer.valueOf(request.getParameter("setCounter")));
                } else if (request.getParameter("getCounter") != null) {
-                    currentSession.setAttribute("count", ((Integer) currentSession.getAttribute("count")));
-               } else if (request.getParameter("setCounter") == null && currentSession.isNew()) {
-                    currentSession.setAttribute("count", new Integer(1));
+                    session.setAttribute("count", ((Integer) session.getAttribute("count")));
+               } else if (request.getParameter("setCounter") == null && session.isNew()) {
+                    session.setAttribute("count", new Integer(1));
                } else {
-                    int count = ((Integer) currentSession.getAttribute("count")).intValue();
-                    currentSession.setAttribute("count", new Integer(++count));
+                    int count = ((Integer) session.getAttribute("count")).intValue();
+                    session.setAttribute("count", new Integer(++count));
                }
 
                out.println(
-                       "<sessioncreatetime>" + currentSession.getCreationTime() + "</sessioncreatetime>");
-               out.println("<sessionid>" + currentSession.getId() + "</sessionid>");
-               out.println("<primary>" + getPrimaryServer(currentSession.getId()) + "</primary>");
-               out.println("<secondary>" + getSecondaryServer(currentSession.getId()) + "</secondary>");
+                       "<sessioncreatetime>" + session.getCreationTime() + "</sessioncreatetime>");
+               out.println("<sessionid>" + session.getId() + "</sessionid>");
+               out.println("<primary>" + getPrimaryServer(session.getId()) + "</primary>");
+               out.println("<secondary>" + getSecondaryServer(session.getId()) + "</secondary>");
                out.println(
-                       "<countattribute>" + currentSession.getAttribute("count") + "</countattribute>");
+                       "<countattribute>" + session.getAttribute("count") + "</countattribute>");
           }
      } else {
           out.println("<primary>NA</primary>");
           out.println("<secondary>NA</secondary>");
           out.println("<countattribute>00</countattribute>");
      }
+
+     out.println("==== buffer size after is: " + out.getRemaining());
 %>


### PR DESCRIPTION
Purpose: 

Set client's timeouts fr default to no timeout to forces the internal HTTP client to keep a long running connection with the server

Two Jenkins Jobs passed:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests-10/300/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/305