### PR TITLE
start sending wls stdout to pod log earlier

### DIFF
--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -71,6 +71,17 @@ function startWLS() {
   traceTiming "POD '${SERVICE_NAME}' MD5 END"
 
   #
+  # We "tail" the future WL Server .out file to stdout in background _before_ starting 
+  # the WLS Server because we use WLST 'nmStart()' to start the server and nmStart doesn't return
+  # control until WLS reaches the RUNNING state.
+  #
+
+  if [ "${SERVER_OUT_IN_POD_LOG}" == 'true' ] ; then
+    trace "Showing the server out file from ${SERVER_OUT_FILE}"
+    ${SCRIPTPATH}/tailLog.sh ${SERVER_OUT_FILE} ${SERVER_PID_FILE} &
+  fi
+
+  #
   # Start WL Server
   #
 
@@ -82,6 +93,12 @@ function startWLS() {
   ${SCRIPTPATH}/wlst.sh $SCRIPTPATH/start-server.py
 
   traceTiming "POD '${SERVICE_NAME}' WLS STARTED"
+
+  FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR=${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR:-true}
+  SERVER_OUT_MONITOR_INTERVAL=${SERVER_OUT_MONITOR_INTERVAL:-3}
+  if [ ${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR} == 'true' ] ; then
+    ${SCRIPTPATH}/monitorLog.sh ${SERVER_OUT_FILE} ${SERVER_OUT_MONITOR_INTERVAL} &
+  fi
 }
 
 function mockWLS() {
@@ -93,22 +110,6 @@ function mockWLS() {
 
   createFolder $STATEFILE_DIR
   echo "RUNNING:Y:N" > $STATEFILE
-}
-
-function waitUntilShutdown() {
-  #
-  # Wait forever.   Kubernetes will monitor this pod via liveness and readyness probes.
-  #
-  if [ "${SERVER_OUT_IN_POD_LOG}" == 'true' ] ; then
-    trace "Showing the server out file from ${SERVER_OUT_FILE}"
-    ${SCRIPTPATH}/tailLog.sh ${SERVER_OUT_FILE} ${SERVER_PID_FILE} &
-  fi
-  FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR=${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR:-true} 
-  SERVER_OUT_MONITOR_INTERVAL=${SERVER_OUT_MONITOR_INTERVAL:-3}
-  if [ ${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR} == 'true' ] ; then
-    ${SCRIPTPATH}/monitorLog.sh ${SERVER_OUT_FILE} ${SERVER_OUT_MONITOR_INTERVAL} &
-  fi
-  waitForShutdownMarker
 }
 
 # Define helper fn to copy sit cfg xml files from one dir to another
@@ -357,12 +358,18 @@ copySitCfgWhileBooting /weblogic-operator/introspector ${DOMAIN_HOME}/optconfig/
 copySitCfgWhileBooting /weblogic-operator/introspector ${DOMAIN_HOME}/optconfig/jdbc        'Sit-Cfg-JDBC--'
 copySitCfgWhileBooting /weblogic-operator/introspector ${DOMAIN_HOME}/optconfig/diagnostics 'Sit-Cfg-WLDF--'
 
-
+#
+# Start WLS
+#
 
 if [ "${MOCK_WLS}" == 'true' ]; then
   mockWLS
-  waitForShutdownMarker
 else
   startWLS
-  waitUntilShutdown
 fi
+
+#
+# Wait forever. Kubernetes will monitor this pod via liveness and readyness probes.
+#
+
+waitForShutdownMarker

--- a/operator/src/main/resources/scripts/tailLog.sh
+++ b/operator/src/main/resources/scripts/tailLog.sh
@@ -10,4 +10,30 @@
 #
 
 echo $$ > $2
-tail -F -n +0 $1
+
+while true ; do
+  if [ -f $1 ]; then
+    tail -F -n +0 $1 || sleep 10
+  fi
+  sleep 0.1
+done
+
+#
+# Work around note:
+#
+#   The forever loop and '[ -f $1 ]' check above work around an
+#   unexpected  behavior  from  'tail -F'.  The  '-F'  expected 
+#   behavior is meant to handle 'rolling' files by both:
+#
+#     A- Waiting  until the  file appears  instead of exiting
+#        with an error code.
+#
+#     B- Once the file is found, gracefully handling the file
+#        getting deleted or moved  (by pausing while the file
+#        is gone,  and starting up again once a new file with
+#        the same name appears in its place).
+#
+#   But 'A' is not working on WL pods and thus the work around.
+#   (Strangely and thankfully 'B' works fine.)
+#
+


### PR DESCRIPTION
Without this fix, there is often a substantial delay between the time when WLST tries to start a WL server in a pod and the time we start sending the WL server's stdout to the pod log.  (WLST doesn't seem to return control until the WL server has about reached the 'running' state - which can take a while - and the original code doesn't start its 'tail' until after WLST returns.)