### PR TITLE
Add owner references to resources associated with a specific domain

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -11,13 +12,158 @@ import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1Toleration;
 import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.operator.TuningParameters;
+import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 
 public abstract class BasePodStepContext extends StepContextBase {
+
+  BasePodStepContext(DomainPresenceInfo info) {
+    super(info);
+  }
+
   final <T> T updateForDeepSubstitution(V1PodSpec podSpec, T target) {
     return getContainer(podSpec)
         .map(c -> doDeepSubstitution(augmentSubVars(deepSubVars(c.getEnv())), target))
         .orElse(target);
+  }
+
+  abstract ServerSpec getServerSpec();
+
+  abstract String getContainerName();
+
+  abstract List<String> getContainerCommand();
+
+  abstract List<V1Container> getContainers();
+
+  protected V1Container createContainer(TuningParameters tuningParameters) {
+    return new V1Container()
+        .name(getContainerName())
+        .image(getServerSpec().getImage())
+        .imagePullPolicy(getServerSpec().getImagePullPolicy())
+        .command(getContainerCommand())
+        .env(getEnvironmentVariables(tuningParameters))
+        .resources(getServerSpec().getResources())
+        .securityContext(getServerSpec().getContainerSecurityContext());
+  }
+
+  protected V1PodSpec createPodSpec(TuningParameters tuningParameters) {
+    return new V1PodSpec()
+        .containers(getContainers())
+        .addContainersItem(createContainer(tuningParameters))
+        .affinity(getServerSpec().getAffinity())
+        .nodeSelector(getServerSpec().getNodeSelectors())
+        .serviceAccountName(getServerSpec().getServiceAccountName())
+        .nodeName(getServerSpec().getNodeName())
+        .schedulerName(getServerSpec().getSchedulerName())
+        .priorityClassName(getServerSpec().getPriorityClassName())
+        .runtimeClassName(getServerSpec().getRuntimeClassName())
+        .tolerations(getTolerations())
+        .restartPolicy(getServerSpec().getRestartPolicy())
+        .securityContext(getServerSpec().getPodSecurityContext())
+        .imagePullSecrets(getServerSpec().getImagePullSecrets());
+  }
+
+  private List<V1Toleration> getTolerations() {
+    List<V1Toleration> tolerations = getServerSpec().getTolerations();
+    return tolerations.isEmpty() ? null : tolerations;
+  }
+
+
+  /**
+   * Abstract method to be implemented by subclasses to return a list of configured and additional
+   * environment variables to be set up in the pod.
+   *
+   * @param tuningParameters TuningParameters that can be used when obtaining
+   * @return A list of configured and additional environment variables
+   */
+  abstract List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters);
+
+  /**
+   * Return a list of environment variables to be set up in the pod. This method does some
+   * processing of the list of environment variables such as token substitution before returning the
+   * list.
+   *
+   * @param tuningParameters TuningParameters containing parameters that may be used in environment
+   *     variables
+   * @return A List of environment variables to be set up in the pod
+   */
+  final List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
+
+    List<V1EnvVar> vars = getConfiguredEnvVars(tuningParameters);
+
+    addDefaultEnvVarIfMissing(
+        vars, "USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom");
+
+    hideAdminUserCredentials(vars);
+    return doDeepSubstitution(varsToSubVariables(vars), vars);
+  }
+
+  protected void addEnvVar(List<V1EnvVar> vars, String name, String value) {
+    vars.add(new V1EnvVar().name(name).value(value));
+  }
+
+  protected void addEnvVarIfTrue(boolean condition, List<V1EnvVar> vars, String name) {
+    if (condition) {
+      addEnvVar(vars, name, "true");
+    }
+  }
+
+  protected boolean hasEnvVar(List<V1EnvVar> vars, String name) {
+    for (V1EnvVar var : vars) {
+      if (name.equals(var.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected void addDefaultEnvVarIfMissing(List<V1EnvVar> vars, String name, String value) {
+    if (!hasEnvVar(vars, name)) {
+      addEnvVar(vars, name, value);
+    }
+  }
+
+  protected V1EnvVar findEnvVar(List<V1EnvVar> vars, String name) {
+    for (V1EnvVar var : vars) {
+      if (name.equals(var.getName())) {
+        return var;
+      }
+    }
+    return null;
+  }
+
+  protected void addOrReplaceEnvVar(List<V1EnvVar> vars, String name, String value) {
+    V1EnvVar var = findEnvVar(vars, name);
+    if (var != null) {
+      var.value(value);
+    } else {
+      addEnvVar(vars, name, value);
+    }
+  }
+
+  // Hide the admin account's user name and password.
+  // Note: need to use null v.s. "" since if you upload a "" to kubectl then download it,
+  // it comes back as a null and V1EnvVar.equals returns false even though it's supposed to
+  // be the same value.
+  // Regardless, the pod ends up with an empty string as the value (v.s. thinking that
+  // the environment variable hasn't been set), so it honors the value (instead of using
+  // the default, e.g. 'weblogic' for the user name).
+  protected void hideAdminUserCredentials(List<V1EnvVar> vars) {
+    addEnvVar(vars, "ADMIN_USERNAME", null);
+    addEnvVar(vars, "ADMIN_PASSWORD", null);
+  }
+
+  protected Map<String, String> varsToSubVariables(List<V1EnvVar> vars) {
+    Map<String, String> substitutionVariables = new HashMap<>();
+    if (vars != null) {
+      for (V1EnvVar envVar : vars) {
+        substitutionVariables.put(envVar.getName(), envVar.getValue());
+      }
+    }
+
+    return substitutionVariables;
   }
 
   final Map<String, String> deepSubVars(List<V1EnvVar> envVars) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -43,11 +43,10 @@ public abstract class JobStepContext extends BasePodStepContext {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final String WEBLOGIC_OPERATOR_SCRIPTS_INTROSPECT_DOMAIN_SH =
         "/weblogic-operator/scripts/introspectDomain.sh";
-  private final DomainPresenceInfo info;
   private V1Job jobModel;
 
   JobStepContext(Packet packet) {
-    info = packet.getSpi(DomainPresenceInfo.class);
+    super(packet.getSpi(DomainPresenceInfo.class));
   }
 
   private static V1VolumeMount readOnlyVolumeMount(String volumeName, String mountPath) {
@@ -214,12 +213,13 @@ public abstract class JobStepContext extends BasePodStepContext {
   }
 
   V1ObjectMeta createMetadata() {
-    return new V1ObjectMeta()
+    return updateForOwnerReference(
+        new V1ObjectMeta()
           .name(getJobName())
           .namespace(getNamespace())
           .putLabelsItem(LabelConstants.RESOURCE_VERSION_LABEL, VersionConstants.DOMAIN_V1)
           .putLabelsItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
-          .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
+          .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true"));
   }
 
   private long getActiveDeadlineSeconds(TuningParameters.PodTuning podTuning) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -72,7 +72,6 @@ public abstract class PodStepContext extends BasePodStepContext {
   private static final String READINESS_PATH = "/weblogic/ready";
 
   final WlsServerConfig scan;
-  private final DomainPresenceInfo info;
   private final WlsDomainConfig domainTopology;
   private final Step conflictStep;
   private V1Pod podModel;
@@ -81,8 +80,8 @@ public abstract class PodStepContext extends BasePodStepContext {
   private final String domainRestartVersion;
 
   PodStepContext(Step conflictStep, Packet packet) {
+    super(packet.getSpi(DomainPresenceInfo.class));
     this.conflictStep = conflictStep;
-    info = packet.getSpi(DomainPresenceInfo.class);
     domainTopology = (WlsDomainConfig) packet.get(ProcessingConstants.DOMAIN_TOPOLOGY);
     miiModelSecretsHash = (String)packet.get(IntrospectorConfigMapKeys.SECRETS_MD_5);
     miiDomainZipHash = (String)packet.get(IntrospectorConfigMapKeys.DOMAINZIP_HASH);
@@ -428,6 +427,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     setTerminationGracePeriod(pod);
     getContainer(pod).map(V1Container::getEnv).ifPresent(this::updateEnv);
 
+    updateForOwnerReference(metadata);
     return updateForDeepSubstitution(pod.getSpec(), pod);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -376,16 +376,15 @@ public class ServiceHelper {
     return true;
   }
 
-  private abstract static class ServiceStepContext {
+  private abstract static class ServiceStepContext extends StepContextBase {
     private final Step conflictStep;
     protected List<V1ServicePort> ports;
-    final DomainPresenceInfo info;
     final WlsDomainConfig domainTopology;
     private final OperatorServiceType serviceType;
 
     ServiceStepContext(Step conflictStep, Packet packet, OperatorServiceType serviceType) {
+      super(packet.getSpi(DomainPresenceInfo.class));
       this.conflictStep = conflictStep;
-      info = packet.getSpi(DomainPresenceInfo.class);
       domainTopology = (WlsDomainConfig) packet.get(ProcessingConstants.DOMAIN_TOPOLOGY);
       this.serviceType = serviceType;
     }
@@ -395,7 +394,13 @@ public class ServiceHelper {
     }
 
     V1Service createModel() {
-      return AnnotationHelper.withSha256Hash(createRecipe());
+      return withNonHashedElements(AnnotationHelper.withSha256Hash(createRecipe()));
+    }
+
+    V1Service withNonHashedElements(V1Service service) {
+      V1ObjectMeta metadata = service.getMetadata();
+      updateForOwnerReference(metadata);
+      return service;
     }
 
     V1Service createRecipe() {
@@ -466,7 +471,6 @@ public class ServiceHelper {
 
       // Add custom annotations
       getServiceAnnotations().forEach(metadata::putAnnotationsItem);
-
       return metadata;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextBase.java
@@ -11,97 +11,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1Toleration;
 import oracle.kubernetes.operator.Pair;
-import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 
 public abstract class StepContextBase implements StepContextConstants {
-  abstract ServerSpec getServerSpec();
+  protected final DomainPresenceInfo info;
 
-  abstract String getContainerName();
-
-  abstract List<String> getContainerCommand();
-
-  abstract List<V1Container> getContainers();
-
-  protected V1Container createContainer(TuningParameters tuningParameters) {
-    return new V1Container()
-        .name(getContainerName())
-        .image(getServerSpec().getImage())
-        .imagePullPolicy(getServerSpec().getImagePullPolicy())
-        .command(getContainerCommand())
-        .env(getEnvironmentVariables(tuningParameters))
-        .resources(getServerSpec().getResources())
-        .securityContext(getServerSpec().getContainerSecurityContext());
-  }
-
-  protected V1PodSpec createPodSpec(TuningParameters tuningParameters) {
-    return new V1PodSpec()
-        .containers(getContainers())
-        .addContainersItem(createContainer(tuningParameters))
-        .affinity(getServerSpec().getAffinity())
-        .nodeSelector(getServerSpec().getNodeSelectors())
-        .serviceAccountName(getServerSpec().getServiceAccountName())
-        .nodeName(getServerSpec().getNodeName())
-        .schedulerName(getServerSpec().getSchedulerName())
-        .priorityClassName(getServerSpec().getPriorityClassName())
-        .runtimeClassName(getServerSpec().getRuntimeClassName())
-        .tolerations(getTolerations())
-        .restartPolicy(getServerSpec().getRestartPolicy())
-        .securityContext(getServerSpec().getPodSecurityContext())
-        .imagePullSecrets(getServerSpec().getImagePullSecrets());
-  }
-
-  private List<V1Toleration> getTolerations() {
-    List<V1Toleration> tolerations = getServerSpec().getTolerations();
-    return tolerations.isEmpty() ? null : tolerations;
-  }
-
-
-  /**
-     * Abstract method to be implemented by subclasses to return a list of configured and additional
-     * environment variables to be set up in the pod.
-     *
-     * @param tuningParameters TuningParameters that can be used when obtaining
-     * @return A list of configured and additional environment variables
-     */
-  abstract List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters);
-
-  /**
-   * Return a list of environment variables to be set up in the pod. This method does some
-   * processing of the list of environment variables such as token substitution before returning the
-   * list.
-   *
-   * @param tuningParameters TuningParameters containing parameters that may be used in environment
-   *     variables
-   * @return A List of environment variables to be set up in the pod
-   */
-  final List<V1EnvVar> getEnvironmentVariables(TuningParameters tuningParameters) {
-
-    List<V1EnvVar> vars = getConfiguredEnvVars(tuningParameters);
-
-    addDefaultEnvVarIfMissing(
-        vars, "USER_MEM_ARGS", "-Djava.security.egd=file:/dev/./urandom");
-
-    hideAdminUserCredentials(vars);
-    return doDeepSubstitution(varsToSubVariables(vars), vars);
-  }
-
-  protected Map<String, String> varsToSubVariables(List<V1EnvVar> vars) {
-    Map<String, String> substitutionVariables = new HashMap<>();
-    if (vars != null) {
-      for (V1EnvVar envVar : vars) {
-        substitutionVariables.put(envVar.getName(), envVar.getValue());
-      }
-    }
-
-    return substitutionVariables;
+  StepContextBase(DomainPresenceInfo info) {
+    this.info = info;
   }
 
   protected <T> T doDeepSubstitution(final Map<String, String> substitutionVariables, T obj) {
@@ -209,58 +129,20 @@ public abstract class StepContextBase implements StepContextConstants {
     return result;
   }
 
-  protected void addEnvVar(List<V1EnvVar> vars, String name, String value) {
-    vars.add(new V1EnvVar().name(name).value(value));
-  }
-
-  protected void addEnvVarIfTrue(boolean condition, List<V1EnvVar> vars, String name) {
-    if (condition) {
-      addEnvVar(vars, name, "true");
-    }
-  }
-
-  protected boolean hasEnvVar(List<V1EnvVar> vars, String name) {
-    for (V1EnvVar var : vars) {
-      if (name.equals(var.getName())) {
-        return true;
+  protected V1ObjectMeta updateForOwnerReference(V1ObjectMeta metadata) {
+    if (info != null) {
+      Domain domain = info.getDomain();
+      if (domain != null) {
+        V1ObjectMeta domainMetadata = domain.getMetadata();
+        metadata.addOwnerReferencesItem(
+            new V1OwnerReference()
+                .apiVersion(domain.getApiVersion())
+                .kind(domain.getKind())
+                .name(domainMetadata.getName())
+                .uid(domainMetadata.getUid())
+                .controller(true));
       }
     }
-    return false;
-  }
-
-  protected void addDefaultEnvVarIfMissing(List<V1EnvVar> vars, String name, String value) {
-    if (!hasEnvVar(vars, name)) {
-      addEnvVar(vars, name, value);
-    }
-  }
-
-  protected V1EnvVar findEnvVar(List<V1EnvVar> vars, String name) {
-    for (V1EnvVar var : vars) {
-      if (name.equals(var.getName())) {
-        return var;
-      }
-    }
-    return null;
-  }
-
-  protected void addOrReplaceEnvVar(List<V1EnvVar> vars, String name, String value) {
-    V1EnvVar var = findEnvVar(vars, name);
-    if (var != null) {
-      var.value(value);
-    } else {
-      addEnvVar(vars, name, value);
-    }
-  }
-
-  // Hide the admin account's user name and password.
-  // Note: need to use null v.s. "" since if you upload a "" to kubectl then download it,
-  // it comes back as a null and V1EnvVar.equals returns false even though it's supposed to
-  // be the same value.
-  // Regardless, the pod ends up with an empty string as the value (v.s. thinking that
-  // the environment variable hasn't been set), so it honors the value (instead of using
-  // the default, e.g. 'weblogic' for the user name).
-  protected void hideAdminUserCredentials(List<V1EnvVar> vars) {
-    addEnvVar(vars, "ADMIN_USERNAME", null);
-    addEnvVar(vars, "ADMIN_PASSWORD", null);
+    return metadata;
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
@@ -32,6 +32,7 @@ public class DomainProcessorTestSetup {
   public static final String UID = "test-domain";
   public static final String NS = "namespace";
   public static final String SECRET_NAME = "secret-name";
+  public static final String KUBERNETES_UID = "12345";
 
   private static final String INTROSPECTION_JOB = LegalNames.toJobIntrospectorName(UID);
   private static final String INTROSPECT_RESULT =
@@ -89,7 +90,9 @@ public class DomainProcessorTestSetup {
    */
   public static Domain createTestDomain() {
     return new Domain()
-        .withMetadata(withTimestamps(new V1ObjectMeta().name(UID).namespace(NS)))
+        .withApiVersion(KubernetesConstants.DOMAIN_GROUP + "/" + KubernetesConstants.DOMAIN_VERSION)
+        .withKind(KubernetesConstants.DOMAIN)
+        .withMetadata(withTimestamps(new V1ObjectMeta().name(UID).namespace(NS).uid(KUBERNETES_UID)))
         .withSpec(
             new DomainSpec()
                 .withWebLogicCredentialsSecret(new V1SecretReference().name(SECRET_NAME).namespace(NS)));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectorCMTestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectorCMTestUtils.java
@@ -29,6 +29,19 @@ public class IntrospectorCMTestUtils {
           .orElseGet(Collections::emptyMap);
   }
 
+  /**
+   * Returns the metadata of the introspector config map for the test domain.
+   * @param testSupport the instance of KubernetesTestSupport holding the data
+   */
+  public static V1ObjectMeta getIntrospectorConfigMapMetadata(KubernetesTestSupport testSupport) {
+    return testSupport.getResources(KubernetesTestSupport.CONFIG_MAP).stream()
+        .map(V1ConfigMap.class::cast)
+        .filter(IntrospectorCMTestUtils::isIntrospectorConfigMap)
+        .map(V1ConfigMap::getMetadata)
+        .findFirst()
+        .orElse(null);
+  }
+
   private static boolean isIntrospectorConfigMap(V1ConfigMap configMap) {
     return getIntrospectorConfigMapName().equals(getConfigMapName(configMap));
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -19,8 +19,10 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServicePort;
+import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.calls.FailureStatusSourceException;
 import oracle.kubernetes.operator.calls.unprocessable.UnprocessableEntityBuilder;
@@ -72,6 +74,7 @@ import static oracle.kubernetes.operator.logging.MessageKeys.MANAGED_SERVICE_REP
 import static oracle.kubernetes.utils.LogMatcher.containsFine;
 import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -199,6 +202,19 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
 
   private DomainConfigurator configureDomain() {
     return DomainConfiguratorFactory.forDomain(domainPresenceInfo.getDomain());
+  }
+
+  @Test
+  public void whenCreated_createWithOwnerReference() {
+    V1OwnerReference expectedReference = new V1OwnerReference()
+        .apiVersion(KubernetesConstants.DOMAIN_GROUP + "/" + KubernetesConstants.DOMAIN_VERSION)
+        .kind(KubernetesConstants.DOMAIN)
+        .name(DOMAIN_NAME)
+        .uid(KUBERNETES_UID)
+        .controller(true);
+
+    V1Service model = testFacade.createServiceModel(testSupport.getPacket());
+    assertThat(model.getMetadata().getOwnerReferences(), contains(expectedReference));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTestBase.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import org.junit.After;
@@ -16,6 +17,7 @@ public class ServiceHelperTestBase {
   static final String DOMAIN_NAME = "domain1";
   static final String NS = "namespace";
   static final String UID = "uid1";
+  static final String KUBERNETES_UID = "12345";
   List<Memento> mementos = new ArrayList<>();
   DomainPresenceInfo domainPresenceInfo = createPresenceInfo();
 
@@ -32,7 +34,9 @@ public class ServiceHelperTestBase {
   private DomainPresenceInfo createPresenceInfo() {
     return new DomainPresenceInfo(
         new Domain()
-            .withMetadata(new V1ObjectMeta().namespace(NS).name(DOMAIN_NAME))
+            .withApiVersion(KubernetesConstants.DOMAIN_GROUP + "/" + KubernetesConstants.DOMAIN_VERSION)
+            .withKind(KubernetesConstants.DOMAIN)
+            .withMetadata(new V1ObjectMeta().namespace(NS).name(DOMAIN_NAME).uid(KUBERNETES_UID))
             .withSpec(createDomainSpec()));
   }
 


### PR DESCRIPTION
Customers noticed that we could not support safely draining a node prior to shutting down that node because `kubectl drain <node-name>` would return an error indicating that some of the pods were not governed by controllers. 

I reviewed the Kubernetes doc. on draining nodes and looked at the Kubernetes code. It turns out that we needed to mark the metadata of our resources with an owner reference so that `kubectl drain` knows it can safely delete pods on the target node because a controller will recreate and reschedule pods on an available node.

With this change, Kubernetes will delete our pods on a node that is being drained and the operator will respond by creating new pods that will then be scheduled on available nodes. 

Again, after reviewing the Kubernetes doc on ownership, it made sense to mark all of the resources created for a specific domain resource with an owner reference, so I've marked the introspector job, introspector config map, and the services as well.