### PR TITLE
Changes to fix retry logic and recover gracefully from lack of RBAC for CRD

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -381,12 +381,6 @@
       <artifactId>simplestub</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>io.kubernetes</groupId>
-          <artifactId>client-java-examples</artifactId>
-          <version>8.0.2-SNAPSHOT</version>
-          <scope>test</scope>
-      </dependency>
   </dependencies>
 
   <properties>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -381,6 +381,12 @@
       <artifactId>simplestub</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>io.kubernetes</groupId>
+          <artifactId>client-java-examples</artifactId>
+          <version>8.0.2-SNAPSHOT</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <properties>

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
@@ -377,21 +377,16 @@ public class AsyncRequestStep<T> extends Step implements RetryStrategyListener {
         }
 
         NextAction na = new NextAction();
-        if (retryCount <= maxRetryCount) {
-          if (statusCode == 0) {
-            na.invoke(retryStep, packet);
-          } else {
-            LOGGER.finer(MessageKeys.ASYNC_RETRY, identityHash(), String.valueOf(waitTime));
-            na.delay(retryStep, packet, waitTime, TimeUnit.MILLISECONDS);
-          }
-          return na;
+        if (!retriesLeft()) {
+          return null;
+        } else if (statusCode == 0) {
+          na.invoke(retryStep, packet);
+        } else {
+          LOGGER.finer(MessageKeys.ASYNC_RETRY, identityHash(), String.valueOf(waitTime));
+          na.delay(retryStep, packet, waitTime, TimeUnit.MILLISECONDS);
         }
-      } else if (statusCode == 409 /* Conflict */
-          && conflictStep != null
-          && retryCount <= maxRetryCount) {
-        // Conflict is an optimistic locking failure.  Therefore, we can't
-        // simply retry the request.  Instead, application code needs to rebuild
-        // the request based on latest contents.  If provided, a conflict step will do that.
+        return na;
+      } else if (retriesLeft() && isRestartableConflict(conflictStep, statusCode)) {
 
         // exponential back-off
         long waitTime = Math.min((2 << ++retryCount) * SCALE, MAX) + (R.nextInt(HIGH - LOW) + LOW);
@@ -404,6 +399,17 @@ public class AsyncRequestStep<T> extends Step implements RetryStrategyListener {
 
       // otherwise, we will not retry
       return null;
+    }
+
+    // Conflict is an optimistic locking failure.  Therefore, we can't
+    // simply retry the request.  Instead, application code needs to rebuild
+    // the request based on latest contents.  If provided, a conflict step will do that.
+    private boolean isRestartableConflict(Step conflictStep, int statusCode) {
+      return statusCode == 409 /* Conflict */ && conflictStep != null;
+    }
+
+    private boolean retriesLeft() {
+      return retryCount <= maxRetryCount;
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
@@ -386,7 +386,7 @@ public class AsyncRequestStep<T> extends Step implements RetryStrategyListener {
           na.delay(retryStep, packet, waitTime, TimeUnit.MILLISECONDS);
         }
         return na;
-      } else if (retriesLeft() && isRestartableConflict(conflictStep, statusCode)) {
+      } else if (isRestartableConflict(conflictStep, statusCode)) {
 
         // exponential back-off
         long waitTime = Math.min((2 << ++retryCount) * SCALE, MAX) + (R.nextInt(HIGH - LOW) + LOW);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -151,8 +151,11 @@ public abstract class ResponseStep<T> extends Step {
    * @return Next action for fiber processing, which may be a retry
    */
   public NextAction onFailure(Step conflictStep, Packet packet, CallResponse<T> callResponse) {
-    return Optional.ofNullable(doPotentialRetry(conflictStep, packet, callResponse))
-        .orElse(onFailureNoRetry(packet, callResponse));
+    Optional<NextAction> optionalNextAction =
+        Optional.ofNullable(doPotentialRetry(conflictStep, packet, callResponse));
+    return optionalNextAction
+        .filter(na -> optionalNextAction.isPresent())
+        .orElseGet(() -> onFailureNoRetry(packet, callResponse));
   }
 
   protected NextAction onFailureNoRetry(Packet packet, CallResponse<T> callResponse) {

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -128,6 +128,8 @@ public class MessageKeys {
   public static final String HTTP_REQUEST_TIMED_OUT = "WLSKO-0170";
   public static final String NAMESPACE_IS_MISSING = "WLSKO-0171";
   public static final String CM_PATCHED = "WLSKO-0172";
+  public static final String REPLACE_CRD_FAILED = "WLSKO-0173";
+  public static final String CREATE_CRD_FAILED = "WLSKO-0174";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -181,6 +181,8 @@ WLSKO-0168={0}: {1}
 WLSKO-0169=Job {0} is created at {1}
 WLSKO-0170=HTTP timeout: exception {0}.
 WLSKO-0171=Namespace {0} is in operator's target namespaces list but doesn't exist
+WLSKO-0173=Replace custom resource definition failed: {0}
+WLSKO-0174=Create custom resource definition failed: {0}
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
@@ -19,6 +19,7 @@ import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -40,10 +41,22 @@ public class AsyncRequestStepTest {
   private RequestParams requestParams = new RequestParams("testcall", "junit", "testName", "body");
   private CallFactoryStub callFactory = new CallFactoryStub();
   private TestStep nextStep = new TestStep();
+  private TestStep conflictStep = new TestStep(new ConflictStep());
   private ClientPool helper = ClientPool.getInstance();
   private final AsyncRequestStep<Integer> asyncRequestStep =
       new AsyncRequestStep<>(
           nextStep,
+          requestParams,
+          callFactory,
+          helper,
+          TIMEOUT_SECONDS,
+          MAX_RETRY_COUNT,
+          null,
+          null,
+          null);
+  private final AsyncRequestStep<Integer> asyncRequestStepWithConflict =
+      new AsyncRequestStep<>(
+          conflictStep,
           requestParams,
           callFactory,
           helper,
@@ -156,6 +169,39 @@ public class AsyncRequestStepTest {
     assertThat(nextStep.result, equalTo(null));
   }
 
+  @Test
+  public void handleTimeoutRetriesLeft_nextStepAppliedWithValue() {
+    testSupport.schedule(
+            () -> callFactory.sendFailedCallback(new ApiException("test failure"), 504));
+    testSupport.setTime(10, TimeUnit.SECONDS);
+    testSupport.schedule(() -> callFactory.sendSuccessfulCallback(17));
+    assertThat(nextStep.result, equalTo(17));
+  }
+
+  @Test
+  public void conflictStatus_verifyCompletionThrowable() {
+    testSupport.runSteps(asyncRequestStepWithConflict);
+    testSupport.schedule(
+        () -> callFactory.sendFailedCallback(new ApiException("test failure"), 409));
+    testSupport.setTime(100, TimeUnit.SECONDS);
+    testSupport.schedule(
+        () -> callFactory.sendFailedCallback(new ApiException("test failure"), 409));
+    testSupport.setTime(200, TimeUnit.SECONDS);
+    testSupport.schedule(() -> callFactory.sendSuccessfulCallback(17));
+    testSupport.verifyCompletionThrowable(FailureStatusSourceException.class);
+    assertThat(nextStep.result, equalTo(null));
+  }
+
+  @Test
+  public void conflictStatus_retryConflictStep() {
+    testSupport.runSteps(asyncRequestStepWithConflict);
+    testSupport.schedule(
+        () -> callFactory.sendFailedCallback(new ApiException("test failure"), 409));
+    testSupport.setTime(100, TimeUnit.SECONDS);
+    testSupport.schedule(() -> callFactory.sendSuccessfulCallback(17));
+    assertThat(nextStep.result, equalTo(17));
+  }
+
   // todo tests
   // can new request clear timeout action?
   // what is accessContinue?
@@ -167,6 +213,24 @@ public class AsyncRequestStepTest {
     private Integer result;
 
     TestStep() {
+      super(null);
+    }
+
+    TestStep(Step next) {
+      super(next);
+    }
+
+    @Override
+    public NextAction onSuccess(Packet packet, CallResponse<Integer> callResponse) {
+      result = callResponse.getResult();
+      return doNext(packet);
+    }
+  }
+
+  static class ConflictStep extends ResponseStep<Integer> {
+    private Integer result;
+
+    ConflictStep() {
       super(null);
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
@@ -171,7 +171,7 @@ public class AsyncRequestStepTest {
   }
 
   @Test
-  public void afterMultipleTimeoutsAndSuccessfulCallback_fiberTerminatesWithException() {
+  public void afterMultipleTimeoutsAndRetriesExhausted_fiberTerminatesWithException() {
     sendMultipleFailedCallbackWithSetTime(504, 3);
 
     testSupport.verifyCompletionThrowable(FailureStatusSourceException.class);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -259,12 +259,38 @@ public class CrdHelperTest {
   }
 
   @Test
+  public void whenReplaceFailsThrowsStreamException_scheduleRetryAndLogFailedMessageInOnFailureNoRetry() {
+    testSupport.addRetryStrategy(retryStrategy);
+    testSupport.defineResources(defineCrd("v1", OPERATOR_V1));
+    testSupport.failOnReplaceWithStreamResetException(CUSTOM_RESOURCE_DEFINITION, KubernetesConstants.CRD_NAME, null);
+
+    Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_16, null);
+    testSupport.runSteps(scriptCrdStep);
+
+    assertThat(logRecords, containsInfo(REPLACE_CRD_FAILED));
+    assertThat(retryStrategy.getConflictStep(), sameInstance(scriptCrdStep));
+  }
+
+  @Test
   public void whenBetaCrdReplaceFails_scheduleRetryAndLogFailedMessageInOnFailureNoRetry() {
     testSupport.addRetryStrategy(retryStrategy);
     testSupport.defineResources(defineBetaCrd("v1", OPERATOR_V1));
-    testSupport.failOnReplace(CUSTOM_RESOURCE_DEFINITION, KubernetesConstants.CRD_NAME, null, 401);
+    testSupport.failOnReplace(BETA_CRD, KubernetesConstants.CRD_NAME, null, 401);
 
-    Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_16, null);
+    Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_15, null);
+    testSupport.runSteps(scriptCrdStep);
+
+    assertThat(logRecords, containsInfo(REPLACE_CRD_FAILED));
+    assertThat(retryStrategy.getConflictStep(), sameInstance(scriptCrdStep));
+  }
+
+  @Test
+  public void whenBetaCrdReplaceThrowsStreamResetException_scheduleRetryAndLogFailedMessageInOnFailureNoRetry() {
+    testSupport.addRetryStrategy(retryStrategy);
+    testSupport.defineResources(defineBetaCrd("v1", OPERATOR_V1));
+    testSupport.failOnReplaceWithStreamResetException(BETA_CRD, KubernetesConstants.CRD_NAME, null);
+
+    Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_15, null);
     testSupport.runSteps(scriptCrdStep);
 
     assertThat(logRecords, containsInfo(REPLACE_CRD_FAILED));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -41,10 +41,11 @@ import static com.meterware.simplestub.Stub.createStrictStub;
 import static oracle.kubernetes.operator.VersionConstants.OPERATOR_V1;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.BETA_CRD;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.CUSTOM_RESOURCE_DEFINITION;
+import static oracle.kubernetes.operator.logging.MessageKeys.CREATE_CRD_FAILED;
 import static oracle.kubernetes.operator.logging.MessageKeys.CREATING_CRD;
+import static oracle.kubernetes.operator.logging.MessageKeys.REPLACE_CRD_FAILED;
 import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class CrdHelperTest {
@@ -120,7 +121,7 @@ public class CrdHelperTest {
   public void setUp() throws Exception {
     mementos.add(
         TestUtils.silenceOperatorLogger()
-            .collectLogMessages(logRecords, CREATING_CRD)
+            .collectLogMessages(logRecords, CREATING_CRD, REPLACE_CRD_FAILED, CREATE_CRD_FAILED)
             .withLogLevel(Level.FINE));
     mementos.add(testSupport.install());
     mementos.add(StaticStubSupport.install(FileGroupReader.class, "uriToPath", pathFunction));
@@ -179,9 +180,7 @@ public class CrdHelperTest {
 
     Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_15, null);
     testSupport.runSteps(scriptCrdStep);
-
-    testSupport.verifyCompletionThrowable(FailureStatusSourceException.class);
-    assertThat(retryStrategy.getConflictStep(), sameInstance(scriptCrdStep));
+    assertThat(logRecords, containsInfo(CREATE_CRD_FAILED));
   }
 
   @Test
@@ -242,8 +241,7 @@ public class CrdHelperTest {
     Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_16, null);
     testSupport.runSteps(scriptCrdStep);
 
-    testSupport.verifyCompletionThrowable(FailureStatusSourceException.class);
-    assertThat(retryStrategy.getConflictStep(), sameInstance(scriptCrdStep));
+    assertThat(logRecords, containsInfo(REPLACE_CRD_FAILED));
   }
 
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -46,6 +46,7 @@ import static oracle.kubernetes.operator.logging.MessageKeys.CREATING_CRD;
 import static oracle.kubernetes.operator.logging.MessageKeys.REPLACE_CRD_FAILED;
 import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class CrdHelperTest {
@@ -174,13 +175,14 @@ public class CrdHelperTest {
   }
 
   @Test
-  public void whenNoCrd_retryOnFailure() {
+  public void whenNoCrd_retryOnFailureAndLogFailedMessageInOnFailureNoRetry() {
     testSupport.addRetryStrategy(retryStrategy);
     testSupport.failOnCreate(BETA_CRD, KubernetesConstants.CRD_NAME, null, 401);
 
     Step scriptCrdStep = CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_15, null);
     testSupport.runSteps(scriptCrdStep);
     assertThat(logRecords, containsInfo(CREATE_CRD_FAILED));
+    assertThat(retryStrategy.getConflictStep(), sameInstance(scriptCrdStep));
   }
 
   @Test
@@ -233,7 +235,7 @@ public class CrdHelperTest {
   }
 
   @Test
-  public void whenReplaceFails_scheduleRetry() {
+  public void whenReplaceFails_scheduleRetryAndLogFailedMessageInOnFailureNoRetry() {
     testSupport.addRetryStrategy(retryStrategy);
     testSupport.defineResources(defineCrd("v1", OPERATOR_V1));
     testSupport.failOnReplace(CUSTOM_RESOURCE_DEFINITION, KubernetesConstants.CRD_NAME, null, 401);
@@ -242,6 +244,7 @@ public class CrdHelperTest {
     testSupport.runSteps(scriptCrdStep);
 
     assertThat(logRecords, containsInfo(REPLACE_CRD_FAILED));
+    assertThat(retryStrategy.getConflictStep(), sameInstance(scriptCrdStep));
   }
 
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -66,6 +66,8 @@ import io.kubernetes.client.openapi.models.V1SubjectAccessReview;
 import io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatus;
 import io.kubernetes.client.openapi.models.V1TokenReview;
 import io.kubernetes.client.openapi.models.V1beta1CustomResourceDefinition;
+import okhttp3.internal.http2.ErrorCode;
+import okhttp3.internal.http2.StreamResetException;
 import oracle.kubernetes.operator.calls.CallFactory;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.calls.RequestParams;
@@ -313,6 +315,20 @@ public class KubernetesTestSupport extends FiberTestSupport {
   }
 
   /**
+   * Specifies that a replace operation should fail if it matches the specified conditions. Applies to
+   * namespaced resources.
+   *
+   * @param resourceType the type of resource
+   * @param name the name of the resource
+   * @param namespace the namespace containing the resource
+   */
+  public void failOnReplaceWithStreamResetException(String resourceType, String name, String namespace) {
+    ApiException ae = new ApiException("StreamResetException: stream was reset: NO_ERROR",
+            new StreamResetException(ErrorCode.NO_ERROR), 0, null, null);
+    failure = new Failure(Operation.replace, resourceType, name, namespace, ae);
+  }
+
+  /**
    * Specifies that a delete operation should fail if it matches the specified conditions. Applies to
    * namespaced resources.
    *
@@ -446,6 +462,11 @@ public class KubernetesTestSupport extends FiberTestSupport {
 
     Failure(Operation operation, String resourceType, String name, String namespace, int httpStatus) {
       this(resourceType, name, namespace, httpStatus);
+      this.operation = operation;
+    }
+
+    Failure(Operation operation, String resourceType, String name, String namespace, ApiException apiException) {
+      this(resourceType, name, namespace, apiException);
       this.operation = operation;
     }
 


### PR DESCRIPTION
Fixed retry logic in AsyncRequestStep (OWLS-82761) and changed CrdHelper so operator can recover gracefully from lack of RBAC for CRD.