### PR TITLE
Istio fix

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -304,6 +304,7 @@ public class JobHelper {
       addEnvVar(vars, IntrospectorJobEnvVars.DOMAIN_SOURCE_TYPE, getDomainHomeSourceType().toString());
       addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_ENABLED, Boolean.toString(isIstioEnabled()));
       addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_READINESS_PORT, Integer.toString(getIstioReadinessPort()));
+      addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_POD_NAMESPACE, getNamespace());
 
       String dataHome = getDataHome();
       if (dataHome != null && !dataHome.isEmpty()) {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/IntrospectorJobEnvVars.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/IntrospectorJobEnvVars.java
@@ -68,6 +68,11 @@ public class IntrospectorJobEnvVars {
   public static final String ISTIO_READINESS_PORT = "ISTIO_READINESS_PORT";
 
   /**
+   * Istio pod namespace.
+   */
+  public static final String ISTIO_POD_NAMESPACE = "ISTIO_POD_NAMESPACE";
+
+  /**
    * Returns true if the specified environment variable name is reserved by the operator for communication with
    * the introspection job.
    * @param name an environment variable name

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1121,14 +1121,12 @@ class SitConfigGenerator(Generator):
     istio_enabled = self.env.getEnvOrDef("ISTIO_ENABLED", "false")
 
     nap_name=nap.getName()
-    if not (nap.getListenAddress() is None) and len(nap.getListenAddress()) > 0 and not (nap_name.startswith('istio-')):
+    if not (nap.getListenAddress() is None) and len(nap.getListenAddress()) > 0:
         self.writeln("<d:network-access-point>")
         self.indent()
         self.writeln("<d:name>" + nap_name + "</d:name>")
         if istio_enabled == 'true':
           self.writeListenAddress("force a replace", '127.0.0.1')
-          replace_action = 'f:combine-mode="replace"'
-          self.writeln('<d:public-address %s>%s</d:public-address>' % (replace_action, listen_address))
         else:
           self.writeListenAddress("force a replace",listen_address)
 

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1167,7 +1167,8 @@ class SitConfigGenerator(Generator):
 
     self.writeln('<d:protocol %s>%s</d:protocol>' % (action, protocol))
     self.writeln('<d:listen-address %s>127.0.0.1</d:listen-address>' % action)
-    self.writeln('<d:public-address %s>%s</d:public-address>' % (action, listen_address))
+    self.writeln('<d:public-address %s>%s.%s</d:public-address>' % (action, listen_address,
+                                                          self.env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default")))
     self.writeln('<d:listen-port %s>%s</d:listen-port>' % (action, listen_port))
     self.writeln('<d:http-enabled-for-this-protocol %s>%s</d:http-enabled-for-this-protocol>' %
                  (action, http_enabled))

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -452,6 +452,21 @@ public class DomainValidationTest {
     assertThat(domain.getValidationFailures(resourceLookup), empty());
   }
 
+  @Test
+  public void whenExposingDefaultChannelIfIstio_Enabled() {
+    configureDomain(domain)
+        .withDomainHomeSourceType(Image)
+        .withIstio()
+        .withDomainType("WLS")
+        .configureAdminServer()
+        .configureAdminService()
+        .withChannel("default");
+
+    assertThat(domain.getValidationFailures(resourceLookup),  contains(stringContainsInOrder(
+        "Istio is enabled and the domain resource specified to expose channel",
+        "default")));
+  }
+
   private DomainConfigurator configureDomain(Domain domain) {
     return new DomainCommonConfigurator(domain);
   }


### PR DESCRIPTION
This changes how we generate the public-address of the generated channels.  Previously we use the short form domain-server;  now we append it with the domain-server-ns.   This helps domain communications between namespaces using the default generated channels
