### PR TITLE
Fix build application utility

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -159,8 +159,7 @@ public class ItIntrospectVersion implements LoggedTest {
           .and().with().pollInterval(10, SECONDS)
           .atMost(5, MINUTES).await();
 
-  private static Path clusterViewAppPath = Paths.get(PV_ROOT,
-      "applications", "clusterview", "dist", "clusterview.war");
+  private static Path clusterViewAppPath;
 
   /**
    * Assigns unique namespaces for operator and domains.
@@ -186,7 +185,9 @@ public class ItIntrospectVersion implements LoggedTest {
     // build the clusterview application
     Path distDir = BuildApplication.buildApplication(Paths.get(APP_DIR, "clusterview"), null, null,
         "dist", introDomainNamespace);
-    assertTrue(Paths.get(distDir.toString(), "u01/application/dist/clusterview.war").toFile().exists());
+    assertTrue(Paths.get(distDir.toString(),
+        "u01/application/dist/clusterview.war").toFile().exists(),
+        "Application archive is not available");
     clusterViewAppPath = Paths.get(distDir.toString(), "u01/application/dist/clusterview.war");
 
     // install operator and verify its running in ready state

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -186,9 +186,9 @@ public class ItIntrospectVersion implements LoggedTest {
     Path distDir = BuildApplication.buildApplication(Paths.get(APP_DIR, "clusterview"), null, null,
         "dist", introDomainNamespace);
     assertTrue(Paths.get(distDir.toString(),
-        "u01/application/dist/clusterview.war").toFile().exists(),
+        "dist/clusterview.war").toFile().exists(),
         "Application archive is not available");
-    clusterViewAppPath = Paths.get(distDir.toString(), "u01/application/dist/clusterview.war");
+    clusterViewAppPath = Paths.get(distDir.toString(), "dist/clusterview.war");
 
     // install operator and verify its running in ready state
     installAndVerifyOperator(opNamespace, introDomainNamespace);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -159,7 +159,7 @@ public class ItIntrospectVersion implements LoggedTest {
           .and().with().pollInterval(10, SECONDS)
           .atMost(5, MINUTES).await();
 
-  private static final Path CLUSTERVIEW_APP_PATH = Paths.get(PV_ROOT,
+  private static Path clusterViewAppPath = Paths.get(PV_ROOT,
       "applications", "clusterview", "dist", "clusterview.war");
 
   /**
@@ -182,8 +182,12 @@ public class ItIntrospectVersion implements LoggedTest {
     assertNotNull(namespaces.get(2), "Namespace is null");
     nginxNamespace = namespaces.get(2);
 
+
     // build the clusterview application
-    BuildApplication.buildApplication(Paths.get(APP_DIR, "clusterview"), null, null, introDomainNamespace);
+    Path distDir = BuildApplication.buildApplication(Paths.get(APP_DIR, "clusterview"), null, null,
+        "dist", introDomainNamespace);
+    assertTrue(Paths.get(distDir.toString(), "u01/application/dist/clusterview.war").toFile().exists());
+    clusterViewAppPath = Paths.get(distDir.toString(), "u01/application/dist/clusterview.war");
 
     // install operator and verify its running in ready state
     installAndVerifyOperator(opNamespace, introDomainNamespace);
@@ -478,9 +482,9 @@ public class ItIntrospectVersion implements LoggedTest {
 
     //deploy clusterview application
     logger.info("Deploying clusterview app {0} to cluster {1}",
-        CLUSTERVIEW_APP_PATH, clusterName);
+        clusterViewAppPath, clusterName);
     deployUsingWlst(K8S_NODEPORT_HOST, Integer.toString(t3channelNodePort),
-        ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, clusterName, CLUSTERVIEW_APP_PATH,
+        ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, clusterName, clusterViewAppPath,
         introDomainNamespace);
 
     //access application in managed servers through NGINX load balancer

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/BuildApplication.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/BuildApplication.java
@@ -3,41 +3,24 @@
 
 package oracle.weblogic.kubernetes.utils;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
-import io.kubernetes.client.openapi.models.V1Job;
-import io.kubernetes.client.openapi.models.V1JobCondition;
-import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1PersistentVolume;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimSpec;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeSpec;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
-import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
-import io.kubernetes.client.openapi.models.V1SecurityContext;
-import io.kubernetes.client.openapi.models.V1Volume;
-import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.kubernetes.TestConstants;
-import oracle.weblogic.kubernetes.actions.impl.Namespace;
+import oracle.weblogic.kubernetes.actions.impl.Exec;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import org.awaitility.core.ConditionFactory;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -48,25 +31,18 @@ import static oracle.weblogic.kubernetes.TestConstants.OCR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_USERNAME;
-import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_TAG;
-import static oracle.weblogic.kubernetes.actions.TestActions.createNamespacedJob;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolume;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolumeClaim;
-import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
-import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listSecrets;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.jobCompleted;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.extensions.LoggedTest.logger;
 import static org.apache.commons.io.FileUtils.copyDirectory;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Utility class to build application.
@@ -75,233 +51,173 @@ public class BuildApplication {
 
   private static String image;
   private static boolean isUseSecret;
-  private static final String APPLICATIONS_MOUNT_PATH = "/application";
-  private static final String SCRIPTS_MOUNT_PATH = "/buildScripts";
+  private static final String APPLICATIONS_PATH = "/u01/application";
   private static final String BUILD_SCRIPT = "build_application.sh";
   private static final Path BUILD_SCRIPT_SOURCE_PATH = Paths.get(RESOURCE_DIR, "bash-scripts", BUILD_SCRIPT);
-
-  private static final ConditionFactory withStandardRetryPolicy
-      = with().pollDelay(2, SECONDS)
-          .and().with().pollInterval(10, SECONDS)
-          .atMost(5, MINUTES).await();
 
   /**
    * Build application.
    *
-   * @param application path of the application source folder
-   * @param parameters system properties for ant
-   * @param targets ant targets to call
-   * @param namespace name of the namespace to use for pvc
+   * <p>The appSrcPath, your application source directory is zipped up and copied to a WebLogic server pod for building.
+   * The application is built under /u01/application inside the pod. If your archives are placed under
+   * /u01/application/build after building, use <b>build</b> as the archiveDistDir param value. This method copies the
+   * folder /u01/application/<b>archiveDistDir</b> to local file system under
+   * WORK_DIR/<b>your_application_name</b>/u01/application/<b>archiveDistDir</b>
+   * <p> Example Usage: </p>
+
+   * <pre>{@literal
+   *     HashMap <String,String> antParams = new HashMap<>();
+   *     antParams.put("key","value");
+   *
+   *     Path archivesDir = BuildApplication.buildApplication(
+   *         "/scratch/speriyat/weblogic-kubernetes-operator/new-integration-tests/src/test/resources/apps/clusterview",
+   *         antParams,
+   *         "clean build all" // these targets must be supported by your build file
+   *         "dist" // whatever the directory your build system creates
+   *         "ns-abcd" // your domain or operator namespace, so that the pods are cleaned up after test is done
+   *     );
+   *     }
+   * The returned archivesDir location will be -
+   * WORK_DIR/<b>your_application_name</b>/u01/application/<b>archiveDistDir</b>
+   * All your built archives will be under the above directory
+   * Example: /tmp/it-results/clusterview/u01/application/dist/clusterview.war
+   * </pre>
+   * </p>
+   *
+   * @param appSrcPath path of the application source folder
+   * @param antParams ant parameters
+   * @param antTargets ant targets to call
+   * @param archiveDistDir location of the archive built inside source directory
+   * @param namespace name of the namespace to create the pod in
+   * @return Path path of the archive built
    */
-  public static void buildApplication(Path application, Map<String, String> parameters,
-      String targets, String namespace) {
+  public static Path buildApplication(Path appSrcPath, Map<String, String> antParams,
+      String antTargets, String archiveDistDir, String namespace) {
 
     setImage(namespace);
 
-    // Copy the application source directory to PV_ROOT/applications/<application_directory_name>
-    // This location is mounted in the build pod under /application
-    Path targetPath = Paths.get(PV_ROOT, "applications", application.getFileName().toString());
-    logger.info("Copy the application {0} to PV hostpath {1}", application, targetPath);
+    // Path of temp location for application source directory
+    Path tempAppPath = Paths.get(WORK_DIR, "j2eeapplications", appSrcPath.getFileName().toString());
+    // directory to copy archives built
+    Path destArchiveDir = Paths.get(WORK_DIR, appSrcPath.getFileName().toString());
+
     assertDoesNotThrow(() -> {
-      Files.createDirectories(targetPath);
-      deleteDirectory(targetPath.toFile());
-      Files.createDirectories(targetPath);
-      copyDirectory(application.toFile(), targetPath.toFile());
-      Files.copy(BUILD_SCRIPT_SOURCE_PATH, targetPath.resolve(BUILD_SCRIPT_SOURCE_PATH.getFileName()));
+      // recreate WORK_DIR/j2eeapplications/<application_directory_name>
+      logger.info("Deleting and recreating {0}", tempAppPath);
+
+      Files.createDirectories(tempAppPath);
+      deleteDirectory(tempAppPath.toFile());
+      Files.createDirectories(tempAppPath);
+
+      // copy the application source to WORK_DIR/j2eeapplications/<application_directory_name>
+      logger.info("Copying {0} to {1}", appSrcPath, tempAppPath);
+      copyDirectory(appSrcPath.toFile(), tempAppPath.toFile());
     });
 
-    // create the persistent volume to make the application archive accessible to pod
-    String uniqueName = Namespace.uniqueName();
-    String pvName = namespace + "-build-pv-" + uniqueName;
-    String pvcName = namespace + "-build-pvc-" + uniqueName;
+    // zip up the application source to be copied to pod for building
+    Path zipFile = Paths.get(FileUtils.createZipFile(tempAppPath));
 
-    assertDoesNotThrow(() -> createPV(targetPath, pvName), "Failed to create PV");
-    createPVC(pvName, pvcName, namespace);
 
-    // build application
-    build(parameters, targets, pvName, pvcName, namespace);
+    assertDoesNotThrow(() -> {
+      // add ant properties to env
+      V1Container buildContainer = new V1Container();
+
+      // set ZIP_FILE location in env variable
+      buildContainer.addEnvItem(new V1EnvVar()
+          .name("ZIP_FILE")
+          .value(zipFile.getFileName().toString()));
+
+      // set ant parameteres in env variable sysprops
+      if (antParams != null) {
+        StringBuilder params = new StringBuilder();
+        antParams.entrySet().forEach((parameter) -> {
+          params.append("-D").append(parameter.getKey()).append("=").append(parameter.getValue()).append(" ");
+        });
+        buildContainer = buildContainer
+            .addEnvItem(new V1EnvVar().name("sysprops").value(params.toString()));
+      }
+
+      // set add targets in env variable targets
+      if (antTargets != null) {
+        buildContainer = buildContainer
+            .addEnvItem(new V1EnvVar().name("targets").value(antTargets));
+      }
+
+      //setup temporary WebLogic to build application
+      V1Pod webLogicPod = setupWebLogicPod(namespace, buildContainer);
+
+      //copy the zip file to /u01 location inside pod
+      Kubernetes.copyFileToPod(namespace, webLogicPod.getMetadata().getName(),
+          null, zipFile, Paths.get("/u01", zipFile.getFileName().toString()));
+      //copy the build script to /u01 location inside pod
+      Kubernetes.copyFileToPod(namespace, webLogicPod.getMetadata().getName(),
+          null, BUILD_SCRIPT_SOURCE_PATH, Paths.get("/u01", BUILD_SCRIPT));
+
+      //Kubernetes.exec(webLogicPod, new String[]{"/bin/sh", "/u01/" + BUILD_SCRIPT});
+      ExecResult exec = Exec.exec(webLogicPod, null, false, "/bin/sh", "/u01/" + BUILD_SCRIPT);
+      assertEquals(0, exec.exitValue());
+      if (exec.stdout() != null) {
+        logger.info(exec.stdout());
+      }
+      if (exec.stderr() != null) {
+        logger.info(exec.stderr());
+      }
+
+      Files.createDirectories(destArchiveDir);
+      deleteDirectory(destArchiveDir.toFile());
+      Files.createDirectories(destArchiveDir);
+
+      Kubernetes.copyDirectoryFromPod(webLogicPod,
+          Paths.get(APPLICATIONS_PATH, archiveDistDir).toString(), destArchiveDir);
+    });
+
+    return destArchiveDir;
   }
 
-  /**
-   * Build application using a WebLogic image pod.
-   *
-   * @param parameters system properties for ant
-   * @param targets ant targets to call
-   * @param pvName name of the persistent volume to create domain in
-   * @param pvcName name of the persistent volume claim
-   * @param namespace name of the domain namespace in which the job is created
-   */
-  private static void build(Map<String, String> parameters, String targets,
-      String pvName, String pvcName, String namespace) {
-    logger.info("Preparing to run build job");
 
-    V1Container jobCreationContainer = new V1Container()
-        .addCommandItem("/bin/sh")
-        .addArgsItem(APPLICATIONS_MOUNT_PATH + "/" + BUILD_SCRIPT);
-
-    // add ant properties to env
-    if (parameters != null) {
-      StringBuilder params = new StringBuilder();
-      parameters.entrySet().forEach((parameter) -> {
-        params.append("-D").append(parameter.getKey()).append("=").append(parameter.getValue()).append(" ");
-      });
-      jobCreationContainer = jobCreationContainer
-          .addEnvItem(new V1EnvVar().name("sysprops").value(params.toString()));
-    }
-
-    // add targets in env
-    if (targets != null) {
-      jobCreationContainer = jobCreationContainer
-          .addEnvItem(new V1EnvVar().name("targets").value(targets));
-    }
-
-    logger.info("Running a Kubernetes job to build application");
-    try {
-      createBuildJob(pvName, pvcName, namespace, jobCreationContainer);
-    } catch (ApiException ex) {
-      logger.severe("Building application failed");
-      fail("Halting test since build failed");
-    }
-
-  }
 
   /**
-   * Create a job to build application inside a WebLogic pod.
+   * Create a temporary WebLogic pod to build j2ee applications.
    *
-   * @param pvName name of the persistent volume containing application source
-   * @param pvcName name of the persistent volume claim
-   * @param buildScriptConfigMapName configmap holding build script files
-   * @param namespace name of the domain namespace in which the job is created
-   * @param jobContainer V1Container with job commands to build application
-   * @throws ApiException when Kubernetes cluster query fails
+   * @param namespace name of the namespace in which to create the temporary pod
+   * @return V1Pod created pod object
+   * @throws ApiException when create pod fails
    */
-  private static void createBuildJob(String pvName,
-      String pvcName, String namespace, V1Container jobContainer)
-      throws ApiException {
-    logger.info("Running Kubernetes job to build application");
-    String uniqueName = Namespace.uniqueName();
-    String name = namespace + "-build-job-" + uniqueName;
+  private static V1Pod setupWebLogicPod(String namespace, V1Container container) throws ApiException {
 
-    V1Job jobBody = new V1Job()
-        .metadata(
-            new V1ObjectMeta()
-                .name(name)
-                .namespace(namespace))
-        .spec(new V1JobSpec()
-            .backoffLimit(0) // try only once
-            .template(new V1PodTemplateSpec()
-                .spec(new V1PodSpec()
-                    .initContainers(Arrays.asList(new V1Container()
-                        .name("fix-pvc-owner") // change the ownership of the pv to opc:opc
-                        .image(image)
-                        .addCommandItem("/bin/sh")
-                        .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 " + APPLICATIONS_MOUNT_PATH)
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name(pvName)
-                                .mountPath(APPLICATIONS_MOUNT_PATH)))
-                        .securityContext(new V1SecurityContext()
-                            .runAsGroup(0L)
-                            .runAsUser(0L))))
-                    .restartPolicy("Never")
-                    .containers(Arrays.asList(jobContainer
-                        .name("build-application-container")
-                        .image(image)
-                        .imagePullPolicy("IfNotPresent")
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name(pvName)
-                                .mountPath(APPLICATIONS_MOUNT_PATH))))) // application source directory
-                    .volumes(Arrays.asList(new V1Volume()
-                        .name(pvName)
-                        .persistentVolumeClaim(
-                            new V1PersistentVolumeClaimVolumeSource()
-                                .claimName(pvcName))))
-                    .imagePullSecrets(isUseSecret ? Arrays.asList(
-                        new V1LocalObjectReference()
-                            .name(OCR_SECRET_NAME))
-                        : null))));
-    String jobName = assertDoesNotThrow(()
-        -> createNamespacedJob(jobBody), "Failed to create Job");
+    ConditionFactory withStandardRetryPolicy = with().pollDelay(10, SECONDS)
+        .and().with().pollInterval(2, SECONDS)
+        .atMost(3, MINUTES).await();
 
-    logger.info("Checking if the build job {0} completed in namespace {1}",
-        jobName, namespace);
+    final String podName = "weblogic-build-pod-" + namespace;
+    V1Pod podBody = new V1Pod()
+        .spec(new V1PodSpec()
+            .containers(Arrays.asList(container
+                .name("weblogic-container")
+                .image(image)
+                .imagePullPolicy("IfNotPresent")
+                .addCommandItem("sleep")
+                .addArgsItem("600")))
+            .imagePullSecrets(isUseSecret
+                ? Arrays.asList(new V1LocalObjectReference()
+                    .name(OCR_SECRET_NAME))
+                : null)) // the persistent volume claim used by the test
+        .metadata(new V1ObjectMeta().name(podName))
+        .apiVersion("v1")
+        .kind("Pod");
+    V1Pod wlsPod = Kubernetes.createPod(namespace, podBody);
+
     withStandardRetryPolicy
         .conditionEvaluationListener(
-            condition -> logger.info("Waiting for job {0} to be completed in namespace {1} "
-                + "(elapsed time {2} ms, remaining time {3} ms)",
-                jobName,
+            condition -> logger.info("Waiting for {0} to be ready in namespace {1}, "
+                + "(elapsed time {2} , remaining time {3}",
+                podName,
                 namespace,
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
-        .until(jobCompleted(jobName, null, namespace));
+        .until(podReady(podName, null, namespace));
 
-    // check job status and fail test if the job failed to finish building
-    V1Job job = getJob(jobName, namespace);
-    if (job != null) {
-      V1JobCondition jobCondition = job.getStatus().getConditions().stream().filter(
-          v1JobCondition -> "Failed".equalsIgnoreCase(v1JobCondition.getType()))
-          .findAny()
-          .orElse(null);
-      if (jobCondition != null) {
-        logger.severe("Job {0} failed to finish build", jobName);
-        List<V1Pod> pods = listPods(namespace, "job-name=" + jobName).getItems();
-        if (!pods.isEmpty()) {
-          logger.severe(getPodLog(pods.get(0).getMetadata().getName(), namespace));
-          fail("Build job failed");
-        }
-      }
-    }
-
-  }
-
-  private static void createPV(Path hostPath, String pvName) throws IOException {
-    logger.info("creating persistent volume");
-    // a dummy label is added so that cleanup can delete all pvs
-    HashMap<String, String> label = new HashMap<String, String>();
-    label.put("weblogic.domainUid", "buildjobs");
-
-    V1PersistentVolume v1pv = new V1PersistentVolume()
-        .spec(new V1PersistentVolumeSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-build-storage-class")
-            .volumeMode("Filesystem")
-            .putCapacityItem("storage", Quantity.fromString("2Gi"))
-            .persistentVolumeReclaimPolicy("Recycle")
-            .accessModes(Arrays.asList("ReadWriteMany"))
-            .hostPath(new V1HostPathVolumeSource()
-                .path(hostPath.toString())))
-        .metadata(new V1ObjectMeta()
-            .name(pvName)
-            .labels(label));
-
-    boolean success = assertDoesNotThrow(() -> createPersistentVolume(v1pv),
-        "Failed to create persistent volume");
-    assertTrue(success, "PersistentVolume creation failed");
-  }
-
-  private static void createPVC(String pvName, String pvcName, String namespace) {
-    logger.info("creating persistent volume claim");
-    // a dummy label is added so that cleanup can delete all pvs
-    HashMap<String, String> label = new HashMap<String, String>();
-    label.put("weblogic.domainUid", "buildjobs");
-
-    V1PersistentVolumeClaim v1pvc = new V1PersistentVolumeClaim()
-        .spec(new V1PersistentVolumeClaimSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-build-storage-class")
-            .volumeName(pvName)
-            .resources(new V1ResourceRequirements()
-                .putRequestsItem("storage", Quantity.fromString("2Gi"))))
-        .metadata(new V1ObjectMeta()
-            .name(pvcName)
-            .namespace(namespace)
-            .labels(label));
-
-    boolean success = assertDoesNotThrow(() -> createPersistentVolumeClaim(v1pvc),
-        "Failed to create persistent volume claim");
-    assertTrue(success, "PersistentVolumeClaim creation failed");
+    return wlsPod;
   }
 
   /**
@@ -337,4 +253,5 @@ public class BuildApplication {
     }
     logger.info("Using image {0}", image);
   }
+
 }

--- a/new-integration-tests/src/test/resources/bash-scripts/build_application.sh
+++ b/new-integration-tests/src/test/resources/bash-scripts/build_application.sh
@@ -26,8 +26,14 @@ fi
 echo "Setting up build environment"
 source ${WL_HOME}/server/bin/setWLSEnv.sh
 
-# call ant all to build
-cd /application
-ant ${sysprops} ${targets}
+# create /u01/application
+mkdir /u01/application
+cd /u01/application
+#unzip the source application archive
+unzip /u01/$ZIP_FILE
 
-chmod -R 777 *
+# call ant to build
+pwd
+ls
+echo "ant ${sysprops} ${targets}"
+ant ${sysprops} ${targets}


### PR DESCRIPTION
The fix involves   

- Removing the persistent volumes for mounting application source directory  to the pod , since PV_ROOT is shared only between the Kubernetes nodes. Jenkins client doesn't have access to the PV_ROOT  so its not working in Jenkins runs.

-   Instead of a Kubernetes job the utility will create a WebLogic pod and copies the source application folder to the pod and builds the application.    

- Once built the archives directory is copied back to the local file system for use by the test code.


Results

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests/1032

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/493/testReport/oracle.weblogic.kubernetes/
