### PR TITLE
Default resources java options

### DIFF
--- a/docs-source/content/faq/resource-settings.md
+++ b/docs-source/content/faq/resource-settings.md
@@ -1,4 +1,9 @@
-# Considerations for Pod Resource (Memory and CPU) Requests and Limits
+---
+title: "Considerations for Pod Resource (Memory and CPU) Requests and Limits"
+date: 2020-06-30T08:55:00-05:00
+draft: true
+weight: 40
+---
 The operator creates a pod for each running WebLogic Server instance and each pod will have a container. It.s important that containers have enough resources in order for applications to run efficiently and expeditiously. 
 
 If a pod is scheduled on a node with limited resources, it.s possible for the node to run out of memory or CPU resources, and for applications to stop working properly or have degraded performance. It.s also possible for a rouge application to use all available memory and/or CPU, which makes other containers running on the same system unresponsive. The same problem can happen if an application has memory leak or bad configuration. 
@@ -8,32 +13,56 @@ A pod.s resource requests and limit parameters can be used to solve these proble
 ## Pod Quality Of Service (QoS) and Prioritization
 Pod.s Quality of Service (QoS) and priority is determined based on whether pod.s resource requests and limits are configured or not and how they.re configured.
 
-Best Effort QoS: If you don.t configure requests and limits, pod receives .best-effort. QoS and pod has the lowest priority. In cases where node runs out of non-shareable resources, kubelet.s out-of-resource eviction policy evicts/kills the pods with best-effort QoS first.
+**Best Effort QoS**: If you don.t configure requests and limits, pod receives .best-effort. QoS and pod has the **lowest priority**. In cases where node runs out of non-shareable resources, kubelet.s out-of-resource eviction policy evicts/kills the pods with best-effort QoS first.
 
-Burstable QoS: If you configure both resource requests and limits, and set the requests to be less than the limit, pod.s QoS will be .Burstable.. Similarly when you only configure the resource requests (without limits), the pod QoS is .Burstable.. When the node runs out of non-shareable resources, kubelet will kill .Burstable. Pods only when there are no more .best-effort. pods running. The Burstable pod receives medium priority.
+**Burstable QoS**: If you configure both resource requests and limits, and set the requests to be less than the limit, pod.s QoS will be .Burstable.. Similarly when you only configure the resource requests (without limits), the pod QoS is .Burstable.. When the node runs out of non-shareable resources, kubelet will kill .Burstable. Pods only when there are no more .best-effort. pods running. The Burstable pod receives **medium priority**.
 
-Guaranteed QoS:  If you set the requests and the limits to equal values, pod will have .Guranteed. QoS and pod will be considered as of the top most priority. These settings indicates that your pod will consume a fixed amount of memory and CPU. With this configuration, if a node runs out of shareable resources, Kubernetes will kill the best-effort and the burstable Pods first before terminating these Guaranteed QoS Pods. These are the highest priority Pods.
+**Guaranteed QoS**:  If you set the requests and the limits to equal values, pod will have .Guranteed. QoS and pod will be considered as of the top most priority. These settings indicates that your pod will consume a fixed amount of memory and CPU. With this configuration, if a node runs out of shareable resources, Kubernetes will kill the best-effort and the burstable Pods first before terminating these Guaranteed QoS Pods. These are the **highest priority** pods.
 
 ## Java heap size and pod memory request/limit considerations
 It.s extremely important to set correct heap size for JVM-based applications.  If available memory on node or memory allocated to container is not sufficient for specified JVM heap arguments (and additional off-heap memory), it is possible for WL process to run out of memory. In order to avoid this, you will need to make sure that configured heap sizes are not too big and that the pod is scheduled on the node with sufficient memory.
 With the latest Java version, it.s possible to rely on the default JVM heap settings which are safe but quite conservative. If you configure the memory limit for a container but don.t configure heap sizes (-Xms and -Xmx), JVM will configure max heap size to 25% (1/4th) of container memory limit by default. The minimum heap size is configured to 1.56% (1/64th) of limit value.
 
-### Default heap size and resource request values for sample WebLogic Server Pods:
-The samples configure default min and max heap size for WebLogic server java process to 256MB and 512MB respectively. This can be changed using USER_MEM_ARGS environment variable. The default min and max heap size for node-manager process is 64MB and 100MB. This can be changed by using NODEMGR_MEM_ARGS environment variable. 
+**Default heap sizes and resource request values for sample WebLogic Server Pods**:
+The WLS samples configure default min and max heap size for WebLogic server java process to 256MB and 512MB respectively. This can be changed using USER_MEM_ARGS environment variable. 
+```
+    resources:
+      env:
+      - name: "USER_MEM_ARGS"
+        value: "-Xms256m -Xmx512m -Djava.security.egd=file:/dev/./urandom"
+```        
 
-The default memory request in samples for WebLogic server pod is 768MB and default CPU request is 250m. This can be changed during domain creation in resources section.
+The default min and max heap size for node-manager process is 64MB and 100MB. This can be changed by using NODEMGR_MEM_ARGS environment variable. 
+
+The default pod memory request in WLS samples is 768MB and default CPU request is 250m. The requests values can be changed in resources section.
+```
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
+```
 
 There.s no memory or CPU limit configured by default in samples and default QoS for WebLogic server pod is Burstable. If your use-case and workload requires higher QoS and priority, this can be achieved by setting memory and CPU limits. You.ll need to run tests and experiment with different memory/CPU limits to determine optimal limit values.
+```
+      limits:
+        cpu: 2
+        memory: "2048Mi"
+```
 
 ### Configure min/max heap size in percentages using "-XX:MinRAMPercentage" and "-XX:MaxRAMPercentage"
-If you specify pod memory limit, it's recommended to configure heap size as a percentage of the total RAM (memory) specified in the pod memory limit. These parameters allow you to fine-tune the heap size . the meaning of those settings is explained in this excellent answer on StackOverflow. Please note . they set the percentage, not the fixed values. Thanks to it changing container memory settings will not break anything. 
+If you specify pod memory limit, it's recommended to configure heap size as a percentage of the total RAM (memory) specified in the pod memory limit. These parameters allow you to fine-tune the heap size. Please note . they set the percentage, not the fixed values. Thanks to it changing container memory settings will not break anything. 
+```
+    resources:
+      env:
+      - name: JAVA_OPTIONS
+        value: "--XX:MinRAMPercentage=25.0 --XX:MaxRAMPercentage=50.0 -Dweblogic.StdoutDebugEnabled=false"
+```
 When configuring memory limits, it.s important to make sure that the limit is sufficiently big to accommodate the configured heap (and off-heap) requirements, but it's not too big to waste memory resource. Since pod memory will never go above the limit, if JVM's memory usage (sum of heap and native memory) goes above the limit, JVM process will be killed due to out-of-memory error and WebLogic container will be restarted due to liveness probe failure.   Additionally there's also a node-manager process that.s running in same container and it has it's own heap and off-heap requirements. You can also fine tune the node manager heap size in percentages by setting "-XX:MinRAMPercentage" and "-XX:MaxRAMPercentage" using .NODEMGR_JAVA_OPTIONS. environment variable. 
 
 ### Using "-Xms" and "-Xmx" parameters when not configuring limits 
 In some cases, it.s difficult to come up with a hard limit for the container and you might only want to configure memory requests but not configure memory limits. In such scenarios, you can use traditional approach to set min/max heap size using .-Xms. and .-Xmx..
 
 ### CPU requests and limits 
-It.s important that the containers running WebLogic applications have enough CPU resources, otherwise applications performance can suffer. You also don't want to set CPU requests and limit too high if your application don't need or use it. Since CPU is a shared resource, if the amount of CPU that you reserve is more than required by your application, the CPU cycles will go unused and be wasted. If no CPU request and limit is configured, it can end up using all CPU resources available on node. This can starve other containers from using shareable CPU cycles. 
+It.s important that the containers running WebLogic applications have enough CPU resources, otherwise applications performance can suffer. You also don't want to set CPU requests and limit too high if your application don't need or use allocated CPU resources. Since CPU is a shared resource, if the amount of CPU that you reserve is more than required by your application, the CPU cycles will go unused and be wasted. If no CPU request and limit is configured, it can end up using all CPU resources available on node. This can starve other containers from using shareable CPU cycles. 
 
 One other thing to keep in mind is that if pod CPU limit is not configured, it might lead to incorrect garbage collection (GC) strategy selection. WebLogic self-tuning work-manager uses pod CPU limit to configure the  number of threads in a default thread pool. If you don.t specify container CPU limit, the performance might be affected due to incorrect number of GC threads or wrong WebLogic server thread pool size. 
 
@@ -43,7 +72,7 @@ Just like CPU, if you put a memory request that.s larger than amount of memory o
 ## CPU Affinity and lock contention in k8s
 We observed much higher lock contention in k8s env when running some workloads in kubernetes as compared to traditional env. The lock contention seem to be caused by the lack of CPU cache affinity and/or scheduling latency when the workload moves to different CPU cores.  
 
-In traditional (non-k8s) environment, often tests are run with CPU affinity by binding WLS java process to particular CPU core(s) (using taskset command). This results in reduced lock contention and better performance. 
+In traditional (non-k8s) environment, often tests are run with CPU affinity achieved by binding WLS java process to particular CPU core(s) (using taskset command). This results in reduced lock contention and better performance. 
 
 In k8s environment. when CPU manager policy is configured to be "static" and QOS is "Guaranteed" for WLS pods, we see reduced lock contention and better performance. The default CPU manager policy is "none" (default). Please refer to controlling CPU management policies for more details.
 
@@ -52,3 +81,4 @@ In k8s environment. when CPU manager policy is configured to be "static" and QOS
 2) https://blog.softwaremill.com/docker-support-in-new-java-8-finally-fd595df0ca54
 3) https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 4) https://www.magalix.com/blog/kubernetes-patterns-capacity-planning 
+

--- a/docs-source/content/faq/resource-settings.md
+++ b/docs-source/content/faq/resource-settings.md
@@ -1,0 +1,54 @@
+# Considerations for Pod Resource (Memory and CPU) Requests and Limits
+The operator creates a pod for each running WebLogic Server instance and each pod will have a container. It.s important that containers have enough resources in order for applications to run efficiently and expeditiously. 
+
+If a pod is scheduled on a node with limited resources, it.s possible for the node to run out of memory or CPU resources, and for applications to stop working properly or have degraded performance. It.s also possible for a rouge application to use all available memory and/or CPU, which makes other containers running on the same system unresponsive. The same problem can happen if an application has memory leak or bad configuration. 
+
+A pod.s resource requests and limit parameters can be used to solve these problems. Setting resource limits prevents an application from using more than it.s share of resource. Thus, limiting resources improves reliability and stability of applications.  It also allows users to plan for the hardware capacity. Additionally, pod.s priority and the Quality of Service (QoS) that pod receives is affected by whether resource requests and limits are specified or not.
+
+## Pod Quality Of Service (QoS) and Prioritization
+Pod.s Quality of Service (QoS) and priority is determined based on whether pod.s resource requests and limits are configured or not and how they.re configured.
+
+Best Effort QoS: If you don.t configure requests and limits, pod receives .best-effort. QoS and pod has the lowest priority. In cases where node runs out of non-shareable resources, kubelet.s out-of-resource eviction policy evicts/kills the pods with best-effort QoS first.
+
+Burstable QoS: If you configure both resource requests and limits, and set the requests to be less than the limit, pod.s QoS will be .Burstable.. Similarly when you only configure the resource requests (without limits), the pod QoS is .Burstable.. When the node runs out of non-shareable resources, kubelet will kill .Burstable. Pods only when there are no more .best-effort. pods running. The Burstable pod receives medium priority.
+
+Guaranteed QoS:  If you set the requests and the limits to equal values, pod will have .Guranteed. QoS and pod will be considered as of the top most priority. These settings indicates that your pod will consume a fixed amount of memory and CPU. With this configuration, if a node runs out of shareable resources, Kubernetes will kill the best-effort and the burstable Pods first before terminating these Guaranteed QoS Pods. These are the highest priority Pods.
+
+## Java heap size and pod memory request/limit considerations
+It.s extremely important to set correct heap size for JVM-based applications.  If available memory on node or memory allocated to container is not sufficient for specified JVM heap arguments (and additional off-heap memory), it is possible for WL process to run out of memory. In order to avoid this, you will need to make sure that configured heap sizes are not too big and that the pod is scheduled on the node with sufficient memory.
+With the latest Java version, it.s possible to rely on the default JVM heap settings which are safe but quite conservative. If you configure the memory limit for a container but don.t configure heap sizes (-Xms and -Xmx), JVM will configure max heap size to 25% (1/4th) of container memory limit by default. The minimum heap size is configured to 1.56% (1/64th) of limit value.
+
+### Default heap size and resource request values for sample WebLogic Server Pods:
+The samples configure default min and max heap size for WebLogic server java process to 256MB and 512MB respectively. This can be changed using USER_MEM_ARGS environment variable. The default min and max heap size for node-manager process is 64MB and 100MB. This can be changed by using NODEMGR_MEM_ARGS environment variable. 
+
+The default memory request in samples for WebLogic server pod is 768MB and default CPU request is 250m. This can be changed during domain creation in resources section.
+
+There.s no memory or CPU limit configured by default in samples and default QoS for WebLogic server pod is Burstable. If your use-case and workload requires higher QoS and priority, this can be achieved by setting memory and CPU limits. You.ll need to run tests and experiment with different memory/CPU limits to determine optimal limit values.
+
+### Configure min/max heap size in percentages using "-XX:MinRAMPercentage" and "-XX:MaxRAMPercentage"
+If you specify pod memory limit, it's recommended to configure heap size as a percentage of the total RAM (memory) specified in the pod memory limit. These parameters allow you to fine-tune the heap size . the meaning of those settings is explained in this excellent answer on StackOverflow. Please note . they set the percentage, not the fixed values. Thanks to it changing container memory settings will not break anything. 
+When configuring memory limits, it.s important to make sure that the limit is sufficiently big to accommodate the configured heap (and off-heap) requirements, but it's not too big to waste memory resource. Since pod memory will never go above the limit, if JVM's memory usage (sum of heap and native memory) goes above the limit, JVM process will be killed due to out-of-memory error and WebLogic container will be restarted due to liveness probe failure.   Additionally there's also a node-manager process that.s running in same container and it has it's own heap and off-heap requirements. You can also fine tune the node manager heap size in percentages by setting "-XX:MinRAMPercentage" and "-XX:MaxRAMPercentage" using .NODEMGR_JAVA_OPTIONS. environment variable. 
+
+### Using "-Xms" and "-Xmx" parameters when not configuring limits 
+In some cases, it.s difficult to come up with a hard limit for the container and you might only want to configure memory requests but not configure memory limits. In such scenarios, you can use traditional approach to set min/max heap size using .-Xms. and .-Xmx..
+
+### CPU requests and limits 
+It.s important that the containers running WebLogic applications have enough CPU resources, otherwise applications performance can suffer. You also don't want to set CPU requests and limit too high if your application don't need or use it. Since CPU is a shared resource, if the amount of CPU that you reserve is more than required by your application, the CPU cycles will go unused and be wasted. If no CPU request and limit is configured, it can end up using all CPU resources available on node. This can starve other containers from using shareable CPU cycles. 
+
+One other thing to keep in mind is that if pod CPU limit is not configured, it might lead to incorrect garbage collection (GC) strategy selection. WebLogic self-tuning work-manager uses pod CPU limit to configure the  number of threads in a default thread pool. If you don.t specify container CPU limit, the performance might be affected due to incorrect number of GC threads or wrong WebLogic server thread pool size. 
+
+## Beware of setting resource limits too high
+It.s important to keep in mind that if you set a value of CPU core count that.s larger than core count of the biggest node, then the pod will never be scheduled. Let.s say you have a pod that needs 4 cores but you have a kubernetes cluster that.s comprised of 2 core VMs. In this case, your pod will never be scheduled.  WebLogic applications are normally designed to take advantage of multiple cores and should be given CPU requests as such. CPUs are considered as a compressible resource. If your apps are hitting CPU limits, kubernetes will start to throttle your container. This means your CPU will be artificially restricted, giving your app potentially worse performance. However it won.t be terminated or evicted. 
+Just like CPU, if you put a memory request that.s larger than amount of memory on your nodes, the pod will never be scheduled.
+## CPU Affinity and lock contention in k8s
+We observed much higher lock contention in k8s env when running some workloads in kubernetes as compared to traditional env. The lock contention seem to be caused by the lack of CPU cache affinity and/or scheduling latency when the workload moves to different CPU cores.  
+
+In traditional (non-k8s) environment, often tests are run with CPU affinity by binding WLS java process to particular CPU core(s) (using taskset command). This results in reduced lock contention and better performance. 
+
+In k8s environment. when CPU manager policy is configured to be "static" and QOS is "Guaranteed" for WLS pods, we see reduced lock contention and better performance. The default CPU manager policy is "none" (default). Please refer to controlling CPU management policies for more details.
+
+## References:
+1) https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-resource-requests-and-limits
+2) https://blog.softwaremill.com/docker-support-in-new-java-8-finally-fd595df0ca54
+3) https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+4) https://www.magalix.com/blog/kubernetes-patterns-capacity-planning 

--- a/docs-source/content/faq/resource-settings.md
+++ b/docs-source/content/faq/resource-settings.md
@@ -8,8 +8,8 @@ weight: 25
 ### Contents
 
  - [Introduction](#introduction)
- - [Setting resource requests and limits in a domain resource](#setting-resource-requests-and-limits-in-a-domain-resource)
- - [Determining pod Quality Of Service](#determining-pod-quality-of-service)
+ - [Setting resource requests and limits in a Domain resource](#setting-resource-requests-and-limits-in-a-domain-resource)
+ - [Determining Pod Quality Of Service](#determining-pod-quality-of-service)
  - [Java heap size and memory resource considerations](#java-heap-size-and-memory-resource-considerations)
    - [Importance of setting heap size and memory resources](#importance-of-setting-heap-size-and-memory-resources)
    - [Default heap sizes](#default-heap-sizes)
@@ -17,18 +17,18 @@ weight: 25
  - [CPU resource considerations](#cpu-resource-considerations)
  - [Operator sample heap and resource configuration](#operator-sample-heap-and-resource-configuration)
  - [Configuring CPU affinity](#configuring-cpu-affinity)
- - [Measuring JVM heap, pod CPU, and pod memory](#measuring-jvm-heap-pod-cpu-and-pod-memory)
+ - [Measuring JVM heap, Pod CPU, and Pod memory](#measuring-jvm-heap-pod-cpu-and-pod-memory)
  - [References](#references)
 
 ### Introduction
 
-An operator creates a pod for each WebLogic Server instance and each pod will have a container. You can tune pod container memory and/or CPU usage by configuring Kubernetes resource requests and limits, and you can tune a WebLogic JVM heap usage using the `USER_MEM_ARGS` environment variable in your domain resource. A resource request sets the minimum amount of a resource that a container requires. A resource limit is the maximum amount of resource a container is given and prevents a container from using more than its share of a resource. Additionally, resource requests and limits determine a pod's Quality of Service.
+The operator creates a container in its own Pod for each WebLogic Server instance. You can tune container memory and CPU usage by configuring Kubernetes resource requests and limits, and you can tune a WebLogic JVM heap usage using the `USER_MEM_ARGS` environment variable in your Domain resource. A resource request sets the minimum amount of a resource that a container requires. A resource limit is the maximum amount of a resource a container is given and prevents a container from using more than its share of a resource. Additionally, resource requests and limits determine a Pod's quality of service.
 
-This FAQ discusses tuning these parameters so WebLogic servers can run efficiently.
+This FAQ discusses tuning these parameters so WebLogic Server instances can run efficiently.
 
-### Setting resource requests and limits in a domain resource
+### Setting resource requests and limits in a Domain resource
 
-You can set Kubernetes memory and CPU requests and limits in a [domain resource]({{< relref "/userguide/managing-domains/domain-resource" >}}) using its `spec.serverPod.resources` stanza, and you can override the setting for individual WebLogic servers or clusters using the `serverPod.resources` element in `spec.adminServer`, `spec.clusters`, and/or `spec.managedServers`. For example: 
+You can set Kubernetes memory and CPU requests and limits in a [Domain resource]({{< relref "/userguide/managing-domains/domain-resource" >}}) using its `spec.serverPod.resources` stanza, and you can override the setting for individual WebLogic servers or clusters using the `serverPod.resources` element in `spec.adminServer`, `spec.clusters`, and/or `spec.managedServers`. For example: 
 
 ```
   spec:
@@ -45,30 +45,30 @@ Limits and requests for CPU resources are measured in cpu units. One cpu, in Kub
 
 Memory can be expressed in various units, where one `Mi` is one IEC unit mega-byte (1024^2), and one `Gi` is one IEC unit giga-byte (1024^3).
 
-See also [Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/), [Assign Memory Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource) and [Assign CPU Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource) in Kubernetes documentation.
+See also [Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/), [Assign Memory Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource) and [Assign CPU Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource) in the Kubernetes documentation.
 
-### Determining pod Quality Of Service
+### Determining Pod Quality Of Service
 
-A pod's Quality of Service (QoS) is based on whether it's configured with resource requests and limits:
+A Pod's Quality of Service (QoS) is based on whether it's configured with resource requests and limits:
 
-- **Best Effort QoS** (lowest priority): If you don't configure requests and limits for a pod, then the pod is given a `best-effort` QoS. In cases where a node runs out of non-shareable resources, a Kubernetes `kubelet` default out-of-resource eviction policy evicts running pods with the `best-effort` QoS first.
+- **Best Effort QoS** (lowest priority): If you don't configure requests and limits for a Pod, then the Pod is given a `best-effort` QoS. In cases where a Node runs out of non-shareable resources, the default out-of-resource eviction policy evicts running Pods with the `best-effort` QoS first.
 
-- **Burstable QoS** (medium priority): If you configure both resource requests and limits for a pod, and set the requests to be less than their respective limits, then the pod will be given a `burstable` QoS. Similarly, if you only configure resource requests (without limits) for a pod, then the pod QoS is also `burstable`. If a node runs out of non-shareable resources, the node's `kubelet` will evict `burstable` pods only when there are no more running `best-effort` pods.
+- **Burstable QoS** (medium priority): If you configure both resource requests and limits for a Pod, and set the requests to be less than their respective limits, then the Pod will be given a `burstable` QoS. Similarly, if you only configure resource requests (without limits) for a Pod, then the Pod QoS is also `burstable`. If a Node runs out of non-shareable resources, the Node's `kubelet` will evict `burstable` Pods only when there are no more running `best-effort` Pods.
 
-- **Guaranteed QoS** (highest priority): If you set a pod's requests and the limits to equal values, then the pod will have a `guaranteed` QoS. These settings indicates that your pod will consume a fixed amount of memory and CPU. With this configuration, if a node runs out of shareable resources, then a Kubernetes node's `kubelet` will evict `best-effort` and `burstable` QoS pods before terminating `guaranteed` QoS pods.
+- **Guaranteed QoS** (highest priority): If you set a Pod's requests and the limits to equal values, then the Pod will have a `guaranteed` QoS. These settings indicates that your Pod will consume a fixed amount of memory and CPU. With this configuration, if a Node runs out of shareable resources, then the Node's `kubelet` will evict `best-effort` and `burstable` QoS Pods before terminating `guaranteed` QoS Pods.
 
 {{% notice note %}} 
-For most use cases, Oracle recommends configuring WebLogic pods with memory and CPU requests and limits, and furthermore setting requests equal to their respective limits in order to ensure a `guaranteed` QoS.
+For most use cases, Oracle recommends configuring WebLogic Pods with memory and CPU requests and limits, and furthermore setting requests equal to their respective limits in order to ensure a `guaranteed` QoS.
 {{% /notice %}}
 
 {{% notice note %}} 
-In newer version of Kubernetes, it is possible to fine tune scheduling and eviction policies using [Pod Priority Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) in combination with the `serverPod.priorityClassName` domain resource attribute. Note that Kubernetes already ships with two PriorityClasses: `system-cluster-critical` and `system-node-critical`. These are common classes and are used to [ensure that critical components are always scheduled first](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
+In newer version of Kubernetes, it is possible to fine tune scheduling and eviction policies using [Pod Priority Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) in combination with the `serverPod.priorityClassName` Domain resource attribute. Note that Kubernetes already ships with two PriorityClasses: `system-cluster-critical` and `system-node-critical`. These are common classes and are used to [ensure that critical components are always scheduled first](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
 {{% /notice %}}
 
 ### Java heap size and memory resource considerations
 
 {{% notice note %}} 
-For most use cases, Oracle recommends configuring Java heap sizes for WebLogic pods instead of relying on defaults.
+Oracle recommends configuring Java heap sizes for WebLogic JVMs instead of relying on defaults.
 {{% /notice %}}
 
 #### Importance of setting heap size and memory resources
@@ -77,12 +77,12 @@ It's extremely important to set correct heap sizes, memory requests, and memory 
 
 A WebLogic JVM heap must be sufficiently sized to run its applications and services, but should not be sized too large so as not to waste memory resources.
 
-A pod memory limit must be sufficiently sized to accommodate the configured heap and native memory requirements, but  not too big to waste memory resources. If a JVM's memory usage (sum of heap and native memory) exceeds its pod's limit, then the JVM process will be abruptly killed due to an out-of-memory error and the WebLogic container will consequently automatically restart due to a liveness probe failure.  
+A Pod memory limit must be sufficiently sized to accommodate the configured heap and native memory requirements, but not too big to waste memory resources. If a JVM's memory usage (sum of heap and native memory) exceeds its Pod's limit, then the JVM process will be abruptly killed due to an out-of-memory error and the WebLogic container will consequently automatically restart due to a liveness probe failure.  
 
 Oracle recommends setting minimum and maximum heap (or heap percentages) and at least a container memory request.
 
 {{% notice warning %}}
-If resource requests and resource limits are set too high, then your pods may not be scheduled due to lack of node resources, will unnecessarily use up CPU shared resources that could be used by other pods, or may prevent other pods from running.
+If resource requests and resource limits are set too high, then your Pods may not be scheduled due to lack of Node resources, will unnecessarily use up CPU shared resources that could be used by other Pods, or may prevent other Pods from running.
 {{% /notice %}}
 
 #### Default heap sizes
@@ -92,20 +92,20 @@ With the latest Java versions, Java 8 update 191 and onwards or Java 11, then if
 
   The default JVM heap settings in this case are often too conservative because the WebLogic JVM is the only major process running in the container.
 
-- If no memory limit is configured, then the JVM default maximum heap size will be  25% (1/4th) of the its node's machine RAM and the default minimum heap size will be 1.56% (1/64th) of the RAM.
+- If no memory limit is configured, then the JVM default maximum heap size will be  25% (1/4th) of the its Node's machine RAM and the default minimum heap size will be 1.56% (1/64th) of the RAM.
 
-  The default JVM heap settings in this case can have undesirable behavior, including using unnecessary amounts of memory to the point where it might affect other pods that run on the same node.
+  The default JVM heap settings in this case can have undesirable behavior, including using unnecessary amounts of memory to the point where it might affect other Pods that run on the same Node.
 
 #### Configuring heap size
 
-If you specify pod memory limits, Oracle recommends configuring WebLogic Server heap sizes as a percentage. The JVM will interpret the percentage as a fraction of the limit. This is done using the JVM `-XX:MinRAMPercentage` and `-XX:MaxRAMPercentage` options in the `USER_MEM_ARGS` [domain resource environment variable]({{< relref "/userguide/managing-domains/domain-resource#jvm-memory-and-java-option-environment-variables" >}}).  For example:
+If you specify Pod memory limits, Oracle recommends configuring WebLogic Server heap sizes as a percentage. The JVM will interpret the percentage as a fraction of the limit. This is done using the JVM `-XX:MinRAMPercentage` and `-XX:MaxRAMPercentage` options in the `USER_MEM_ARGS` [Domain resource environment variable]({{< relref "/userguide/managing-domains/domain-resource#jvm-memory-and-java-option-environment-variables" >}}).  For example:
 
 ```
   spec:
     resources:
       env:
       - name: USER_MEM_ARGS
-        value: "--XX:MinRAMPercentage=25.0 --XX:MaxRAMPercentage=50.0 -Djava.security.egd=file:/dev/./urandom"
+        value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 -Djava.security.egd=file:/dev/./urandom"
 ```
 
 Additionally there's also a node-manager process that's running in the same container as the WebLogic Server which has its own heap and native memory requirements. Its heap is tuned by using `-Xms` and `-Xmx` in the `NODEMGR_MEM_ARGS` environment variable. Oracle recommends setting the node manager heap memory to fixed sizes, instead of percentages, where [the default tuning]({{< relref "/userguide/managing-domains/domain-resource#jvm-memory-and-java-option-environment-variables" >}}) is usually sufficient.
@@ -118,16 +118,16 @@ In some cases, you might only want to configure memory resource requests but not
 
 ### CPU resource considerations
 
-It's important to set both a CPU request and a limit for WebLogic Server pods. This ensures that all WebLogic server pods have enough CPU resources, and, as discussed earlier, if the request and limit are set to the same value, then they get a `guaranteed` QoS. A `guaranteed` QoS ensures the pods are handled with a higher priority during scheduling and so are the least likely to be evicted.
+It's important to set both a CPU request and a limit for WebLogic Server Pods. This ensures that all WebLogic server Pods have enough CPU resources, and, as discussed earlier, if the request and limit are set to the same value, then they get a `guaranteed` QoS. A `guaranteed` QoS ensures the Pods are handled with a higher priority during scheduling and so are the least likely to be evicted.
 
-If a CPU request and limit are _not_ configured for a WebLogic Server pod:
-- The pod can end up using all CPU resources available on its node and starve other containers from using shareable CPU cycles. 
+If a CPU request and limit are _not_ configured for a WebLogic Server Pod:
+- The Pod can end up using all CPU resources available on its Node and starve other containers from using shareable CPU cycles. 
 
 - The WebLogic server JVM may choose an unsuitable garbage collection (GC) strategy.
 
 - A WebLogic Server self-tuning work-manager may incorrectly optimize the number of threads it allocates for the default thread pool. 
 
-It's also important to keep in mind that if you set a value of CPU core count that's larger than core count of your biggest node, then the pod will never be scheduled. Let's say you have a pod that needs 4 cores but you have a kubernetes cluster that's comprised of 2 core VMs. In this case, your pod will never be scheduled and will have `Pending` status. For example:
+It's also important to keep in mind that if you set a value of CPU core count that's larger than core count of your biggest Node, then the Pod will never be scheduled. Let's say you have a Pod that needs 4 cores but you have a kubernetes cluster that's comprised of 2 core VMs. In this case, your Pod will never be scheduled and will have `Pending` status. For example:
 
 ```
 $ kubectl get pod sample-domain1-managed-server1 -n sample-domain1-ns
@@ -143,27 +143,27 @@ Events:
 
 ### Operator sample heap and resource configuration
 
-The operator samples configure non-default minimum and maximum heap sizes for WebLogic server JVMs of at least 256MB and 512MB respectively. You can edit a sample's template or domain resource `resources.env` `USER_MEM_ARGS` to have different values. See [Configuring heap size](#configuring-heap-size).
+The operator samples configure non-default minimum and maximum heap sizes for WebLogic server JVMs of at least 256MB and 512MB respectively. You can edit a sample's template or Domain resource `resources.env` `USER_MEM_ARGS` to have different values. See [Configuring heap size](#configuring-heap-size).
 
 Similarly, the operator samples configure CPU and memory resource requests to at least `250m` and `768Mi` respectively.
 
-There's no memory or CPU limit configured by default in samples and so the default QoS for sample WebLogic server pod's is `Burstable`. 
+There's no memory or CPU limit configured by default in samples and so the default QoS for sample WebLogic server Pod's is `Burstable`. 
 
-If you wish to set resource requests or limits differently on a sample domain resource or domain resource template, see [Setting resource requests and limits in a domain resource](#setting-resource-requests-and-limits-in-a-domain-resource). Or for samples that generate their domain resource using an 'inputs' file, see the `serverPodMemoryRequest`, `serverPodMemoryLimit`, `serverPodCpuRequest`, and `serverPodCpuLimit` parameters in the sample's `create-domain.sh` input file.
+If you wish to set resource requests or limits differently on a sample Domain resource or Domain resource template, see [Setting resource requests and limits in a Domain resource](#setting-resource-requests-and-limits-in-a-domain-resource). Or for samples that generate their Domain resource using an 'inputs' file, see the `serverPodMemoryRequest`, `serverPodMemoryLimit`, `serverPodCpuRequest`, and `serverPodCpuLimit` parameters in the sample's `create-domain.sh` input file.
 
 ### Configuring CPU affinity
 
-A Kubernetes hosted WebLogic server may exhibit high lock contention in comparison to an on-premise deployment. This lock contention may be due to lack of CPU cache affinity and/or scheduling latency when workloads move between different CPU cores.  
+A Kubernetes hosted WebLogic server may exhibit high lock contention in comparison to an on-premise deployment. This lock contention may be due to lack of CPU cache affinity or scheduling latency when workloads move between different CPU cores.  
 
 In an on-premise deployment, CPU cache affinity, and therefore reduced lock contention, can be achieved by binding WLS java process to particular CPU core(s) (using the `taskset` command).
 
 In a Kubernetes deployment, similar cache affinity can be achieved by doing the following:
-- Ensuring a pod's CPU resource request and limit are set and equal (to ensure a `guaranteed` QoS).
+- Ensuring a Pod's CPU resource request and limit are set and equal (to ensure a `guaranteed` QoS).
 - Configuring the `kubelet` CPU manager policy to be `static` (the default is `none`). See [Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies). 
 Note that some Kubernetes environments may not allow changing the CPU management policy.
 
-### Measuring JVM heap, pod CPU, and pod memory
-You can monitor JVM heap, pod CPU and pod memory using Prometheus and Grafana using steps similar to the [Monitor a SOA Domain]({{< relref "/samples/simple/elastic-stack/soa-domain/weblogic-monitoring-exporter-setup" >}}) sample. Also see [Tools for Monitoring Resources](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-usage-monitoring/) in the Kubernetes documentation.
+### Measuring JVM heap, Pod CPU, and Pod memory
+You can monitor JVM heap, Pod CPU and Pod memory using Prometheus and Grafana using steps similar to the [Monitor a SOA Domain]({{< relref "/samples/simple/elastic-stack/soa-domain/weblogic-monitoring-exporter-setup" >}}) sample. Also see [Tools for Monitoring Resources](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-usage-monitoring/) in the Kubernetes documentation.
 
 ### References:
 1. [Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) in the Kubernetes documentation.

--- a/docs-source/content/faq/resource-settings.md
+++ b/docs-source/content/faq/resource-settings.md
@@ -1,11 +1,12 @@
 ---
-title: "Pod Memory and CPU Resources"
+title: "Pod memory and CPU resources"
 date: 2020-06-30T08:55:00-05:00
 draft: false
-weight: 25
+weight: 13
+description: "Tune container memory and CPU usage by configuring Kubernetes resource requests and limits, and tune a WebLogic JVM heap usage using the `USER_MEM_ARGS` environment variable in your Domain resource."
 ---
 
-### Contents
+#### Contents
 
  - [Introduction](#introduction)
  - [Setting resource requests and limits in a Domain resource](#setting-resource-requests-and-limits-in-a-domain-resource)
@@ -20,15 +21,15 @@ weight: 25
  - [Measuring JVM heap, Pod CPU, and Pod memory](#measuring-jvm-heap-pod-cpu-and-pod-memory)
  - [References](#references)
 
-### Introduction
+#### Introduction
 
 The operator creates a container in its own Pod for each WebLogic Server instance. You can tune container memory and CPU usage by configuring Kubernetes resource requests and limits, and you can tune a WebLogic JVM heap usage using the `USER_MEM_ARGS` environment variable in your Domain resource. A resource request sets the minimum amount of a resource that a container requires. A resource limit is the maximum amount of a resource a container is given and prevents a container from using more than its share of a resource. Additionally, resource requests and limits determine a Pod's quality of service.
 
-This FAQ discusses tuning these parameters so WebLogic Server instances can run efficiently.
+This FAQ discusses tuning these parameters so WebLogic Server instances run efficiently.
 
-### Setting resource requests and limits in a Domain resource
+#### Setting resource requests and limits in a Domain resource
 
-You can set Kubernetes memory and CPU requests and limits in a [Domain resource]({{< relref "/userguide/managing-domains/domain-resource" >}}) using its `spec.serverPod.resources` stanza, and you can override the setting for individual WebLogic servers or clusters using the `serverPod.resources` element in `spec.adminServer`, `spec.clusters`, and/or `spec.managedServers`. For example: 
+You can set Kubernetes memory and CPU requests and limits in a [Domain resource]({{< relref "/userguide/managing-domains/domain-resource" >}}) using its `spec.serverPod.resources` stanza, and you can override the setting for individual WebLogic Server instances or clusters using the `serverPod.resources` element in `spec.adminServer`, `spec.clusters`, or `spec.managedServers`. For example:
 
 ```
   spec:
@@ -41,13 +42,13 @@ You can set Kubernetes memory and CPU requests and limits in a [Domain resource]
         memory: "2Gi"
 ```
 
-Limits and requests for CPU resources are measured in cpu units. One cpu, in Kubernetes, is equivalent to 1 vCPU/Core for cloud providers and 1 hyperthread on bare-metal Intel processors. An `m` suffix in a CPU attribute indicates 'milli-CPU', so `250m` is 25% of a CPU. 
+Limits and requests for CPU resources are measured in CPU units. One CPU, in Kubernetes, is equivalent to 1 vCPU/Core for cloud providers and 1 hyperthread on bare-metal Intel processors. An `m` suffix in a CPU attribute indicates 'milli-CPU', so `250m` is 25% of a CPU.
 
 Memory can be expressed in various units, where one `Mi` is one IEC unit mega-byte (1024^2), and one `Gi` is one IEC unit giga-byte (1024^3).
 
 See also [Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/), [Assign Memory Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource) and [Assign CPU Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource) in the Kubernetes documentation.
 
-### Determining Pod Quality Of Service
+#### Determining Pod Quality Of Service
 
 A Pod's Quality of Service (QoS) is based on whether it's configured with resource requests and limits:
 
@@ -55,48 +56,48 @@ A Pod's Quality of Service (QoS) is based on whether it's configured with resour
 
 - **Burstable QoS** (medium priority): If you configure both resource requests and limits for a Pod, and set the requests to be less than their respective limits, then the Pod will be given a `burstable` QoS. Similarly, if you only configure resource requests (without limits) for a Pod, then the Pod QoS is also `burstable`. If a Node runs out of non-shareable resources, the Node's `kubelet` will evict `burstable` Pods only when there are no more running `best-effort` Pods.
 
-- **Guaranteed QoS** (highest priority): If you set a Pod's requests and the limits to equal values, then the Pod will have a `guaranteed` QoS. These settings indicates that your Pod will consume a fixed amount of memory and CPU. With this configuration, if a Node runs out of shareable resources, then the Node's `kubelet` will evict `best-effort` and `burstable` QoS Pods before terminating `guaranteed` QoS Pods.
+- **Guaranteed QoS** (highest priority): If you set a Pod's requests and the limits to equal values, then the Pod will have a `guaranteed` QoS. These settings indicate that your Pod will consume a fixed amount of memory and CPU. With this configuration, if a Node runs out of shareable resources, then the Node's `kubelet` will evict `best-effort` and `burstable` QoS Pods before terminating `guaranteed` QoS Pods.
 
-{{% notice note %}} 
-For most use cases, Oracle recommends configuring WebLogic Pods with memory and CPU requests and limits, and furthermore setting requests equal to their respective limits in order to ensure a `guaranteed` QoS.
+{{% notice note %}}
+For most use cases, Oracle recommends configuring WebLogic Pods with memory and CPU requests and limits, and furthermore, setting requests equal to their respective limits in order to ensure a `guaranteed` QoS.
 {{% /notice %}}
 
-{{% notice note %}} 
-In newer version of Kubernetes, it is possible to fine tune scheduling and eviction policies using [Pod Priority Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) in combination with the `serverPod.priorityClassName` Domain resource attribute. Note that Kubernetes already ships with two PriorityClasses: `system-cluster-critical` and `system-node-critical`. These are common classes and are used to [ensure that critical components are always scheduled first](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
+{{% notice note %}}
+In later versions of Kubernetes, it is possible to fine tune scheduling and eviction policies using [Pod Priority Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) in combination with the `serverPod.priorityClassName` Domain resource attribute. Note that Kubernetes already ships with two PriorityClasses: `system-cluster-critical` and `system-node-critical`. These are common classes and are used to [ensure that critical components are always scheduled first](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
 {{% /notice %}}
 
-### Java heap size and memory resource considerations
+#### Java heap size and memory resource considerations
 
-{{% notice note %}} 
-Oracle recommends configuring Java heap sizes for WebLogic JVMs instead of relying on defaults.
+{{% notice note %}}
+Oracle recommends configuring Java heap sizes for WebLogic JVMs instead of relying on the defaults.
 {{% /notice %}}
 
-#### Importance of setting heap size and memory resources
+##### Importance of setting heap size and memory resources
 
-It's extremely important to set correct heap sizes, memory requests, and memory limits for WebLogic JVMs and Pods. 
+It's extremely important to set correct heap sizes, memory requests, and memory limits for WebLogic JVMs and Pods.
 
 A WebLogic JVM heap must be sufficiently sized to run its applications and services, but should not be sized too large so as not to waste memory resources.
 
-A Pod memory limit must be sufficiently sized to accommodate the configured heap and native memory requirements, but not too big to waste memory resources. If a JVM's memory usage (sum of heap and native memory) exceeds its Pod's limit, then the JVM process will be abruptly killed due to an out-of-memory error and the WebLogic container will consequently automatically restart due to a liveness probe failure.  
+A Pod memory limit must be sufficiently sized to accommodate the configured heap and native memory requirements, but should not be sized too large so as not to waste memory resources. If a JVM's memory usage (sum of heap and native memory) exceeds its Pod's limit, then the JVM process will be abruptly killed due to an out-of-memory error and the WebLogic container will consequently automatically restart due to a liveness probe failure.  
 
 Oracle recommends setting minimum and maximum heap (or heap percentages) and at least a container memory request.
 
 {{% notice warning %}}
-If resource requests and resource limits are set too high, then your Pods may not be scheduled due to lack of Node resources, will unnecessarily use up CPU shared resources that could be used by other Pods, or may prevent other Pods from running.
+If resource requests and resource limits are set too high, then your Pods may not be scheduled due to a lack of Node resources. It will unnecessarily use up CPU shared resources that could be used by other Pods, or may prevent other Pods from running.
 {{% /notice %}}
 
-#### Default heap sizes
+##### Default heap sizes
 
-With the latest Java versions, Java 8 update 191 and onwards or Java 11, then if you don't configure a heap size (no '-Xms' or '-Xms') the default heap size is dynamically determined:
-- If you configure the memory limit for a container, then the JVM default maximum heap size will be 25% (1/4th) of container memory limit and the default minimum heap size will be 1.56% (1/64th) of the limit value. 
+With the latest Java versions, Java 8 update 191 and later, or Java 11, if you don't configure a heap size (no `-Xms` or `-Xms`), the default heap size is dynamically determined:
+- If you configure the memory limit for a container, then the JVM default maximum heap size will be 25% (1/4th) of container memory limit and the default minimum heap size will be 1.56% (1/64th) of the limit value.
 
-  The default JVM heap settings in this case are often too conservative because the WebLogic JVM is the only major process running in the container.
+  In this case, the default JVM heap settings are often too conservative because the WebLogic JVM is the only major process running in the container.
 
-- If no memory limit is configured, then the JVM default maximum heap size will be  25% (1/4th) of the its Node's machine RAM and the default minimum heap size will be 1.56% (1/64th) of the RAM.
+- If no memory limit is configured, then the JVM default maximum heap size will be  25% (1/4th) of its Node's machine RAM and the default minimum heap size will be 1.56% (1/64th) of the RAM.
 
-  The default JVM heap settings in this case can have undesirable behavior, including using unnecessary amounts of memory to the point where it might affect other Pods that run on the same Node.
+  In this case, the default JVM heap settings can have undesirable behavior, including using unnecessary amounts of memory to the point where it might affect other Pods that run on the same Node.
 
-#### Configuring heap size
+##### Configuring heap size
 
 If you specify Pod memory limits, Oracle recommends configuring WebLogic Server heap sizes as a percentage. The JVM will interpret the percentage as a fraction of the limit. This is done using the JVM `-XX:MinRAMPercentage` and `-XX:MaxRAMPercentage` options in the `USER_MEM_ARGS` [Domain resource environment variable]({{< relref "/userguide/managing-domains/domain-resource#jvm-memory-and-java-option-environment-variables" >}}).  For example:
 
@@ -108,26 +109,26 @@ If you specify Pod memory limits, Oracle recommends configuring WebLogic Server 
         value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 -Djava.security.egd=file:/dev/./urandom"
 ```
 
-Additionally there's also a node-manager process that's running in the same container as the WebLogic Server which has its own heap and native memory requirements. Its heap is tuned by using `-Xms` and `-Xmx` in the `NODEMGR_MEM_ARGS` environment variable. Oracle recommends setting the node manager heap memory to fixed sizes, instead of percentages, where [the default tuning]({{< relref "/userguide/managing-domains/domain-resource#jvm-memory-and-java-option-environment-variables" >}}) is usually sufficient.
+Additionally, there's a `node-manager` process that's running in the same container as the WebLogic Server, which has its own heap and native memory requirements. Its heap is tuned by using `-Xms` and `-Xmx` in the `NODEMGR_MEM_ARGS` environment variable. Oracle recommends setting the Node Manager heap memory to fixed sizes, instead of percentages, where [the default tuning]({{< relref "/userguide/managing-domains/domain-resource#jvm-memory-and-java-option-environment-variables" >}}) is usually sufficient.
 
 {{% notice note %}}
-Notice that the `NODEMGR_MEM_ARGS` and `USER_MEM_ARGS` environment variables both set `-Djava.security.egd=file:/dev/./urandom` by default so we have also included them in the above example for specifying a `USER_MEM_ARGS` value. This helps speed up Node Manager and WebLogic Server startup on systems with low entropy. 
+Notice that the `NODEMGR_MEM_ARGS` and `USER_MEM_ARGS` environment variables both set `-Djava.security.egd=file:/dev/./urandom` by default, so we have also included them in the above example for specifying a `USER_MEM_ARGS` value. This helps speed up Node Manager and WebLogic Server startup time on systems with low entropy.
 {{% /notice %}}
 
 In some cases, you might only want to configure memory resource requests but not configure memory resource limits. In such scenarios, you can use the traditional fixed heap size settings (`-Xms` and `-Xmx`) in your WebLogic Server `USER_MEM_ARGS` instead of the percentage settings (`-XX:MinRAMPercentage` and `-XX:MaxRAMPercentage`).
 
-### CPU resource considerations
+#### CPU resource considerations
 
-It's important to set both a CPU request and a limit for WebLogic Server Pods. This ensures that all WebLogic server Pods have enough CPU resources, and, as discussed earlier, if the request and limit are set to the same value, then they get a `guaranteed` QoS. A `guaranteed` QoS ensures the Pods are handled with a higher priority during scheduling and so are the least likely to be evicted.
+It's important to set both a CPU request and a limit for WebLogic Server Pods. This ensures that all WebLogic Server Pods have enough CPU resources, and, as discussed earlier, if the request and limit are set to the same value, then they get a `guaranteed` QoS. A `guaranteed` QoS ensures that the Pods are handled with a higher priority during scheduling and as such, are the least likely to be evicted.
 
 If a CPU request and limit are _not_ configured for a WebLogic Server Pod:
-- The Pod can end up using all CPU resources available on its Node and starve other containers from using shareable CPU cycles. 
+- The Pod can end up using all the CPU resources available on its Node and starve other containers from using shareable CPU cycles.
 
-- The WebLogic server JVM may choose an unsuitable garbage collection (GC) strategy.
+- The WebLogic Server JVM may choose an unsuitable garbage collection (GC) strategy.
 
-- A WebLogic Server self-tuning work-manager may incorrectly optimize the number of threads it allocates for the default thread pool. 
+- A WebLogic Server self-tuning `work-manager` may incorrectly optimize the number of threads it allocates for the default thread pool.
 
-It's also important to keep in mind that if you set a value of CPU core count that's larger than core count of your biggest Node, then the Pod will never be scheduled. Let's say you have a Pod that needs 4 cores but you have a kubernetes cluster that's comprised of 2 core VMs. In this case, your Pod will never be scheduled and will have `Pending` status. For example:
+It's also important to keep in mind that if you set a value of CPU core count that's larger than the core count of your biggest Node, then the Pod will never be scheduled. Let's say you have a Pod that needs 4 cores but you have a Kubernetes cluster that's comprised of 2 core VMs. In this case, your Pod will never be scheduled and will have `Pending` status. For example:
 
 ```
 $ kubectl get pod sample-domain1-managed-server1 -n sample-domain1-ns
@@ -141,31 +142,31 @@ Events:
   Warning  FailedScheduling  16s (x3 over 26s)  default-scheduler  0/2 nodes are available: 2 Insufficient cpu.
 ```
 
-### Operator sample heap and resource configuration
+#### Operator sample heap and resource configuration
 
-The operator samples configure non-default minimum and maximum heap sizes for WebLogic server JVMs of at least 256MB and 512MB respectively. You can edit a sample's template or Domain resource `resources.env` `USER_MEM_ARGS` to have different values. See [Configuring heap size](#configuring-heap-size).
+The operator samples configure non-default minimum and maximum heap sizes for WebLogic Server JVMs of at least 256MB and 512MB respectively. You can edit a sample's template or Domain resource `resources.env` `USER_MEM_ARGS` to have different values. See [Configuring heap size](#configuring-heap-size).
 
 Similarly, the operator samples configure CPU and memory resource requests to at least `250m` and `768Mi` respectively.
 
-There's no memory or CPU limit configured by default in samples and so the default QoS for sample WebLogic server Pod's is `Burstable`. 
+There's no memory or CPU limit configured by default in samples and so the default QoS for sample WebLogic Server Pod's is `burstable`.
 
-If you wish to set resource requests or limits differently on a sample Domain resource or Domain resource template, see [Setting resource requests and limits in a Domain resource](#setting-resource-requests-and-limits-in-a-domain-resource). Or for samples that generate their Domain resource using an 'inputs' file, see the `serverPodMemoryRequest`, `serverPodMemoryLimit`, `serverPodCpuRequest`, and `serverPodCpuLimit` parameters in the sample's `create-domain.sh` input file.
+If you wish to set resource requests or limits differently on a sample Domain resource or Domain resource template, see [Setting resource requests and limits in a Domain resource](#setting-resource-requests-and-limits-in-a-domain-resource). Or, for samples that generate their Domain resource using an 'inputs' file, see the `serverPodMemoryRequest`, `serverPodMemoryLimit`, `serverPodCpuRequest`, and `serverPodCpuLimit` parameters in the sample's `create-domain.sh` input file.
 
-### Configuring CPU affinity
+#### Configuring CPU affinity
 
-A Kubernetes hosted WebLogic server may exhibit high lock contention in comparison to an on-premise deployment. This lock contention may be due to lack of CPU cache affinity or scheduling latency when workloads move between different CPU cores.  
+A Kubernetes hosted WebLogic Server may exhibit high lock contention in comparison to an on-premises deployment. This lock contention may be due to a lack of CPU cache affinity or scheduling latency when workloads move between different CPU cores.  
 
-In an on-premise deployment, CPU cache affinity, and therefore reduced lock contention, can be achieved by binding WLS java process to particular CPU core(s) (using the `taskset` command).
+In an on-premises deployment, CPU cache affinity, and therefore reduced lock contention, can be achieved by binding WLS Java process to a particular CPU core(s) (using the `taskset` command).
 
 In a Kubernetes deployment, similar cache affinity can be achieved by doing the following:
 - Ensuring a Pod's CPU resource request and limit are set and equal (to ensure a `guaranteed` QoS).
-- Configuring the `kubelet` CPU manager policy to be `static` (the default is `none`). See [Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies). 
+- Configuring the `kubelet` CPU manager policy to be `static` (the default is `none`). See [Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies).
 Note that some Kubernetes environments may not allow changing the CPU management policy.
 
-### Measuring JVM heap, Pod CPU, and Pod memory
-You can monitor JVM heap, Pod CPU and Pod memory using Prometheus and Grafana using steps similar to the [Monitor a SOA Domain]({{< relref "/samples/simple/elastic-stack/soa-domain/weblogic-monitoring-exporter-setup" >}}) sample. Also see [Tools for Monitoring Resources](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-usage-monitoring/) in the Kubernetes documentation.
+#### Measuring JVM heap, Pod CPU, and Pod memory
+You can monitor JVM heap, Pod CPU, and Pod memory using Prometheus and Grafana with steps similar to the [Monitor a SOA Domain]({{< relref "/samples/simple/elastic-stack/soa-domain/weblogic-monitoring-exporter-setup" >}}) sample. Also, see [Tools for Monitoring Resources](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-usage-monitoring/) in the Kubernetes documentation.
 
-### References:
+#### References:
 1. [Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) in the Kubernetes documentation.
 1. [Assign Memory Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource) in the Kubernetes documentation.
 1. [Assign CPU Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/) in the Kubernetes documentation.
@@ -174,4 +175,3 @@ You can monitor JVM heap, Pod CPU and Pod memory using Prometheus and Grafana us
 1. [Tools for Monitoring Resources](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-usage-monitoring/) in the Kubernetes documentation.
 1. [Blog -- Docker support in Java 8](https://blog.softwaremill.com/docker-support-in-new-java-8-finally-fd595df0ca54). (Discusses Java container support in general.)
 1. [Blog -- Kubernetes Patterns : Capacity Planning](https://www.magalix.com/blog/kubernetes-patterns-capacity-planning)
-

--- a/kubernetes/samples/scripts/common/domain-template.yaml
+++ b/kubernetes/samples/scripts/common/domain-template.yaml
@@ -63,7 +63,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "%JAVA_OPTIONS%"
     - name: USER_MEM_ARGS
-      value: "-Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m "
     %OPTIONAL_SERVERPOD_RESOURCES%
     %LOG_HOME_ON_PV_PREFIX%volumes:
     %LOG_HOME_ON_PV_PREFIX%- name: weblogic-domain-storage-volume

--- a/kubernetes/samples/scripts/common/jrf-domain-template.yaml
+++ b/kubernetes/samples/scripts/common/jrf-domain-template.yaml
@@ -3,13 +3,12 @@
 #
 # This is an example of how to define a Domain resource.
 #
-apiVersion: "weblogic.oracle/v7"
+apiVersion: "weblogic.oracle/v8"
 kind: Domain
 metadata:
   name: %DOMAIN_UID%
   namespace: %NAMESPACE%
   labels:
-    weblogic.resourceVersion: domain-v2
     weblogic.domainUID: %DOMAIN_UID%
 spec:
   # The WebLogic Domain Home
@@ -50,11 +49,6 @@ spec:
   # data storage directories are determined from the WebLogic domain home configuration.
   dataHome: "%DATA_HOME%"
 
-  # Istio service mesh support is experimental.
-  %ISTIO_PREFIX%experimental:
-  %ISTIO_PREFIX%  istio:
-  %ISTIO_PREFIX%    enabled: %ISTIO_ENABLED%
-  %ISTIO_PREFIX%    readinessPort: %ISTIO_READINESS_PORT%
 
   # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
   # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
@@ -121,3 +115,10 @@ spec:
     replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
   # The number of managed servers to start for unlisted clusters
   # replicas: 1
+
+  # Istio
+  %ISTIO_PREFIX%configuration:
+  %ISTIO_PREFIX%  istio:
+  %ISTIO_PREFIX%    enabled: %ISTIO_ENABLED%
+  %ISTIO_PREFIX%    readinessPort: %ISTIO_READINESS_PORT%
+

--- a/kubernetes/samples/scripts/common/jrf-domain-template.yaml
+++ b/kubernetes/samples/scripts/common/jrf-domain-template.yaml
@@ -1,0 +1,123 @@
+# Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# This is an example of how to define a Domain resource.
+#
+apiVersion: "weblogic.oracle/v7"
+kind: Domain
+metadata:
+  name: %DOMAIN_UID%
+  namespace: %NAMESPACE%
+  labels:
+    weblogic.resourceVersion: domain-v2
+    weblogic.domainUID: %DOMAIN_UID%
+spec:
+  # The WebLogic Domain Home
+  domainHome: %DOMAIN_HOME%
+
+  # The domain home source type
+  # Set to PersistentVolume for domain-in-pv, Image for domain-in-image, or FromModel for model-in-image
+  domainHomeSourceType: %DOMAIN_HOME_SOURCE_TYPE%
+
+  # The WebLogic Server Docker image that the Operator uses to start the domain
+  image: "%WEBLOGIC_IMAGE%"
+
+  # imagePullPolicy defaults to "Always" if image version is :latest
+  imagePullPolicy: "%WEBLOGIC_IMAGE_PULL_POLICY%"
+
+  # Identify which Secret contains the credentials for pulling an image
+  %WEBLOGIC_IMAGE_PULL_SECRET_PREFIX%imagePullSecrets:
+  %WEBLOGIC_IMAGE_PULL_SECRET_PREFIX%- name: %WEBLOGIC_IMAGE_PULL_SECRET_NAME%
+
+  # Identify which Secret contains the WebLogic Admin credentials (note that there is an example of
+  # how to create that Secret at the end of this file)
+  webLogicCredentialsSecret: 
+    name: %WEBLOGIC_CREDENTIALS_SECRET_NAME%
+
+  # Whether to include the server out file into the pod's stdout, default is true
+  includeServerOutInPodLog: %INCLUDE_SERVER_OUT_IN_POD_LOG%
+
+  # Whether to enable log home
+  %LOG_HOME_ON_PV_PREFIX%logHomeEnabled: %LOG_HOME_ENABLED%
+
+  # Whether to write HTTP access log file to log home
+  %LOG_HOME_ON_PV_PREFIX%httpAccessLogInLogHome: %HTTP_ACCESS_LOG_IN_LOG_HOME%
+
+  # The in-pod location for domain log, server logs, server out, and Node Manager log files
+  %LOG_HOME_ON_PV_PREFIX%logHome: %LOG_HOME%
+  # An (optional) in-pod location for data storage of default and custom file stores.
+  # If not specified or the value is either not set or empty (e.g. dataHome: "") then the
+  # data storage directories are determined from the WebLogic domain home configuration.
+  dataHome: "%DATA_HOME%"
+
+  # Istio service mesh support is experimental.
+  %ISTIO_PREFIX%experimental:
+  %ISTIO_PREFIX%  istio:
+  %ISTIO_PREFIX%    enabled: %ISTIO_ENABLED%
+  %ISTIO_PREFIX%    readinessPort: %ISTIO_READINESS_PORT%
+
+  # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
+  # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
+  # - "NEVER" will not start any server in the domain
+  # - "ADMIN_ONLY" will start up only the administration server (no managed servers will be started)
+  # - "IF_NEEDED" will start all non-clustered servers, including the administration server and clustered servers up to the replica count
+  serverStartPolicy: "%SERVER_START_POLICY%"
+
+  serverPod:
+    # an (optional) list of environment variable to be set on the servers
+    env:
+    - name: JAVA_OPTIONS
+      value: "%JAVA_OPTIONS%"
+    - name: USER_MEM_ARGS
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx1024m "
+    %OPTIONAL_SERVERPOD_RESOURCES%
+    %LOG_HOME_ON_PV_PREFIX%volumes:
+    %LOG_HOME_ON_PV_PREFIX%- name: weblogic-domain-storage-volume
+    %LOG_HOME_ON_PV_PREFIX%  persistentVolumeClaim:
+    %LOG_HOME_ON_PV_PREFIX%    claimName: %DOMAIN_PVC_NAME%
+    %LOG_HOME_ON_PV_PREFIX%volumeMounts:
+    %LOG_HOME_ON_PV_PREFIX%- mountPath: %DOMAIN_ROOT_DIR%
+    %LOG_HOME_ON_PV_PREFIX%  name: weblogic-domain-storage-volume
+
+  # adminServer is used to configure the desired behavior for starting the administration server.
+  adminServer:
+    # serverStartState legal values are "RUNNING" or "ADMIN"
+    # "RUNNING" means the listed server will be started up to "RUNNING" mode
+    # "ADMIN" means the listed server will be start up to "ADMIN" mode
+    serverStartState: "RUNNING"
+    %EXPOSE_ANY_CHANNEL_PREFIX%adminService:
+    %EXPOSE_ANY_CHANNEL_PREFIX%  channels:
+    # The Admin Server's NodePort
+    %EXPOSE_ADMIN_PORT_PREFIX%   - channelName: default
+    %EXPOSE_ADMIN_PORT_PREFIX%     nodePort: %ADMIN_NODE_PORT%
+    # Uncomment to export the T3Channel as a service
+    %EXPOSE_T3_CHANNEL_PREFIX%   - channelName: T3Channel
+    serverPod:
+      # an (optional) list of environment variable to be set on the admin servers
+      env:
+      - name: USER_MEM_ARGS
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx1024m "
+
+  # clusters is used to configure the desired behavior for starting member servers of a cluster.  
+  # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
+  clusters:
+  - clusterName: %CLUSTER_NAME%
+    serverStartState: "RUNNING"
+    serverPod:
+      # Instructs Kubernetes scheduler to prefer nodes for new cluster members where there are not
+      # already members of the same cluster.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "weblogic.clusterName"
+                      operator: In
+                      values:
+                        - $(CLUSTER_NAME)
+                topologyKey: "kubernetes.io/hostname"
+    replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
+  # The number of managed servers to start for unlisted clusters
+  # replicas: 1

--- a/kubernetes/samples/scripts/common/jrf-domain-template.yaml
+++ b/kubernetes/samples/scripts/common/jrf-domain-template.yaml
@@ -49,7 +49,6 @@ spec:
   # data storage directories are determined from the WebLogic domain home configuration.
   dataHome: "%DATA_HOME%"
 
-
   # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
   # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
   # - "NEVER" will not start any server in the domain

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -142,16 +142,20 @@ domainHomeImageBase: container-registry.oracle.com/middleware/fmw-infrastructure
 # which uses WDT, instead of WLST, to generate the domain configuration.
 domainHomeImageBuildPath: ./docker-images/OracleFMWInfrastructure/samples/12213-domain-home-in-image
 
-# Uncomment and edit value(s) below to specify the maximum amount of
-# compute resources allowed, and minimum amount of compute resources
-# required for each server pod.
-# These are optional.
+# Resource request for each server pod (Memory and CPU). This is minimum amount of compute
+# resources required for each server pod. Edit value(s) below as per pod sizing requirements.
+# These are optional. 
 # Please refer to the kubernetes documentation on Managing Compute
 # Resources for Containers for details.
-#
-# serverPodMemoryRequest: "64Mi"
-# serverPodCpuRequest: "250m"
-# serverPodMemoryLimit: "1Gi"
+serverPodMemoryRequest: "1280Mi"
+serverPodCpuRequest: "500m"
+
+# Uncomment and edit value(s) below to specify the maximum amount of compute resources allowed 
+# for each server pod.
+# These are optional. 
+# Please refer to the kubernetes documentation on Managing Compute
+# Resources for Containers for details.
+# serverPodMemoryLimit: "2Gi"
 # serverPodCpuLimit: "1000m"
 
 #

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
@@ -141,7 +141,7 @@ function initialize {
     validationError "The template file ${domainPropertiesInput} for creating a WebLogic domain was not found"
   fi
 
-  dcrInput="${scriptDir}/../../common/domain-template.yaml"
+  dcrInput="${scriptDir}/../../common/jrf-domain-template.yaml"
   if [ ! -f ${dcrInput} ]; then
     validationError "The template file ${dcrInput} for creating the domain resource was not found"
   fi

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -142,16 +142,20 @@ createDomainScriptName: create-domain-job.sh
 # so that the Kubernetes pod can use the scripts and supporting files to create a domain home.
 createDomainFilesDir: wlst
 
-# Uncomment and edit value(s) below to specify the maximum amount of
-# compute resources allowed, and minimum amount of compute resources
-# required for each server pod.
-# These are optional.
+# Resource request for each server pod (Memory and CPU). This is minimum amount of compute
+# resources required for each server pod. Edit value(s) below as per pod sizing requirements.
+# These are optional. 
 # Please refer to the kubernetes documentation on Managing Compute
 # Resources for Containers for details.
-#
-# serverPodMemoryRequest: "64Mi"
-# serverPodCpuRequest: "250m"
-# serverPodMemoryLimit: "1Gi"
+serverPodMemoryRequest: "1280Mi"
+serverPodCpuRequest: "500m"
+
+# Uncomment and edit value(s) below to specify the maximum amount of compute resources allowed 
+# for each server pod.
+# These are optional. 
+# Please refer to the kubernetes documentation on Managing Compute
+# Resources for Containers for details.
+# serverPodMemoryLimit: "2Gi"
 # serverPodCpuLimit: "1000m"
 
 #

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/create-domain.sh
@@ -118,7 +118,7 @@ function initialize {
     validationError "The template file ${deleteJobInput} for deleting a WebLogic domain was not found"
   fi
 
-  dcrInput="${scriptDir}/../../common/domain-template.yaml"
+  dcrInput="${scriptDir}/../../common/jrf-domain-template.yaml"
   if [ ! -f ${dcrInput} ]; then
     validationError "The template file ${dcrInput} for creating the domain resource was not found"
   fi

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -159,15 +159,19 @@ domainHomeImageBase: container-registry.oracle.com/middleware/weblogic:12.2.1.4
 # which uses WDT, instead of WLST, to generate the domain configuration.
 domainHomeImageBuildPath: ./docker-images/OracleWebLogic/samples/12213-domain-home-in-image
 
-# Uncomment and edit value(s) below to specify the maximum amount of 
-# compute resources allowed, and minimum amount of compute resources 
-# required for each server pod.
-# These are optional.                
+# Resource request for each server pod (Memory and CPU). This is minimum amount of compute
+# resources required for each server pod. Edit value(s) below as per pod sizing requirements.
+# These are optional. 
 # Please refer to the kubernetes documentation on Managing Compute
 # Resources for Containers for details.
-#
-# serverPodMemoryRequest: "64Mi"
-# serverPodCpuRequest: "250m"
+serverPodMemoryRequest: "768Mi"
+serverPodCpuRequest: "250m"
+
+# Uncomment and edit value(s) below to specify the maximum amount of compute resources allowed 
+# for each server pod.
+# These are optional. 
+# Please refer to the kubernetes documentation on Managing Compute
+# Resources for Containers for details.
 # serverPodMemoryLimit: "1Gi"
 # serverPodCpuLimit: "1000m"
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-inputs.yaml
@@ -145,16 +145,22 @@ createDomainScriptName: create-domain-job.sh
 # Kubernetes config map, which in turn is mounted to the `createDomainScriptsMountPath`,
 # so that the Kubernetes pod can use the scripts and supporting files to create a domain home.
 createDomainFilesDir: wlst
+ 
+# Resource request for each server pod (Memory and CPU). This is minimum amount of compute
+# resources required for each server pod. Edit value(s) below as per pod sizing requirements.
+# These are optional 
+# Please refer to the kubernetes documentation on Managing Compute
+# Resources for Containers for details.
+#
+serverPodMemoryRequest: "768Mi"
+serverPodCpuRequest: "250m"
 
-# Uncomment and edit value(s) below to specify the maximum amount of 
-# compute resources allowed, and minimum amount of compute resources
-# required for each server pod.
+# Uncomment and edit value(s) below to specify the maximum amount of compute resources allowed 
+# for each server pod.
 # These are optional. 
 # Please refer to the kubernetes documentation on Managing Compute
 # Resources for Containers for details.
 #
-# serverPodMemoryRequest: "64Mi"
-# serverPodCpuRequest: "250m"
 # serverPodMemoryLimit: "1Gi"
 # serverPodCpuLimit: "1000m"
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/manually-create-domain/domain.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/manually-create-domain/domain.yaml
@@ -65,7 +65,10 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-Xms64m -Xmx256m "
+      value: "-Xms256m -Xmx512m "
+    requests:
+      cpu: "250m"
+      memory: "768Mi"
 
     # If you are storing your domain on a persistent volume (as opposed to inside the Docker image),
     # then uncomment this section and provide the PVC details and mount path here (standard images

--- a/kubernetes/samples/scripts/create-weblogic-domain/manually-create-domain/domain.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/manually-create-domain/domain.yaml
@@ -65,7 +65,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-Xms256m -Xmx512m "
+      value: "-Xms256m -Xmx512m -Djava.security.egd=file:/dev/./urandom "
     requests:
       cpu: "250m"
       memory: "768Mi"

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-initial-d1-JRF-v1.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-initial-d1-JRF-v1.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx1024m "
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1280Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:
@@ -83,6 +87,11 @@ spec:
     #  channels:
     #  - channelName: default
     #    nodePort: 30701
+    serverPod:
+      # Optional new or overridden environment variables for the admin pods
+      env:
+      - name: USER_MEM_ARGS
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx1024m "
    
   # The number of managed servers to start for unlisted clusters
   replicas: 1

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-update1-d1-JRF-v1-ds.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-update1-d1-JRF-v1-ds.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx1024m "
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1280Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:
@@ -83,6 +87,11 @@ spec:
     #  channels:
     #  - channelName: default
     #    nodePort: 30701
+    serverPod:
+      # Optional new or overridden environment variables for the admin pods
+      env:
+      - name: USER_MEM_ARGS
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx1024m "
    
   # The number of managed servers to start for unlisted clusters
   replicas: 1

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-update2-d2-JRF-v1-ds.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-update2-d2-JRF-v1-ds.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx1024m "
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1280Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:
@@ -83,6 +87,11 @@ spec:
     #  channels:
     #  - channelName: default
     #    nodePort: 30701
+    serverPod:
+      # Optional new or overridden environment variables for the admin pods
+      env:
+      - name: USER_MEM_ARGS
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx1024m "
    
   # The number of managed servers to start for unlisted clusters
   replicas: 1

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-update3-d1-JRF-v2-ds.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF/mii-update3-d1-JRF-v2-ds.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx1024m "
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1280Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:
@@ -83,6 +87,11 @@ spec:
     #  channels:
     #  - channelName: default
     #    nodePort: 30701
+    serverPod:
+      # Optional new or overridden environment variables for the admin pods
+      env:
+      - name: USER_MEM_ARGS
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx1024m "
    
   # The number of managed servers to start for unlisted clusters
   replicas: 1

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-initial-d1-WLS-v1.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-initial-d1-WLS-v1.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m "
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-update1-d1-WLS-v1-ds.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-update1-d1-WLS-v1-ds.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m "
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-update2-d2-WLS-v1-ds.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-update2-d2-WLS-v1-ds.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m "
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-update3-d1-WLS-v2-ds.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/WLS/mii-update3-d1-WLS-v2-ds.yaml
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m "
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:

--- a/src/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-JRF
+++ b/src/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-JRF
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx1024m "
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1280Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:
@@ -83,6 +87,11 @@ spec:
     #  channels:
     #  - channelName: default
     #    nodePort: 30701
+    serverPod:
+      # Optional new or overridden environment variables for the admin pods
+      env:
+      - name: USER_MEM_ARGS
+        value: "-Djava.security.egd=file:/dev/./urandom -Xms512m -Xmx1024m "
    
   # The number of managed servers to start for unlisted clusters
   replicas: 1

--- a/src/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-WLS
+++ b/src/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-WLS
@@ -61,7 +61,11 @@ spec:
     - name: JAVA_OPTIONS
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
-      value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m "
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
 
     # Optional volumes and mounts for the domain's pods. See also 'logHome'.
     #volumes:


### PR DESCRIPTION
Changes for OWLS-80384 - Verify that operator deployment and WebLogic pods have good default cpu/memory resources. 
Changed WLS samples to use below defaults - 
- Min and Max heap size of 256MB and 512MB
- Memory requests of 768MB and CPU request of 250m
Changed JRF samples to use below defaults -
- Min and Max heap size of 512MB and 1024MB for admin server and 256MB and 1024MB for managed servers
- Memory requests of 1280MB and CPU request of 500m

Created first draft of FAQ document for resource requests/limits and Java options for heap size considerations. 