### PR TITLE
Improve test verification

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -410,7 +410,7 @@ class ItMiiDomain {
         } catch (InterruptedException ie) {
           // do nothing
         }
- 
+
         // check the application availability data that we have collected, and see if
         // the application has been available all the time since the beginning of this test method
         logger.info("Verify that V2 application was available when domain {0} was being patched with image {1}",
@@ -1045,10 +1045,11 @@ class ItMiiDomain {
       String appPath
   ) {
     boolean v2AppAvailable = false;
- 
+    boolean failed = false;
+
     // Access the pod periodically to check application's availability across the duration
     // of patching the domain with newer version of the application.
-    while (!v2AppAvailable)  {
+    while (!v2AppAvailable && !failed)  {
       v2AppAvailable = true;
       for (int i = 1; i <= replicaCount; i++) {
         v2AppAvailable = v2AppAvailable && appAccessibleInPod(
@@ -1074,6 +1075,7 @@ class ItMiiDomain {
       
       if (count == 0) {
         logger.info("XXXXXXXXXXX: application not available XXXXXXXX");
+        failed = true;
       } else {
         logger.fine("YYYYYYYYYYY: application available YYYYYYYY count = " + count);   
       }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -1045,11 +1045,10 @@ class ItMiiDomain {
       String appPath
   ) {
     boolean v2AppAvailable = false;
-    boolean failed = false;
 
     // Access the pod periodically to check application's availability across the duration
     // of patching the domain with newer version of the application.
-    while (!v2AppAvailable && !failed)  {
+    while (!v2AppAvailable)  {
       v2AppAvailable = true;
       for (int i = 1; i <= replicaCount; i++) {
         v2AppAvailable = v2AppAvailable && appAccessibleInPod(
@@ -1075,7 +1074,7 @@ class ItMiiDomain {
       
       if (count == 0) {
         logger.info("XXXXXXXXXXX: application not available XXXXXXXX");
-        failed = true;
+        break;
       } else {
         logger.fine("YYYYYYYYYYY: application available YYYYYYYY count = " + count);   
       }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestartWhenPodRoll.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestartWhenPodRoll.java
@@ -34,9 +34,8 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.actions.TestActions.deletePod;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.isOperatorPodRestarted;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
-import static oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isPodRestarted;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonPatchTestUtils.checkPodRestartVersionUpdated;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
@@ -235,18 +234,14 @@ public class ItOperatorRestartWhenPodRoll {
             opNamespace,
             condition.getElapsedTimeInMS(),
             condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> operatorIsReady(opNamespace),
-          "operatorIsReady failed with ApiException"));
+        .until(assertDoesNotThrow(() -> isOperatorPodRestarted(opNamespace, opPodCreationTime),
+            "Failed to check if the operator is restarted with ApiException"));
 
-    String opPodNameNew = 
+    String opPodNameNew =
         assertDoesNotThrow(() -> getOperatorPodName(TestConstants.OPERATOR_RELEASE_NAME, opNamespace),
-        "Failed to get the name of the operator pod");
+            "Failed to get the name of the operator pod");
 
     assertFalse(opPodNameNew.equals(opPodName),
         "The operator names before and after a restart should be different");
-
-    assertTrue(assertDoesNotThrow(() -> isPodRestarted(opPodNameNew, opNamespace, opPodCreationTime),
-        "Failed to check the operator for its new creation time with ApiException"),
-        "Operator restart failed");
   }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -447,6 +447,22 @@ public class TestAssertions {
   }
 
   /**
+   * Check if the oeprator pod in a given namespace is restarted based on podCreationTimestamp.
+   *
+   * @param namespace in which the pod is running
+   * @param timestamp the initial podCreationTimestamp
+   * @return true if the pod new timestamp is not equal to initial PodCreationTimestamp otherwise false
+   */
+  public static Callable<Boolean> isOperatorPodRestarted(
+      String namespace,
+      DateTime timestamp
+  ) {
+    return () -> {
+      return Kubernetes.isOperatorPodRestarted(namespace, timestamp);
+    };
+  }
+
+  /**
    * Verify the pod state is not changed.
    *
    * @param podName the name of the pod to check


### PR DESCRIPTION
1) In ItMiiDomain testPatchAppV2 test case, stop the application availability thread when it detects a failure, instead of waiting for the patched application is accessible on all managed servers.
2) In ItOperatorRestartWhenPodRoll test case, check and wait for the operator pod to be restarted, instead of,  ready to close a window between async deletion of the operator and check for podIsReady.