### PR TITLE
Change image version from default, latest to 7

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -330,7 +330,7 @@ public class LoggingUtil {
             .containers(Arrays.asList(
                 new V1Container()
                     .name("pv-container")
-                    .image("oraclelinux")
+                    .image("oraclelinux:7")
                     .imagePullPolicy("IfNotPresent")
                     .volumeMounts(Arrays.asList(
                         new V1VolumeMount()


### PR DESCRIPTION
The LoggingUtil.java uses oraclelinux:latest image to setup a pod to copy PV_ROOT contents.
The latest version tag was deleted from repo and this change uses 7as the tag.