### PR TITLE
Make Calico CNI an option when running tests with Kind

### DIFF
--- a/kindtest.sh
+++ b/kindtest.sh
@@ -142,6 +142,9 @@ echo 'Create a cluster with the local registry enabled in containerd'
 cat <<EOF | kind create cluster --name "${kind_name}" --kubeconfig "${RESULT_ROOT}/kubeconfig" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
@@ -161,6 +164,11 @@ echo "  export KUBECONFIG=\"${RESULT_ROOT}/kubeconfig\""
 echo "  kubectl cluster-info --context \"kind-${kind_name}\""
 export KUBECONFIG="${RESULT_ROOT}/kubeconfig"
 kubectl cluster-info --context "kind-${kind_name}"
+
+echo "Install Calico"
+kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml
+kubectl create -f https://docs.projectcalico.org/manifests/custom-resources.yaml
+
 kubectl get node -o wide
 
 for node in $(kind get nodes --name "${kind_name}"); do

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -36,7 +36,7 @@ script="${BASH_SOURCE[0]}"
 scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
 
 function usage {
-  echo "usage: ${script} [-v <version>] [-n <name>] [-o <directory>] [-t <tests>] [-h]"
+  echo "usage: ${script} [-v <version>] [-n <name>] [-o <directory>] [-t <tests>] [-c <name>] [-p true|false] [-h]"
   echo "  -v Kubernetes version (optional) "
   echo "      (default: 1.15.11, supported values: 1.18, 1.18.2, 1.17, 1.17.5, 1.16, 1.16.9, 1.15, 1.15.11, 1.14, 1.14.10) "
   echo "  -n Kind cluster name (optional) "
@@ -45,6 +45,8 @@ function usage {
   echo "      (default: \${WORKSPACE}/logdir/\${BUILD_TAG}, if \${WORKSPACE} defined, else /scratch/\${USER}/kindtest) "
   echo "  -t Test filter (optional) "
   echo "      (default: **/It*) "
+  echo "  -c CNI implementation (optional) "
+  echo "      (default: kindnet, supported values: kindnet, calico) "
   echo "  -p Run It classes in parallel"
   echo "      (default: false) "
   echo "  -h Help"
@@ -59,9 +61,10 @@ else
   outdir="${WORKSPACE}/logdir/${BUILD_TAG}"
 fi
 test_filter="**/It*"
+cni_implementation="kindnet"
 parallel_classes="false"
 
-while getopts ":h:n:o:t:v:p:" opt; do
+while getopts ":h:n:o:t:v:c:p:" opt; do
   case $opt in
     v) k8s_version="${OPTARG}"
     ;;
@@ -70,6 +73,8 @@ while getopts ":h:n:o:t:v:p:" opt; do
     o) outdir="${OPTARG}"
     ;;
     t) test_filter="${OPTARG}"
+    ;;
+    c) cni_implementation="${OPTARG}"
     ;;
     p) parallel_classes="${OPTARG}"
     ;;
@@ -91,6 +96,22 @@ if [ -z "${kind_image}" ]; then
 fi
 
 echo "Using Kubernetes version: ${k8s_version}"
+
+networking=""
+if [ "${cni_implementation}" = "calico" ]; then
+  if [ "${k8s_version}" = "1.15" ] || [ "${k8s_version}" = "1.15.11" ] || [ "${k8s_version}" = "1.14" ] || [ "${k8s_version}" = "1.14.10" ]; then
+    echo "Calico CNI is not supported with Kubernetes versions below 1.16."
+    exit 1
+  fi
+  read -d '' networking << EOF
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet
+EOF
+elif [ "${cni_implementation}" != "kindnet" ]; then
+  echo "Unsupported CNI implementation: ${cni_implementation}"
+  exit 1
+fi
 
 mkdir -m777 -p "${outdir}"
 export RESULT_ROOT="${outdir}/wl_k8s_test_results"
@@ -142,9 +163,7 @@ echo 'Create a cluster with the local registry enabled in containerd'
 cat <<EOF | kind create cluster --name "${kind_name}" --kubeconfig "${RESULT_ROOT}/kubeconfig" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  disableDefaultCNI: true # disable kindnet
-  podSubnet: 192.168.0.0/16 # set to Calico's default subnet
+${networking}
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]


### PR DESCRIPTION
Kind includes a built-in simple CNI called kindnet; however, it's possible to use other CNI implementations with Kind clusters. Since Calico is becoming more prominent, I've started with that implementation.

This change adds an option for the CNI implementation supporting Calico and with kindnet still the default.

I'm using the default install YAML's from the Calico site, which use a "v1" CRD and so only work on K8s 1.16 or greater.