### PR TITLE
Fix for ItJrfDomainInPV failures in kind cluster

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItJrfDomainInPV.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItJrfDomainInPV.java
@@ -126,6 +126,15 @@ public class ItJrfDomainInPV {
     assertNotNull(namespaces.get(2), "Namespace is null");
     jrfDomainNamespace = namespaces.get(2);
 
+    //determine if the tests are running in Kind cluster. if true use images from Kind registry
+    if (KIND_REPO != null) {
+      dbImage = KIND_REPO + DB_IMAGE_NAME.substring(OCR_REGISTRY.length() + 1)
+          + ":" + DB_IMAGE_TAG;
+      fmwImage = KIND_REPO + JRF_BASE_IMAGE_NAME.substring(OCR_REGISTRY.length() + 1)
+          + ":" + JRF_BASE_IMAGE_TAG;
+      isUseSecret = false;
+    }
+
     final int dbPort = getNextFreePort(30000, 32767);
     logger.info("Start DB and create RCU schema for namespace: {0}, RCU prefix: {1}, dbPort: {2} "
         + "dbUrl: {3} dbImage: {4},  fmwImage: {5} isUseSecret: {6}", dbNamespace, RCUSCHEMAPREFIX, dbPort, dbUrl,
@@ -136,15 +145,6 @@ public class ItJrfDomainInPV {
 
     // install operator and verify its running in ready state
     installAndVerifyOperator(opNamespace, jrfDomainNamespace);
-
-    //determine if the tests are running in Kind cluster. if true use images from Kind registry
-    if (KIND_REPO != null) {
-      dbImage = KIND_REPO + DB_IMAGE_NAME.substring(OCR_REGISTRY.length() + 1)
-        + ":" + DB_IMAGE_TAG;
-      fmwImage = KIND_REPO + JRF_BASE_IMAGE_NAME.substring(OCR_REGISTRY.length() + 1)
-        + ":" + JRF_BASE_IMAGE_TAG;
-      isUseSecret = false;
-    }
 
     logger.info("For ItJrfDomainInPV using DB image: {0}, FMW image {1}", dbImage, fmwImage);
 


### PR DESCRIPTION
Move the KIND_REPO check before calling the DbUtils.setupDBandRCUschema to set the image repos for dbimage and fmwimage.

Before fix

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/618/testReport/junit/oracle.weblogic.kubernetes/ItJrfDomainInPV/oracle_weblogic_kubernetes_ItJrfDomainInPV/

<07-02-2020 20:22:54> <INFO> <oracle.weblogic.kubernetes.ItJrfDomainInPV initAll> <Start DB and create RCU schema for namespace: ns-hmxx, RCU prefix: jrfdomainpv, dbPort: 30,000 dbUrl: oracledb.ns-hmxx.svc.cluster.local:1521/devpdb.k8s **dbImage: container-registry.oracle.com/database/enterprise:12.2.0.1-slim,  fmwImage: container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.4 isUseSecret: true**>
<07-02-2020 20:22:54> <INFO> <oracle.weblogic.kubernetes.utils.DbUtils setupDBandRCUschema> <Start Oracle DB with dbImage: container-registry.oracle.com/database/enterprise:12.2.0.1-slim, dbPort: 30,000, dbNamespace: ns-hmxx, isUseSecret: true>

After fix

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/622/console

<07-02-2020 23:04:07> <INFO> <oracle.weblogic.kubernetes.ItJrfDomainInPV initAll> <Start DB and create RCU schema for namespace: ns-yvwx, RCU prefix: jrfdomainpv, dbPort: 30,000 dbUrl: oracledb.ns-yvwx.svc.cluster.local:1521/devpdb.k8s **dbImage: localhost:5000/database/enterprise:12.2.0.1-slim,  fmwImage: localhost:5000/middleware/fmw-infrastructure:12.2.1.4 isUseSecret: false**>