### PR TITLE
un-hide demo video

### DIFF
--- a/docs-source/content/userguide/introduction/demo.md
+++ b/docs-source/content/userguide/introduction/demo.md
@@ -1,7 +1,7 @@
 ---
 title: "Demo"
 date: 2019-02-23T20:51:59-05:00
-draft: true
+draft: false
 weight: 2
 description: "Watch a video demonstration of the WebLogic Server Kubernetes Operator."
 ---


### PR DESCRIPTION
YouTube video for WKO 2.0 is now displayed (was previously hidden due to a permission loss).