### PR TITLE
Create an unique Voyager release name for each test suite jenkins-ignore

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -79,7 +79,7 @@ public interface TestConstants {
 
   // Voyager constants
   public static final String APPSCODE_REPO_URL = "https://charts.appscode.com/stable/";
-  public static final String VOYAGER_RELEASE_NAME = "voyager-release";
+  public static final String VOYAGER_RELEASE_NAME = "voyager-release" + BUILD_ID;
   public static final String APPSCODE_REPO_NAME = "appscode";
   public static final String VOYAGER_CHART_NAME = "voyager";
   public static final String VOYAGER_CHART_VERSION = "12.0.0";

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -398,11 +398,11 @@ public class CommonTestUtils {
                                                    String cloudProvider,
                                                    boolean enableValidatingWebhook) {
     LoggingFacade logger = getLogger();
-    final String voyagerPodNamePrefix = VOYAGER_CHART_NAME +  "-release-";
+    final String voyagerPodNamePrefix = VOYAGER_CHART_NAME +  "-release";
 
     // Helm install parameters
     HelmParams voyagerHelmParams = new HelmParams()
-        .releaseName(VOYAGER_RELEASE_NAME)
+        .releaseName(VOYAGER_RELEASE_NAME + "-" + voyagerNamespace.substring(3))
         .namespace(voyagerNamespace)
         .repoUrl(APPSCODE_REPO_URL)
         .repoName(APPSCODE_REPO_NAME)


### PR DESCRIPTION
Create an unique Voyager release name for each test suite using Voyager as LBer to fix the error below:

<06-29-2020 20:13:21> <INFO> <oracle.weblogic.kubernetes.actions.impl.primitive.Helm exec> <Command failed with errors Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: kind: ClusterRole, namespace: , name: voyager-release