### PR TITLE
Using different ports instead of starting at default 30000

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -22,33 +22,15 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.custom.V1Patch;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
-import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
-import io.kubernetes.client.openapi.models.V1Job;
-import io.kubernetes.client.openapi.models.V1JobCondition;
-import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1PersistentVolume;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimSpec;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeSpec;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
-import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1SecretReference;
-import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.AdminServer;
@@ -86,39 +68,34 @@ import static oracle.weblogic.kubernetes.TestConstants.OCR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_USERNAME;
-import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
-import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
-import static oracle.weblogic.kubernetes.actions.TestActions.createNamespacedJob;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolume;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolumeClaim;
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteConfigMap;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteSecret;
-import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
 import static oracle.weblogic.kubernetes.actions.TestActions.getNextIntrospectVersion;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
-import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
 import static oracle.weblogic.kubernetes.actions.TestActions.shutdownDomain;
 import static oracle.weblogic.kubernetes.actions.TestActions.startDomain;
 import static oracle.weblogic.kubernetes.actions.impl.Domain.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listConfigMaps;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listSecrets;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.jobCompleted;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChanged;
 import static oracle.weblogic.kubernetes.utils.BuildApplication.buildApplication;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapFromFiles;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDockerRegistrySecret;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainJob;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPV;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPVC;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getPodCreationTime;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
@@ -127,7 +104,6 @@ import static oracle.weblogic.kubernetes.utils.MySQLDBUtils.createMySQLDB;
 import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static oracle.weblogic.kubernetes.utils.WLSTUtils.executeWLSTScript;
-import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -135,7 +111,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests related to overrideDistributionStrategy attribute.
@@ -207,9 +182,9 @@ public class ItConfigDistributionStrategy {
     domainNamespace = namespaces.get(1);
 
     //start two MySQL database instances
-    mysqlDBPort1 = getNextFreePort(30000, 32767);
+    mysqlDBPort1 = getNextFreePort(30020, 32767);
     createMySQLDB("mysqldb-1", "root", "root123", mysqlDBPort1, domainNamespace, null);
-    mysqlDBPort2 = getNextFreePort(31000, 32767);
+    mysqlDBPort2 = getNextFreePort(31020, 32767);
     createMySQLDB("mysqldb-2", "root", "root456", mysqlDBPort2, domainNamespace, null);
 
     dsUrl1 = "jdbc:mysql://" + K8S_NODEPORT_HOST + ":" + mysqlDBPort1;
@@ -799,7 +774,7 @@ public class ItConfigDistributionStrategy {
 
     // create persistent volume and persistent volume claim for domain
     // these resources should be labeled with domainUid for cleanup after testing
-    createPV(pvName, domainUid);
+    createPV(pvName, domainUid, this.getClass().getSimpleName());
     createPVC(pvName, pvcName, domainUid, domainNamespace);
 
     t3ChannelPort = getNextFreePort(31500, 32767);
@@ -1004,8 +979,10 @@ public class ItConfigDistributionStrategy {
 
     logger.info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm";
+
     assertDoesNotThrow(
-        () -> createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles, namespace),
+        () -> createConfigMapForDomainCreation(
+            domainScriptConfigMapName, domainScriptFiles, namespace, this.getClass().getSimpleName()),
         "Create configmap for domain creation failed");
 
     // create a V1Container with specific scripts and properties for creating domain
@@ -1020,229 +997,8 @@ public class ItConfigDistributionStrategy {
     //domain property file
 
     logger.info("Running a Kubernetes job to create the domain");
-    createDomainJob(pvName, pvcName, domainScriptConfigMapName, namespace, jobCreationContainer);
-
-  }
-
-  /**
-   * Create configmap containing domain creation scripts.
-   *
-   * @param configMapName name of the configmap to create
-   * @param files files to add in configmap
-   * @param namespace name of the namespace in which to create configmap
-   * @throws IOException when reading the domain script files fail
-   * @throws ApiException if create configmap fails
-   */
-  private void createConfigMapForDomainCreation(String configMapName, List<Path> files, String namespace)
-      throws ApiException, IOException {
-    logger.info("Creating configmap {0}", configMapName);
-
-    Path domainScriptsDir = Files.createDirectories(
-        Paths.get(TestConstants.LOGS_DIR, this.getClass().getSimpleName(), namespace));
-
-    // add domain creation scripts and properties files to the configmap
-    Map<String, String> data = new HashMap<>();
-    for (Path file : files) {
-      logger.info("Adding file {0} in configmap", file);
-      data.put(file.getFileName().toString(), Files.readString(file));
-      logger.info("Making a copy of file {0} to {1} for diagnostic purposes", file,
-          domainScriptsDir.resolve(file.getFileName()));
-      Files.copy(file, domainScriptsDir.resolve(file.getFileName()));
-    }
-    V1ObjectMeta meta = new V1ObjectMeta()
-        .name(configMapName)
-        .namespace(namespace);
-    V1ConfigMap configMap = new V1ConfigMap()
-        .data(data)
-        .metadata(meta);
-
-    boolean cmCreated = assertDoesNotThrow(() -> createConfigMap(configMap),
-        String.format("Failed to create configmap %s with files %s", configMapName, files));
-    assertTrue(cmCreated, String.format("Failed while creating ConfigMap %s", configMapName));
-  }
-
-  /**
-   * Create a job to create a domain in persistent volume.
-   *
-   * @param pvName name of the persistent volume to create domain in
-   * @param pvcName name of the persistent volume claim
-   * @param domainScriptCM configmap holding domain creation script files
-   * @param namespace name of the domain namespace in which the job is created
-   * @param jobContainer V1Container with job commands to create domain
-   */
-  private void createDomainJob(String pvName,
-      String pvcName, String domainScriptCM, String namespace, V1Container jobContainer) {
-    logger.info("Running Kubernetes job to create domain");
-
-    V1Job jobBody = new V1Job()
-        .metadata(
-            new V1ObjectMeta()
-                .name("create-domain-onpv-job-" + pvName) // name of the create domain job
-                .namespace(namespace))
-        .spec(new V1JobSpec()
-            .backoffLimit(0) // try only once
-            .template(new V1PodTemplateSpec()
-                .spec(new V1PodSpec()
-                    .restartPolicy("Never")
-                    .initContainers(Arrays.asList(new V1Container()
-                        .name("fix-pvc-owner") //
-                        // change the ownership
-                        // of the pv to opc:opc
-                        .image(image)
-                        .addCommandItem("/bin/sh")
-                        .addArgsItem("-c")
-                        .addArgsItem("chown -R "
-                            + "1000"
-                            + ":1000 "
-                            + "/shared")
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name(pvName)
-                                .mountPath(
-                                    "/shared")))
-                        .securityContext(new V1SecurityContext()
-                            .runAsGroup(0L)
-                            .runAsUser(0L))))
-                    .containers(Arrays.asList(jobContainer // container
-                        // containing WLST or WDT
-                        // details
-                        .name("create-weblogic-domain"
-                            + "-onpv-container")
-                        .image(image)
-                        .imagePullPolicy("Always")
-                        .ports(Arrays.asList(new V1ContainerPort()
-                            .containerPort(7001)))
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name("create-weblogic-domain-job-cm-volume") // domain creation scripts volume
-                                .mountPath("/u01/weblogic"), // availble under /u01/weblogic inside pod
-                            new V1VolumeMount()
-                                .name(pvName) //
-                                // location to write
-                                // domain
-                                .mountPath("/shared"))))) // mounted under /shared inside pod
-                    .volumes(Arrays.asList(
-                        new V1Volume()
-                            .name(pvName)
-                            .persistentVolumeClaim(
-                                new V1PersistentVolumeClaimVolumeSource()
-                                    .claimName(pvcName)),
-                        new V1Volume()
-                            .name("create-weblogic-domain-job-cm-volume")
-                            .configMap(
-                                new V1ConfigMapVolumeSource()
-                                    .name(domainScriptCM)))) //config map containing domain scripts
-                    .imagePullSecrets(isUseSecret ? Arrays.asList(
-                        new V1LocalObjectReference()
-                            .name(OCR_SECRET_NAME))
-                        : null))));
-    String jobName = assertDoesNotThrow(()
-        -> createNamespacedJob(jobBody), "Failed to create Job");
-
-    logger.info("Checking if the domain creation job {0} completed in namespace {1}",
-        jobName, namespace);
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for job {0} to be completed in namespace {1} "
-                + "(elapsed time {2} ms, remaining time {3} ms)",
-                jobName,
-                namespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(jobCompleted(jobName, null, namespace));
-
-    // check job status and fail test if the job failed to create domain
-    V1Job job = assertDoesNotThrow(() -> getJob(jobName, namespace),
-        "Getting the job failed");
-    if (job != null) {
-      V1JobCondition jobCondition = job.getStatus().getConditions().stream().filter(
-          v1JobCondition -> "Failed".equalsIgnoreCase(v1JobCondition.getType()))
-          .findAny()
-          .orElse(null);
-      if (jobCondition != null) {
-        logger.severe("Job {0} failed to create domain", jobName);
-        List<V1Pod> pods = assertDoesNotThrow(()
-            -> listPods(namespace, "job-name=" + jobName).getItems(),
-            "Listing pods failed");
-        if (!pods.isEmpty()) {
-          String podLog = assertDoesNotThrow(() -> getPodLog(pods.get(0).getMetadata().getName(), namespace),
-              "Failed to get pod log");
-          logger.severe(podLog);
-          fail("Domain create job failed");
-        }
-      }
-    }
-
-  }
-
-  /**
-   * Create a persistent volume.
-   *
-   * @param pvName name of the persistent volume to create
-   * @param domainUid domain UID
-   * @throws IOException when creating pv path fails
-   */
-  private void createPV(String pvName, String domainUid) {
-    logger.info("creating persistent volume");
-
-    Path pvHostPath = null;
-    try {
-      pvHostPath = Files.createDirectories(Paths.get(
-          PV_ROOT, this.getClass().getSimpleName(), pvName));
-      logger.info("Creating PV directory host path {0}", pvHostPath);
-      deleteDirectory(pvHostPath.toFile());
-      Files.createDirectories(pvHostPath);
-    } catch (IOException ioex) {
-      logger.severe(ioex.getMessage());
-      fail("Create persistent volume host path failed");
-    }
-
-    V1PersistentVolume v1pv = new V1PersistentVolume()
-        .spec(new V1PersistentVolumeSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
-            .volumeMode("Filesystem")
-            .putCapacityItem("storage", Quantity.fromString("5Gi"))
-            .persistentVolumeReclaimPolicy("Recycle")
-            .accessModes(Arrays.asList("ReadWriteMany"))
-            .hostPath(new V1HostPathVolumeSource()
-                .path(pvHostPath.toString())))
-        .metadata(new V1ObjectMeta()
-            .name(pvName)
-            .putLabelsItem("weblogic.resourceVersion", "domain-v2")
-            .putLabelsItem("weblogic.domainUid", domainUid));
-    boolean success = assertDoesNotThrow(() -> createPersistentVolume(v1pv),
-        "Failed to create persistent volume");
-    assertTrue(success, "PersistentVolume creation failed");
-  }
-
-  /**
-   * Create a persistent volume claim.
-   *
-   * @param pvName name of the persistent volume
-   * @param pvcName name of the persistent volume to create
-   * @param domainUid UID of the WebLogic domain
-   * @param namespace name of the namespace in which to create the persistent volume claim
-   */
-  private void createPVC(String pvName, String pvcName, String domainUid, String namespace) {
-    logger.info("creating persistent volume claim");
-
-    V1PersistentVolumeClaim v1pvc = new V1PersistentVolumeClaim()
-        .spec(new V1PersistentVolumeClaimSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
-            .volumeName(pvName)
-            .resources(new V1ResourceRequirements()
-                .putRequestsItem("storage", Quantity.fromString("5Gi"))))
-        .metadata(new V1ObjectMeta()
-            .name(pvcName)
-            .namespace(namespace)
-            .putLabelsItem("weblogic.resourceVersion", "domain-v2")
-            .putLabelsItem("weblogic.domainUid", domainUid));
-
-    boolean success = assertDoesNotThrow(() -> createPersistentVolumeClaim(v1pvc),
-        "Failed to create persistent volume claim");
-    assertTrue(success, "PersistentVolumeClaim creation failed");
+    createDomainJob(image, isUseSecret, pvName, pvcName, domainScriptConfigMapName,
+        namespace, jobCreationContainer);
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -802,7 +802,7 @@ public class ItConfigDistributionStrategy {
     createPV(pvName, domainUid);
     createPVC(pvName, pvcName, domainUid, domainNamespace);
 
-    t3ChannelPort = getNextFreePort(30000, 32767);
+    t3ChannelPort = getNextFreePort(31500, 32767);
 
     // create a temporary WebLogic domain property file
     File domainPropertiesFile = assertDoesNotThrow(()

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainInPV.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainInPV.java
@@ -484,7 +484,7 @@ public class ItDomainInPV {
     final int managedServerPort = 8001;
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
     final int replicaCount = 2;
-    final int t3ChannelPort = getNextFreePort(32001, 32767);  // the port range has to be between 30,000 to 32,767
+    final int t3ChannelPort = getNextFreePort(31101, 32767);  // the port range has to be between 30,000 to 32,767
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainInPV.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainInPV.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -17,30 +16,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import io.kubernetes.client.custom.Quantity;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
-import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
-import io.kubernetes.client.openapi.models.V1Job;
-import io.kubernetes.client.openapi.models.V1JobCondition;
-import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1PersistentVolume;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimSpec;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeSpec;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
-import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1SecretReference;
-import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.AdminServer;
@@ -58,8 +39,6 @@ import oracle.weblogic.kubernetes.utils.CommonTestUtils;
 import oracle.weblogic.kubernetes.utils.DeployUtil;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import oracle.weblogic.kubernetes.utils.OracleHttpClient;
-import org.apache.commons.io.FileUtils;
-import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -69,8 +48,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
@@ -81,29 +58,21 @@ import static oracle.weblogic.kubernetes.TestConstants.OCR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_USERNAME;
-import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WDT_VERSION;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_TAG;
-import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
-import static oracle.weblogic.kubernetes.actions.TestActions.createNamespacedJob;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolume;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolumeClaim;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getContainerRestartCount;
-import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
-import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallNginx;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.copyFileToPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.jobCompleted;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createIngressForDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyNginx;
@@ -112,13 +81,11 @@ import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndCheckForSe
 import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests to create domain in persistent volume using WLST and WDT.
@@ -143,13 +110,8 @@ public class ItDomainInPV {
   private final String wlSecretName = "weblogic-credentials";
   private boolean previousTestSuccessful = false;
   private String wdtCurlRequest = null;
-  private List<String> wdtDomainManagedServers = new ArrayList<>();
+  private final List<String> wdtDomainManagedServers = new ArrayList<>();
 
-  // create standard, reusable retry/backoff policy
-  private static final ConditionFactory withStandardRetryPolicy
-      = with().pollDelay(2, SECONDS)
-      .and().with().pollInterval(10, SECONDS)
-      .atMost(5, MINUTES).await();
   private static LoggingFacade logger = null;
 
   /**
@@ -227,8 +189,8 @@ public class ItDomainInPV {
 
     // create persistent volume and persistent volume claim for domain
     // these resources should be labeled with domainUid for cleanup after testing
-    createPV(pvName, wdtDomainUid);
-    createPVC(pvName, pvcName, wdtDomainUid, wdtDomainNamespace);
+    CommonTestUtils.createPV(pvName, wdtDomainUid, this.getClass().getSimpleName());
+    CommonTestUtils.createPVC(pvName, pvcName, wdtDomainUid, wdtDomainNamespace);
 
     // create a temporary WebLogic domain property file as a input for WDT model file
     File domainPropertiesFile = assertDoesNotThrow(() ->
@@ -500,8 +462,8 @@ public class ItDomainInPV {
 
     // create persistent volume and persistent volume claim for domain
     // these resources should be labeled with domainUid for cleanup after testing
-    createPV(pvName, domainUid);
-    createPVC(pvName, pvcName, domainUid, wlstDomainNamespace);
+    CommonTestUtils.createPV(pvName, domainUid, this.getClass().getSimpleName());
+    CommonTestUtils.createPVC(pvName, pvcName, domainUid, wlstDomainNamespace);
 
     // create a temporary WebLogic domain property file
     File domainPropertiesFile = assertDoesNotThrow(() ->
@@ -700,7 +662,8 @@ public class ItDomainInPV {
     logger.info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm";
     assertDoesNotThrow(
-        () -> createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles, namespace),
+        () -> CommonTestUtils.createConfigMapForDomainCreation(
+            domainScriptConfigMapName, domainScriptFiles, namespace, this.getClass().getSimpleName()),
         "Create configmap for domain creation failed");
 
     // create a V1Container with specific scripts and properties for creating domain
@@ -713,7 +676,8 @@ public class ItDomainInPV {
         .addArgsItem("/u01/weblogic/" + domainPropertiesFile.getFileName()); //domain property file
 
     logger.info("Running a Kubernetes job to create the domain");
-    createDomainJob(pvName, pvcName, domainScriptConfigMapName, namespace, jobCreationContainer);
+    createDomainJob(image, isUseSecret, pvName, pvcName, domainScriptConfigMapName,
+        namespace, jobCreationContainer);
 
   }
 
@@ -743,7 +707,8 @@ public class ItDomainInPV {
     logger.info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm";
     assertDoesNotThrow(
-        () -> createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles, namespace),
+        () -> CommonTestUtils.createConfigMapForDomainCreation(
+            domainScriptConfigMapName, domainScriptFiles, namespace, this.getClass().getSimpleName()),
         "Create configmap for domain creation failed");
 
     // create a V1Container with specific scripts and properties for creating domain
@@ -764,216 +729,9 @@ public class ItDomainInPV {
             .value("/shared/domains/" + domainUid)); // domain location
 
     logger.info("Running a Kubernetes job to create the domain");
-    createDomainJob(pvName, pvcName, domainScriptConfigMapName, namespace, jobCreationContainer);
+    createDomainJob(image, isUseSecret, pvName, pvcName, domainScriptConfigMapName,
+        namespace, jobCreationContainer);
 
-  }
-
-  /**
-   * Create configmap containing domain creation scripts.
-   *
-   * @param configMapName name of the configmap to create
-   * @param files files to add in configmap
-   * @param namespace name of the namespace in which to create configmap
-   * @throws IOException when reading the domain script files fail
-   * @throws ApiException if create configmap fails
-   */
-  private void createConfigMapForDomainCreation(String configMapName, List<Path> files, String namespace)
-      throws ApiException, IOException {
-    logger.info("Creating configmap {0}", configMapName);
-
-    Path domainScriptsDir = Files.createDirectories(
-        Paths.get(TestConstants.LOGS_DIR, this.getClass().getSimpleName(), namespace));
-
-    // add domain creation scripts and properties files to the configmap
-    Map<String, String> data = new HashMap<>();
-    for (Path file : files) {
-      logger.info("Adding file {0} in configmap", file);
-      data.put(file.getFileName().toString(), Files.readString(file));
-      logger.info("Making a copy of file {0} to {1} for diagnostic purposes", file,
-          domainScriptsDir.resolve(file.getFileName()));
-      Files.copy(file, domainScriptsDir.resolve(file.getFileName()));
-    }
-    V1ObjectMeta meta = new V1ObjectMeta()
-        .name(configMapName)
-        .namespace(namespace);
-    V1ConfigMap configMap = new V1ConfigMap()
-        .data(data)
-        .metadata(meta);
-
-    boolean cmCreated = assertDoesNotThrow(() -> createConfigMap(configMap),
-        String.format("Failed to create configmap %s with files %s", configMapName, files));
-    assertTrue(cmCreated, String.format("Failed while creating ConfigMap %s", configMapName));
-  }
-
-  /**
-   * Create a job to create a domain in persistent volume.
-   *
-   * @param pvName name of the persistent volume to create domain in
-   * @param pvcName name of the persistent volume claim
-   * @param domainScriptCM configmap holding domain creation script files
-   * @param namespace name of the domain namespace in which the job is created
-   * @param jobContainer V1Container with job commands to create domain
-   */
-  private void createDomainJob(String pvName,
-                               String pvcName, String domainScriptCM, String namespace, V1Container jobContainer) {
-    logger.info("Running Kubernetes job to create domain");
-
-    V1Job jobBody = new V1Job()
-        .metadata(
-            new V1ObjectMeta()
-                .name("create-domain-onpv-job-" + pvName) // name of the create domain job
-                .namespace(namespace))
-        .spec(new V1JobSpec()
-            .backoffLimit(0) // try only once
-            .template(new V1PodTemplateSpec()
-                .spec(new V1PodSpec()
-                    .restartPolicy("Never")
-                    .initContainers(Arrays.asList(new V1Container()
-                        .name("fix-pvc-owner") // change the ownership of the pv to opc:opc
-                        .image(image)
-                        .addCommandItem("/bin/sh")
-                        .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /shared")
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name(pvName)
-                                .mountPath("/shared")))
-                        .securityContext(new V1SecurityContext()
-                            .runAsGroup(0L)
-                            .runAsUser(0L))))
-                    .containers(Arrays.asList(jobContainer  // container containing WLST or WDT details
-                        .name("create-weblogic-domain-onpv-container")
-                        .image(image)
-                        .imagePullPolicy("Always")
-                        .ports(Arrays.asList(new V1ContainerPort()
-                            .containerPort(7001)))
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name("create-weblogic-domain-job-cm-volume") // domain creation scripts volume
-                                .mountPath("/u01/weblogic"), // availble under /u01/weblogic inside pod
-                            new V1VolumeMount()
-                                .name(pvName) // location to write domain
-                                .mountPath("/shared"))))) // mounted under /shared inside pod
-                    .volumes(Arrays.asList(
-                        new V1Volume()
-                            .name(pvName)
-                            .persistentVolumeClaim(
-                                new V1PersistentVolumeClaimVolumeSource()
-                                    .claimName(pvcName)),
-                        new V1Volume()
-                            .name("create-weblogic-domain-job-cm-volume")
-                            .configMap(
-                                new V1ConfigMapVolumeSource()
-                                    .name(domainScriptCM)))) //config map containing domain scripts
-                    .imagePullSecrets(isUseSecret ? Arrays.asList(
-                        new V1LocalObjectReference()
-                            .name(OCR_SECRET_NAME))
-                        : null))));
-    String jobName = assertDoesNotThrow(()
-        -> createNamespacedJob(jobBody), "Failed to create Job");
-
-    logger.info("Checking if the domain creation job {0} completed in namespace {1}",
-        jobName, namespace);
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for job {0} to be completed in namespace {1} "
-                    + "(elapsed time {2} ms, remaining time {3} ms)",
-                jobName,
-                namespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(jobCompleted(jobName, null, namespace));
-
-    // check job status and fail test if the job failed to create domain
-    V1Job job = assertDoesNotThrow(() -> getJob(jobName, namespace),
-        "Getting the job failed");
-    if (job != null) {
-      V1JobCondition jobCondition = job.getStatus().getConditions().stream().filter(
-          v1JobCondition -> "Failed".equalsIgnoreCase(v1JobCondition.getType()))
-          .findAny()
-          .orElse(null);
-      if (jobCondition != null) {
-        logger.severe("Job {0} failed to create domain", jobName);
-        List<V1Pod> pods = assertDoesNotThrow(() -> listPods(
-            namespace, "job-name=" + jobName).getItems(),
-            "Listing pods failed");
-        if (!pods.isEmpty()) {
-          String podLog = assertDoesNotThrow(() -> getPodLog(pods.get(0).getMetadata().getName(), namespace),
-              "Failed to get pod log");
-          logger.severe(podLog);
-          fail("Domain create job failed");
-        }
-      }
-    }
-
-  }
-
-  /**
-   * Create a persistent volume.
-   *
-   * @param pvName name of the persistent volume to create
-   * @param domainUid domain UID
-   * @throws IOException when creating pv path fails
-   */
-  private void createPV(String pvName, String domainUid) {
-    logger.info("creating persistent volume");
-
-    Path pvHostPath = null;
-    try {
-      pvHostPath = Files.createDirectories(Paths.get(
-          PV_ROOT, this.getClass().getSimpleName(), pvName));
-      logger.info("Creating PV directory host path {0}", pvHostPath);
-      FileUtils.deleteDirectory(pvHostPath.toFile());
-      Files.createDirectories(pvHostPath);
-    } catch (IOException ioex) {
-      logger.severe(ioex.getMessage());
-      fail("Create persistent volume host path failed");
-    }
-
-    V1PersistentVolume v1pv = new V1PersistentVolume()
-        .spec(new V1PersistentVolumeSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
-            .volumeMode("Filesystem")
-            .putCapacityItem("storage", Quantity.fromString("5Gi"))
-            .persistentVolumeReclaimPolicy("Recycle")
-            .accessModes(Arrays.asList("ReadWriteMany"))
-            .hostPath(new V1HostPathVolumeSource()
-                .path(pvHostPath.toString())))
-        .metadata(new V1ObjectMeta()
-            .name(pvName)
-            .putLabelsItem("weblogic.domainUid", domainUid));
-    boolean success = assertDoesNotThrow(() -> createPersistentVolume(v1pv),
-        "Failed to create persistent volume");
-    assertTrue(success, "PersistentVolume creation failed");
-  }
-
-  /**
-   * Create a persistent volume claim.
-   *
-   * @param pvName name of the persistent volume
-   * @param pvcName name of the persistent volume to create
-   * @param domainUid UID of the WebLogic domain
-   * @param namespace name of the namespace in which to create the persistent volume claim
-   */
-  private void createPVC(String pvName, String pvcName, String domainUid, String namespace) {
-    logger.info("creating persistent volume claim");
-
-    V1PersistentVolumeClaim v1pvc = new V1PersistentVolumeClaim()
-        .spec(new V1PersistentVolumeClaimSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
-            .volumeName(pvName)
-            .resources(new V1ResourceRequirements()
-                .putRequestsItem("storage", Quantity.fromString("5Gi"))))
-        .metadata(new V1ObjectMeta()
-            .name(pvcName)
-            .namespace(namespace)
-            .putLabelsItem("weblogic.domainUid", domainUid));
-
-    boolean success = assertDoesNotThrow(() -> createPersistentVolumeClaim(v1pvc),
-        "Failed to create persistent volume claim");
-    assertTrue(success, "PersistentVolumeClaim creation failed");
   }
 
   /**
@@ -990,10 +748,10 @@ public class ItDomainInPV {
     File killServerScript = File.createTempFile("killserver", ".sh");
     //deletes the file when VM terminates
     killServerScript.deleteOnExit();
-    FileWriter fw = new FileWriter(killServerScript);
-    fw.write("#!/bin/bash\n");
-    fw.write("kill -9 `jps | grep Server | awk '{print $1}'`");
-    fw.close();
+    try (FileWriter fw = new FileWriter(killServerScript)) {
+      fw.write("#!/bin/bash\n");
+      fw.write("kill -9 `jps | grep Server | awk '{print $1}'`");
+    }
     killServerScript.setExecutable(true, false);
     return killServerScript;
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainInPV.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDomainInPV.java
@@ -484,7 +484,7 @@ public class ItDomainInPV {
     final int managedServerPort = 8001;
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
     final int replicaCount = 2;
-    final int t3ChannelPort = getNextFreePort(30000, 32767);  // the port range has to be between 30,000 to 32,767
+    final int t3ChannelPort = getNextFreePort(32001, 32767);  // the port range has to be between 30,000 to 32,767
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -5,9 +5,7 @@ package oracle.weblogic.kubernetes;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.net.http.HttpResponse;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -19,33 +17,15 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
-import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.custom.V1Patch;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
-import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
-import io.kubernetes.client.openapi.models.V1Job;
-import io.kubernetes.client.openapi.models.V1JobCondition;
-import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1PersistentVolume;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimSpec;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
-import io.kubernetes.client.openapi.models.V1PersistentVolumeSpec;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
-import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1SecretReference;
-import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.AdminServer;
@@ -62,7 +42,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.BuildApplication;
 import oracle.weblogic.kubernetes.utils.CommonTestUtils;
 import oracle.weblogic.kubernetes.utils.OracleHttpClient;
-import org.apache.commons.io.FileUtils;
 import org.awaitility.core.ConditionEvaluationListener;
 import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.EvaluatedCondition;
@@ -87,28 +66,19 @@ import static oracle.weblogic.kubernetes.TestConstants.OCR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_USERNAME;
-import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_TAG;
-import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
-import static oracle.weblogic.kubernetes.actions.TestActions.createNamespacedJob;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolume;
-import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolumeClaim;
 import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
-import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
 import static oracle.weblogic.kubernetes.actions.TestActions.getNextIntrospectVersion;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServicePort;
-import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallNginx;
 import static oracle.weblogic.kubernetes.actions.impl.Domain.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listSecrets;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.jobCompleted;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChanged;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodDoesNotExist;
@@ -133,7 +103,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests related to introspectVersion attribute.
@@ -242,7 +211,10 @@ public class ItIntrospectVersion {
 
     int replicaCount = 2;
 
-    final int t3ChannelPort = getNextFreePort(30100, 32767);  // the port range has to be between 30,000 to 32,767
+    // in general the node port range has to be between 30,000 to 32,767
+    // to avoid port conflict because of the delay in using it, the port here
+    // starts with 30100
+    final int t3ChannelPort = getNextFreePort(30100, 32767);
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
@@ -253,8 +225,8 @@ public class ItIntrospectVersion {
 
     // create persistent volume and persistent volume claim for domain
     // these resources should be labeled with domainUid for cleanup after testing
-    createPV(pvName, domainUid);
-    createPVC(pvName, pvcName, domainUid, introDomainNamespace);
+    CommonTestUtils.createPV(pvName, domainUid, this.getClass().getSimpleName());
+    CommonTestUtils.createPVC(pvName, pvcName, domainUid, introDomainNamespace);
 
     // create a temporary WebLogic domain property file
     File domainPropertiesFile = assertDoesNotThrow(() ->
@@ -735,7 +707,8 @@ public class ItIntrospectVersion {
     logger.info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm";
     assertDoesNotThrow(
-        () -> createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles, namespace),
+        () -> CommonTestUtils.createConfigMapForDomainCreation(
+            domainScriptConfigMapName, domainScriptFiles, namespace, this.getClass().getSimpleName()),
         "Create configmap for domain creation failed");
 
     // create a V1Container with specific scripts and properties for creating domain
@@ -748,216 +721,9 @@ public class ItIntrospectVersion {
         .addArgsItem("/u01/weblogic/" + domainPropertiesFile.getFileName()); //domain property file
 
     logger.info("Running a Kubernetes job to create the domain");
-    createDomainJob(pvName, pvcName, domainScriptConfigMapName, namespace, jobCreationContainer);
+    CommonTestUtils.createDomainJob(image, isUseSecret, pvName, pvcName, domainScriptConfigMapName,
+        namespace, jobCreationContainer);
 
-  }
-
-  /**
-   * Create configmap containing domain creation scripts.
-   *
-   * @param configMapName name of the configmap to create
-   * @param files files to add in configmap
-   * @param namespace name of the namespace in which to create configmap
-   * @throws IOException when reading the domain script files fail
-   * @throws ApiException if create configmap fails
-   */
-  private void createConfigMapForDomainCreation(String configMapName, List<Path> files, String namespace)
-      throws ApiException, IOException {
-    logger.info("Creating configmap {0}", configMapName);
-
-    Path domainScriptsDir = Files.createDirectories(
-        Paths.get(TestConstants.LOGS_DIR, this.getClass().getSimpleName(), namespace));
-
-    // add domain creation scripts and properties files to the configmap
-    Map<String, String> data = new HashMap<>();
-    for (Path file : files) {
-      logger.info("Adding file {0} in configmap", file);
-      data.put(file.getFileName().toString(), Files.readString(file));
-      logger.info("Making a copy of file {0} to {1} for diagnostic purposes", file,
-          domainScriptsDir.resolve(file.getFileName()));
-      Files.copy(file, domainScriptsDir.resolve(file.getFileName()));
-    }
-    V1ObjectMeta meta = new V1ObjectMeta()
-        .name(configMapName)
-        .namespace(namespace);
-    V1ConfigMap configMap = new V1ConfigMap()
-        .data(data)
-        .metadata(meta);
-
-    boolean cmCreated = assertDoesNotThrow(() -> createConfigMap(configMap),
-        String.format("Failed to create configmap %s with files %s", configMapName, files));
-    assertTrue(cmCreated, String.format("Failed while creating ConfigMap %s", configMapName));
-  }
-
-  /**
-   * Create a job to create a domain in persistent volume.
-   *
-   * @param pvName name of the persistent volume to create domain in
-   * @param pvcName name of the persistent volume claim
-   * @param domainScriptCM configmap holding domain creation script files
-   * @param namespace name of the domain namespace in which the job is created
-   * @param jobContainer V1Container with job commands to create domain
-   */
-  private void createDomainJob(String pvName,
-                               String pvcName, String domainScriptCM, String namespace, V1Container jobContainer) {
-    logger.info("Running Kubernetes job to create domain");
-
-    V1Job jobBody = new V1Job()
-        .metadata(
-            new V1ObjectMeta()
-                .name("create-domain-onpv-job-" + pvName) // name of the create domain job
-                .namespace(namespace))
-        .spec(new V1JobSpec()
-            .backoffLimit(0) // try only once
-            .template(new V1PodTemplateSpec()
-                .spec(new V1PodSpec()
-                    .restartPolicy("Never")
-                    .initContainers(Arrays.asList(new V1Container()
-                        .name("fix-pvc-owner") // change the ownership of the pv to opc:opc
-                        .image(image)
-                        .addCommandItem("/bin/sh")
-                        .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /shared")
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name(pvName)
-                                .mountPath("/shared")))
-                        .securityContext(new V1SecurityContext()
-                            .runAsGroup(0L)
-                            .runAsUser(0L))))
-                    .containers(Arrays.asList(jobContainer  // container containing WLST or WDT details
-                        .name("create-weblogic-domain-onpv-container")
-                        .image(image)
-                        .imagePullPolicy("Always")
-                        .ports(Arrays.asList(new V1ContainerPort()
-                            .containerPort(7001)))
-                        .volumeMounts(Arrays.asList(
-                            new V1VolumeMount()
-                                .name("create-weblogic-domain-job-cm-volume") // domain creation scripts volume
-                                .mountPath("/u01/weblogic"), // availble under /u01/weblogic inside pod
-                            new V1VolumeMount()
-                                .name(pvName) // location to write domain
-                                .mountPath("/shared"))))) // mounted under /shared inside pod
-                    .volumes(Arrays.asList(
-                        new V1Volume()
-                            .name(pvName)
-                            .persistentVolumeClaim(
-                                new V1PersistentVolumeClaimVolumeSource()
-                                    .claimName(pvcName)),
-                        new V1Volume()
-                            .name("create-weblogic-domain-job-cm-volume")
-                            .configMap(
-                                new V1ConfigMapVolumeSource()
-                                    .name(domainScriptCM)))) //config map containing domain scripts
-                    .imagePullSecrets(isUseSecret ? Arrays.asList(
-                        new V1LocalObjectReference()
-                            .name(OCR_SECRET_NAME))
-                        : null))));
-    String jobName = assertDoesNotThrow(()
-        -> createNamespacedJob(jobBody), "Failed to create Job");
-
-    logger.info("Checking if the domain creation job {0} completed in namespace {1}",
-        jobName, namespace);
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Waiting for job {0} to be completed in namespace {1} "
-                    + "(elapsed time {2} ms, remaining time {3} ms)",
-                jobName,
-                namespace,
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(jobCompleted(jobName, null, namespace));
-
-    // check job status and fail test if the job failed to create domain
-    V1Job job = assertDoesNotThrow(() -> getJob(jobName, namespace),
-        "Getting the job failed");
-    if (job != null) {
-      V1JobCondition jobCondition = job.getStatus().getConditions().stream().filter(
-          v1JobCondition -> "Failed".equalsIgnoreCase(v1JobCondition.getType()))
-          .findAny()
-          .orElse(null);
-      if (jobCondition != null) {
-        logger.severe("Job {0} failed to create domain", jobName);
-        List<V1Pod> pods = assertDoesNotThrow(()
-            -> listPods(namespace, "job-name=" + jobName).getItems(),
-            "Listing pods failed");
-        if (!pods.isEmpty()) {
-          String podLog = assertDoesNotThrow(() -> getPodLog(pods.get(0).getMetadata().getName(), namespace),
-              "Failed to get pod log");
-          logger.severe(podLog);
-          fail("Domain create job failed");
-        }
-      }
-    }
-
-  }
-
-  /**
-   * Create a persistent volume.
-   *
-   * @param pvName name of the persistent volume to create
-   * @param domainUid domain UID
-   * @throws IOException when creating pv path fails
-   */
-  private void createPV(String pvName, String domainUid) {
-    logger.info("creating persistent volume");
-
-    Path pvHostPath = null;
-    try {
-      pvHostPath = Files.createDirectories(Paths.get(
-          PV_ROOT, this.getClass().getSimpleName(), pvName));
-      logger.info("Creating PV directory host path {0}", pvHostPath);
-      FileUtils.deleteDirectory(pvHostPath.toFile());
-      Files.createDirectories(pvHostPath);
-    } catch (IOException ioex) {
-      logger.severe(ioex.getMessage());
-      fail("Create persistent volume host path failed");
-    }
-
-    V1PersistentVolume v1pv = new V1PersistentVolume()
-        .spec(new V1PersistentVolumeSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
-            .volumeMode("Filesystem")
-            .putCapacityItem("storage", Quantity.fromString("5Gi"))
-            .persistentVolumeReclaimPolicy("Recycle")
-            .accessModes(Arrays.asList("ReadWriteMany"))
-            .hostPath(new V1HostPathVolumeSource()
-                .path(pvHostPath.toString())))
-        .metadata(new V1ObjectMeta()
-            .name(pvName)
-            .putLabelsItem("weblogic.domainUid", domainUid));
-    boolean success = assertDoesNotThrow(() -> createPersistentVolume(v1pv),
-        "Failed to create persistent volume");
-    assertTrue(success, "PersistentVolume creation failed");
-  }
-
-  /**
-   * Create a persistent volume claim.
-   *
-   * @param pvName name of the persistent volume
-   * @param pvcName name of the persistent volume to create
-   * @param domainUid UID of the WebLogic domain
-   * @param namespace name of the namespace in which to create the persistent volume claim
-   */
-  private void createPVC(String pvName, String pvcName, String domainUid, String namespace) {
-    logger.info("creating persistent volume claim");
-
-    V1PersistentVolumeClaim v1pvc = new V1PersistentVolumeClaim()
-        .spec(new V1PersistentVolumeClaimSpec()
-            .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
-            .volumeName(pvName)
-            .resources(new V1ResourceRequirements()
-                .putRequestsItem("storage", Quantity.fromString("5Gi"))))
-        .metadata(new V1ObjectMeta()
-            .name(pvcName)
-            .namespace(namespace)
-            .putLabelsItem("weblogic.domainUid", domainUid));
-
-    boolean success = assertDoesNotThrow(() -> createPersistentVolumeClaim(v1pvc),
-        "Failed to create persistent volume claim");
-    assertTrue(success, "PersistentVolumeClaim creation failed");
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -242,7 +242,7 @@ public class ItIntrospectVersion {
 
     int replicaCount = 2;
 
-    final int t3ChannelPort = getNextFreePort(30000, 32767);  // the port range has to be between 30,000 to 32,767
+    final int t3ChannelPort = getNextFreePort(30100, 32767);  // the port range has to be between 30,000 to 32,767
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -1808,7 +1808,7 @@ public class CommonTestUtils {
 
   /**
    * Generate a text file in RESULTS_ROOT directory by replacing template value.
-   * @param inputTemplateFile input template file 
+   * @param inputTemplateFile input template file
    * @param outputFile output file to be generated. This file will be copied to RESULTS_ROOT. If outputFile contains
    *                   a directory, then the directory will created if it does not exist.
    *                   example - crossdomxaction/istio-cdt-http-srvice.yaml
@@ -1906,7 +1906,7 @@ public class CommonTestUtils {
     V1PersistentVolume v1pv = new V1PersistentVolume()
         .spec(new V1PersistentVolumeSpec()
             .addAccessModesItem("ReadWriteMany")
-            .storageClassName("weblogic-domain-storage-class")
+            .storageClassName(className)
             .volumeMode("Filesystem")
             .putCapacityItem("storage", Quantity.fromString("5Gi"))
             .persistentVolumeReclaimPolicy("Recycle")


### PR DESCRIPTION
Using a different starting node port range for t3channel nodeport. The tests tries to get a unused port and then creates a domain with that t3channel nodeport. But by the time the domain starts up the port is gone and domain startup fails.

So using a different starting port ranges in hope of reducing the port clash.