### PR TITLE
Write pod logs as string to the file

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -248,16 +248,6 @@ public class LoggingUtil {
           logger.info("Found {0} container(s) in the pod {1}", containers.size(), podName);
           for (var container : containers) {
             String containerName = container.getName();
-            // write pod logs using kubectl logs command
-            /* ExecResult result = ExecCommand.exec(
-                "kubectl logs " + podName + " -n " + namespace + " -c " + containerName);
-            if (result.exitValue() != 0) {
-              getLogger().warning("kubectl logs failed, not collecting pod {0}/container {1} logs in namespace {2}",
-                  podName, containerName, namespace);
-            } else {
-              writeToFile(result.stdout(), resultDir,
-                  namespace + ".pod." + podName + ".container." + containerName + ".log", false);
-            } */
             writeToFile(Kubernetes.getPodLog(podName, namespace, containerName), resultDir,
                 namespace + ".pod." + podName + ".container." + containerName + ".log", false);
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -249,7 +249,7 @@ public class LoggingUtil {
           for (var container : containers) {
             String containerName = container.getName();
             // write pod logs using kubectl logs command
-            ExecResult result = ExecCommand.exec(
+            /* ExecResult result = ExecCommand.exec(
                 "kubectl logs " + podName + " -n " + namespace + " -c " + containerName);
             if (result.exitValue() != 0) {
               getLogger().warning("kubectl logs failed, not collecting pod {0}/container {1} logs in namespace {2}",
@@ -257,7 +257,9 @@ public class LoggingUtil {
             } else {
               writeToFile(result.stdout(), resultDir,
                   namespace + ".pod." + podName + ".container." + containerName + ".log", false);
-            }
+            } */
+            writeToFile(Kubernetes.getPodLog(podName, namespace, containerName), resultDir,
+                namespace + ".pod." + podName + ".container." + containerName + ".log", false);
 
           }
         }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -248,8 +248,17 @@ public class LoggingUtil {
           logger.info("Found {0} container(s) in the pod {1}", containers.size(), podName);
           for (var container : containers) {
             String containerName = container.getName();
-            writeToFile(Kubernetes.getPodLog(podName, namespace, containerName), resultDir,
-                namespace + ".pod." + podName + ".container." + containerName + ".log");
+            // write pod logs using kubectl logs command
+            ExecResult result = ExecCommand.exec(
+                "kubectl logs " + podName + " -n " + namespace + " -c " + containerName);
+            if (result.exitValue() != 0) {
+              getLogger().warning("kubectl logs failed, not collecting pod {0}/container {1} logs in namespace {2}",
+                  podName, containerName, namespace);
+            } else {
+              writeToFile(result.stdout(), resultDir,
+                  namespace + ".pod." + podName + ".container." + containerName + ".log");
+            }
+
           }
         }
       }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -287,7 +287,7 @@ public class LoggingUtil {
     logger.info("Generating {0}", Paths.get(resultDir, fileName));
     if (obj != null) {
       Files.write(Paths.get(resultDir, fileName),
-          (asYaml == true ? dump(obj).getBytes(StandardCharsets.UTF_8) : ((String)obj).getBytes(StandardCharsets.UTF_8))
+          (asYaml ? dump(obj).getBytes(StandardCharsets.UTF_8) : ((String)obj).getBytes(StandardCharsets.UTF_8))
       );
     } else {
       logger.info("Nothing to write in {0} list is empty", Paths.get(resultDir, fileName));

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -256,7 +256,7 @@ public class LoggingUtil {
                   podName, containerName, namespace);
             } else {
               writeToFile(result.stdout(), resultDir,
-                  namespace + ".pod." + podName + ".container." + containerName + ".log");
+                  namespace + ".pod." + podName + ".container." + containerName + ".log", false);
             }
 
           }
@@ -277,11 +277,25 @@ public class LoggingUtil {
    */
   private static void writeToFile(Object obj, String resultDir, String fileName)
       throws IOException {
+    writeToFile(obj, resultDir, fileName, true);
+  }
+
+  /**
+   * Write the YAML representation of object or String to a file in the resultDir.
+   *
+   * @param obj to write to the file as YAML or String
+   * @param resultDir directory in which to write the log file
+   * @param fileName name of the log file
+   * @param asYaml write as yaml or string
+   * @throws IOException when write fails
+   */
+  private static void writeToFile(Object obj, String resultDir, String fileName, boolean asYaml)
+      throws IOException {
     LoggingFacade logger = getLogger();
     logger.info("Generating {0}", Paths.get(resultDir, fileName));
     if (obj != null) {
       Files.write(Paths.get(resultDir, fileName),
-          dump(obj).getBytes(StandardCharsets.UTF_8)
+          (asYaml == true ? dump(obj).getBytes(StandardCharsets.UTF_8) : ((String)obj).getBytes(StandardCharsets.UTF_8))
       );
     } else {
       logger.info("Nothing to write in {0} list is empty", Paths.get(resultDir, fileName));


### PR DESCRIPTION
Currently YAML representation of pod log is written, fixing that to write the string without getting the YAML representation.

Now, the pod logs looks like - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests/1159/artifact/RESULT_ROOT/diagnosticlogs/ItMiiDomain/testCreateMiiDomain/ns-efgl.pod.domain1-admin-server.container.weblogic-server.log

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests/1159/artifact/RESULT_ROOT/diagnosticlogs/ItMiiDomain/testCreateMiiDomain/


