### PR TITLE
Update Deployment and Ingress apiVersions

### DIFF
--- a/docs-source/content/samples/simple/domains/model-in-image/prerequisites.md
+++ b/docs-source/content/samples/simple/domains/model-in-image/prerequisites.md
@@ -52,8 +52,8 @@ weight: 1
 
     - Option 1: To create the ingresses, use the following YAML file to create a file called `/tmp/mii-sample/ingresses/myingresses.yaml` and then call `kubectl apply -f /tmp/mii-sample/ingresses/myingresses.yaml`:
 
-       ```
-       apiVersion: extensions/v1beta1
+       ```yaml
+       apiVersion: networking.k8s.io/v1beta1
        kind: Ingress
        metadata:
          name: traefik-ingress-sample-domain1-admin-server
@@ -72,7 +72,7 @@ weight: 1
                  serviceName: sample-domain1-admin-server
                  servicePort: 7001
        ---
-       apiVersion: extensions/v1beta1
+       apiVersion: networking.k8s.io/v1beta1
        kind: Ingress
        metadata:
          name: traefik-ingress-sample-domain1-cluster-cluster-1
@@ -91,7 +91,7 @@ weight: 1
                  serviceName: sample-domain1-cluster-cluster-1
                  servicePort: 8001
        ---
-       apiVersion: extensions/v1beta1
+       apiVersion: networking.k8s.io/v1beta1
        kind: Ingress
        metadata:
          name: traefik-ingress-sample-domain2-cluster-cluster-1

--- a/docs-source/content/userguide/managing-fmw-domains/fmw-infra/_index.md
+++ b/docs-source/content/userguide/managing-fmw-domains/fmw-infra/_index.md
@@ -167,7 +167,7 @@ Here is an example of a Kubernetes YAML file to define a deployment of the Oracl
 database:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: oracle-db

--- a/docs-source/content/userguide/overview/database.md
+++ b/docs-source/content/userguide/overview/database.md
@@ -30,8 +30,8 @@ kubectl create namespace database-namespace
 Next, create a file called `database.yml` with the following content.  Make sure you update the
 password field with your chosen administrator password for the database.
 
-```
-apiVersion: extensions/v1beta1
+```yaml
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: database

--- a/integration-tests/src/test/java/oracle/kubernetes/operator/utils/K8sTestUtils.java
+++ b/integration-tests/src/test/java/oracle/kubernetes/operator/utils/K8sTestUtils.java
@@ -16,9 +16,9 @@ import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
-import io.kubernetes.client.openapi.apis.ExtensionsV1beta1Api;
+import io.kubernetes.client.openapi.apis.NetworkingV1beta1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressList;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressList;
 import io.kubernetes.client.openapi.models.V1APIGroup;
 import io.kubernetes.client.openapi.models.V1APIGroupList;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBindingList;
@@ -60,7 +60,7 @@ public class K8sTestUtils {
   private CoreV1Api coreV1Api = new CoreV1Api();
   private BatchV1Api batchV1Api = new BatchV1Api();
   private AppsV1Api appsV1Api = new AppsV1Api();
-  private ExtensionsV1beta1Api extensionsV1beta1Api = new ExtensionsV1beta1Api();
+  private NetworkingV1beta1Api networkingV1beta1Api = new NetworkingV1beta1Api();
   private RbacAuthorizationV1Api rbacAuthorizationV1Api = new RbacAuthorizationV1Api();
   private ApiextensionsV1beta1Api apiextensionsV1beta1Api = new ApiextensionsV1beta1Api();
   private ApiextensionsV1Api apiextensionsV1Api = new ApiextensionsV1Api();
@@ -271,8 +271,8 @@ public class K8sTestUtils {
   public void verifyIngresses(
       String domainNs, String domainUid, String labelSelectors, int expectedLabeled)
       throws Exception {
-    ExtensionsV1beta1IngressList labeledIngressList =
-        extensionsV1beta1Api.listIngressForAllNamespaces(
+    NetworkingV1beta1IngressList labeledIngressList =
+        networkingV1beta1Api.listIngressForAllNamespaces(
             Boolean.FALSE,
             null,
             null,
@@ -287,8 +287,8 @@ public class K8sTestUtils {
         labeledIngressList.getItems().size(), expectedLabeled, "Number of labeled ingress");
     labeledIngressList.getItems().stream()
         .forEach(li -> li.getMetadata().getNamespace().equals(domainNs));
-    ExtensionsV1beta1IngressList traefikIngressList =
-        extensionsV1beta1Api.listIngressForAllNamespaces(
+    NetworkingV1beta1IngressList traefikIngressList =
+        networkingV1beta1Api.listIngressForAllNamespaces(
             Boolean.FALSE,
             null,
             String.format("metadata.name=traefik-hostrouting-%s", domainUid),

--- a/integration-tests/src/test/resources/charts/ingress-per-domain/templates/traefik-ingress.yaml
+++ b/integration-tests/src/test/resources/charts/ingress-per-domain/templates/traefik-ingress.yaml
@@ -3,7 +3,7 @@
 
 {{- if eq .Values.type "TRAEFIK" }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Values.wlsDomain.domainUID }}-traefik

--- a/integration-tests/src/test/resources/charts/traefik/host-routing.yaml
+++ b/integration-tests/src/test/resources/charts/traefik/host-routing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/integration-tests/src/test/resources/exporter/coordinator_test5.yaml
+++ b/integration-tests/src/test/resources/exporter/coordinator_test5.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coordinator

--- a/integration-tests/src/test/resources/exporter/server.yaml
+++ b/integration-tests/src/test/resources/exporter/server.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upload
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment 
 metadata:
   name: webhook 

--- a/integration-tests/src/test/resources/webhook/webhook-deployment.yaml
+++ b/integration-tests/src/test/resources/webhook/webhook-deployment.yaml
@@ -46,7 +46,7 @@ subjects:
   namespace: monitortestns
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/hands-on-lab/tutorials/deploy.weblogic_short.ocishell.md
+++ b/kubernetes/hands-on-lab/tutorials/deploy.weblogic_short.ocishell.md
@@ -82,7 +82,7 @@ As a simple solution, it's best to configure path routing, which will route exte
 Execute the following Ingress resource definition:
 ```bash
 cat << EOF | kubectl apply -f -
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-pathrouting-1

--- a/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "apache.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/kubernetes/samples/charts/ingress-per-domain/templates/traefik-ingress.yaml
+++ b/kubernetes/samples/charts/ingress-per-domain/templates/traefik-ingress.yaml
@@ -3,7 +3,7 @@
 
 {{- if eq .Values.type "TRAEFIK" }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Values.wlsDomain.domainUID }}-traefik

--- a/kubernetes/samples/charts/traefik/samples/host-routing.yaml
+++ b/kubernetes/samples/charts/traefik/samples/host-routing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
@@ -16,7 +16,7 @@ spec:
           servicePort: 8001
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/samples/charts/traefik/samples/path-routing.yaml
+++ b/kubernetes/samples/charts/traefik/samples/path-routing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-pathrouting-1
@@ -17,7 +17,7 @@ spec:
           serviceName: domain1-cluster-cluster-1
           servicePort: 8001
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-pathrouting-2

--- a/kubernetes/samples/charts/traefik/samples/tls.yaml
+++ b/kubernetes/samples/charts/traefik/samples/tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion:networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-tls
@@ -20,7 +20,7 @@ spec:
     - domain1.org
     secretName: domain1-tls-cert
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-tls-2

--- a/kubernetes/samples/scripts/create-oracle-db-service/common/oracle.db.yaml
+++ b/kubernetes/samples/scripts/create-oracle-db-service/common/oracle.db.yaml
@@ -16,7 +16,7 @@ spec:
   sessionAffinity: None
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: oracle-db

--- a/kubernetes/samples/scripts/create-soa-domain/domain-home-on-pv/create-database/db-with-pv.yaml
+++ b/kubernetes/samples/scripts/create-soa-domain/domain-home-on-pv/create-database/db-with-pv.yaml
@@ -18,7 +18,7 @@ spec:
   sessionAffinity: None
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: oracle-db

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/ingresses/traefik-ingress-sample-domain1-admin-server.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/ingresses/traefik-ingress-sample-domain1-admin-server.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-ingress-sample-domain1-admin-server

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/ingresses/traefik-ingress-sample-domain1-cluster-cluster-1.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/ingresses/traefik-ingress-sample-domain1-cluster-cluster-1.yaml
@@ -24,7 +24,7 @@
 #      "curl -s -S -m 10 http://sample-domain1-cluster-cluster-1:8001/myapp_war/index.jsp"
 # 
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-ingress-sample-domain1-cluster-cluster-1

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/ingresses/traefik-ingress-sample-domain2-cluster-cluster-1.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/ingresses/traefik-ingress-sample-domain2-cluster-cluster-1.yaml
@@ -24,7 +24,7 @@
 #      "curl -s -S -m 10 http://sample-domain2-cluster-cluster-1:8001/myapp_war/index.jsp"
 # 
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-ingress-sample-domain2-cluster-cluster-1

--- a/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
+++ b/kubernetes/samples/scripts/elasticsearch-and-kibana/elasticsearch_and_kibana.yaml
@@ -24,7 +24,7 @@
 #   kubectl delete -f kubernetes/samples/scripts/elasticsearch_and_kibana.yaml
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: "default"
@@ -78,7 +78,7 @@ spec:
     app: "elasticsearch"
 
 ---
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   namespace: "default"

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesDebugEnabledTestBase.java
@@ -3,7 +3,7 @@
 
 package oracle.kubernetes.operator.create;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
@@ -30,8 +30,8 @@ public abstract class CreateOperatorGeneratedFilesDebugEnabledTestBase
   }
 
   @Override
-  public ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
-    ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
+  public V1Deployment getExpectedWeblogicOperatorDeployment() {
+    V1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
     expectRemoteDebug(expected.getSpec().getTemplate().getSpec().getContainers().get(0), "n");
     return expected;
   }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBase.java
@@ -3,7 +3,7 @@
 
 package oracle.kubernetes.operator.create;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
@@ -20,8 +20,8 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesDisabledTestBa
   }
 
   @Override
-  protected ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
-    ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
+  protected V1Deployment getExpectedWeblogicOperatorDeployment() {
+    V1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
     expectProbes(expected.getSpec().getTemplate().getSpec().getContainers().get(0));
     return expected;
   }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBase.java
@@ -3,8 +3,8 @@
 
 package oracle.kubernetes.operator.create;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Service;
 import oracle.kubernetes.operator.utils.OperatorYamlFactory;
 
@@ -51,8 +51,8 @@ public abstract class CreateOperatorGeneratedFilesOptionalFeaturesEnabledTestBas
   }
 
   @Override
-  public ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
-    ExtensionsV1beta1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
+  public V1Deployment getExpectedWeblogicOperatorDeployment() {
+    V1Deployment expected = super.getExpectedWeblogicOperatorDeployment();
     V1Container operatorContainer =
         expected.getSpec().getTemplate().getSpec().getContainers().get(0);
     operatorContainer.addVolumeMountsItem(

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -4,11 +4,11 @@
 package oracle.kubernetes.operator.create;
 
 import io.kubernetes.client.custom.Quantity;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1Probe;
@@ -160,11 +160,11 @@ public abstract class CreateOperatorGeneratedFilesTestBase {
         yamlEqualTo(getExpectedWeblogicOperatorDeployment()));
   }
 
-  private ExtensionsV1beta1Deployment getActualWeblogicOperatorDeployment() {
+  private V1Deployment getActualWeblogicOperatorDeployment() {
     return getGeneratedFiles().getOperatorDeployment();
   }
 
-  protected ExtensionsV1beta1Deployment getExpectedWeblogicOperatorDeployment() {
+  protected V1Deployment getExpectedWeblogicOperatorDeployment() {
     return newDeployment()
         .metadata(
             newObjectMeta()

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/GeneratedOperatorObjects.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/GeneratedOperatorObjects.java
@@ -3,10 +3,10 @@
 
 package oracle.kubernetes.operator.utils;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1Role;
 import io.kubernetes.client.openapi.models.V1RoleBinding;
@@ -46,7 +46,7 @@ public class GeneratedOperatorObjects {
     return securityYaml.getOperatorNamespace();
   }
 
-  public ExtensionsV1beta1Deployment getOperatorDeployment() {
+  public V1Deployment getOperatorDeployment() {
     return operatorYaml.getOperatorDeployment();
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/KubernetesArtifactUtils.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/KubernetesArtifactUtils.java
@@ -16,14 +16,14 @@ import com.appscode.voyager.client.models.V1beta1IngressSpec;
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.ApiregistrationV1beta1ServiceReference;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1DeploymentSpec;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1DeploymentSpec;
 import io.kubernetes.client.openapi.models.V1EmptyDirVolumeSource;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1EnvVarSource;
@@ -124,8 +124,8 @@ public class KubernetesArtifactUtils {
    * Create deployment.
    * @return deployment
    */
-  public static ExtensionsV1beta1Deployment newDeployment() {
-    return (new ExtensionsV1beta1Deployment())
+  public static V1Deployment newDeployment() {
+    return (new V1Deployment())
         .apiVersion(API_VERSION_APPS_V1)
         .kind(KIND_DEPLOYMENT);
   }
@@ -248,8 +248,8 @@ public class KubernetesArtifactUtils {
     return new V1ObjectMeta();
   }
 
-  public static ExtensionsV1beta1DeploymentSpec newDeploymentSpec() {
-    return new ExtensionsV1beta1DeploymentSpec();
+  public static V1DeploymentSpec newDeploymentSpec() {
+    return new V1DeploymentSpec();
   }
 
   public static V1JobSpec newJobSpec() {

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedApacheYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedApacheYaml.java
@@ -5,7 +5,7 @@ package oracle.kubernetes.operator.utils;
 
 import java.nio.file.Path;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
 
@@ -28,7 +28,7 @@ public class ParsedApacheYaml extends ParsedKubernetesYaml {
     return getServiceAccounts().find(getApacheName());
   }
 
-  public ExtensionsV1beta1Deployment getApacheDeployment() {
+  public V1Deployment getApacheDeployment() {
     return getDeployments().find(getApacheName());
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedKubernetesYaml.java
@@ -8,11 +8,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.openapi.models.NetworkingV1beta1Ingress;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -150,8 +150,8 @@ public class ParsedKubernetesYaml {
     return (TypeHandler<V1ClusterRoleBinding>) getHandler(KIND_CLUSTER_ROLE_BINDING);
   }
 
-  TypeHandler<ExtensionsV1beta1Deployment> getDeployments() {
-    return (TypeHandler<ExtensionsV1beta1Deployment>) getHandler(KIND_DEPLOYMENT);
+  TypeHandler<V1Deployment> getDeployments() {
+    return (TypeHandler<V1Deployment>) getHandler(KIND_DEPLOYMENT);
   }
 
   TypeHandler<Domain> getDomains() {
@@ -384,13 +384,13 @@ public class ParsedKubernetesYaml {
     }
   }
 
-  private static class DeploymentHandler extends TypeHandler<ExtensionsV1beta1Deployment> {
+  private static class DeploymentHandler extends TypeHandler<V1Deployment> {
     private DeploymentHandler() {
-      super(ExtensionsV1beta1Deployment.class);
+      super(V1Deployment.class);
     }
 
     @Override
-    protected V1ObjectMeta getMetadata(ExtensionsV1beta1Deployment instance) {
+    protected V1ObjectMeta getMetadata(V1Deployment instance) {
       return instance.getMetadata();
     }
   }

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedTraefikYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedTraefikYaml.java
@@ -5,8 +5,8 @@ package oracle.kubernetes.operator.utils;
 
 import java.nio.file.Path;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import oracle.kubernetes.operator.helpers.LegalNames;
@@ -34,7 +34,7 @@ public class ParsedTraefikYaml extends ParsedKubernetesYaml {
     return getServiceAccounts().find(getTraefikScope());
   }
 
-  public ExtensionsV1beta1Deployment getTraefikDeployment() {
+  public V1Deployment getTraefikDeployment() {
     return getDeployments().find(getTraefikScope());
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedVoyagerOperatorYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedVoyagerOperatorYaml.java
@@ -5,7 +5,7 @@ package oracle.kubernetes.operator.utils;
 
 import java.nio.file.Path;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1beta1APIService;
@@ -25,7 +25,7 @@ public class ParsedVoyagerOperatorYaml extends ParsedKubernetesYaml {
     this.inputs = inputs;
   }
 
-  public ExtensionsV1beta1Deployment getVoyagerOperatorDeployment() {
+  public V1Deployment getVoyagerOperatorDeployment() {
     return getDeployments().find(getVoyagerOperatorName());
   }
 

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedWeblogicOperatorYaml.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/utils/ParsedWeblogicOperatorYaml.java
@@ -5,8 +5,8 @@ package oracle.kubernetes.operator.utils;
 
 import java.nio.file.Path;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Deployment;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1Service;
 
@@ -35,7 +35,7 @@ public class ParsedWeblogicOperatorYaml extends ParsedKubernetesYaml {
     return getSecrets().find("weblogic-operator-secrets");
   }
 
-  public ExtensionsV1beta1Deployment getOperatorDeployment() {
+  public V1Deployment getOperatorDeployment() {
     return getDeployments().find("weblogic-operator");
   }
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/ActionConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/ActionConstants.java
@@ -70,6 +70,6 @@ public interface ActionConstants {
       = "https://github.com/oracle/weblogic-monitoring-exporter.git";
 
   // ------------ Ingress constants----------------------------
-  public static final String INGRESS_API_VERSION = "extensions/v1beta1";
+  public static final String INGRESS_API_VERSION = "networking.k8s.io/v1beta1";
   public static final String INGRESS_KIND = "Ingress";
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Ingress.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Ingress.java
@@ -9,13 +9,13 @@ import java.util.Map;
 
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1HTTPIngressPath;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1HTTPIngressRuleValue;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressBackend;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressList;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressRule;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressSpec;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1HTTPIngressPath;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1HTTPIngressRuleValue;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1Ingress;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressBackend;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressList;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressRule;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressSpec;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -47,23 +47,23 @@ public class Ingress {
                                            Map<String, String> annotations) {
     LoggingFacade logger = getLogger();
     List<String> ingressHostList = new ArrayList<>();
-    ArrayList<ExtensionsV1beta1IngressRule> ingressRules = new ArrayList<>();
+    ArrayList<NetworkingV1beta1IngressRule> ingressRules = new ArrayList<>();
     clusterNameMsPortMap.forEach((clusterName, managedServerPort) -> {
       // set the http ingress paths
-      ExtensionsV1beta1HTTPIngressPath httpIngressPath = new ExtensionsV1beta1HTTPIngressPath()
+      NetworkingV1beta1HTTPIngressPath httpIngressPath = new NetworkingV1beta1HTTPIngressPath()
           .path(null)
-          .backend(new ExtensionsV1beta1IngressBackend()
+          .backend(new NetworkingV1beta1IngressBackend()
               .serviceName(domainUid + "-cluster-" + clusterName.toLowerCase().replace("_", "-"))
               .servicePort(new IntOrString(managedServerPort))
         );
-      ArrayList<ExtensionsV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
+      ArrayList<NetworkingV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
       httpIngressPaths.add(httpIngressPath);
 
       // set the ingress rule
       String ingressHost = domainUid + "." + domainNamespace + "." + clusterName + ".test";
-      ExtensionsV1beta1IngressRule ingressRule = new ExtensionsV1beta1IngressRule()
+      NetworkingV1beta1IngressRule ingressRule = new NetworkingV1beta1IngressRule()
           .host(ingressHost)
-          .http(new ExtensionsV1beta1HTTPIngressRuleValue()
+          .http(new NetworkingV1beta1HTTPIngressRuleValue()
               .paths(httpIngressPaths));
 
       ingressRules.add(ingressRule);
@@ -71,14 +71,14 @@ public class Ingress {
     });
 
     // set the ingress
-    ExtensionsV1beta1Ingress ingress = new ExtensionsV1beta1Ingress()
+    NetworkingV1beta1Ingress ingress = new NetworkingV1beta1Ingress()
         .apiVersion(INGRESS_API_VERSION)
         .kind(INGRESS_KIND)
         .metadata(new V1ObjectMeta()
             .name(ingressName)
             .namespace(domainNamespace)
             .annotations(annotations))
-        .spec(new ExtensionsV1beta1IngressSpec()
+        .spec(new NetworkingV1beta1IngressSpec()
             .rules(ingressRules));
 
     // create the ingress
@@ -111,16 +111,16 @@ public class Ingress {
                                            Map<String, String> annotations, boolean setIngressHost) {
 
     List<String> ingressHostList = new ArrayList<>();
-    ArrayList<ExtensionsV1beta1IngressRule> ingressRules = new ArrayList<>();
+    ArrayList<NetworkingV1beta1IngressRule> ingressRules = new ArrayList<>();
     clusterNameMsPortMap.forEach((clusterName, managedServerPort) -> {
       // set the http ingress paths
-      ExtensionsV1beta1HTTPIngressPath httpIngressPath = new ExtensionsV1beta1HTTPIngressPath()
+      NetworkingV1beta1HTTPIngressPath httpIngressPath = new NetworkingV1beta1HTTPIngressPath()
               .path(null)
-              .backend(new ExtensionsV1beta1IngressBackend()
+              .backend(new NetworkingV1beta1IngressBackend()
                       .serviceName(domainUid + "-cluster-" + clusterName.toLowerCase().replace("_", "-"))
                       .servicePort(new IntOrString(managedServerPort))
               );
-      ArrayList<ExtensionsV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
+      ArrayList<NetworkingV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
       httpIngressPaths.add(httpIngressPath);
 
       // set the ingress rule
@@ -129,9 +129,9 @@ public class Ingress {
         ingressHost = "";
         ingressHostList.add("*");
       }
-      ExtensionsV1beta1IngressRule ingressRule = new ExtensionsV1beta1IngressRule()
+      NetworkingV1beta1IngressRule ingressRule = new NetworkingV1beta1IngressRule()
               .host(ingressHost)
-              .http(new ExtensionsV1beta1HTTPIngressRuleValue()
+              .http(new NetworkingV1beta1HTTPIngressRuleValue()
                       .paths(httpIngressPaths));
 
       ingressRules.add(ingressRule);
@@ -139,14 +139,14 @@ public class Ingress {
     });
 
     // set the ingress
-    ExtensionsV1beta1Ingress ingress = new ExtensionsV1beta1Ingress()
+    NetworkingV1beta1Ingress ingress = new NetworkingV1beta1Ingress()
             .apiVersion(INGRESS_API_VERSION)
             .kind(INGRESS_KIND)
             .metadata(new V1ObjectMeta()
                     .name(ingressName)
                     .namespace(domainNamespace)
                     .annotations(annotations))
-            .spec(new ExtensionsV1beta1IngressSpec()
+            .spec(new NetworkingV1beta1IngressSpec()
                     .rules(ingressRules));
 
     // create the ingress
@@ -170,8 +170,8 @@ public class Ingress {
   public static List<String> listIngresses(String namespace) throws ApiException {
 
     List<String> ingressNames = new ArrayList<>();
-    ExtensionsV1beta1IngressList ingressList = Kubernetes.listNamespacedIngresses(namespace);
-    List<ExtensionsV1beta1Ingress> listOfIngress = ingressList.getItems();
+    NetworkingV1beta1IngressList ingressList = Kubernetes.listNamespacedIngresses(namespace);
+    List<NetworkingV1beta1Ingress> listOfIngress = ingressList.getItems();
 
     listOfIngress.forEach(ingress -> {
       if (ingress.getMetadata() != null) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
@@ -10,13 +10,13 @@ import java.util.Map;
 
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1HTTPIngressPath;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1HTTPIngressRuleValue;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressBackend;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressList;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressRule;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressSpec;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1HTTPIngressPath;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1HTTPIngressRuleValue;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1Ingress;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressBackend;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressList;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressRule;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressSpec;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Helm;
 import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
@@ -103,16 +103,16 @@ public class Nginx {
     annotation.put("kubernetes.io/ingress.class", INGRESS_NGINX_CLASS);
 
     List<String> ingressHostList = new ArrayList<>();
-    ArrayList<ExtensionsV1beta1IngressRule> ingressRules = new ArrayList<>();
+    ArrayList<NetworkingV1beta1IngressRule> ingressRules = new ArrayList<>();
     clusterNameMsPortMap.forEach((clusterName, managedServerPort) -> {
       // set the http ingress paths
-      ExtensionsV1beta1HTTPIngressPath httpIngressPath = new ExtensionsV1beta1HTTPIngressPath()
+      NetworkingV1beta1HTTPIngressPath httpIngressPath = new NetworkingV1beta1HTTPIngressPath()
               .path(null)
-              .backend(new ExtensionsV1beta1IngressBackend()
+              .backend(new NetworkingV1beta1IngressBackend()
                       .serviceName(domainUid + "-cluster-" + clusterName.toLowerCase().replace("_", "-"))
                       .servicePort(new IntOrString(managedServerPort))
               );
-      ArrayList<ExtensionsV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
+      ArrayList<NetworkingV1beta1HTTPIngressPath> httpIngressPaths = new ArrayList<>();
       httpIngressPaths.add(httpIngressPath);
 
       // set the ingress rule
@@ -121,9 +121,9 @@ public class Nginx {
         ingressHost = "";
         ingressHostList.add("*");
       }
-      ExtensionsV1beta1IngressRule ingressRule = new ExtensionsV1beta1IngressRule()
+      NetworkingV1beta1IngressRule ingressRule = new NetworkingV1beta1IngressRule()
               .host(ingressHost)
-              .http(new ExtensionsV1beta1HTTPIngressRuleValue()
+              .http(new NetworkingV1beta1HTTPIngressRuleValue()
                       .paths(httpIngressPaths));
 
       ingressRules.add(ingressRule);
@@ -132,14 +132,14 @@ public class Nginx {
     });
 
     // set the ingress
-    ExtensionsV1beta1Ingress ingress = new ExtensionsV1beta1Ingress()
+    NetworkingV1beta1Ingress ingress = new NetworkingV1beta1Ingress()
             .apiVersion(INGRESS_API_VERSION)
             .kind(INGRESS_KIND)
             .metadata(new V1ObjectMeta()
                     .name(ingressName)
                     .namespace(domainNamespace)
                     .annotations(annotation))
-            .spec(new ExtensionsV1beta1IngressSpec()
+            .spec(new NetworkingV1beta1IngressSpec()
                     .rules(ingressRules));
 
     // create the ingress
@@ -162,8 +162,8 @@ public class Nginx {
   public static List<String> listIngresses(String namespace) throws ApiException {
 
     List<String> ingressNames = new ArrayList<>();
-    ExtensionsV1beta1IngressList ingressList = Kubernetes.listNamespacedIngresses(namespace);
-    List<ExtensionsV1beta1Ingress> listOfIngress = ingressList.getItems();
+    NetworkingV1beta1IngressList ingressList = Kubernetes.listNamespacedIngresses(namespace);
+    List<NetworkingV1beta1Ingress> listOfIngress = ingressList.getItems();
 
     listOfIngress.forEach(ingress -> {
       if (ingress.getMetadata() != null) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Nginx.java
@@ -29,7 +29,7 @@ import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
  */
 public class Nginx {
 
-  private static final String INGRESS_API_VERSION = "extensions/v1beta1";
+  private static final String INGRESS_API_VERSION = "networking.k8s.io/v1beta1";
   private static final String INGRESS_KIND = "Ingress";
   private static final String INGRESS_NGINX_CLASS = "nginx";
 

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -33,10 +33,10 @@ import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
-import io.kubernetes.client.openapi.apis.ExtensionsV1beta1Api;
+import io.kubernetes.client.openapi.apis.NetworkingV1beta1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressList;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1Ingress;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressList;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBindingList;
@@ -2232,13 +2232,13 @@ public class Kubernetes {
    * List Ingresses in the given namespace.
    *
    * @param namespace name of the namespace
-   * @return ExtensionsV1beta1IngressList list of {@link ExtensionsV1beta1Ingress} objects
+   * @return NetworkingV1beta1IngressList list of {@link NetworkingV1beta1Ingress} objects
    * @throws ApiException when listing fails
    */
-  public static ExtensionsV1beta1IngressList listNamespacedIngresses(String namespace) throws ApiException {
-    ExtensionsV1beta1IngressList ingressList;
+  public static NetworkingV1beta1IngressList listNamespacedIngresses(String namespace) throws ApiException {
+    NetworkingV1beta1IngressList ingressList;
     try {
-      ExtensionsV1beta1Api apiInstance = new ExtensionsV1beta1Api(apiClient);
+      NetworkingV1beta1Api apiInstance = new NetworkingV1beta1Api(apiClient);
       ingressList = apiInstance.listNamespacedIngress(
           namespace, // namespace
           PRETTY, // String | If 'true', then the output is pretty printed.
@@ -2263,13 +2263,13 @@ public class Kubernetes {
    *
    * @param namespace name of the namespace
    * @param name name of the Ingress object
-   * @return ExtensionsV1beta1Ingress Ingress object when found, otherwise null
+   * @return NetworkingV1beta1Ingress Ingress object when found, otherwise null
    * @throws ApiException when get fails
    */
-  public static ExtensionsV1beta1Ingress getNamespacedIngress(String namespace, String name)
+  public static NetworkingV1beta1Ingress getNamespacedIngress(String namespace, String name)
       throws ApiException {
     try {
-      for (ExtensionsV1beta1Ingress item
+      for (NetworkingV1beta1Ingress item
           : listNamespacedIngresses(namespace).getItems()) {
         if (name.equals(item.getMetadata().getName())) {
           return item;
@@ -2372,18 +2372,18 @@ public class Kubernetes {
    * Create an Ingress in the specified namespace.
    *
    * @param namespace the namespace in which the ingress will be created
-   * @param ingressBody ExtensionsV1beta1Ingress object, representing the ingress details
+   * @param ingressBody NetworkingV1beta1Ingress object, representing the ingress details
    * @return the ingress created
    * @throws ApiException if Kubernetes client API call fails
    */
-  public static ExtensionsV1beta1Ingress createIngress(String namespace, ExtensionsV1beta1Ingress ingressBody)
+  public static NetworkingV1beta1Ingress createIngress(String namespace, NetworkingV1beta1Ingress ingressBody)
       throws ApiException {
-    ExtensionsV1beta1Ingress ingress;
+    NetworkingV1beta1Ingress ingress;
     try {
-      ExtensionsV1beta1Api apiInstance = new ExtensionsV1beta1Api(apiClient);
+      NetworkingV1beta1Api apiInstance = new NetworkingV1beta1Api(apiClient);
       ingress = apiInstance.createNamespacedIngress(
           namespace, //namespace
-          ingressBody, // ExtensionsV1beta1Ingress object, representing the ingress details
+          ingressBody, // NetworkingV1beta1Ingress object, representing the ingress details
           PRETTY, // pretty print output
           null, // when present, indicates that modifications should not be persisted
           null // a name associated with the actor or entity that is making these changes

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CleanupUtil.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1Ingress;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
@@ -333,7 +333,7 @@ public class CleanupUtil {
       try {
         if (!Kubernetes.listNamespacedIngresses(namespace).getItems().isEmpty()) {
           logger.info("Ingresses still exists!!!");
-          List<ExtensionsV1beta1Ingress> items = Kubernetes.listNamespacedIngresses(namespace).getItems();
+          List<NetworkingV1beta1Ingress> items = Kubernetes.listNamespacedIngresses(namespace).getItems();
           for (var item : items) {
             logger.info(item.getMetadata().getName());
           }

--- a/operator/src/test/java/oracle/kubernetes/operator/work/InMemoryDatabaseTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/InMemoryDatabaseTest.java
@@ -8,8 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1Ingress;
-import io.kubernetes.client.openapi.models.ExtensionsV1beta1IngressList;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1Ingress;
+import io.kubernetes.client.openapi.models.NetworkingV1beta1IngressList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import org.junit.Test;
 
@@ -25,11 +25,11 @@ public class InMemoryDatabaseTest {
   private static final String NAME1 = "name1";
   private static final String NAME2 = "name2";
 
-  private InMemoryDatabase<ExtensionsV1beta1Ingress, ExtensionsV1beta1IngressList> database =
-      new InMemoryDatabase<ExtensionsV1beta1Ingress, ExtensionsV1beta1IngressList>() {
+  private InMemoryDatabase<NetworkingV1beta1Ingress, NetworkingV1beta1IngressList> database =
+      new InMemoryDatabase<NetworkingV1beta1Ingress, NetworkingV1beta1IngressList>() {
         @Override
-        ExtensionsV1beta1IngressList createList(List<ExtensionsV1beta1Ingress> items) {
-          return new ExtensionsV1beta1IngressList().items(items);
+        NetworkingV1beta1IngressList createList(List<NetworkingV1beta1Ingress> items) {
+          return new NetworkingV1beta1IngressList().items(items);
         }
       };
 
@@ -49,7 +49,7 @@ public class InMemoryDatabaseTest {
 
     try {
       database.create(
-          new ExtensionsV1beta1Ingress().metadata(new V1ObjectMeta().namespace(NS1).name(NAME1)),
+          new NetworkingV1beta1Ingress().metadata(new V1ObjectMeta().namespace(NS1).name(NAME1)),
           keys().namespace(NS1).map());
       fail("Should have thrown an InMemoryDatabaseException");
     } catch (InMemoryDatabaseException e) {
@@ -57,16 +57,16 @@ public class InMemoryDatabaseTest {
     }
   }
 
-  private ExtensionsV1beta1Ingress createItem(String name, String namespace) {
-    ExtensionsV1beta1Ingress item =
-        new ExtensionsV1beta1Ingress().metadata(new V1ObjectMeta().namespace(namespace).name(name));
+  private NetworkingV1beta1Ingress createItem(String name, String namespace) {
+    NetworkingV1beta1Ingress item =
+        new NetworkingV1beta1Ingress().metadata(new V1ObjectMeta().namespace(namespace).name(name));
     database.create(item, keys().namespace(namespace).map());
     return item;
   }
 
   @Test
   public void afterItemCreated_canRetrieveIt() throws Exception {
-    ExtensionsV1beta1Ingress item = createItem(NAME1, NS1);
+    NetworkingV1beta1Ingress item = createItem(NAME1, NS1);
 
     assertThat(database.read(keys().name(NAME1).namespace(NS1).map()), equalTo(item));
   }
@@ -75,7 +75,7 @@ public class InMemoryDatabaseTest {
   public void whenItemAbsent_replaceThrowsException() throws Exception {
     try {
       database.replace(
-          new ExtensionsV1beta1Ingress().metadata(new V1ObjectMeta().namespace(NS1).name(NAME1)),
+          new NetworkingV1beta1Ingress().metadata(new V1ObjectMeta().namespace(NS1).name(NAME1)),
           keys().namespace(NS1).map());
       fail("Should have thrown an InMemoryDatabaseException");
     } catch (InMemoryDatabaseException e) {
@@ -87,8 +87,8 @@ public class InMemoryDatabaseTest {
   public void afterReplaceItem_canRetrieveNewItem() throws Exception {
     createItem(NAME1, NS1).kind("old item");
 
-    ExtensionsV1beta1Ingress replacement =
-        new ExtensionsV1beta1Ingress()
+    NetworkingV1beta1Ingress replacement =
+        new NetworkingV1beta1Ingress()
             .metadata(new V1ObjectMeta().namespace(NS1).name(NAME1))
             .kind("new item");
     database.replace(replacement, keys().namespace(NS1).map());
@@ -116,9 +116,9 @@ public class InMemoryDatabaseTest {
 
   @Test
   public void afterItemsCreated_canListMatches() throws Exception {
-    ExtensionsV1beta1Ingress item1 = createItem(NAME1, NS1);
-    ExtensionsV1beta1Ingress item2 = createItem(NAME2, NS1);
-    ExtensionsV1beta1Ingress item3 = createItem(NAME1, NS2);
+    NetworkingV1beta1Ingress item1 = createItem(NAME1, NS1);
+    NetworkingV1beta1Ingress item2 = createItem(NAME2, NS1);
+    NetworkingV1beta1Ingress item3 = createItem(NAME1, NS2);
 
     assertThat(
         database.list(keys().namespace(NS1).map()).getItems(), containsInAnyOrder(item1, item2));

--- a/src/integration-tests/kubernetes/elasticsearch.yaml
+++ b/src/integration-tests/kubernetes/elasticsearch.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: elasticsearch

--- a/src/integration-tests/kubernetes/flannel.yml
+++ b/src/integration-tests/kubernetes/flannel.yml
@@ -72,7 +72,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds

--- a/src/integration-tests/kubernetes/kibana.yaml
+++ b/src/integration-tests/kubernetes/kibana.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana

--- a/src/integration-tests/kubernetes/logstash.yaml
+++ b/src/integration-tests/kubernetes/logstash.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: apps/v1beta1 # for versions before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: logstash

--- a/src/integration-tests/model-in-image/mii-sample-wrapper/stage-and-create-ingresses.sh
+++ b/src/integration-tests/model-in-image/mii-sample-wrapper/stage-and-create-ingresses.sh
@@ -112,7 +112,7 @@ do
 
 $(get_help "# " "$service_name")
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-ingress-$(get_service_name $service_name)
@@ -149,7 +149,7 @@ EOF
 # Copyright (c) 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-ingress-$(get_service_name $service_name)


### PR DESCRIPTION
This PR resolves issue #1769, which we've been asked to expedite. The issue only mentions the Deployment apiVersion, but while reviewing recent changes to Kubernetes, I noticed that both Ingress and Deployment have been long-since moved to new apiVersions and the updated versions are now supported by our minimum Kubernetes version (1.14).

Therefore, I've updated references to both Deployment and Ingress in this PR.