### PR TITLE
correct host-name in health check REST url when Pod IP is null

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -245,8 +245,7 @@ public class ReadHealthStep extends Step {
           portalIP =
               getService().getMetadata().getName()
                   + "."
-                  + getService().getMetadata().getNamespace()
-                  + ".pod.cluster.local";
+                  + getService().getMetadata().getNamespace();
         }
       }
       return portalIP;


### PR DESCRIPTION
Remove the default "cluster.local" search path when creating host-name for health check REST URL. This search path can be different for different cloud providers for e.g. it's ".svc.occloud" in GBU CNE team's environment. If the services are in same cluster, just adding namespace to service-name should be sufficient.