### PR TITLE
Removed -t flag from create and drop rcu scripts

### DIFF
--- a/kubernetes/samples/scripts/create-rcu-schema/create-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/create-rcu-schema.sh
@@ -135,7 +135,7 @@ kubectl exec -n $namespace -i rcu -- bash -c 'cat > /u01/oracle/createRepository
 kubectl exec -n $namespace -i rcu -- bash -c 'cat > /u01/oracle/pwd.txt' < pwd.txt 
 rm -rf createRepository.sh pwd.txt
 
-kubectl exec -n $namespace -it rcu /bin/bash /u01/oracle/createRepository.sh ${dburl} ${schemaPrefix} ${rcuType} ${sysPassword}
+kubectl exec -n $namespace -i rcu /bin/bash /u01/oracle/createRepository.sh ${dburl} ${schemaPrefix} ${rcuType} ${sysPassword}
 if [ $? != 0  ]; then
  echo "######################";
  echo "[ERROR] Could not create the RCU Repository";

--- a/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
@@ -87,7 +87,7 @@ kubectl exec -n $namespace -i rcu -- bash -c 'cat > /u01/oracle/dropRepository.s
 kubectl exec -n $namespace -i rcu -- bash -c 'cat > /u01/oracle/pwd.txt' < pwd.txt
 rm -rf dropRepository.sh pwd.txt
 
-kubectl exec -n $namespace -it rcu /bin/bash /u01/oracle/dropRepository.sh ${dburl} ${schemaPrefix} ${rcuType} ${sysPassword}
+kubectl exec -n $namespace -i rcu /bin/bash /u01/oracle/dropRepository.sh ${dburl} ${schemaPrefix} ${rcuType} ${sysPassword}
 if [ $? != 0  ]; then
  echo "######################";
  echo "[ERROR] Could not drop the RCU Repository based on dburl[${dburl}] schemaPrefix[${schemaPrefix}]  ";


### PR DESCRIPTION
Hi,

This is the fix for bug 31480432. Fix is to remove the -t flag from the kubectl commands used for RCU.
Please review.

Thanks
Samba