### PR TITLE
Don't use a TTY for execs

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -2364,8 +2364,7 @@ public class Kubernetes {
         .apiClient(apiClient) // the Kubernetes api client to dispatch the "exec" command
         .pod(pod) // The pod where the command is to be run
         .containerName(containerName) // the container in which the command is to be run
-        .passStdinAsStream() // pass a stdin stream into the container
-        .stdinIsTty(); // stdin is a TTY (only applies if stdin is true)
+        .passStdinAsStream(); // pass a stdin stream into the container
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/KubernetesExec.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/KubernetesExec.java
@@ -26,9 +26,6 @@ public class KubernetesExec {
   // If true, pass a stdin stream into the container
   private boolean passStdinAsStream;
 
-  // If true, stdin is a TTY (only applies if stdin is true)
-  private boolean stdinIsTty;
-
   /**
    * Set the API client for subsequent exec commands.
    *
@@ -73,16 +70,6 @@ public class KubernetesExec {
   }
 
   /**
-   * Enable the stdin input stream as a TTY terminal.
-   *
-   * @return a KubernetesExec instance where a stdin stream will be a TTY terminal
-   */
-  public KubernetesExec stdinIsTty() {
-    this.stdinIsTty = true;
-    return this;
-  }
-
-  /**
    * Execute a command in a container.
    *
    * @param command the command to run
@@ -91,6 +78,6 @@ public class KubernetesExec {
    * @throws IOException if another problem occurs while trying to run the command
    */
   public Process exec(String... command) throws ApiException, IOException {
-    return new Exec(apiClient).exec(pod, command, containerName, passStdinAsStream, stdinIsTty);
+    return new Exec(apiClient).exec(pod, command, containerName, passStdinAsStream, false);
   }
 }


### PR DESCRIPTION
We just changed the sample and the product code already does not use TTYs for `kubectl exec` calls.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/748/