### PR TITLE
update WDT version used by domain-in-image samples...

### DIFF
--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -346,8 +346,6 @@ function createFiles {
     weblogicCredentialsSecretName="${domainUID}-weblogic-credentials"
   fi
 
-  wdtVersion="${WDT_VERSION}"
-
   if [ "${domainHomeInImage}" == "true" ]; then
     domainPropertiesOutput="${domainOutputDir}/domain.properties"
     domainHome="/u01/oracle/user_projects/domains/${domainName}"
@@ -389,6 +387,9 @@ function createFiles {
       sed -i -e "s|%IMAGE_NAME%|${image}|g" ${domainPropertiesOutput}
     fi
   else
+    # we're in the domain in PV case
+
+    wdtVersion="${WDT_VERSION:-${wdtVersion}}"
 
     createJobOutput="${domainOutputDir}/create-domain-job.yaml"
     deleteJobOutput="${domainOutputDir}/delete-domain-job.yaml"

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -142,6 +142,11 @@ domainHomeImageBase: container-registry.oracle.com/middleware/fmw-infrastructure
 # which uses WDT, instead of WLST, to generate the domain configuration.
 domainHomeImageBuildPath: ./docker-images/OracleFMWInfrastructure/samples/12213-domain-home-in-image
 
+# Uncomment to customize the WebLogic Deploy Tool (WDT) version used by the WDT
+# "domain home in image" Docker image sample in the Docker images project. See
+# "domainHomeImageBuildPath". Set to "LATEST" to use the latest version.
+# wdtVersion: LATEST
+
 # Resource request for each server pod (Memory and CPU). This is minimum amount of compute
 # resources required for each server pod. Edit value(s) below as per pod sizing requirements.
 # These are optional. 

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
@@ -213,6 +213,9 @@ function createDomainHome {
   cp -f ${scriptDir}/common/createFMWDomain.py \
         ${dockerDir}/container-scripts/createFMWDomain.py
 
+  # Set WDT_VERSION in case dockerDir references a WDT sample
+  # (wdtVersion comes from the inputs file)
+  export WDT_VERSION="${WDT_VERSION:-${wdtVersion:-1.9.1}}"
   bash ${dockerDir}/build.sh
 
   if [ "$?" != "0" ]; then

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -159,6 +159,11 @@ domainHomeImageBase: container-registry.oracle.com/middleware/weblogic:12.2.1.4
 # which uses WDT, instead of WLST, to generate the domain configuration.
 domainHomeImageBuildPath: ./docker-images/OracleWebLogic/samples/12213-domain-home-in-image
 
+# Uncomment to customize the WebLogic Deploy Tool (WDT) version used by the WDT
+# "domain home in image" Docker image sample in the Docker images project. See
+# "domainHomeImageBuildPath". Set to "LATEST" to use the latest version.
+# wdtVersion: LATEST
+
 # Resource request for each server pod (Memory and CPU). This is minimum amount of compute
 # resources required for each server pod. Edit value(s) below as per pod sizing requirements.
 # These are optional. 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -203,6 +203,9 @@ function createDomainHome {
     sed -i -e "s|\(FROM \).*|\1 ${domainHomeImageBase}|g" ${dockerDir}/Dockerfile
   fi
 
+  # Set WDT_VERSION in case dockerDir references a WDT sample
+  # (wdtVersion comes from the inputs file)
+  export WDT_VERSION="${WDT_VERSION:-${wdtVersion:-1.9.1}}"
   bash ${dockerDir}/build.sh
 
   if [ "$?" != "0" ]; then


### PR DESCRIPTION
…and make it configurable

Old version: Previously, the DII default was effectively 0.17, as DII depends on the docker image project's sample which has that default.  

Work around: Manually export WDT_VERSION first. The docker image sample accepts a WDT_VERSION env var with either a specific version or the keyword 'LATEST'.

Fix: Have the DII sample set the WDT_VERSION env var prior to calling the docker image sample build.sh script. Allow users to specify the value as an 'input' (input attr 'wdtVersion'). The DII default is now 1.9.1.

Note that the DIPV WDT samples already default to 1.9.1 (it's set to 1.9.1 in the DIPV 'create domain job' script).