### PR TITLE
Fix broken hugo doc relrefs using a link formatting workaround: 

### DIFF
--- a/docs-source/content/userguide/managing-domains/configoverrides/_index.md
+++ b/docs-source/content/userguide/managing-domains/configoverrides/_index.md
@@ -58,7 +58,7 @@ For a detailed walk-through of these steps, see the [Step-by-step guide](#step-b
 * Introspection automatically occurs when:
   1. The operator is starting a WebLogic Server instance when there are currently no other servers running. This occurs when the operator first starts servers for a domain or when starting servers following a full domain shutdown.
   2. For Model in Image, the operator determines that at least one WebLogic Server instance that is currently running must be shut down and restarted. This could be a rolling of one or more clusters, the shut down and restart of one or more WebLogic Server instances, or a combination.
-* You can [initiate introspection]({{< relref "/userguide/managing-domains/domain-lifecycle/introspection.md#initiating-introspection" >}}) by changing the value of the Domain `introspectVersion` field.
+* You can [initiate introspection]({{< relref "/userguide/managing-domains/domain-lifecycle/introspection/_index.md#initiating-introspection" >}}) by changing the value of the Domain `introspectVersion` field.
 * For configuration overrides and during introspection, the operator will:
   * Resolve any macros in your override templates.
   * Place expanded override templates in the `optconfig` directory located in each WebLogic domain home directory.  
@@ -130,9 +130,9 @@ The behavior when using an unsupported override is undefined.
 
 ### Overrides distribution
 
-The operator generates the final configuration overrides, combining customer-provided configuration overrides and operator-generated overrides, during the operator's introspection phase. These overrides are then used when starting or restarting WebLogic Server instances. Starting with operator version 3.0.0, these [overrides can also be distributed]({{< relref "/userguide/managing-domains/domain-lifecycle/introspection.md#distributing-changes-to-configuration-overrides" >}}) and applied to already running WebLogic Server instances.
+The operator generates the final configuration overrides, combining customer-provided configuration overrides and operator-generated overrides, during the operator's introspection phase. These overrides are then used when starting or restarting WebLogic Server instances. Starting with operator version 3.0.0, these [overrides can also be distributed]({{< relref "/userguide/managing-domains/domain-lifecycle/introspection/_index.md#distributing-changes-to-configuration-overrides" >}}) and applied to already running WebLogic Server instances.
 
-For [Domain in PV]({{< relref "/userguide/managing-domains/domain-lifecycle/restarting.md#domain-in-pv" >}}), the ability to change WebLogic domain configuration using traditional management transactions involving the Administration Console or WLST can be combined with the ability to initiate a repeat introspection and distribute updated configuration overrides. This combination supports use cases such as defining a new WebLogic cluster and then immediately starting Managed Server cluster members.
+For [Domain in PV]({{< relref "/userguide/managing-domains/domain-lifecycle/restarting/_index.md#domain-in-pv" >}}), the ability to change WebLogic domain configuration using traditional management transactions involving the Administration Console or WLST can be combined with the ability to initiate a repeat introspection and distribute updated configuration overrides. This combination supports use cases such as defining a new WebLogic cluster and then immediately starting Managed Server cluster members.
 
 ---
 ### Override template names and syntax


### PR DESCRIPTION
.../foo.md#bar --> .../foo/_index.md#bar