### PR TITLE
Added timeout and debugger to fix hanging issue on kind-new and Jenkins

### DIFF
--- a/new-integration-tests/src/test/resources/apps/coherence-proxy-client/buildRunProxyClient.sh
+++ b/new-integration-tests/src/test/resources/apps/coherence-proxy-client/buildRunProxyClient.sh
@@ -40,12 +40,22 @@ echo -e "running ant build from ${APP_DIR_INPOD}"
 ant
 
 # Proxy client will return exit code of 0 for success
-echo -e "running proxy client"
-java -Dtangosol.coherence.proxy.address=${PROXY_HOST} -Dtangosol.coherence.proxy.port=${PROXY_PORT} -cp ${ORACLE_HOME}/coherence/lib/coherence.jar:./target/proxy-client-1.0.jar cohapp.Main ${OP}
+#echo -e "running proxy client"
+#java -Dtangosol.coherence.proxy.address=${PROXY_HOST} -Dtangosol.coherence.proxy.port=${PROXY_PORT} -cp ${ORACLE_HOME}/coherence/lib/coherence.jar:./target/proxy-client-1.0.jar cohapp.Main ${OP}
+
+echo "@@ running Coherence proxy client and send SIGKILL to kill the command after one minute"
+echo "@@ timeout --kill-after=5 --signal=SIGKILL 1m java -Dtangosol.coherence.log.level=9 java -Dtangosol.coherence.proxy.address=${PROXY_HOST} -Dtangosol.coherence.proxy.port=${PROXY_PORT} -cp ${ORACLE_HOME}/coherence/lib/coherence.jar:./target/proxy-client-1.0.jar cohapp.Main ${OP}"
+
+timeout --kill-after=5 --signal=SIGKILL 1m java -Dtangosol.coherence.log.level=9 -Dtangosol.coherence.proxy.address=${PROXY_HOST} -Dtangosol.coherence.proxy.port=${PROXY_PORT} -cp ${ORACLE_HOME}/coherence/lib/coherence.jar:./target/proxy-client-1.0.jar cohapp.Main ${OP} 2>&1 | tee error_msg.out
+
 retVal=$?
 if [ $retVal -eq 0 ] ; then
   # echo the marker string that is expected by the integration test
   echo "CACHE-SUCCESS"
+else
+  echo "Failed to run Coherence proxy client. Error is"
+  OUTPUT=$(cat error_msg.out)
+  echo $OUTPUT
 fi
 
 exit $retVal


### PR DESCRIPTION
ItCoherenceTest hangs on wko-kind-nightly and kind-new

https://build.weblogick8s.org:8443/job/wko-kind-nightly/33/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/781

Changes in the PR:

1. timeout the java process in 1  minute by adding "timeout --kill-after=5 --signal=SIGKILL 1m "
2. enable the debug by adding "-Dtangosol.coherence.log.level=9"

Last time ItCoherenceTest passed was on https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/764

it first failed on "develop" branch run, https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/771

There is no useful info for debugger, only shows the failure is from calling "coherence-proxy-client/buildRunProxyClient.sh", with exit code = 202

ItCoherenceTest still PASSES on https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-model-in-image-tests-10/538