### PR TITLE
Changes for OWLS-82011 to reflect introspector status in domain status

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -17,8 +17,6 @@ import java.util.function.BiConsumer;
 
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ContainerState;
-import io.kubernetes.client.openapi.models.V1ContainerStateTerminated;
-import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Event;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -345,13 +343,8 @@ public class DomainProcessorImpl implements DomainProcessor {
     switch (watchType) {
       case "ADDED":
       case "MODIFIED":
-        if (PodWatcher.isFailed(pod)) {
-          new DomainStatusUpdate(pod, domainUid, delegate, info).runFailedStep();
-        } else if (PodWatcher.isUnschedulable(pod)) {
-          new DomainStatusUpdate(pod, domainUid, delegate, info).runPendingStep();
-        } else {
-          new DomainStatusUpdate(pod, domainUid, delegate, info).runProgressingStep();
-        }
+        PodWatcher.PodStatus podStatus = PodWatcher.getPodStatus(pod);
+        new DomainStatusUpdate(pod, domainUid, delegate, info, podStatus).invoke();
         break;
       default:
     }
@@ -991,50 +984,58 @@ public class DomainProcessorImpl implements DomainProcessor {
     private final String domainUid;
     private DomainProcessorDelegate delegate = null;
     private DomainPresenceInfo info = null;
+    private PodWatcher.PodStatus podStatus;
 
-    DomainStatusUpdate(V1Pod pod, String domainUid, DomainProcessorDelegate delegate, DomainPresenceInfo info) {
+    DomainStatusUpdate(V1Pod pod, String domainUid, DomainProcessorDelegate delegate,
+                       DomainPresenceInfo info, PodWatcher.PodStatus podStatus) {
       this.pod = pod;
       this.domainUid = domainUid;
       this.delegate = delegate;
       this.info = info;
+      this.podStatus = podStatus;
     }
 
-    private void runFailedStep() {
-      Optional<V1ContainerStateWaiting> waiting = Optional.ofNullable(getMatchingContainerStatus())
-              .map(V1ContainerStatus::getState)
-              .map(V1ContainerState::getWaiting);
-      if (waiting.isPresent() && waiting.get().getMessage() != null) {
-        delegate.runSteps(
-                DomainStatusUpdater.createFailedStep(
-                        info, waiting.get().getReason(), waiting.get().getMessage(), null));
-      } else {
-        Optional<V1ContainerStateTerminated> terminated = Optional.ofNullable(getMatchingContainerStatus())
-                .map(V1ContainerStatus::getState)
-                .map(V1ContainerState::getTerminated);
-        if (terminated.isPresent() && terminated.get().getReason().contains("Error")) {
-          delegate.runSteps(
-                  DomainStatusUpdater.createFailedStep(
-                          info, terminated.get().getReason(), terminated.get().getMessage(), null));
-        }
+    private void invoke() {
+      switch (podStatus) {
+        case PHASE_FAILED:
+          DomainStatusUpdater.createFailedStep(
+                  info, pod.getStatus().getReason(), pod.getStatus().getMessage(), null);
+          break;
+        case WAITING_NON_NULL_MESSAGE:
+          Optional.ofNullable(getMatchingContainerStatus())
+                  .map(V1ContainerStatus::getState)
+                  .map(V1ContainerState::getWaiting)
+                  .ifPresent(waiting ->
+                    delegate.runSteps(
+                            DomainStatusUpdater.createFailedStep(
+                                    info, waiting.getReason(), waiting.getMessage(), null)));
+          break;
+        case TERMINATED_ERROR_REASON:
+          Optional.ofNullable(getMatchingContainerStatus())
+                  .map(V1ContainerStatus::getState)
+                  .map(V1ContainerState::getTerminated)
+                  .ifPresent(terminated -> delegate.runSteps(
+                          DomainStatusUpdater.createFailedStep(
+                                  info, terminated.getReason(), terminated.getMessage(), null)));
+          break;
+        case UNSCHEDULABLE:
+          Optional.ofNullable(getMatchingPodCondition())
+                  .ifPresent(condition ->
+                          delegate.runSteps(
+                                  DomainStatusUpdater.createFailedStep(
+                                          info, condition.getReason(), condition.getMessage(), null)));
+          break;
+        case SUCCESS:
+          Optional.ofNullable(getMatchingContainerStatus())
+                  .map(V1ContainerStatus::getState)
+                  .map(V1ContainerState::getWaiting)
+                  .ifPresent(waiting ->
+                          delegate.runSteps(
+                                  DomainStatusUpdater.createProgressingStep(
+                                          info, waiting.getReason(), false, null)));
+          break;
+        default:
       }
-    }
-
-    private void runPendingStep() {
-      Optional.ofNullable(getMatchingPodCondition())
-              .ifPresent(condition ->
-                      delegate.runSteps(
-                              DomainStatusUpdater.createFailedStep(
-                                      info, condition.getReason(), condition.getMessage(), null)));
-    }
-
-    private void runProgressingStep() {
-      Optional.ofNullable(getMatchingContainerStatus())
-              .map(V1ContainerStatus::getState)
-              .map(V1ContainerState::getWaiting)
-              .ifPresent(waiting ->
-                      delegate.runSteps(
-                              DomainStatusUpdater.createProgressingStep(
-                                      info, waiting.getReason(), false, null)));
     }
 
     private V1ContainerStatus getMatchingContainerStatus() {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -17,11 +17,14 @@ import java.util.function.BiConsumer;
 
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateTerminated;
+import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Event;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodCondition;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1Service;
@@ -34,7 +37,6 @@ import oracle.kubernetes.operator.calls.FailureStatusSourceException;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.ConfigMapHelper;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
-import oracle.kubernetes.operator.helpers.DomainStatusPatch;
 import oracle.kubernetes.operator.helpers.DomainValidationSteps;
 import oracle.kubernetes.operator.helpers.JobHelper;
 import oracle.kubernetes.operator.helpers.KubernetesUtils;
@@ -65,7 +67,9 @@ import oracle.kubernetes.weblogic.domain.model.AdminService;
 import oracle.kubernetes.weblogic.domain.model.Channel;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
+import static oracle.kubernetes.operator.DomainStatusUpdater.ADMIN_SERVER_STARTING_PROGRESS_REASON;
 import static oracle.kubernetes.operator.DomainStatusUpdater.INSPECTING_DOMAIN_PROGRESS_REASON;
+import static oracle.kubernetes.operator.DomainStatusUpdater.MANAGED_SERVERS_STARTING_PROGRESS_REASON;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECT_REQUESTED;
 import static oracle.kubernetes.operator.ProcessingConstants.MAKE_RIGHT_DOMAIN_OPERATION;
@@ -341,7 +345,13 @@ public class DomainProcessorImpl implements DomainProcessor {
     switch (watchType) {
       case "ADDED":
       case "MODIFIED":
-        new DomainStatusUpdate(info.getDomain(), pod, domainUid).invoke();
+        if (PodWatcher.isFailed(pod)) {
+          new DomainStatusUpdate(pod, domainUid, delegate, info).runFailedStep();
+        } else if (PodWatcher.isUnschedulable(pod)) {
+          new DomainStatusUpdate(pod, domainUid, delegate, info).runPendingStep();
+        } else {
+          new DomainStatusUpdate(pod, domainUid, delegate, info).runProgressingStep();
+        }
         break;
       default:
     }
@@ -784,12 +794,15 @@ public class DomainProcessorImpl implements DomainProcessor {
 
   Step createDomainUpPlan(DomainPresenceInfo info) {
     Step managedServerStrategy =
-        bringManagedServersUp(DomainStatusUpdater.createEndProgressingStep(new TailStep()));
+        Step.chain(
+            DomainStatusUpdater.createProgressingStep(MANAGED_SERVERS_STARTING_PROGRESS_REASON, true, null),
+            bringManagedServersUp(DomainStatusUpdater.createEndProgressingStep(new TailStep())));
 
     Step domainUpStrategy =
         Step.chain(
             domainIntrospectionSteps(info),
             new DomainStatusStep(info, null),
+            DomainStatusUpdater.createProgressingStep(ADMIN_SERVER_STARTING_PROGRESS_REASON,true, null),
             bringAdminServerUp(info, delegate.getPodAwaiterStepFactory(info.getNamespace())),
             managedServerStrategy);
 
@@ -974,40 +987,76 @@ public class DomainProcessorImpl implements DomainProcessor {
   }
 
   private static class DomainStatusUpdate {
-    private final Domain domain;
     private final V1Pod pod;
     private final String domainUid;
+    private DomainProcessorDelegate delegate = null;
+    private DomainPresenceInfo info = null;
 
-    DomainStatusUpdate(Domain domain, V1Pod pod, String domainUid) {
-      this.domain = domain;
+    DomainStatusUpdate(V1Pod pod, String domainUid, DomainProcessorDelegate delegate, DomainPresenceInfo info) {
       this.pod = pod;
       this.domainUid = domainUid;
+      this.delegate = delegate;
+      this.info = info;
     }
 
-    public void invoke() {
-      Optional.ofNullable(getMatchingContainerStatus())
-            .map(V1ContainerStatus::getState)
-            .map(V1ContainerState::getWaiting)
-            .ifPresent(waiting -> updateStatus(waiting.getReason(), waiting.getMessage()));
-    }
-
-    private void updateStatus(String reason, String message) {
-      if (reason == null || message == null) {
-        return;
+    private void runFailedStep() {
+      Optional<V1ContainerStateWaiting> waiting = Optional.ofNullable(getContainerStatus())
+              .map(V1ContainerStatus::getState)
+              .map(V1ContainerState::getWaiting);
+      if (waiting.isPresent() && waiting.get().getMessage() != null) {
+        delegate.runSteps(
+                DomainStatusUpdater.createFailedStep(
+                        info, waiting.get().getReason(), waiting.get().getMessage(), null));
+      } else {
+        Optional<V1ContainerStateTerminated> terminated = Optional.ofNullable(getContainerStatus())
+                .map(V1ContainerStatus::getState)
+                .map(V1ContainerState::getTerminated);
+        if (terminated.isPresent() && terminated.get().getReason().contains("Error")) {
+          delegate.runSteps(
+                  DomainStatusUpdater.createFailedStep(
+                          info, terminated.get().getReason(), terminated.get().getMessage(), null));
+        }
       }
-      
-      DomainStatusPatch.updateSynchronously(domain, reason, message);
     }
 
-    private V1ContainerStatus getMatchingContainerStatus() {
+    private void runPendingStep() {
+      Optional.ofNullable(getMatchingPodCondition())
+              .ifPresent(condition ->
+                      delegate.runSteps(
+                              DomainStatusUpdater.createFailedStep(
+                                      info, condition.getReason(), condition.getMessage(), null)));
+    }
+
+    private void runProgressingStep() {
+      Optional.ofNullable(getContainerStatus())
+              .map(V1ContainerStatus::getState)
+              .map(V1ContainerState::getWaiting)
+              .ifPresent(waiting ->
+                      delegate.runSteps(
+                              DomainStatusUpdater.createProgressingStep(
+                                      info, waiting.getReason(), false, null)));
+    }
+
+    private V1ContainerStatus getContainerStatus() {
       return Optional.ofNullable(pod.getStatus())
-            .map(V1PodStatus::getContainerStatuses)
-            .flatMap(this::getMatchingContainerStatus)
-            .orElse(null);
+              .map(V1PodStatus::getContainerStatuses)
+              .flatMap(this::getMatchingContainerStatus)
+              .orElse(null);
+    }
+
+    private V1PodCondition getMatchingPodCondition() {
+      return Optional.ofNullable(pod.getStatus())
+              .map(V1PodStatus::getConditions)
+              .flatMap(this::getPodCondition)
+              .orElse(null);
     }
 
     private Optional<V1ContainerStatus> getMatchingContainerStatus(Collection<V1ContainerStatus> statuses) {
       return statuses.stream().filter(this::hasInstrospectorJobName).findFirst();
+    }
+
+    private Optional<V1PodCondition> getPodCondition(Collection<V1PodCondition> conditions) {
+      return conditions.stream().findFirst();
     }
 
     private boolean hasInstrospectorJobName(V1ContainerStatus s) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -164,7 +164,6 @@ public class DomainStatusUpdater {
    * @return Step
    */
   static Step createFailedStep(Throwable throwable, Step next) {
-
     return throwable.getMessage() == null ? createFailedStep("Exception", throwable.toString(), next)
         : createFailedStep("Exception", throwable.getMessage(), next);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -37,6 +37,7 @@ import oracle.kubernetes.operator.rest.ScanCache;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
+import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
@@ -65,6 +66,7 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Progre
 @SuppressWarnings("WeakerAccess")
 public class DomainStatusUpdater {
   public static final String INSPECTING_DOMAIN_PROGRESS_REASON = "InspectingDomainPresence";
+  public static final String ADMIN_SERVER_STARTING_PROGRESS_REASON = "AdminServerStarting";
   public static final String MANAGED_SERVERS_STARTING_PROGRESS_REASON = "ManagedServersStarting";
   public static final String SERVERS_READY_REASON = "ServersReady";
   public static final String ALL_STOPPED_AVAILABLE_REASON = "AllServersStopped";
@@ -97,7 +99,21 @@ public class DomainStatusUpdater {
    * @return Step
    */
   public static Step createProgressingStep(String reason, boolean isPreserveAvailable, Step next) {
-    return new ProgressingStep(reason, isPreserveAvailable, next);
+    return new ProgressingStep(null, reason, isPreserveAvailable, next);
+  }
+
+  /**
+   * Asynchronous step to set Domain condition to Progressing.
+   *
+   * @param info Domain presence info
+   * @param reason Progressing reason
+   * @param isPreserveAvailable true, if existing Available=True condition should be preserved
+   * @param next Next step
+   * @return Step
+   */
+  public static Step createProgressingStep(DomainPresenceInfo info, String reason, boolean isPreserveAvailable,
+                                           Step next) {
+    return new ProgressingStep(info, reason, isPreserveAvailable, next);
   }
 
   /**
@@ -148,7 +164,9 @@ public class DomainStatusUpdater {
    * @return Step
    */
   static Step createFailedStep(Throwable throwable, Step next) {
-    return createFailedStep("Exception", throwable.getMessage(), next);
+
+    return throwable.getMessage() == null ? createFailedStep("Exception", throwable.toString(), next)
+        : createFailedStep("Exception", throwable.getMessage(), next);
   }
 
   /**
@@ -160,10 +178,24 @@ public class DomainStatusUpdater {
    * @return Step
    */
   public static Step createFailedStep(String reason, String message, Step next) {
-    return new FailedStep(reason, message, next);
+    return new FailedStep(null, reason, message, next);
+  }
+
+  /**
+   * Asynchronous step to set Domain condition to Failed.
+   *
+   * @param info Domain presence info
+   * @param reason the reason for the failure
+   * @param message a fuller description of the problem
+   * @param next Next step
+   * @return Step
+   */
+  public static Step createFailedStep(DomainPresenceInfo info, String reason, String message, Step next) {
+    return new FailedStep(info, reason, message, next);
   }
 
   abstract static class DomainStatusUpdaterStep extends Step {
+    private DomainPresenceInfo info = null;
 
     DomainStatusUpdaterStep(Step next) {
       super(next);
@@ -177,6 +209,14 @@ public class DomainStatusUpdater {
 
     @Override
     public NextAction apply(Packet packet) {
+      if ((packet.getSpi(DomainPresenceInfo.class) == null)
+          && (info != null)) {
+        packet
+            .getComponents()
+            .put(
+              ProcessingConstants.DOMAIN_COMPONENT_NAME,
+              Component.createFor(info));
+      }
       DomainStatusUpdaterContext context = createContext(packet);
       DomainStatus newStatus = context.getNewStatus();
 
@@ -556,8 +596,9 @@ public class DomainStatusUpdater {
     private final String reason;
     private final boolean isPreserveAvailable;
 
-    private ProgressingStep(String reason, boolean isPreserveAvailable, Step next) {
+    private ProgressingStep(DomainPresenceInfo info, String reason, boolean isPreserveAvailable, Step next) {
       super(next);
+      super.info = info;
       this.reason = reason;
       this.isPreserveAvailable = isPreserveAvailable;
     }
@@ -602,8 +643,9 @@ public class DomainStatusUpdater {
     private final String reason;
     private final String message;
 
-    private FailedStep(String reason, String message, Step next) {
+    private FailedStep(DomainPresenceInfo info, String reason, String message, Step next) {
       super(next);
+      super.info = info;
       this.reason = reason;
       this.message = message;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -305,7 +305,8 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
     // be available for reading
     @Override
     boolean shouldTerminateFiber(V1Job job) {
-      return isFailed(job) && "DeadlineExceeded".equals(getFailedReason(job));
+      return isFailed(job) && ("DeadlineExceeded".equals(getFailedReason(job))
+              || "BackoffLimitExceeded".equals(getFailedReason(job)));
     }
 
     // create an exception to terminate the fiber

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -215,15 +215,10 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
   }
 
   private static boolean isPodFailed(V1ContainerStatus conStatus) {
-    LOGGER.fine("PodWatcher.isReady for container status " + conStatus + " is " + isReady(conStatus) + " and "
-            + " waiting message is " + getContainerStateWaitingMessage(conStatus)
-            + " and terminated reason is " + getContainerStateTerminatedReason(conStatus));
-    boolean res  =
+    return
         !isReady(conStatus)
         && (getContainerStateWaitingMessage(conStatus) != null
         || getContainerStateTerminatedReason(conStatus).contains("Error"));
-    LOGGER.fine("PodWatcher.isPodFailed.. returning " + res);
-    return res;
   }
 
   static boolean isUnschedulable(@Nonnull V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -205,11 +205,6 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
     return PodStatus.SUCCESS;
   }
 
-  private static boolean testFailed(V1PodStatus stat) {
-    return ((stat.getPhase() != null) && stat.getPhase().equals("Failed"));
-
-  }
-
   static List<V1ContainerStatus> getContainerStatuses(@Nonnull V1Pod pod) {
     return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getContainerStatuses).orElse(Collections.emptyList());
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
@@ -21,6 +22,7 @@ import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodCondition;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.TuningParameters.WatchTuning;
@@ -170,27 +172,39 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
    * @param pod pob
    * @return true, if failed
    */
-  private static boolean isFailed(V1Pod pod) {
-    if (pod == null) {
-      return false;
-    }
+  static boolean isFailed(@Nonnull V1Pod pod) {
 
-    V1PodStatus status = pod.getStatus();
     LOGGER.fine(
-        "PodWatcher.isFailed status of pod " + pod.getMetadata().getName() + ": " + status);
-    if (status != null) {
-      java.util.List<V1ContainerStatus> conStatuses = status.getContainerStatuses();
-      if (conStatuses != null) {
-        for (V1ContainerStatus conStatus : conStatuses) {
-          if (!isReady(conStatus)
-              && (getContainerStateWaitingMessage(conStatus) != null
-              || getContainerStateTerminatedReason(conStatus).contains("Error"))) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
+        "PodWatcher.isFailed status of pod " + pod.getMetadata().getName() + ": " + pod.getStatus());
+    return getContainerStatuses(pod).stream().anyMatch(PodWatcher::isPodFailed);
+  }
+
+  static List<V1ContainerStatus> getContainerStatuses(@Nonnull V1Pod pod) {
+    return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getContainerStatuses).orElse(Collections.emptyList());
+  }
+
+  private static boolean isPodFailed(V1ContainerStatus conStatus) {
+    return !isReady(conStatus)
+        && (getContainerStateWaitingMessage(conStatus) != null
+        || getContainerStateTerminatedReason(conStatus).contains("Error"));
+  }
+
+  static boolean isUnschedulable(@Nonnull V1Pod pod) {
+
+    LOGGER.fine("PodWatcher.isUnschedulable status of pod " + pod.getMetadata().getName() + ": " + pod.getStatus());
+    return getPodConditions(pod).stream().anyMatch(PodWatcher::isPodUnschedulable);
+  }
+
+  private static List<V1PodCondition> getPodConditions(@Nonnull V1Pod pod) {
+    return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getConditions).orElse(Collections.emptyList());
+  }
+
+  private static boolean isPodUnschedulable(V1PodCondition podCondition) {
+    return getReason(podCondition).contains("Unschedulable");
+  }
+
+  private static String getReason(V1PodCondition podCondition) {
+    return Optional.ofNullable(podCondition).map(V1PodCondition::getReason).orElse("");
   }
 
   private static boolean isReady(V1ContainerStatus conStatus) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -59,6 +59,11 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
     return testSupport.scheduleWithFixedDelay(command, initialDelay, delay, unit);
   }
 
+  @Override
+  public void runSteps(Step firstStep) {
+    testSupport.runSteps(firstStep);
+  }
+
   private static class PassthroughPodAwaiterStepFactory implements PodAwaiterStepFactory {
     @Override
     public Step waitForReady(V1Pod pod, Step next) {

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -153,7 +153,11 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   }
 
   private V1Job markJobTimedOut(V1Job job) {
-    return setFailedWithReason(job, "DeadlineExceeded");
+    return markJobTimedOut(job, "DeadlineExceeded");
+  }
+
+  private V1Job markJobTimedOut(V1Job job, String reason) {
+    return setFailedWithReason(job, reason);
   }
 
   private V1Job setFailedWithReason(V1Job job, String reason) {
@@ -222,8 +226,16 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   }
 
   @Test
-  public void whenWaitForReadyAppliedToTimedOutJob_terminateWithException() {
-    startWaitForReady(this::markJobTimedOut);
+  public void whenWaitForReadyAppliedToTimedOutJobWithDeadlineExceeded_terminateWithException() {
+    startWaitForReady(job -> markJobTimedOut(job, "DeadlineExceeded"));
+
+    assertThat(terminalStep.wasRun(), is(false));
+    testSupport.verifyCompletionThrowable(JobWatcher.DeadlineExceededException.class);
+  }
+
+  @Test
+  public void whenWaitForReadyAppliedToTimedOutJobWithBackoffLimitExceeded_terminateWithException() {
+    startWaitForReady(job -> markJobTimedOut(job, "BackoffLimitExceeded"));
 
     assertThat(terminalStep.wasRun(), is(false));
     testSupport.verifyCompletionThrowable(JobWatcher.DeadlineExceededException.class);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionStatusTest.java
@@ -14,6 +14,8 @@ import io.kubernetes.client.openapi.models.V1ContainerState;
 import io.kubernetes.client.openapi.models.V1ContainerStateBuilder;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodCondition;
+import io.kubernetes.client.openapi.models.V1PodConditionBuilder;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodStatusBuilder;
 import oracle.kubernetes.operator.DomainProcessorDelegateStub;
@@ -41,6 +43,7 @@ public class IntrospectionStatusTest {
   private static final String IMAGE_NAME = "abc";
   private static final String MESSAGE = "asdf";
   private static final String IMAGE_PULL_FAILURE = "ErrImagePull";
+  private static final String UNSCHEDULABLE = "Unschedulable";
   private static final String IMAGE_PULL_BACKOFF = "ImagePullBackoff";
   private List<Memento> mementos = new ArrayList<>();
   private KubernetesTestSupport testSupport = new KubernetesTestSupport();
@@ -131,6 +134,18 @@ public class IntrospectionStatusTest {
   }
 
   @Test
+  public void whenIntrospectorJobPodPendingWithUnschedulableStatus_patchDomain() {
+    processor.dispatchPodWatch(
+            WatchEvent.createModifiedEvent(
+                    createIntrospectorJobPodWithConditions(createPodConditions(UNSCHEDULABLE, MESSAGE)))
+                    .toWatchResponse());
+
+    Domain updatedDomain = testSupport.getResourceWithName(KubernetesTestSupport.DOMAIN, UID);
+    assertThat(updatedDomain.getStatus().getReason(), equalTo(UNSCHEDULABLE));
+    assertThat(updatedDomain.getStatus().getMessage(), equalTo(MESSAGE));
+  }
+
+  @Test
   public void whenNewIntrospectorJobPodStatusReasonNullAfterImagePullFailure_dontPatchDomain() {
     processor.dispatchPodWatch(
         WatchEvent.createAddedEvent(
@@ -142,8 +157,8 @@ public class IntrospectionStatusTest {
             .toWatchResponse());
 
     Domain updatedDomain = testSupport.getResourceWithName(KubernetesTestSupport.DOMAIN, UID);
-    assertThat(updatedDomain.getStatus().getReason(), equalTo(IMAGE_PULL_FAILURE));
-    assertThat(updatedDomain.getStatus().getMessage(), equalTo(MESSAGE));
+    assertThat(updatedDomain.getStatus().getReason(), emptyOrNullString());
+    assertThat(updatedDomain.getStatus().getMessage(), emptyOrNullString());
   }
 
   private V1Pod createIntrospectorJobPod(V1ContainerState waitingState) {
@@ -172,6 +187,14 @@ public class IntrospectionStatusTest {
             .spec(new V1PodSpec()));
   }
 
+  private V1Pod createIntrospectorJobPodWithConditions(V1PodCondition condition) {
+    return createIntrospectorJobPod(UID)
+            .status(
+                    new V1PodStatusBuilder()
+                            .withConditions(condition)
+                            .build());
+  }
+
   private V1ContainerState createWaitingState(String reason, String message) {
     return new V1ContainerStateBuilder()
         .withNewWaiting()
@@ -180,6 +203,14 @@ public class IntrospectionStatusTest {
         .endWaiting()
         .build();
   }
+
+  private V1PodCondition createPodConditions(String reason, String message) {
+    return new V1PodConditionBuilder()
+            .withReason(reason)
+            .withMessage(message)
+            .build();
+  }
+
 
   private String getPodSuffix() {
     return "-" + RandomStringUtils.randomAlphabetic(5).toLowerCase();


### PR DESCRIPTION
Changes for OWLS-82011 to reflect introspector status in domain status in below conditions -
1. Missing image
2. Missing PV/C mount
3. Introspector job timeout (deadline exceeded)