### PR TITLE
added extra steps to clean up intermittent leftovers from prometheus and grafana artifacts

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporter.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporter.java
@@ -1474,6 +1474,22 @@ class ItMonitoringExporter {
       grafanaHelmParams = null;
       logger.info("Grafana is uninstalled");
     }
+    //extra cleanup
+    try {
+      Kubernetes.deleteClusterRole("prometheus-kube-state-metrics");
+      Kubernetes.deleteClusterRole("prometheus-server");
+      Kubernetes.deleteClusterRole("prometheus-alertmanager");
+      Kubernetes.deleteClusterRole("grafana-clusterrole");
+      Kubernetes.deleteClusterRoleBinding("grafana-clusterrolebinding");
+      Kubernetes.deleteClusterRoleBinding("prometheus-alertmanager");
+      Kubernetes.deleteClusterRoleBinding("prometheus-kube-state-metrics");
+      Kubernetes.deleteClusterRoleBinding("prometheus-server");
+      String command = "kubectl delete psp grafana grafana-test";
+      ExecCommand.exec(command);
+    } catch (Exception ex) {
+      //ignoring
+      logger.info("getting exception during delete artifacts for grafana and prometheus");
+    }
   }
 
   private void changeConfigNegative(String effect, String configFile, String expectedErrorMsg)


### PR DESCRIPTION
added extra steps to clean up intermittent leftovers from prometheus and grafana artifacts (cluster role bindings, cluster roles)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/906/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/907/