### PR TITLE
added extra properties required for domain creation 

### DIFF
--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -447,6 +447,8 @@ function createFiles {
     sed -i -e "s:%CUSTOM_RCUPREFIX%:${rcuSchemaPrefix}:g" ${createJobOutput}
     sed -i -e "s|%CUSTOM_CONNECTION_STRING%|${rcuDatabaseURL}|g" ${createJobOutput}
     sed -i -e "s:%EXPOSE_T3_CHANNEL_PREFIX%:${exposeAdminT3Channel}:g" ${createJobOutput}
+    sed -i -e "s:%FRONTEND_HOST%:${frontEndHost}:g" ${createJobOutput}
+    sed -i -e "s:%FRONTEND_PORT%:${frontEndPort}:g" ${createJobOutput}
     # entries for Istio
     sed -i -e "s:%ISTIO_PREFIX%:${istioPrefix}:g" ${createJobOutput}
     sed -i -e "s:%ISTIO_ENABLED%:${istioEnabled}:g" ${createJobOutput}


### PR DESCRIPTION
added extra properties required for domain creation of Oracle Identity Governance
Signed-off-by: Tanmay Garg<tanmay.garg@oracle.com>

This needs to be available in release/2.6.0 branch as well.