### PR TITLE
Apache Webtier Support for non-priviledged port, Persistence Volume Claim and ImagePullSecrets

### DIFF
--- a/kubernetes/samples/charts/apache-samples/custom-sample/README.md
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/README.md
@@ -8,7 +8,7 @@ $ kubectl create namespace apache-sample
 ```
 
 ## 2. Create WebLogic domains
-We need to prepare some backend domains for load balancing by the Apache webtier. Refer to the [sample](/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README.md), to create two WebLogic domains under the namespace `apache-sample`.
+We need to prepare some backend domains for load balancing by the Apache webtier. Refer to the [sample](/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv), to create two WebLogic domains under the namespace `apache-sample`.
 
 The first domain uses the following custom configuration parameters:
 - namespace: `apache-sample`
@@ -78,9 +78,9 @@ PathTrim /weblogic2
 </Location>
 ```
 
-* Place the `custom_mod_wl_apache.conf` file in a local directory `<host-config-dir>` on the host machine.
+## 5. Create  PV / PVC (pv-claim-name) that can be used to place the custom_mod_wl_apache.confi.  Refer to the [Sample for creating a PV or PVC](/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/README.md).
 
-## 5. Prepare your own certificate and private key
+## 6. Prepare your own certificate and private key
 In production, Oracle strongly recommends that you provide your own certificates. Run the following commands to generate your own certificate and private key using `openssl`.
 
 ```
@@ -91,7 +91,7 @@ $ export SSL_CERT_KEY_FILE=apache-sample.key
 $ sh certgen.sh
 ```
 
-## 6. Prepare the input values for the Apache webtier Helm chart
+## 7. Prepare the input values for the Apache webtier Helm chart
 Run the following commands to prepare the input value file for the Apache webtier Helm chart.
 
 ```
@@ -123,15 +123,15 @@ customCert: <cert_data>
 customKey: <key_data>
 ```
 
-## 7. Install the Apache webtier Helm chart
+## 8. Install the Apache webtier Helm chart
 The Apache webtier Helm chart is located in the `kubernetes/samples/charts/apache-webtier` directory. Install the Apache webtier Helm chart to the `apache-sample` namespace with the specified input parameters:
 
 ```
 $ cd kubernetes/samples/charts
-$ helm install --name my-release --values apache-samples/custom-sample/input.yaml --namespace apache-sample apache-webtier
+$ helm install my-release --values apache-samples/custom-sample/input.yaml --namespace apache-sample apache-webtier
 ```
 
-## 8. Run the sample application
+## 9. Run the sample application
 Now you can send requests to different WebLogic domains with the unique entry point of Apache with different paths. Alternatively, you can access the URLs in a web browser.
 ```
 $ curl --silent http://${HOSTNAME}:30305/weblogic1/testwebapp/
@@ -143,7 +143,7 @@ $ curl -k --silent https://${HOSTNAME}:30443/weblogic1/testwebapp/
 $ curl -k --silent https://${HOSTNAME}:30443/weblogic2/testwebapp/
 ```
 
-## 9. Uninstall the Apache webtier
+## 10. Uninstall the Apache webtier
 ```
-$ helm delete --purge my-release
+$ helm uninstall my-release --namespace apache-sample
 ```

--- a/kubernetes/samples/charts/apache-samples/custom-sample/README.md
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/README.md
@@ -106,8 +106,8 @@ Edit the input parameters file, `input.yaml`. The file content is similar to bel
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Use this to provide your own Apache webtier configuration as needed; simply define this
-# path and put your own custom_mod_wl_apache.conf file under this path.
-volumePath: <host-config-dir>
+# Persistence Volume which contains your own custom_mod_wl_apache.conf file.
+persistentVolumeClaimName: <pv-claim-name>
 
 # The VirtualHostName of the Apache HTTP server. It is used to enable custom SSL configuration.
 virtualHostName: apache-sample-host

--- a/kubernetes/samples/charts/apache-samples/custom-sample/input.yaml
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/input.yaml
@@ -1,9 +1,18 @@
 # Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# Use this to provide your own Apache webtier configuration as needed; simply define this
-# Persistence Volume which contains your own custom_mod_wl_apache.conf file.
+# Use this to provide your own Apache webtier configuration as needed; simply define the
+# Persistence Volume which contains your own custom_mod_wl_apache.conf file and provide the Persistence Volume Claim Name
 persistentVolumeClaimName: <pv-claim-name>
+
+# imagePullSecrets contains an optional list of Kubernetes secrets, that are needed
+# to access the registry containing the apache webtier Docker image.
+# If no secrets are required, then omit this property.
+# 
+# Example : a secret is needed, and has been stored in 'my-apache-webtier-secret'
+#
+# imagePullSecrets:
+# - name: my-apache-webtier-secret
 
 # The VirtualHostName of the Apache HTTP server. It is used to enable custom SSL configuration.
 virtualHostName: apache-sample-host

--- a/kubernetes/samples/charts/apache-samples/custom-sample/input.yaml
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/input.yaml
@@ -2,8 +2,8 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Use this to provide your own Apache webtier configuration as needed; simply define this
-# path and put your own custom_mod_wl_apache.conf file under this path.
-volumePath: <host-config-dir>
+# Persistence Volume which contains your own custom_mod_wl_apache.conf file.
+persistentVolumeClaimName: <pv-claim-name>
 
 # The VirtualHostName of the Apache HTTP server. It is used to enable custom SSL configuration.
 virtualHostName: apache-sample-host

--- a/kubernetes/samples/charts/apache-samples/default-sample/README.md
+++ b/kubernetes/samples/charts/apache-samples/default-sample/README.md
@@ -2,7 +2,7 @@
 In this sample, we will configure the Apache webtier as a load balancer for a WebLogic domain using the default configuration. We will demonstrate how to use the Apache webtier to handle traffic to a backend WebLogic domain.
 
 ## 1. Create a WebLogic domain
-We need to prepare a backend domain for load balancing by the Apache webtier. Refer to the [sample](/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README.md), to create a WebLogic domain. Keep the default values for the following configuration parameters:
+We need to prepare a backend domain for load balancing by the Apache webtier. Refer to the [sample](/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/), to create a WebLogic domain. Keep the default values for the following configuration parameters:
 - namespace: `default`
 - domainUID: `domain1`
 - clusterName: `cluster-1`
@@ -20,7 +20,7 @@ The Apache webtier Helm chart [is located here](../../apache-webtier/README.md).
 Install the Apache webtier Helm chart into the default namespace with the default settings:
 ```
 $ cd kubernetes/samples/charts
-$ helm install --name my-release apache-webtier
+$ helm install my-release apache-webtier
 ```
 
 ## 4. Run the sample application
@@ -35,5 +35,5 @@ $ curl -k --silent https://${HOSTNAME}:30443/weblogic/testwebapp/
 
 ## 5. Uninstall the Apache webtier
 ```
-$ helm delete --purge my-release
+$ helm uninstall my-release
 ```

--- a/kubernetes/samples/charts/apache-webtier/README.md
+++ b/kubernetes/samples/charts/apache-webtier/README.md
@@ -12,7 +12,7 @@ in order to use this load balancer.
 ## Installing the Chart
 To install the chart with the release name `my-release`:
 ```console
-$ helm install --name my-release apache-webtier
+$ helm install my-release apache-webtier
 ```
 The command deploys the Apache HTTP Server on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
@@ -20,10 +20,10 @@ The command deploys the Apache HTTP Server on the Kubernetes cluster with the de
 
 ## Uninstalling the Chart
 
-To uninstall/delete `my-release`:
+To uninstall `my-release`:
 
 ```console
-$ helm delete --purge my-release
+$ helm uninstall my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -37,7 +37,8 @@ The following table lists the configurable parameters of the Apache webtier char
 | -----------------------------------| ------------------------------------------------------------- | ----------------------|
 | `image`                            | Apache webtier Docker image                                   | `store/oracle/apache:12.2.1.3` |
 | `imagePullPolicy`                  | Image pull policy for the Apache webtier Docker image         | `IfNotPresent`        |
-| `persistentVolumeClaimName`                       | Persistence Volume Claim name Apache webtier                     | ``                    |
+| `imagePullSecrets`                 | Image pull Secrets required to access the registry containing the apache webtier Docker image| ``|
+| `persistentVolumeClaimName`        | Persistence Volume Claim name Apache webtier                  | ``                    |
 | `createRBAC`                       | Boolean indicating if RBAC resources should be created        | `true`                |
 | `httpNodePort`                     | Node port to expose for HTTP access                           | `30305`               |
 | `httpsNodePort`                    | Node port to expose for HTTPS access                          | `30443`               |
@@ -54,20 +55,20 @@ The following table lists the configurable parameters of the Apache webtier char
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install --name my-release --set persistentVolumeClaimName=webtier-apache-pvc apache-webtier
+$ helm install my-release --set persistentVolumeClaimName=webtier-apache-pvc apache-webtier
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install --name my-release --values values.yaml apache-webtier
+$ helm install my-release --values values.yaml apache-webtier
 ```
 
 ## RBAC
 By default, the chart will install the recommended RBAC roles and role bindings.
 
-You need to have the flag `--authorization-mode=RBAC` on the API server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/).
+You need to have the flag `--authorization-mode=RBAC` on the API server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 To determine if your cluster supports RBAC, run the following command:
 
@@ -82,5 +83,5 @@ If the output contains "beta", you may install the chart with RBAC enabled.
 To disable the creation of RBAC resources (on clusters with RBAC). Do the following:
 
 ```console
-$ helm install --name my-release apache-webtier --set createRBAC=false
+$ helm install my-release apache-webtier --set createRBAC=false
 ```

--- a/kubernetes/samples/charts/apache-webtier/README.md
+++ b/kubernetes/samples/charts/apache-webtier/README.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the Apache webtier char
 | -----------------------------------| ------------------------------------------------------------- | ----------------------|
 | `image`                            | Apache webtier Docker image                                   | `store/oracle/apache:12.2.1.3` |
 | `imagePullPolicy`                  | Image pull policy for the Apache webtier Docker image         | `IfNotPresent`        |
-| `volumePath`                       | Docker volume path for the Apache webtier                     | ``                    |
+| `persistentVolumeClaimName`                       | Persistence Volume Claim name Apache webtier                     | ``                    |
 | `createRBAC`                       | Boolean indicating if RBAC resources should be created        | `true`                |
 | `httpNodePort`                     | Node port to expose for HTTP access                           | `30305`               |
 | `httpsNodePort`                    | Node port to expose for HTTPS access                          | `30443`               |
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the Apache webtier char
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install --name my-release --set volumePath=/scratch/my-config apache-webtier
+$ helm install --name my-release --set persistentVolumeClaimName=webtier-apache-pvc apache-webtier
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while

--- a/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: {{ template "apache.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
-{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.volumePath) }}
+{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.persistentVolumeClaimName) }}
       volumes:
 {{- end }}
 {{- if and (.Values.virtualHostName) (.Values.customCert) }}
@@ -29,30 +29,34 @@ spec:
           defaultMode: 420
           secretName: {{ template "apache.fullname" . }}-cert
 {{- end }}
-{{- if .Values.volumePath }}
+{{- if .Values.persistentVolumeClaimName }}
       - name: {{ template "apache.fullname" . }}
-        hostPath:
-          path: {{ .Values.volumePath | quote }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistentVolumeClaimName | quote }}
+{{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets | quote }}
 {{- end }}
       containers:
       - name: {{ template "apache.fullname" . }}
         image: {{ .Values.image | quote }}
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.volumePath) }}
+{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.persistentVolumeClaimName) }}
         volumeMounts:
 {{- end }}
 {{- if and (.Values.virtualHostName) (.Values.customCert) }}
         - name: serving-cert
           mountPath: "/var/serving-cert"
 {{- end }}
-{{- if .Values.volumePath }}
+{{- if .Values.persistentVolumeClaimName }}
         - name: {{ template "apache.fullname" . }}
           mountPath: "/config"
 {{- end }}
-{{- if or (not (.Values.volumePath)) (.Values.virtualHostName) }}
+{{- if or (not (.Values.persistentVolumeClaimName)) (.Values.virtualHostName) }}
         env:
 {{- end }}
-{{- if not (.Values.volumePath) }}
+{{- if not (.Values.persistentVolumeClaimName) }}
           - name: WEBLOGIC_CLUSTER
             value: "{{ .Values.domainUID | replace "_" "-" | lower }}-cluster-{{ .Values.clusterName | replace "_" "-" | lower }}:{{ .Values.managedServerPort }}"
           - name: LOCATION
@@ -74,7 +78,7 @@ spec:
 {{- end }}
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -82,7 +86,7 @@ spec:
           timeoutSeconds: 2
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
@@ -34,10 +34,10 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistentVolumeClaimName | quote }}
 {{- end }}
-{{- if .Values.imagePullSecrets }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets | quote }}
-{{- end }}
+      {{ .Values.imagePullSecrets | toYaml }}
+      {{- end }}
       containers:
       - name: {{ template "apache.fullname" . }}
         image: {{ .Values.image | quote }}

--- a/kubernetes/samples/charts/apache-webtier/templates/service.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app: {{ template "apache.fullname" . }}
   ports:
-    - port: 80
+    - port: 8080
       nodePort: {{ .Values.httpNodePort }}
       name: http
 {{- if .Values.virtualHostName }}

--- a/kubernetes/samples/charts/apache-webtier/values.yaml
+++ b/kubernetes/samples/charts/apache-webtier/values.yaml
@@ -13,8 +13,11 @@ imagePullPolicy: "IfNotPresent"
 # 
 # Example : a secret is needed, and has been stored in 'my-apache-webtier-secret'
 #
-# imagePullSecrets: my-apache-webtier-secret
+# imagePullSecrets: 
+# - name: my-apache-webtier-secret
 #
+# imagePullSecrets:
+# - name:
 
 # Docker volume path for Apache webtier. By default, it is empty, which causes the volume
 # mount be disabled and, thereforem the built-in Apache plugin config be used.

--- a/kubernetes/samples/charts/apache-webtier/values.yaml
+++ b/kubernetes/samples/charts/apache-webtier/values.yaml
@@ -13,17 +13,14 @@ imagePullPolicy: "IfNotPresent"
 # 
 # Example : a secret is needed, and has been stored in 'my-apache-webtier-secret'
 #
-# imagePullSecrets:
-# - name: my-apache-webtier-secret
+# imagePullSecrets: my-apache-webtier-secret
 #
-# imagePullSecrets:
-# - name:
 
 # Docker volume path for Apache webtier. By default, it is empty, which causes the volume
 # mount be disabled and, thereforem the built-in Apache plugin config be used.
 # Use this to provide your own Apache webtier configuration as needed; simply define this 
 # path and put your own custom_mod_wl_apache.conf file under this path.
-volumePath:
+persistentVolumeClaimName:
 
 # Boolean indicating if RBAC resources should be created
 createRBAC: true


### PR DESCRIPTION
Hi @mriccell, @rjeberhard, @doxiao,

This PR has fix for Apache Webtier to run with non-root user and non-privileged port.
Mainly this is fixed to be in sync with the latest changes done to the Apache Webtier Docker images as part of PR - https://github.com/oracle/docker-images/pull/1630.

Along with this below changes are also added so that it can be used in Cloud Setup where Kubernetes Cluster nodes are private and have restricted access:
1. Persistent Volume Claim support instead of Host path as volume
2. Image Pull Secrets that is needed to pull registry containing the apache webtier Docker image.
3. Readme changes to support helm v3