### PR TITLE
Resolution to Jenkin log archive issue

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -64,9 +64,9 @@ public interface TestConstants {
   public static final String K8S_NODEPORT_HOST = Optional.ofNullable(System.getenv("K8S_NODEPORT_HOST"))
         .orElse(assertDoesNotThrow(() -> InetAddress.getLocalHost().getHostName()));
   public static final String GOOGLE_REPO_URL = "https://kubernetes-charts.storage.googleapis.com/";
-  public static final String RESULTS_ROOT = System.getenv().getOrDefault("RESULTS_ROOT",
+  public static final String RESULTS_ROOT = System.getenv().getOrDefault("RESULT_ROOT",
       System.getProperty("java.io.tmpdir")) + "/ittestsresults";
-  public static final String LOGS_DIR = System.getenv().getOrDefault("RESULTS_ROOT",
+  public static final String LOGS_DIR = System.getenv().getOrDefault("RESULT_ROOT",
       System.getProperty("java.io.tmpdir")) + "/diagnosticlogs";
 
   public static final String PV_ROOT = System.getenv().getOrDefault("PV_ROOT",


### PR DESCRIPTION

Revert the ENV variable Change from RESULTS_ROOT to RESULT_ROOT since jenkin job uses the environment variable RESULT_ROOT  not RESULTS_ROOT even if the value is stored in a variable name RESULTS_ROOT
