### PR TITLE
Helm upgrade command removes private key from Kubernetes secret 'weblogic-operator-secrets'

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-secret.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-secret.tpl
@@ -9,6 +9,13 @@ data:
   {{- if (and .externalRestEnabled (hasKey . "externalOperatorKey")) }}
   externalOperatorKey: {{ .externalOperatorKey | quote }}
   {{- end }}
+  {{- $secret := (lookup "v1" "Secret" .Release.Namespace "weblogic-operator-secrets") }}
+  {{- if $secret }}
+  {{- $internalOperatorKey := index $secret.data "internalOperatorKey" }}
+  {{- if $internalOperatorKey }}
+  internalOperatorKey: {{ $internalOperatorKey }}
+  {{- end }}
+  {{- end }}
 metadata:
   labels:
     weblogic.operatorName: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
Customer OFSS discovered that the Operator's internal REST interface is not started after first executing a 'Helm upgrade' command and then recycling/restarting the Operator pod.

The Operator's helm chart manages the 'weblogic-operator-secrets' Kubernetes Secret and the 'Helm upgrade' command reverts the Secret to its original chart content, which is empty.  Subsequent restart of the Operator pod disables the start of the internal REST interface due to the missing private key. 

This change uses the 'lookup' function to check if the 'weblogic-operator-secrets' Kubernetes Secret exists and if so, stores the 'internalOperatorKey' to a template variable and sets the value when recreating the resource.  During install of the chart, the Secret resource creation behaves the same as before where the empty Secret is created and then the internal REST certificate and key are created and copied into the secret using the 'patch' command.