### PR TITLE
first cut of ItPodsShutdown

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdown.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdown.java
@@ -1,0 +1,282 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes;
+
+import java.util.HashMap;
+import java.util.List;
+//import java.util.Map;
+
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1SecretReference;
+import oracle.weblogic.domain.AdminServer;
+import oracle.weblogic.domain.Cluster;
+import oracle.weblogic.domain.Configuration;
+import oracle.weblogic.domain.Domain;
+import oracle.weblogic.domain.DomainSpec;
+import oracle.weblogic.domain.ManagedServer;
+import oracle.weblogic.domain.Model;
+import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.domain.Shutdown;
+//import oracle.weblogic.kubernetes.actions.impl.Service;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
+import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
+import oracle.weblogic.kubernetes.annotations.IntegrationTest;
+import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+//import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
+//import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
+//import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.REPO_SECRET_NAME;
+//import static oracle.weblogic.kubernetes.TestConstants.WLS_DEFAULT_CHANNEL_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.WLS_DOMAIN_TYPE;
+import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
+//import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
+import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDockerRegistrySecret;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.dockerLoginAndPushImageToRegistry;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This test is used for testing pods being shutdowned by some properties change.
+ */
+@DisplayName("Test pods are being shutdowned by some properties change")
+@IntegrationTest
+class ItPodsShutdown {
+
+  private static String domainNamespace = null;
+
+  // domain constants
+  private static final String domainUid = "domain1";
+  private static final String clusterName = "cluster-1";
+  private static final int replicaCount = 1;
+  private static final String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+  private static final String managedServerPrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
+  private static final String managedServer1Name = "managed-server1";
+  private static LoggingFacade logger = null;
+
+  /**
+   * Get namespaces for operator and WebLogic domain.
+   *
+   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
+   *                   JUnit engine parameter resolution mechanism
+   */
+  @BeforeAll
+  public static void initAll(@Namespaces(2) List<String> namespaces) {
+    logger = getLogger();
+    // get a unique operator namespace
+    logger.info("Getting a unique namespace for operator");
+    assertNotNull(namespaces.get(0), "Namespace list is null");
+    String opNamespace = namespaces.get(0);
+
+    // get a unique domain namespace
+    logger.info("Getting a unique namespace for WebLogic domain");
+    assertNotNull(namespaces.get(1), "Namespace list is null");
+    domainNamespace = namespaces.get(1);
+
+    // install and verify operator
+    installAndVerifyOperator(opNamespace, domainNamespace);
+
+    // create a basic model in image domain
+    createAndVerifyMiiDomain();
+  }
+
+  @Test
+  @DisplayName("Verify shutdown rules when shutdown properties defined at different levels ")
+  public void testShutdownProps() {
+
+    // get the original domain resource before update
+    Domain domain1 = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
+        String.format("getDomainCustomResource failed with ApiException when tried to get domain %s in namespace %s",
+            domainUid, domainNamespace));
+
+    assertNotNull(domain1, domain1 + " is null");
+    assertTrue(verifyServerShutdownProp(adminServerPodName, domainNamespace, "Graceful", "40", "false"));
+
+    assertThat(assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, 2)))
+        .as("Verify scaling cluster {0} of domain {1} in namespace {2} succeeds",
+              clusterName, domainUid, domainNamespace)
+        .withFailMessage("Scaling cluster {0} of domain {1} in namespace {2} failed",
+              clusterName, domainUid, domainNamespace)
+        .isTrue();
+    assertTrue(verifyServerShutdownProp(managedServerPrefix + 1, domainNamespace, "Graceful", "100", "true"));
+    assertTrue(verifyServerShutdownProp(managedServerPrefix + 2, domainNamespace, "Graceful", "30", "true"));
+  }
+
+  /**
+   * Create a model in image domain and verify the server pods are ready.
+   */
+  private static void createAndVerifyMiiDomain() {
+
+    // get the pre-built image created by IntegrationTestWatcher
+    String miiImage = MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;
+
+    // docker login and push image to docker registry if necessary
+    dockerLoginAndPushImageToRegistry(miiImage);
+
+    // create docker registry secret to pull the image from registry
+    logger.info("Creating docker registry secret in namespace {0}", domainNamespace);
+    createDockerRegistrySecret(domainNamespace);
+
+    // create secret for admin credentials
+    logger.info("Creating secret for admin credentials");
+    String adminSecretName = "weblogic-credentials";
+    createSecretWithUsernamePassword(adminSecretName, domainNamespace, "weblogic", "welcome1");
+
+    // create encryption secret
+    logger.info("Creating encryption secret");
+    String encryptionSecretName = "encryptionsecret";
+    createSecretWithUsernamePassword(encryptionSecretName, domainNamespace, "weblogicenc", "weblogicenc");
+
+    // create the domain CR
+    Domain domain = new Domain()
+        .apiVersion(DOMAIN_API_VERSION)
+        .kind("Domain")
+        .metadata(new V1ObjectMeta()
+            .name(domainUid)
+            .namespace(domainNamespace))
+        .spec(new DomainSpec()
+            .domainUid(domainUid)
+            .domainHomeSourceType("FromModel")
+            .image(miiImage)
+            .addImagePullSecretsItem(new V1LocalObjectReference()
+                .name(REPO_SECRET_NAME))
+            .webLogicCredentialsSecret(new V1SecretReference()
+                .name(adminSecretName)
+                .namespace(domainNamespace))
+            .includeServerOutInPodLog(true)
+            .serverStartPolicy("IF_NEEDED")
+            .serverPod(new ServerPod()
+                .addEnvItem(new V1EnvVar()
+                    .name("JAVA_OPTIONS")
+                    .value("-Dweblogic.StdoutDebugEnabled=false"))
+                .addEnvItem(new V1EnvVar()
+                    .name("USER_MEM_ARGS")
+                    .value("-Djava.security.egd=file:/dev/./urandom "))
+                .addEnvItem(new V1EnvVar()
+                    .name("SHUTDOWN_TYPE")
+                    .value("Graceful")))
+            //   .shutdown(new Shutdown().timeoutSeconds(160L)))
+            .adminServer(new AdminServer()
+                .serverStartState("RUNNING")
+                .serverPod(new ServerPod().shutdown(new Shutdown().shutdownType("Forced")))
+                .serverPod(new ServerPod().shutdown(new Shutdown().ignoreSessions(true)))
+                .serverPod(new ServerPod().shutdown(new Shutdown().timeoutSeconds(40L))))
+            .addClustersItem(new Cluster()
+                .clusterName(clusterName)
+                .replicas(replicaCount)
+                .serverStartState("RUNNING")
+                .serverPod(new ServerPod().shutdown(new Shutdown().timeoutSeconds(80L)))
+                .serverPod(new ServerPod().shutdown(new Shutdown().ignoreSessions(true))))
+            .configuration(new Configuration()
+                .model(new Model()
+                    .domainType(WLS_DOMAIN_TYPE)
+                    .runtimeEncryptionSecret(encryptionSecretName)))
+            .addManagedServersItem(new ManagedServer()
+                .serverName(managedServer1Name)
+                .serverPod(new ServerPod().shutdown(new Shutdown().timeoutSeconds(100L))))
+                .serverPod(new ServerPod().shutdown(new Shutdown().ignoreSessions(false))));
+
+    // create model in image domain
+    logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",
+        domainUid, domainNamespace, miiImage);
+    createDomainAndVerify(domain, domainNamespace);
+
+    // check that admin server pod exists in the domain namespace
+    logger.info("Checking that admin server pod {0} exists in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkPodExists(adminServerPodName, domainUid, domainNamespace);
+
+    // check that admin server pod is ready
+    logger.info("Checking that admin server pod {0} is ready in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
+
+    // check that admin service exists in the domain namespace
+    logger.info("Checking that admin service {0} exists in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkServiceExists(adminServerPodName, domainNamespace);
+
+    // check for managed server pods existence in the domain namespace
+    for (int i = 1; i <= replicaCount; i++) {
+      String managedServerPodName = managedServerPrefix + i;
+
+      // check that the managed server pod exists in the domain namespace
+      logger.info("Checking that managed server pod {0} exists in namespace {1}",
+          managedServerPodName, domainNamespace);
+      checkPodExists(managedServerPodName, domainUid, domainNamespace);
+
+      // check that the managed server pod is ready
+      logger.info("Checking that managed server pod {0} is ready in namespace {1}",
+          managedServerPodName, domainNamespace);
+      checkPodReady(managedServerPodName, domainUid, domainNamespace);
+
+      // check that the managed server service exists in the domain namespace
+      logger.info("Checking that managed server service {0} exists in namespace {1}",
+          managedServerPodName, domainNamespace);
+      checkServiceExists(managedServerPodName, domainNamespace);
+    }
+  }
+
+  /**
+   * Verify the server pod Shutdown properties.
+   */
+  private static boolean verifyServerShutdownProp(
+      String podName,
+      String domainNS,
+      String... props) {
+
+    StringBuffer cmd = new StringBuffer("kubectl get pod ");
+    cmd.append(podName);
+    cmd.append(" -o yaml ");
+    cmd.append(" -n ").append(domainNS);
+    cmd.append(" | grep SHUTDOWN -A 1 ");
+
+    CommandParams params = Command
+        .defaultCommandParams()
+        .command(cmd.toString())
+        .saveResults(true)
+        .redirect(true);
+
+    Command.withParams(params).execute();
+    String stdout = params.stdout();
+    logger.info("The result of command is: " + stdout);
+
+    boolean found = false;
+    HashMap<String, Boolean> propFound = new HashMap<String, Boolean>();
+    for (String prop : props) {
+      if (stdout.contains(prop)) {
+        logger.info("Property with value " + prop + " has found");
+        propFound.put(prop, true);
+      }
+    }
+    if (props.length == propFound.size()) {
+      found = true;
+    }
+    return found;
+  }
+
+
+}
+


### PR DESCRIPTION
This PR is to test  fields on the domain that cause WebLogic server instance pods to be rolling restarted.

Jenkins parallel test passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1149
Jenkins sequential test passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1150