### PR TITLE
duplicate -srcstorepass parameter used in script

### DIFF
--- a/src/scripts/initialize-internal-operator-identity.sh
+++ b/src/scripts/initialize-internal-operator-identity.sh
@@ -73,7 +73,6 @@ function generateInternalIdentity {
     -srckeystore ${OP_JKS} \
     -srcstorepass ${TEMP_PW} \
     -destkeystore ${OP_PKCS12} \
-    -srcstorepass ${TEMP_PW} \
     -deststorepass ${TEMP_PW} \
     -deststoretype PKCS12
 


### PR DESCRIPTION
initialize-internal-operator-identity.sh  keytool command specify the parameter -srcstorepass twice.