### PR TITLE
add NGINX for production ICs

### DIFF
--- a/docs-source/content/userguide/managing-domains/ingress/_index.md
+++ b/docs-source/content/userguide/managing-domains/ingress/_index.md
@@ -34,7 +34,7 @@ The service, `serviceName` and `servicePort`, of a WebLogic cluster will be used
 object and the load balancer will route traffic to the WebLogic Servers within the cluster based on the rules.
 
 {{% notice note %}}
-Most common ingress controllers, for example Traefik, Voyager, and nginx,
+Most common ingress controllers, for example Traefik, Voyager, and NGINX,
 understand that there are zero or more actual pods behind the service, and they actually
 build their backend list and route requests to those backends directly, not through the service.  This means that
 requests are properly balanced across the pods, according to the load balancing algorithm
@@ -70,7 +70,7 @@ Information about how to install and configure these to load balance WebLogic cl
  - [Voyager guide](https://github.com/oracle/weblogic-kubernetes-operator/blob/master/kubernetes/samples/charts/voyager/README.md)
 
  {{% notice note %}}
- For production environments, we recommend Traefik (2.2.1 or later), Apache or Voyager ingress controllers, or the load balancer provided by your cloud provider.
+ For production environments, we recommend Traefik (2.2.1 or later), Apache, NGINX, or Voyager ingress controllers, or the load balancer provided by your cloud provider.
  {{% /notice %}}
 
 Samples are also provided for these two ingress controllers, showing how to manage multiple WebLogic clusters as the backends, using different routing rules, host-routing and path-routing; and TLS termination:


### PR DESCRIPTION
Added NGINX to the note that describes the ICs that we support in production, as per OWLS-84127: WKP Document that Nginx is supported in production environments