### PR TITLE
Adding assertions in upgrade test

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
@@ -222,7 +222,8 @@ public class ItOperatorUpgrade {
       opServiceAccount = opNamespace2 + "-sa";
 
       // uninstall operator 2.5.0/2.6.0
-      uninstallOperator(opHelmParams);
+      assertTrue(uninstallOperator(opHelmParams),
+          String.format("Uninstall operator failed in namespace %s", opNamespace1));
 
       // install latest operator
       installAndVerifyOperator(opNamespace, opServiceAccount, true, 0, domainNamespace);

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
@@ -202,7 +202,8 @@ public class ItOperatorUpgrade {
           .image(latestOperatorImageName)
           .externalRestEnabled(true);
 
-      upgradeAndVerifyOperator(opNamespace, opParams);
+      assertTrue(upgradeAndVerifyOperator(opNamespace, opParams),
+          String.format("Failed to upgrade operator in namespace %s", opNamespace));
 
       // check operator image name after upgrade
       logger.info("Checking image name in operator container ");


### PR DESCRIPTION
Jenkins results - 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1415/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1416/

Failure is because of product bug - https://jira.oraclecorp.com/jira/browse/OWLS-84141, Test now asserts when helm upgrade fails.