### PR TITLE
Re-enable ItCoherenceTests

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
@@ -26,8 +26,6 @@ import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
-import oracle.weblogic.kubernetes.annotations.tags.MustNotRunInParallel;
-import oracle.weblogic.kubernetes.annotations.tags.Slow;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import oracle.weblogic.kubernetes.utils.FileUtils;
@@ -35,7 +33,6 @@ import org.awaitility.core.ConditionFactory;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -143,11 +140,8 @@ class ItCoherenceTests {
    * Test rolling restart of Coherence managed servers and verify
    * that data are not lost during a domain restart.
    */
-  @Disabled
   @Test
   @DisplayName("Create domain with a Coherence cluster using WDT and test rolling restart")
-  @Slow
-  @MustNotRunInParallel
   public void testCohernceServerRollingRestart() {
     final String successMarker = "CACHE-SUCCESS";
 


### PR DESCRIPTION
The test was disabled due to an issue in the test framework. It's fixed now and we bring this test back

Passed Jenkins Jobs

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1565/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1580/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1582/

there is one failure that is not from ItCoherence test
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1581/