### PR TITLE
temporarily adding chown option to imagetool command

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
@@ -95,7 +95,8 @@ public class WebLogicImageTool {
         + " update "
         + " --tag " + params.modelImageName() + ":" + params.modelImageTag()
         + " --fromImage " + params.baseImageName() + ":" + params.baseImageTag()
-        + " --wdtDomainType " + params.domainType();
+        + " --wdtDomainType " + params.domainType()
+        + " --chown oracle:root";
 
     if (params.wdtModelOnly()) {
       command += " --wdtModelOnly ";


### PR DESCRIPTION
imagetool fails with "[SEVERE ] Response code: -1, message: docker command failed with error: unable to convert uid/gid chown string to host mapping: cant find gid for group oracle: no such group: oracle". Since it will be a while before the next release of WIT, checking in a temporary fix.

Jenkin Run 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1825/
