### PR TITLE
Support for persistentVolumeClaimName, support for both non privilege…

### DIFF
--- a/kubernetes/samples/charts/apache-samples/README.md
+++ b/kubernetes/samples/charts/apache-samples/README.md
@@ -1,8 +1,8 @@
 # Apache load balancer samples
 
-The sample package contains two samples that use the [Apache helm chart](../apache-webtier/README.md). The samples use the Docker image for the Apache HTTP Server with the 12.2.1.3.0 Oracle WebLogic Server Proxy Plugin.  See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
+The sample package contains two samples that use the [Apache helm chart](../apache-webtier/README.md). The samples use the Docker image for the Apache HTTP Server with the 12.2.1.3.0 and 12.2.1.4.0 Oracle WebLogic Server Proxy Plugin.  See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
 
 * [The default sample](default-sample/README.md) uses the built-in configuration in the above Docker image.
 
-* [The custom sample](custom-sample/README.md) demonstrates how to customize the configuration of the Apache HTTP Server with the 12.2.1.3.0 Oracle WebLogic Server Proxy Plugins.
+* [The custom sample](custom-sample/README.md) demonstrates how to customize the configuration of the Apache HTTP Server with the 12.2.1.3.0  and 12.2.1.4.0 Oracle WebLogic Server Proxy Plugins.
 

--- a/kubernetes/samples/charts/apache-samples/README.md
+++ b/kubernetes/samples/charts/apache-samples/README.md
@@ -1,8 +1,8 @@
 # Apache load balancer samples
 
-The sample package contains two samples that use the [Apache helm chart](../apache-webtier/README.md). The samples use the Docker image for the Apache HTTP Server with the 12.2.1.3.0 and 12.2.1.4.0 Oracle WebLogic Server Proxy Plugin.  See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
+The sample package contains two samples that use the [Apache Helm chart](../apache-webtier/README.md). The samples use the Docker image for the Apache HTTP Server with the 12.2.1.3.0 and 12.2.1.4.0 Oracle WebLogic Server Proxy Plugin.  See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
 
-* [The default sample](default-sample/README.md) uses the built-in configuration in the above Docker image.
+* [The default sample](default-sample/README.md) uses the built-in configuration in the Docker image.
 
 * [The custom sample](custom-sample/README.md) demonstrates how to customize the configuration of the Apache HTTP Server with the 12.2.1.3.0  and 12.2.1.4.0 Oracle WebLogic Server Proxy Plugins.
 

--- a/kubernetes/samples/charts/apache-samples/custom-sample/README.md
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/README.md
@@ -78,7 +78,7 @@ PathTrim /weblogic2
 </Location>
 ```
 
-* Create  PV / PVC (pv-claim-name) that can be used to place the `custom_mod_wl_apache.conf`.  Refer to the [Sample for creating a PV or PVC](/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/README.md).
+* Create a PV / PVC (pv-claim-name) that can be used to store the `custom_mod_wl_apache.conf`. Refer to the [Sample for creating a PV or PVC](/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/README.md).
 
 ## 5. Prepare your own certificate and private key
 In production, Oracle strongly recommends that you provide your own certificates. Run the following commands to generate your own certificate and private key using `openssl`.

--- a/kubernetes/samples/charts/apache-samples/custom-sample/README.md
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/README.md
@@ -78,7 +78,7 @@ PathTrim /weblogic2
 </Location>
 ```
 
-* Place the `custom_mod_wl_apache.conf` file in a local directory `<host-config-dir>` on the host machine.
+* Create  PV / PVC (pv-claim-name) that can be used to place the `custom_mod_wl_apache.conf`.  Refer to the [Sample for creating a PV or PVC](/kubernetes/samples/scripts/create-weblogic-domain-pv-pvc/README.md).
 
 ## 5. Prepare your own certificate and private key
 In production, Oracle strongly recommends that you provide your own certificates. Run the following commands to generate your own certificate and private key using `openssl`.
@@ -106,8 +106,8 @@ Edit the input parameters file, `input.yaml`. The file content is similar to bel
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Use this to provide your own Apache webtier configuration as needed; simply define this
-# path and put your own custom_mod_wl_apache.conf file under this path.
-volumePath: <host-config-dir>
+# Persistence Volume which contains your own custom_mod_wl_apache.conf file.
+persistentVolumeClaimName: <pv-claim-name>
 
 # The VirtualHostName of the Apache HTTP server. It is used to enable custom SSL configuration.
 virtualHostName: apache-sample-host

--- a/kubernetes/samples/charts/apache-samples/custom-sample/input.yaml
+++ b/kubernetes/samples/charts/apache-samples/custom-sample/input.yaml
@@ -1,9 +1,18 @@
 # Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# Use this to provide your own Apache webtier configuration as needed; simply define this
-# path and put your own custom_mod_wl_apache.conf file under this path.
-volumePath: <host-config-dir>
+# Use this to provide your own Apache webtier configuration as needed; simply define the
+# Persistence Volume which contains your own custom_mod_wl_apache.conf file and provide the Persistence Volume Claim Name
+persistentVolumeClaimName: <pv-claim-name>
+
+# imagePullSecrets contains an optional list of Kubernetes secrets, that are needed
+# to access the registry containing the apache webtier Docker image.
+# If no secrets are required, then omit this property.
+# 
+# Example : a secret is needed, and has been stored in 'my-apache-webtier-secret'
+#
+# imagePullSecrets:
+# - name: my-apache-webtier-secret
 
 # The VirtualHostName of the Apache HTTP server. It is used to enable custom SSL configuration.
 virtualHostName: apache-sample-host

--- a/kubernetes/samples/charts/apache-webtier/README.md
+++ b/kubernetes/samples/charts/apache-webtier/README.md
@@ -2,7 +2,7 @@
 
 This Helm chart bootstraps an Apache HTTP Server deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
  
-The chart depends on the Docker image for the Apache HTTP Server with Oracle WebLogic Server Proxy Plugin (supported verions, 12.2.1.3.0 and 12.2.1.4.0). See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
+The chart depends on the Docker image for the Apache HTTP Server with Oracle WebLogic Server Proxy Plugin (supported versions 12.2.1.3.0 and 12.2.1.4.0). See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
 
 ## Prerequisites
 
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the Apache webtier char
 | -----------------------------------| ------------------------------------------------------------- | ----------------------|
 | `image`                            | Apache webtier Docker image                                   | `store/oracle/apache:12.2.1.3` |
 | `imagePullPolicy`                  | Image pull policy for the Apache webtier Docker image         | `IfNotPresent`        |
-| `imagePullSecrets`                 | Image pull Secrets required to access the registry containing the apache webtier Docker image| ``|
+| `imagePullSecrets`                 | Image pull Secrets required to access the registry containing the Apache webtier Docker image| ``|
 | `persistentVolumeClaimName`        | Persistence Volume Claim name Apache webtier                  | ``                    |
 | `createRBAC`                       | Boolean indicating if RBAC resources should be created        | `true`                |
 | `httpNodePort`                     | Node port to expose for HTTP access                           | `30305`               |
@@ -67,13 +67,13 @@ installing the chart. For example:
 $ helm install my-release --values values.yaml apache-webtier
 ```
 ## useNonPriviledgedPorts
-By default, the chart will install the Apache webtier on PriviledgedPort i.e port 80. You need to have the flag `useNonPriviledgedPorts=true` to enable the Apache webtier to listen on port `8080`
+By default, the chart will install the Apache webtier on PriviledgedPort (port 80). Set the flag `useNonPriviledgedPorts=true` to enable the Apache webtier to listen on port `8080`
 
 
 ## RBAC
 By default, the chart will install the recommended RBAC roles and role bindings.
 
-You need to have the flag `--authorization-mode=RBAC` on the API server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+Set the flag `--authorization-mode=RBAC` on the API server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 To determine if your cluster supports RBAC, run the following command:
 

--- a/kubernetes/samples/charts/apache-webtier/README.md
+++ b/kubernetes/samples/charts/apache-webtier/README.md
@@ -2,7 +2,7 @@
 
 This Helm chart bootstraps an Apache HTTP Server deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
  
-The chart depends on the Docker image for the Apache HTTP Server with the 12.2.1.3.0 Oracle WebLogic Server Proxy Plugin.  See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
+The chart depends on the Docker image for the Apache HTTP Server with Oracle WebLogic Server Proxy Plugin (supported verions, 12.2.1.3.0 and 12.2.1.4.0). See the details in [Apache HTTP Server with Oracle WebLogic Server Proxy Plugin on Docker](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-webtier-apache).
 
 ## Prerequisites
 
@@ -37,7 +37,8 @@ The following table lists the configurable parameters of the Apache webtier char
 | -----------------------------------| ------------------------------------------------------------- | ----------------------|
 | `image`                            | Apache webtier Docker image                                   | `store/oracle/apache:12.2.1.3` |
 | `imagePullPolicy`                  | Image pull policy for the Apache webtier Docker image         | `IfNotPresent`        |
-| `volumePath`                       | Docker volume path for the Apache webtier                     | ``                    |
+| `imagePullSecrets`                 | Image pull Secrets required to access the registry containing the apache webtier Docker image| ``|
+| `persistentVolumeClaimName`        | Persistence Volume Claim name Apache webtier                  | ``                    |
 | `createRBAC`                       | Boolean indicating if RBAC resources should be created        | `true`                |
 | `httpNodePort`                     | Node port to expose for HTTP access                           | `30305`               |
 | `httpsNodePort`                    | Node port to expose for HTTPS access                          | `30443`               |
@@ -50,11 +51,13 @@ The following table lists the configurable parameters of the Apache webtier char
 | `adminPort`                        | Port number for Administration Server                         | `7001`                |
 | `managedServerPort`                | Port number for each Managed Server                           | `8001`                |
 | `location`                         | Prepath for all applications deployed on the WebLogic cluster | `/weblogic`           |
+| `useNonPriviledgedPorts`           | Configuration of Apache webtier on NonPriviledgedPort         | `false`               |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install my-release --set volumePath=/scratch/my-config apache-webtier
+$ helm install my-release --set persistentVolumeClaimName=webtier-apache-pvc apache-webtier
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
@@ -63,11 +66,14 @@ installing the chart. For example:
 ```console
 $ helm install my-release --values values.yaml apache-webtier
 ```
+## useNonPriviledgedPorts
+By default, the chart will install the Apache webtier on PriviledgedPort i.e port 80. You need to have the flag `useNonPriviledgedPorts=true` to enable the Apache webtier to listen on port `8080`
+
 
 ## RBAC
 By default, the chart will install the recommended RBAC roles and role bindings.
 
-You need to have the flag `--authorization-mode=RBAC` on the API server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/).
+You need to have the flag `--authorization-mode=RBAC` on the API server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 To determine if your cluster supports RBAC, run the following command:
 

--- a/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: {{ template "apache.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
-{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.volumePath) }}
+{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.persistentVolumeClaimName) }}
       volumes:
 {{- end }}
 {{- if and (.Values.virtualHostName) (.Values.customCert) }}
@@ -29,34 +29,38 @@ spec:
           defaultMode: 420
           secretName: {{ template "apache.fullname" . }}-cert
 {{- end }}
-{{- if .Values.volumePath }}
+{{- if .Values.persistentVolumeClaimName }}
       - name: {{ template "apache.fullname" . }}
-        hostPath:
-          path: {{ .Values.volumePath | quote }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistentVolumeClaimName | quote }}
 {{- end }}
-{{- if .Values.imagePullSecrets }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ (index .Values.imagePullSecrets 0).name }}
-{{- end }}
+      {{ .Values.imagePullSecrets | toYaml }}
+      {{- end }}
       containers:
       - name: {{ template "apache.fullname" . }}
         image: {{ .Values.image | quote }}
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.volumePath) }}
+{{- if or (and (.Values.virtualHostName) (.Values.customCert)) (.Values.persistentVolumeClaimName) }}
         volumeMounts:
 {{- end }}
 {{- if and (.Values.virtualHostName) (.Values.customCert) }}
         - name: serving-cert
           mountPath: "/var/serving-cert"
 {{- end }}
-{{- if .Values.volumePath }}
+{{- if .Values.persistentVolumeClaimName }}
         - name: {{ template "apache.fullname" . }}
           mountPath: "/config"
 {{- end }}
-{{- if or (not (.Values.volumePath)) (.Values.virtualHostName) }}
+{{- if or (not (.Values.persistentVolumeClaimName)) (.Values.virtualHostName) }}
         env:
 {{- end }}
-{{- if not (.Values.volumePath) }}
+{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+          - name: NonPriviledgedPorts
+            value: "true"
+{{- end }}
+{{- if not (.Values.persistentVolumeClaimName) }}
           - name: WEBLOGIC_CLUSTER
             value: "{{ .Values.domainUID | replace "_" "-" | lower }}-cluster-{{ .Values.clusterName | replace "_" "-" | lower }}:{{ .Values.managedServerPort }}"
           - name: LOCATION
@@ -78,7 +82,11 @@ spec:
 {{- end }}
         readinessProbe:
           tcpSocket:
+{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+            port: 8080
+{{- else }}
             port: 80
+{{- end }}
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -86,7 +94,11 @@ spec:
           timeoutSeconds: 2
         livenessProbe:
           tcpSocket:
+{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+            port: 8080
+{{- else }}
             port: 80
+{{- end }}
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/kubernetes/samples/charts/apache-webtier/templates/service.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/service.yaml
@@ -11,7 +11,11 @@ spec:
   selector:
     app: {{ template "apache.fullname" . }}
   ports:
+{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+    - port: 8080
+{{- else}}
     - port: 80
+{{- end }}
       nodePort: {{ .Values.httpNodePort }}
       name: http
 {{- if .Values.virtualHostName }}

--- a/kubernetes/samples/charts/apache-webtier/values.yaml
+++ b/kubernetes/samples/charts/apache-webtier/values.yaml
@@ -23,7 +23,7 @@ imagePullPolicy: "IfNotPresent"
 # mount be disabled and, thereforem the built-in Apache plugin config be used.
 # Use this to provide your own Apache webtier configuration as needed; simply define this 
 # path and put your own custom_mod_wl_apache.conf file under this path.
-volumePath:
+persistentVolumeClaimName:
 
 # Boolean indicating if RBAC resources should be created
 createRBAC: true
@@ -74,4 +74,5 @@ managedServerPort: 8001
 # where 'myhost' is the IP of the machine that runs the Apache web tier, and 
 #       'myport' is the port that the Apache web tier is publicly exposed to.
 location: "/weblogic"
-
+# Use non privileged port 8080 to listen. If set to false, default privileged port 80 will be used.
+useNonPriviledgedPorts: false


### PR DESCRIPTION
Hi @mriccell, @rjeberhard, @doxiao,

Older PR (oracle/weblogic-kubernetes-operator#1840) got closed while rebase with latest develop branch which was far ahead with many commits, hence created a new one.

This PR has fix for Apache Webtier to run with non-root user and non-privileged port.
Mainly this is fixed to be in sync with the latest changes done to the Apache Webtier Docker images as part of PR - oracle/docker-images#1630.

Along with this below changes are also added so that it can be used in Cloud Setup where Kubernetes Cluster nodes are private and have restricted access:

    1. Persistent Volume Claim support instead of Host path as volume
    2. Support for both default privileged port (80) and non-privileged port (8080)
    3. Readme updates
    4. Image Pull Secrets (initial PR changes) that is needed to pull registry containing the apache webtier Docker image.