### PR TITLE
Testfixpostimageupdate

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -19,7 +19,7 @@ public interface TestConstants {
   public static final String MANAGED_SERVER_NAME_BASE = "managed-server";
   public static final String WLS_DOMAIN_TYPE = "WLS";
   public static final String WLS_DEFAULT_CHANNEL_NAME = "default";
-  public static final String DEFAULT_WLS_IMAGE_TAGS = "12.2.1.3, 14.1.1.0";
+  public static final String DEFAULT_WLS_IMAGE_TAGS = "12.2.1.4, 14.1.1.0-11";
 
   // operator constants
   public static final String OPERATOR_RELEASE_NAME = "weblogic-operator";

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
@@ -95,7 +95,8 @@ public class WebLogicImageTool {
         + " update "
         + " --tag " + params.modelImageName() + ":" + params.modelImageTag()
         + " --fromImage " + params.baseImageName() + ":" + params.baseImageTag()
-        + " --wdtDomainType " + params.domainType();
+        + " --wdtDomainType " + params.domainType()
+        + " --chown oracle:root";
 
     if (params.wdtModelOnly()) {
       command += " --wdtModelOnly ";

--- a/src/integration-tests/model-in-image/mii-sample-wrapper/build-model-image.sh
+++ b/src/integration-tests/model-in-image/mii-sample-wrapper/build-model-image.sh
@@ -72,6 +72,9 @@ function output_dryrun() {
 MODEL_YAML_FILES="$(ls $WORKDIR/$MODEL_DIR/*.yaml | xargs | sed 's/ /,/g')"
 MODEL_ARCHIVE_FILES=$WORKDIR/$MODEL_DIR/archive.zip
 MODEL_VARIABLE_FILES="$(ls $WORKDIR/$MODEL_DIR/*.properties | xargs | sed 's/ /,/g')"
+if [ "$WDT_DOMAIN_TYPE" = "WLS" ]; then
+  CHOWN_ROOT="--chown oracle:root"
+fi
 
 cat << EOF
 
@@ -109,6 +112,7 @@ dryrun:  ${MODEL_YAML_FILES:+--wdtModel ${MODEL_YAML_FILES}} \\
 dryrun:  ${MODEL_VARIABLE_FILES:+--wdtVariables ${MODEL_VARIABLE_FILES}} \\
 dryrun:  ${MODEL_ARCHIVE_FILES:+--wdtArchive ${MODEL_ARCHIVE_FILES}} \\
 dryrun:  --wdtModelOnly \\
+dryrun:  ${CHOWN_ROOT:+${CHOWN_ROOT}} \\
 dryrun:  --wdtDomainType ${WDT_DOMAIN_TYPE}
 dryrun:
 dryrun:echo "@@ Info: Success! Model image '$MODEL_IMAGE' build complete. Seconds=\$SECONDS."


### PR DESCRIPTION
New weblogic images have been uploaded to the registry and so we need to fix weblogic image tag for ItMiiDomain. The updated image also changed the uid/gid to oracle:root. WIT by default uses oracle:oracle and so changing the ItMiiSamole to use the chown option when running imagetool.
Will update this with the jenkins job once there is a successful run.