### PR TITLE
Configure JMS Server logs on PV and verify

### DIFF
--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
@@ -384,8 +384,6 @@ class ItCoherenceTests {
     String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
     logger.info("New restart version : {0}", newRestartVersion);
 
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-            "More than one pod was restarted at same time"), "Rolling restart failed");
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace), "Rolling restart failed");
   }
 }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -458,7 +458,7 @@ class ItMiiUpdateDomainConfig {
     logger.info("Found the JMSSystemResource configuration");
 
     // check JMS logs are written on PV
-    checkLogsOnPV("ls -ltr /shared/logs/*jms_messages.log", managedServerPrefix + "1");
+    // checkLogsOnPV("ls -ltr /shared/logs/*jms_messages.log", managedServerPrefix + "1");
   }
 
   /**

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -372,10 +372,8 @@ class ItMiiUpdateDomainConfig {
     String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
     logger.log(Level.INFO, "New restart version is {0}", newRestartVersion);
     
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-         "More than one pod was restarted at same time"),
-        "Rolling restart failed");
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
+                "Rolling restart failed");
 
     // Even if pods are created, need the service to created
     for (int i = 1; i <= replicaCount; i++) {
@@ -437,10 +435,8 @@ class ItMiiUpdateDomainConfig {
     String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
     logger.log(Level.INFO, "New restart version is {0}", newRestartVersion);
     
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-         "More than one pod was restarted at same time"),
-        "Rolling restart failed");
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
+         "Rolling restart failed");
 
     // Even if pods are created, need the service to created
     for (int i = 1; i <= replicaCount; i++) {
@@ -458,7 +454,7 @@ class ItMiiUpdateDomainConfig {
     logger.info("Found the JMSSystemResource configuration");
 
     // check JMS logs are written on PV
-    // checkLogsOnPV("ls -ltr /shared/logs/*jms_messages.log", managedServerPrefix + "1");
+    checkLogsOnPV("ls -ltr /shared/logs/*jms_messages.log", managedServerPrefix + "1");
   }
 
   /**
@@ -506,9 +502,7 @@ class ItMiiUpdateDomainConfig {
     String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
     logger.log(Level.INFO, "New restart version : {0}", newRestartVersion);
 
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-         "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
         "Rolling restart failed");
 
     // The ServerNamePrefix for the new configured cluster is config-server
@@ -584,9 +578,7 @@ class ItMiiUpdateDomainConfig {
     // Check if the admin server pod has been restarted
     // by comparing the PodCreationTime before and after rolling restart
 
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-         "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
         "Rolling restart failed");
 
     // The ServerNamePrefix for the new dynamic cluster is dynamic-server
@@ -661,9 +653,7 @@ class ItMiiUpdateDomainConfig {
     String newRestartVersion = patchDomainResourceWithNewRestartVersion(domainUid, domainNamespace);
     logger.log(Level.INFO, "New restart version : {0}", newRestartVersion);
 
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-         "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
         "Rolling restart failed");
 
     // The ServerNamePrefix for the new configured cluster is config-server
@@ -729,9 +719,7 @@ class ItMiiUpdateDomainConfig {
     logger.info("Wait for domain {0} admin server pod {1} in namespace {2} to be restarted",
         domainUid, adminServerPodName, domainNamespace);
 
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-         "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
         "Rolling restart failed");
 
     // check if the new credentials are valid and the old credentials are not valid any more

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestart.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestart.java
@@ -300,9 +300,7 @@ public class ItOperatorRestart {
     logger.info("Wait for domain {0} server pods in namespace {1} to be restarted",
         domainUid, domainNamespace);
 
-    assertTrue(assertDoesNotThrow(
-        () -> (verifyRollingRestartOccurred(pods, 1, domainNamespace)),
-        "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(pods, 1, domainNamespace),
         "Rolling restart failed");
 
     for (int i = 1; i <= replicaCount; i++) {

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
@@ -97,7 +97,7 @@ class ItPodsRestart {
     // get a unique operator namespace
     logger.info("Getting a unique namespace for operator");
     assertNotNull(namespaces.get(0), "Namespace list is null");
-    String opNamespace = namespaces.get(0);
+    final String opNamespace = namespaces.get(0);
 
     // get a unique domain namespace
     logger.info("Getting a unique namespace for WebLogic domain");
@@ -215,9 +215,7 @@ class ItPodsRestart {
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
         domainUid, domainNamespace);
-    assertTrue(assertDoesNotThrow(
-        () -> verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
-        "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
   }
@@ -272,9 +270,7 @@ class ItPodsRestart {
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
         domainUid, domainNamespace);
-    assertTrue(assertDoesNotThrow(
-        () -> verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
-        "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
   }
@@ -340,9 +336,7 @@ class ItPodsRestart {
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
         domainUid, domainNamespace);
-    assertTrue(assertDoesNotThrow(
-        () -> verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
-        "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
   }
@@ -407,9 +401,7 @@ class ItPodsRestart {
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
         domainUid, domainNamespace);
-    assertTrue(assertDoesNotThrow(
-        () -> verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
-        "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
   }
@@ -465,9 +457,7 @@ class ItPodsRestart {
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
         domainUid, domainNamespace);
-    assertTrue(assertDoesNotThrow(
-        () -> verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
-        "More than one pod was restarted at same time"),
+    assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
   }

--- a/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Pod.java
+++ b/new-integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Pod.java
@@ -15,7 +15,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class Pod {
 
@@ -48,8 +47,7 @@ public class Pod {
           namespace,
           condition.getElapsedTimeInMS(),
           condition.getRemainingTimeInMS()))
-          .until(assertDoesNotThrow(() -> podRestarted(entry.getKey(), pods, maxUnavailable, namespace),
-              String.format("pod %s didn't restart in namespace %s", entry.getKey(), namespace)));
+          .until(podRestarted(entry.getKey(), pods, maxUnavailable, namespace));
 
       // check pods are in ready status
       retry
@@ -60,8 +58,7 @@ public class Pod {
           namespace,
           condition.getElapsedTimeInMS(),
           condition.getRemainingTimeInMS()))
-          .until(assertDoesNotThrow(() -> podReady(namespace, null, entry.getKey()),
-              String.format("pod %s didn't become ready in namespace %s", entry.getKey(), namespace)));
+          .until(podReady(namespace, null, entry.getKey()));
     }
 
     return true;

--- a/new-integration-tests/src/test/resources/wdt-models/model.jms2.yaml
+++ b/new-integration-tests/src/test/resources/wdt-models/model.jms2.yaml
@@ -6,12 +6,14 @@ resources:
            Target: 'cluster-1'
     JMSServer:
         TestClusterJmsServer2:
-            ProductionPausedAtStartup: false
-            ConsumptionPausedAtStartup: false
-            Target: 'cluster-1'
-            PersistentStore: 'TestClusterFileStore2'
-            InsertionPausedAtStartup: false
-            MessageCompressionOptions: GZIP_DEFAULT_COMPRESSION
+          JmsMessageLogFile:
+            FileName: "@@ENV:LOG_HOME@@/jms_messages.log"
+          ProductionPausedAtStartup: false
+          ConsumptionPausedAtStartup: false
+          Target: 'cluster-1'
+          PersistentStore: 'TestClusterFileStore2'
+          InsertionPausedAtStartup: false
+          MessageCompressionOptions: GZIP_DEFAULT_COMPRESSION
 
     JMSSystemResource:
         TestClusterJmsModule2:

--- a/new-integration-tests/src/test/resources/wdt-models/model.jms2.yaml
+++ b/new-integration-tests/src/test/resources/wdt-models/model.jms2.yaml
@@ -6,6 +6,8 @@ resources:
            Target: 'cluster-1'
     JMSServer:
         TestClusterJmsServer2:
+          JmsMessageLogFile:
+            FileName: "@@ENV:LOG_HOME@@/jms_messages.log"
             ProductionPausedAtStartup: false
             ConsumptionPausedAtStartup: false
             Target: 'cluster-1'

--- a/new-integration-tests/src/test/resources/wdt-models/model.jms2.yaml
+++ b/new-integration-tests/src/test/resources/wdt-models/model.jms2.yaml
@@ -6,8 +6,6 @@ resources:
            Target: 'cluster-1'
     JMSServer:
         TestClusterJmsServer2:
-          JmsMessageLogFile:
-            FileName: "@@ENV:LOG_HOME@@/jms_messages.log"
             ProductionPausedAtStartup: false
             ConsumptionPausedAtStartup: false
             Target: 'cluster-1'


### PR DESCRIPTION
Modified the existing test which patches the domain with config map to create JMS server to use LOG_HOME env var to log on PV for JMS message log file.
Also fixed the rolling restart assertions which were reporting incorrect error messages.

Jenkins results -
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1940/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1945/ - known failures 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/1951/ - just started a run after syncing to latest develop
