### PR TITLE
owls84294 check existence of sa in helm templates

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_utils.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_utils.tpl
@@ -458,3 +458,18 @@ Verify that a list of strings can not be defined if another string is already de
 {{- define "utils.mutexString" -}}
 {{- include "utils.mutexValue" (append . "string") -}}
 {{- end -}}
+
+{{/*
+Verify that a Kubernetes resource exists in a given namespace
+*/}}
+{{- define "utils.verifyK8SResource" -}}
+{{- $scope := index . 0 -}}
+{{- $name := index . 1 -}}
+{{- $type := index . 2 -}}
+{{- $namespace := index . 3 -}}
+{{- $found := (lookup "v1" $type $namespace $name) }}
+{{- if not $found }}
+{{-   $errorMsg := cat $type $name " does not exist in namespace " $namespace -}}
+{{-   include "utils.recordValidationError" (list $scope $errorMsg) -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/charts/weblogic-operator/templates/_validate-inputs.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_validate-inputs.tpl
@@ -8,6 +8,7 @@
 {{- $ignore := include "utils.verifyResourceName" (list $scope "Namespace") -}}
 {{- $ignore := include "utils.popValidationContext" $scope -}}
 {{- $ignore := include "utils.verifyString" (list $scope "serviceAccount") -}}
+{{- $ignore := include "utils.verifyK8SResource" (list $scope .serviceAccount "ServiceAccount" .Release.Namespace) -}}
 {{- $ignore := include "utils.verifyString" (list $scope "image") -}}
 {{- $ignore := include "utils.verifyEnum" (list $scope "imagePullPolicy" (list "Always" "IfNotPresent" "Never")) -}}
 {{- $ignore := include "utils.verifyOptionalDictionaryList" (list $scope "imagePullSecrets") -}}


### PR DESCRIPTION
Add a check in helm templates for the existence of the specified service account in an operator installation because Helm V3 does not check it anymore. 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2038/