### PR TITLE
Change domain name

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -124,6 +124,8 @@ public class ItIntrospectVersion {
   private static String opNamespace = null;
   private static String introDomainNamespace = null;
 
+  private static final String domainUid = "myintrodomain";
+
   private static String nginxNamespace = null;
   private static int nodeportshttp;
   private static HelmParams nginxHelmParams = null;
@@ -208,7 +210,6 @@ public class ItIntrospectVersion {
   @DisplayName("Test introSpectVersion starting a introspector and updating domain status")
   public void testDomainIntrospectVersionNotRolling() {
 
-    final String domainUid = "mydomain";
     final String clusterName = "mycluster";
 
     final String adminServerName = "admin-server";
@@ -505,7 +506,6 @@ public class ItIntrospectVersion {
   @DisplayName("Test introspectVersion rolling server pods when admin server port is changed")
   public void testDomainIntrospectVersionRolling() {
 
-    final String domainUid = "mydomain";
     final String clusterName = "mycluster";
 
     final String adminServerName = "admin-server";
@@ -624,8 +624,6 @@ public class ItIntrospectVersion {
   @Test
   @DisplayName("Test change WebLogic admin credentials for domain running in persistent volume")
   public void testCredentialChange() {
-
-    final String domainUid = "mydomain";
 
     final String adminServerName = "admin-server";
     final String adminServerPodName = domainUid + "-" + adminServerName;
@@ -773,7 +771,6 @@ public class ItIntrospectVersion {
   @DisplayName("Test new cluster creation on demand using WLST and introspection")
   public void testCreateNewCluster() {
 
-    final String domainUid = "mydomain";
     final String clusterName = "cl2";
 
     final String adminServerName = "admin-server";


### PR DESCRIPTION
The ItIntrospectVersion and ItConfigDistributionStrategy are using the same persistent volume names which are derived from domainUid + "-pv" 

When these tests are running in parallel the pv creatiopn fails in one of the test due to the fact that pv are cluster objects.

This PR changes the domain name used in the test to be different to avoid this conflict.

Jenkins test results

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2114/