### PR TITLE
OWLS-84380 enable disabled test cases

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -36,7 +36,6 @@ import org.awaitility.core.ConditionFactory;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -637,7 +636,6 @@ class ItServerStartPolicy {
 
   // The usecase fails NEVER->ALWAYS
   // https://bug.oraclecorp.com/pls/bug/webbug_print.show?c_rptno=31833260
-  @Disabled
   @Test
   @DisplayName("Restart the standalone managed server with serverStartPolicy")
   public void testStandaloneManagedRestartAlways() {
@@ -677,7 +675,6 @@ class ItServerStartPolicy {
 
   // The usecase fails NEVER->IF_NEEDED
   // https://bug.oraclecorp.com/pls/bug/webbug_print.show?c_rptno=31833260
-  @Disabled
   @Test
   @DisplayName("Restart the standalone managed server with serverStartPolicy")
   public void testStandaloneManagedRestartIfNeeded() {


### PR DESCRIPTION
Enable the disabled test cases for standalone managed servers now that the issue has been fixed by PR#1941.

The ItServerStartPolicy test suite passed in Jenkins https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2121/.