### PR TITLE
Fix missing ODL configuration that may presents in the model

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -925,9 +925,9 @@ class MII_DomainConfigGenerator(Generator):
     # all the many policies files
     packcmd = "tar -pczf /tmp/domain.tar.gz %s/config/config.xml %s/config/jdbc/ %s/config/jms %s/config/coherence " \
               "%s/config/diagnostics %s/config/startup %s/config/configCache %s/config/nodemanager " \
-              "%s/config/security %s" % (
+              "%s/config/security %s/config/fmwconfig/servers %s" % (
               self.domain_home, self.domain_home, self.domain_home, self.domain_home, self.domain_home,
-              self.domain_home, self.domain_home, self.domain_home, self.domain_home, empath)
+              self.domain_home, self.domain_home, self.domain_home, self.domain_home, self.domain_home, empath)
     os.system(packcmd)
     domain_data = self.env.readBinaryFile("/tmp/domain.tar.gz")
     b64 = ""

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -925,7 +925,7 @@ class MII_DomainConfigGenerator(Generator):
     # all the many policies files
     packcmd = "tar -pczf /tmp/domain.tar.gz %s/config/config.xml %s/config/jdbc/ %s/config/jms %s/config/coherence " \
               "%s/config/diagnostics %s/config/startup %s/config/configCache %s/config/nodemanager " \
-              "%s/config/security %s/config/fmwconfig/servers %s" % (
+              "%s/config/security %s/config/fmwconfig/servers/*/logging.xml %s" % (
               self.domain_home, self.domain_home, self.domain_home, self.domain_home, self.domain_home,
               self.domain_home, self.domain_home, self.domain_home, self.domain_home, self.domain_home, empath)
     os.system(packcmd)


### PR DESCRIPTION
ODL configuration is written to a logging.xml file under $domain/config/fmwconfig/servers/<server name> and not in config.xml file, archive the directories for any customization may have been supplied by user's customization. 