### PR TITLE
Add a testcase for -wdtModelHome option to the imagetool

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -32,6 +32,8 @@ import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.Domain;
 import oracle.weblogic.kubernetes.actions.impl.Exec;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
+import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
@@ -431,6 +433,7 @@ public class ItMiiDomainModelInPV {
   // create a model in image with no domain and custom wdtModelHome
   // push the image to repo
   private static void buildMIIandPushToRepo(String image, String customWDTHome) {
+    logger.info("Building image {0}", image);
     Path emptyModelFile = Paths.get(TestConstants.RESULTS_ROOT, "miitemp", "empty-wdt-model.yaml");
     assertDoesNotThrow(() -> Files.createDirectories(emptyModelFile.getParent()));
     emptyModelFile.toFile().delete();
@@ -452,6 +455,10 @@ public class ItMiiDomainModelInPV {
         .wdtVersion(WDT_VERSION)
         .env(env)
         .redirect(true));
+    CommandParams cmdParams = Command.defaultCommandParams()
+        .command("docker images")
+        .saveResults(true)
+        .redirect(false);
     assertTrue(doesImageExist(image.split(":")[1]),
         String.format("Image %s doesn't exist", image));
     dockerLoginAndPushImage(image);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -156,7 +156,7 @@ public class ItMiiDomainModelInPV {
 
     logger.info("Building image with custom wdt model home location");
     miiImageTagCustom = TestUtils.getDateAndTimeStamp();
-    miiImagePV = MII_BASIC_IMAGE_NAME + ":" + miiImageTagCustom;
+    miiImageCustom = MII_BASIC_IMAGE_NAME + ":" + miiImageTagCustom;
 
     // build a new MII image with custom wdtHome
     buildMIIWithwdtModelHomeandPushToRepo();
@@ -257,6 +257,8 @@ public class ItMiiDomainModelInPV {
     String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
     String managedServerPodNamePrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
 
+    logger.info("Creating domain {0} with model in image {1} in namespace {2}",
+        domainUid, image, domainNamespace);
     createVerifyDomain(domainUid, domainCR, adminServerPodName, managedServerPodNamePrefix);
 
     List<String> managedServerNames = new ArrayList<String>();
@@ -282,8 +284,6 @@ public class ItMiiDomainModelInPV {
   private void createVerifyDomain(String domainUid, Domain domain,
       String adminServerPodName, String managedServerPodNamePrefix) {
     // create model in image domain
-    logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",
-        domainUid, domainNamespace, miiImagePV);
     createDomainAndVerify(domain, domainNamespace);
 
     // check that admin service/pod exists in the domain namespace

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -101,7 +101,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This test class verify creating a domain from model and application archive files stored in the persistent
  * volume.
  */
-@DisplayName("Verify MII domain can be created from model file in PV location")
+@DisplayName("Verify MII domain can be created from model file in PV location and custom wdtModelHome")
 @IntegrationTest
 public class ItMiiDomainModelInPV {
 
@@ -144,7 +144,7 @@ public class ItMiiDomainModelInPV {
   /**
    * 1. Get namespaces for operator and WebLogic domain.
    * 2. Create operator.
-   * 3. Build a MII with no domain and push it to repository.
+   * 3. Build a MII with no domain, MII with custom wdtModelHome and push it to repository.
    * 4. Create WebLogic credential and model encryption secrets
    * 5. Create PV and PVC to store model and application files.
    * 6. Copy the model file and application files to PV.
@@ -208,7 +208,7 @@ public class ItMiiDomainModelInPV {
     clusterViewAppPath = Paths.get(distDir.toString(), "clusterview.war");
     assertTrue(clusterViewAppPath.toFile().exists(), "Application archive is not available");
 
-    //V1Pod pvPod = setupPVPod(domainNamespace);
+    logger.info("Setting up WebLogic pod to access PV");
     V1Pod pvPod = setupWebLogicPod(domainNamespace);
 
     ExecResult exec = null;
@@ -268,12 +268,13 @@ public class ItMiiDomainModelInPV {
        /userguide/managing-domains/domain-resource/#domain-spec-elements
     1.Create the domain custom resource using mii with no domain and specifying a PV location for modelHome
     2.Create the domain custom resource using mii with custom wdt model home in a pv location
-    2. Verify the domain creation is successful and application is accessible.
+    3. Verify the domain creation is successful and application is accessible.
+    4. Repeat the test the above test using image created with custom wdtModelHome.
    * @param params domain name and image parameters
    */
   @ParameterizedTest
   @MethodSource("paramProvider")
-  @DisplayName("Create MII domain with model and application file from PV")
+  @DisplayName("Create MII domain with model and application file from PV and custon wdtModelHome")
   public void testMiiDomainWithModelAndApplicationInPV(Entry<String, String> params) {
 
     String domainUid = params.getKey();
@@ -311,11 +312,7 @@ public class ItMiiDomainModelInPV {
 
   }
 
-
-  /**
-   * Generate a steam of Domain objects used in parameterized tests.
-   * @return stream of oracle.weblogic.domain.Domain objects
-   */
+  // generates the stream of objects used by parametrized test.
   private static Stream<Entry<String,String>> paramProvider() {
     return params.entrySet().stream();
   }
@@ -430,7 +427,7 @@ public class ItMiiDomainModelInPV {
     return wlsPod;
   }
 
-  // create a model in image with no domain
+  // create a model in image with no domain and custom wdtModelHome
   // push the image to repo
   private static void buildMIIandPushToRepo(String image, String customWDTHome) {
     Path emptyModelFile = Paths.get(TestConstants.RESULTS_ROOT, "miitemp", "empty-wdt-model.yaml");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -27,6 +27,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
+import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.Domain;
@@ -381,6 +382,19 @@ public class ItMiiDomainModelInPV {
     final String podName = "pv-pod-" + namespace;
     V1Pod podBody = new V1Pod()
         .spec(new V1PodSpec()
+            .initContainers(Arrays.asList(new V1Container()
+                .name("fix-pvc-owner") // change the ownership of the pv to opc:opc
+                .image("oraclelinux:7")
+                .addCommandItem("/bin/sh")
+                .addArgsItem("-c")
+                .addArgsItem("chown -R 1000:1000 /u01/modelHome")
+                .volumeMounts(Arrays.asList(
+                    new V1VolumeMount()
+                        .name(pvName)
+                        .mountPath("/u01/modelHome")))
+                .securityContext(new V1SecurityContext()
+                    .runAsGroup(0L)
+                    .runAsUser(0L))))
             .containers(Arrays.asList(
                 new V1Container()
                     .name("pv-container")
@@ -425,6 +439,19 @@ public class ItMiiDomainModelInPV {
     final String podName = "weblogic-pv-pod-" + namespace;
     V1Pod podBody = new V1Pod()
         .spec(new V1PodSpec()
+            .initContainers(Arrays.asList(new V1Container()
+                .name("fix-pvc-owner") // change the ownership of the pv to opc:opc
+                .image(wlsImage)
+                .addCommandItem("/bin/sh")
+                .addArgsItem("-c")
+                .addArgsItem("chown -R 1000:1000 /u01/modelHome")
+                .volumeMounts(Arrays.asList(
+                    new V1VolumeMount()
+                        .name(pvName)
+                        .mountPath("/u01/modelHome")))
+                .securityContext(new V1SecurityContext()
+                    .runAsGroup(0L)
+                    .runAsUser(0L))))
             .containers(Arrays.asList(
                 new V1Container()
                     .name("weblogic-container")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -240,8 +240,8 @@ public class ItMiiDomainModelInPV {
     String image = params.getValue();
 
     // create domain custom resource and verify all the pods came up
-    logger.info("Creating domain custom resource");
-
+    logger.info("Creating domain custom resource with domainUid {0} and image {1}",
+        domainUid, image);
     Domain domainCR = CommonMiiTestUtils.createDomainResource(domainUid, domainNamespace,
         image, adminSecretName, REPO_SECRET_NAME, encryptionSecretName, replicaCount, clusterName);
     domainCR.spec().configuration().model().withModelHome("/u01/modelHome/model");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -172,14 +172,14 @@ public class ItMiiDomainModelInPV {
     miiImagePV = MII_BASIC_IMAGE_NAME + ":" + miiImageTagPV;
 
     // build a new MII image with no domain
-    buildMIIandPushToRepo(null);
+    buildMIIandPushToRepo(miiImagePV, null);
 
     logger.info("Building image with custom wdt model home location");
     miiImageTagCustom = TestUtils.getDateAndTimeStamp();
     miiImageCustom = MII_BASIC_IMAGE_NAME + ":" + miiImageTagCustom;
 
     // build a new MII image with custom wdtHome
-    buildMIIandPushToRepo(modelMountPath + "/model");
+    buildMIIandPushToRepo(miiImageCustom, modelMountPath + "/model");
 
     params.put("domain2", miiImageCustom);
     params.put("domain1", miiImagePV);
@@ -432,7 +432,7 @@ public class ItMiiDomainModelInPV {
 
   // create a model in image with no domain
   // push the image to repo
-  private static void buildMIIandPushToRepo(String customWDTHome) {
+  private static void buildMIIandPushToRepo(String image, String customWDTHome) {
     Path emptyModelFile = Paths.get(TestConstants.RESULTS_ROOT, "miitemp", "empty-wdt-model.yaml");
     assertDoesNotThrow(() -> Files.createDirectories(emptyModelFile.getParent()));
     emptyModelFile.toFile().delete();
@@ -447,14 +447,14 @@ public class ItMiiDomainModelInPV {
       defaultWitParams.wdtModelHome(customWDTHome);
     }
     createImage(defaultWitParams
-        .modelImageName(MII_BASIC_IMAGE_NAME)
-        .modelImageTag(miiImageTagCustom)
+        .modelImageName(image.split(":")[0])
+        .modelImageTag(image.split(":")[1])
         .modelFiles(modelList)
         .wdtModelOnly(true)
         .wdtVersion(WDT_VERSION)
         .env(env)
         .redirect(true));
-    dockerLoginAndPushImage(miiImageCustom);
+    dockerLoginAndPushImage(image);
   }
 
   private static void dockerLoginAndPushImage(String image) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -32,7 +32,6 @@ import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.Domain;
 import oracle.weblogic.kubernetes.actions.impl.Exec;
-import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
@@ -266,7 +265,7 @@ public class ItMiiDomainModelInPV {
   }
 
   /**
-   * Test domain creation from model file stored in PV.https://oracle.github.io/weblogic-kubernetes-operator
+   * Test domain creation from model file stored in PV. https://oracle.github.io/weblogic-kubernetes-operator
        /userguide/managing-domains/domain-resource/#domain-spec-elements
     1.Create the domain custom resource using mii with no domain and specifying a PV location for modelHome
     2.Create the domain custom resource using mii with custom wdt model home in a pv location
@@ -455,10 +454,6 @@ public class ItMiiDomainModelInPV {
         .wdtVersion(WDT_VERSION)
         .env(env)
         .redirect(true));
-    Command.defaultCommandParams()
-        .command("docker images")
-        .saveResults(true)
-        .redirect(false);
     assertTrue(doesImageExist(imageTag),
         String.format("Image %s doesn't exist", imageName));
     dockerLoginAndPushImage(image);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -120,8 +120,8 @@ public class ItMiiDomainModelInPV {
   private static String adminSecretName;
   private static String encryptionSecretName;
 
-  private static String pvName = domainUid1 + "-pv"; // name of the persistent volume
-  private static String pvcName = domainUid1 + "-pvc"; // name of the persistent volume claim
+  private static String pvName = domainUid1 + "-wdtmodel-pv"; // name of the persistent volume
+  private static String pvcName = domainUid1 + "-wdtmodel-pvc"; // name of the persistent volume claim
 
   private static Path clusterViewAppPath;
   private static String modelFile = "modelinpv-with-war.yaml";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -39,7 +39,6 @@ import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -234,7 +233,6 @@ public class ItMiiDomainModelInPV {
    */
   @ParameterizedTest
   @MethodSource("paramProvider")
-  @Test
   @DisplayName("Create MII domain with model and application file from PV")
   public void testMiiDomainWithModelAndApplicationInPV(Entry<String, String> params) {
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -516,6 +516,11 @@ public class ItMiiDomainModelInPV {
   // create a model in image with no domain
   // push the image to repo
   private static void buildMIIWithwdtModelHomeandPushToRepo() {
+    Path emptyModelFile = Paths.get(TestConstants.RESULTS_ROOT, "miitemp", "empty-wdt-model.yaml");
+    assertDoesNotThrow(() -> Files.createDirectories(emptyModelFile.getParent()));
+    emptyModelFile.toFile().delete();
+    assertTrue(assertDoesNotThrow(() -> emptyModelFile.toFile().createNewFile()));
+    final List<String> modelList = Collections.singletonList(emptyModelFile.toString());
     // Set additional environment variables for WIT
     checkDirectory(WIT_BUILD_DIR);
     Map<String, String> env = new HashMap<>();
@@ -523,6 +528,7 @@ public class ItMiiDomainModelInPV {
     createImage(defaultWitParams()
         .modelImageName(MII_BASIC_IMAGE_NAME)
         .modelImageTag(miiImageTagCustom)
+        .modelFiles(modelList)
         .wdtModelHome(modelMountPath + "/model")
         .wdtModelOnly(true)
         .wdtVersion(WDT_VERSION)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -80,7 +80,6 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExis
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.utils.BuildApplication.buildApplication;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
-import static oracle.weblogic.kubernetes.utils.CommonTestUtils.copyFileToPod;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDockerRegistrySecret;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPV;
@@ -89,6 +88,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithU
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.execInPod;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.FileUtils.checkDirectory;
+import static oracle.weblogic.kubernetes.utils.FileUtils.copyFileToPod;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -219,13 +219,15 @@ public class ItMiiDomainModelInPV {
     //copy the model file to PV using the temp pod - we don't have access to PVROOT in Jenkins env
     logger.info("Copying model file {0} to pv directory {1}",
         Paths.get(MODEL_DIR, modelFile).toString(), modelMountPath + "/model", modelFile);
-    copyFileToPod(domainNamespace, pvPod.getMetadata().getName(), null,
-        Paths.get(MODEL_DIR, modelFile), Paths.get(modelMountPath + "/model", modelFile));
+    assertDoesNotThrow(() -> copyFileToPod(domainNamespace, pvPod.getMetadata().getName(), null,
+        Paths.get(MODEL_DIR, modelFile), Paths.get(modelMountPath + "/model", modelFile)),
+        "Copying file to pod failed");
 
     logger.info("Copying application file {0} to pv directory {1}",
         clusterViewAppPath.toString(), modelMountPath + "/applications", "clusterview.war");
-    copyFileToPod(domainNamespace, pvPod.getMetadata().getName(), null,
-        clusterViewAppPath, Paths.get(modelMountPath + "/applications", "clusterview.war"));
+    assertDoesNotThrow(() -> copyFileToPod(domainNamespace, pvPod.getMetadata().getName(), null,
+        clusterViewAppPath, Paths.get(modelMountPath + "/applications", "clusterview.war")),
+        "Copying file to pod failed");
 
     logger.info("Changing file ownership {0} to oracle:root in PV", modelMountPath);
     execInPod(pvPod, null, true, "chown -R oracle:root " + modelMountPath);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -181,7 +181,7 @@ public class ItMiiDomainModelInPV {
 
     // build a new MII image with custom wdtHome
     buildMIIandPushToRepo(miiImageCustom, modelMountPath + "/model");
-    
+
     params.put("domain2", miiImageCustom);
     params.put("domain1", miiImagePV);
 
@@ -452,7 +452,7 @@ public class ItMiiDomainModelInPV {
         .wdtVersion(WDT_VERSION)
         .env(env)
         .redirect(true));
-    assertTrue(doesImageExist(image),
+    assertTrue(doesImageExist(image.split(":")[1]),
         String.format("Image %s doesn't exist", image));
     dockerLoginAndPushImage(image);
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -160,7 +160,7 @@ public class ItMiiDomainModelInPV {
     miiImagePV = MII_BASIC_IMAGE_NAME + ":" + miiImageTagCustom;
 
     // build a new MII image with custom wdtHome
-    buildMIIWithwdtModelHomeandPushToRepo(Paths.get(MODEL_DIR, modelFile).toString());
+    buildMIIWithwdtModelHomeandPushToRepo();
 
     params.put("domain1", miiImagePV);
     params.put("domain2", miiImageCustom);
@@ -409,7 +409,7 @@ public class ItMiiDomainModelInPV {
 
   // create a model in image with no domain
   // push the image to repo
-  private static void buildMIIWithwdtModelHomeandPushToRepo(String wdtModelHome) {
+  private static void buildMIIWithwdtModelHomeandPushToRepo() {
     // Set additional environment variables for WIT
     checkDirectory(WIT_BUILD_DIR);
     Map<String, String> env = new HashMap<>();
@@ -417,7 +417,7 @@ public class ItMiiDomainModelInPV {
     createImage(defaultWitParams()
         .modelImageName(MII_BASIC_IMAGE_NAME)
         .modelImageTag(miiImageTagCustom)
-        .wdtModelHome(wdtModelHome)
+        .wdtModelHome("/shared/model")
         .wdtModelOnly(true)
         .wdtVersion(WDT_VERSION)
         .env(env)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -80,6 +80,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listSecrets;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.utils.BuildApplication.buildApplication;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
@@ -180,7 +181,7 @@ public class ItMiiDomainModelInPV {
 
     // build a new MII image with custom wdtHome
     buildMIIandPushToRepo(miiImageCustom, modelMountPath + "/model");
-
+    
     params.put("domain2", miiImageCustom);
     params.put("domain1", miiImagePV);
 
@@ -451,6 +452,8 @@ public class ItMiiDomainModelInPV {
         .wdtVersion(WDT_VERSION)
         .env(env)
         .redirect(true));
+    assertTrue(doesImageExist(image),
+        String.format("Image %s doesn't exist", image));
     dockerLoginAndPushImage(image);
   }
 
@@ -469,11 +472,11 @@ public class ItMiiDomainModelInPV {
 
     // push the image to repo
     if (!REPO_NAME.isEmpty()) {
-      logger.info("docker push image {0} to {1}", miiImagePV, REPO_NAME);
+      logger.info("docker push image {0} to {1}", image, REPO_NAME);
       withStandardRetryPolicy
           .conditionEvaluationListener(condition -> logger.info("Waiting for docker push for image {0} to be successful"
           + "(elapsed time {1} ms, remaining time {2} ms)",
-          miiImagePV,
+          image,
           condition.getElapsedTimeInMS(),
           condition.getRemainingTimeInMS()))
           .until(() -> dockerPush(image));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -181,8 +181,8 @@ public class ItMiiDomainModelInPV {
     // build a new MII image with custom wdtHome
     buildMIIWithwdtModelHomeandPushToRepo();
 
-    params.put("domain1", miiImagePV);
     params.put("domain2", miiImageCustom);
+    params.put("domain1", miiImagePV);
 
     // create docker registry secret to pull the image from registry
     logger.info("Creating docker registry secret in namespace {0}", domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -37,6 +37,7 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonMiiTestUtils;
 import oracle.weblogic.kubernetes.utils.CommonTestUtils;
+import oracle.weblogic.kubernetes.utils.ExecResult;
 import oracle.weblogic.kubernetes.utils.OracleHttpClient;
 import oracle.weblogic.kubernetes.utils.TestUtils;
 import org.awaitility.core.ConditionFactory;
@@ -208,15 +209,28 @@ public class ItMiiDomainModelInPV {
     //V1Pod pvPod = setupPVPod(domainNamespace);
     V1Pod pvPod = setupWebLogicPod(domainNamespace);
 
+    ExecResult exec = null;
     try {
       logger.info("Creating directory {0} in PV", "/u01/modelHome/applications");
-      Exec.exec(pvPod, null, false, "/bin/sh", "-c", "mkdir -p /u01/modelHome/applications");
+      exec = Exec.exec(pvPod, null, false, "/bin/sh", "-c", "mkdir -p /u01/modelHome/applications");
+      if (exec.stdout() != null) {
+        logger.info("Exec stdout {0}", exec.stdout());
+      }
+      if (exec.stderr() != null) {
+        logger.info("Exec stderr {0}", exec.stderr());
+      }
     } catch (IOException | ApiException | InterruptedException ex) {
       logger.warning(ex.getMessage());
     }
     try {
       logger.info("Creating directory {0} in PV", "/u01/modelHome/model");
-      Exec.exec(pvPod, null, false, "/bin/sh", "-c", "mkdir -p /u01/modelHome/model");
+      exec = Exec.exec(pvPod, null, false, "/bin/sh", "-c", "mkdir -p /u01/modelHome/model");
+      if (exec.stdout() != null) {
+        logger.info("Exec stdout {0}", exec.stdout());
+      }
+      if (exec.stderr() != null) {
+        logger.info("Exec stderr {0}", exec.stderr());
+      }
     } catch (IOException | ApiException | InterruptedException ex) {
       logger.warning(ex.getMessage());
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
@@ -29,14 +29,14 @@ public class WebLogicImageTool {
 
   /**
    * Set up the WebLogicImageTool with given parameters.
-   * 
+   *
    * @param params instance of {@link WitParams} that contains parameters to run WebLogic Image Tool
-   * @return the instance of WebLogicImageTool 
+   * @return the instance of WebLogicImageTool
    */
   public static WebLogicImageTool withParams(WitParams params) {
     return new WebLogicImageTool().params(params);
   }
-  
+
   private WebLogicImageTool params(WitParams params) {
     this.params = params;
     return this;
@@ -44,18 +44,18 @@ public class WebLogicImageTool {
 
   /**
    * Create an image using the params using WIT update command.
-   * @return true if the command succeeds 
+   * @return true if the command succeeds
    */
   public boolean updateImage() {
-    // download WIT if it is not in the expected location 
+    // download WIT if it is not in the expected location
     if (!downloadWit()) {
       return false;
-    } 
+    }
 
-    // download WDT if it is not in the expected location 
+    // download WDT if it is not in the expected location
     if (!downloadWdt()) {
       return false;
-    } 
+    }
 
     // delete the old cache entry for the WDT installer
     if (!deleteEntry()) {
@@ -66,7 +66,7 @@ public class WebLogicImageTool {
     if (!addInstaller()) {
       return false;
     }
-  
+
     return Command.withParams(
         defaultCommandParams()
             .command(buildiWitCommand())
@@ -74,20 +74,20 @@ public class WebLogicImageTool {
             .redirect(params.redirect()))
         .execute();
   }
-  
+
   private boolean downloadWit() {
     // install WIT if needed
     return Installer.withParams(
         defaultInstallWitParams())
         .download();
   }
-  
+
   private boolean downloadWdt() {
     // install WDT if needed
     return Installer.withParams(
         defaultInstallWdtParams())
         .download();
-  } 
+  }
 
   private String buildiWitCommand() {
     String command =
@@ -102,13 +102,17 @@ public class WebLogicImageTool {
       command += " --wdtModelOnly ";
     }
 
-    if (params.modelFiles() != null && params.modelFiles().size() != 0) {
+    if (params.wdtModelHome() != null) {
+      command += " --wdtModelHome " + params.wdtModelHome();
+    }
+
+    if (params.modelFiles() != null && !params.modelFiles().isEmpty()) {
       command += " --wdtModel " + buildList(params.modelFiles());
     }
-    if (params.modelVariableFiles() != null && params.modelVariableFiles().size() != 0) {
+    if (params.modelVariableFiles() != null && !params.modelVariableFiles().isEmpty()) {
       command += " --wdtVariables " + buildList(params.modelVariableFiles());
     }
-    if (params.modelArchiveFiles() != null && params.modelArchiveFiles().size() != 0) {
+    if (params.modelArchiveFiles() != null && !params.modelArchiveFiles().isEmpty()) {
       command += " --wdtArchive " + buildList(params.modelArchiveFiles());
     }
 
@@ -133,26 +137,26 @@ public class WebLogicImageTool {
 
   private String buildList(List<String> list) {
     StringBuilder sbString = new StringBuilder("");
-        
+
     //iterate through ArrayList
     for (String item : list) {
       //append ArrayList element followed by comma
       sbString.append(item).append(",");
     }
-        
+
     //convert StringBuffer to String
     String strList = sbString.toString();
-        
+
     //remove last comma from String if you want
     if (strList.length() > 0) {
       strList = strList.substring(0, strList.length() - 1);
     }
     return strList;
   }
-  
+
   /**
    * Add WDT installer to the WebLogic Image Tool cache.
-   * @return true if the command succeeds 
+   * @return true if the command succeeds
    */
   public boolean addInstaller() {
     String command = String.format(
@@ -160,7 +164,7 @@ public class WebLogicImageTool {
         IMAGE_TOOL,
         params.wdtVersion(),
         WDT_ZIP_PATH);
-        
+
     return Command.withParams(
             defaultCommandParams()
             .command(command)
@@ -168,7 +172,7 @@ public class WebLogicImageTool {
             .redirect(params.redirect()))
         .execute();
   }
-  
+
   /**
    * Delete the WDT installer cache entry from the WebLogic Image Tool.
    * @return true if the command succeeds
@@ -177,7 +181,7 @@ public class WebLogicImageTool {
     String command = String.format("%s cache deleteEntry --key wdt_%s",
         IMAGE_TOOL,
         params.wdtVersion());
-        
+
     return Command.withParams(
             defaultCommandParams()
             .command(command)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WitParams.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WitParams.java
@@ -17,31 +17,31 @@ import static oracle.weblogic.kubernetes.actions.ActionConstants.WLS_BASE_IMAGE_
  *
  */
 public class WitParams {
- 
+
   // The name of the Docker image that is used as the base of a new image
   private String baseImageName;
-  
+
   // The tag of the Docker image that is used as the base of a new image
   private String baseImageTag;
-  
+
   // The name of the to be generated Docker image
   private String modelImageName;
-  
+
   // The name of the to be generated Docker image
   private String modelImageTag;
-  
+
   // A comma separated list of the names of the WDT model yaml files
   private List<String> modelFiles;
-  
+
   // A comma separated list of the names of the WDT model properties files
   private List<String> modelVariableFiles;
-  
+
   // A comma separated list of the names of the WDT model achieve files
   private List<String> modelArchiveFiles;
-  
+
   // The version of WDT
   private String wdtVersion;
-  
+
   // The type of the WebLogic domain. The valid values are "WLS, "JRF", and "Restricted JRF"
   private String domainType;
 
@@ -53,7 +53,10 @@ public class WitParams {
 
   //Install WDT and copy the models to the image, but do not create the domain
   private boolean wdtModelOnly;
-  
+
+  // Custom WDT model home
+  private String wdtModelHome;
+
   // The env variables that are needed for running WIT
   private Map<String, String> env;
 
@@ -83,20 +86,20 @@ public class WitParams {
     this.baseImageName = baseImageName;
     return this;
   }
-  
+
   public String baseImageName() {
     return baseImageName;
   }
-  
+
   public WitParams baseImageTag(String baseImageTag) {
     this.baseImageTag = baseImageTag;
     return this;
   }
-  
+
   public String baseImageTag() {
     return baseImageTag;
   }
-  
+
   public WitParams modelImageName(String modelImageName) {
     this.modelImageName = modelImageName;
     return this;
@@ -105,21 +108,21 @@ public class WitParams {
   public String modelImageName() {
     return modelImageName;
   }
-  
+
   public WitParams modelImageTag(String modelImageTag) {
     this.modelImageTag = modelImageTag;
     return this;
   }
-    
+
   public String modelImageTag() {
     return modelImageTag;
   }
-     
+
   public WitParams wdtVersion(String wdtVersion) {
     this.wdtVersion = wdtVersion;
     return this;
   }
-      
+
   public String wdtVersion() {
     return wdtVersion;
   }
@@ -155,6 +158,15 @@ public class WitParams {
     return wdtModelOnly;
   }
 
+  public String wdtModelHome() {
+    return wdtModelHome;
+  }
+
+  public WitParams wdtModelOnly(String wdtModelHome) {
+    this.wdtModelHome = wdtModelHome;
+    return this;
+  }
+
   public WitParams wdtModelOnly(boolean wdtModelOnly) {
     this.wdtModelOnly = wdtModelOnly;
     return this;
@@ -182,7 +194,7 @@ public class WitParams {
     this.modelArchiveFiles = modelArchiveFiles;
     return this;
   }
-  
+
   public List<String> modelArchiveFiles() {
     return modelArchiveFiles;
   }
@@ -190,7 +202,7 @@ public class WitParams {
   public String generatedImageName() {
     return modelImageName + ":" + modelImageTag;
   }
-  
+
   public WitParams env(Map<String, String> env) {
     this.env = env;
     return this;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WitParams.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WitParams.java
@@ -158,17 +158,17 @@ public class WitParams {
     return wdtModelOnly;
   }
 
+  public WitParams wdtModelOnly(boolean wdtModelOnly) {
+    this.wdtModelOnly = wdtModelOnly;
+    return this;
+  }
+
   public String wdtModelHome() {
     return wdtModelHome;
   }
 
-  public WitParams wdtModelOnly(String wdtModelHome) {
+  public WitParams wdtModelHome(String wdtModelHome) {
     this.wdtModelHome = wdtModelHome;
-    return this;
-  }
-
-  public WitParams wdtModelOnly(boolean wdtModelOnly) {
-    this.wdtModelOnly = wdtModelOnly;
     return this;
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -1332,29 +1332,6 @@ public class CommonTestUtils {
     }
   }
 
-
-  /**
-   * Copy a file to the pod.
-   *
-   * @param namespace the namespace in which the pod exists
-   * @param podName name of the pod
-   * @param containerName name of the container inside the pod
-   * @param srcPath source path of the file to copy
-   * @param dstPath destination path for the file inside the pod
-   */
-  public static void copyFileToPod(String namespace, String podName,
-      String containerName, Path srcPath, Path dstPath) {
-    LoggingFacade logger = getLogger();
-    try {
-      logger.info("Copying file {0} inside pod location {1}", srcPath, dstPath);
-      Kubernetes.copyFileToPod(namespace, podName, containerName, srcPath, dstPath);
-    } catch (ApiException | IOException ex) {
-      logger.warning(ex.getMessage());
-    }
-  }
-
-
-
   /**
    * Check pod exists in the specified namespace.
    *

--- a/integration-tests/src/test/resources/wdt-models/modelinpv-with-war.yaml
+++ b/integration-tests/src/test/resources/wdt-models/modelinpv-with-war.yaml
@@ -28,6 +28,6 @@ topology:
 appDeployments:
     Application:
         myear:
-            SourcePath: "/shared/applications/clusterview.war"
+            SourcePath: "/u01/modelHome/applications/clusterview.war"
             ModuleType: war
             Target: 'admin-server,cluster-1'


### PR DESCRIPTION
Added a  test case to use Image Tool's new --wdtModelHome to specify a custom location in the image, instead of the default location /u01/wdt/models, for the WDT model files.

The test does the following

1. Extended the WebLogicImageTool action to
a) add a new parameter wdtModelHome, to specify the desired wdt model home
b) add --wdtModelHome option in the WIT command line to pass the location to WIT.

2. Added a test case that
a) uses the new --wdtModelHome option to create an image where the wdt models are in a custom location.
b) creates a domain resource that sets spec.configuration.model.modelHome to the custom location that is specified in 2.a).
c) creates the domain resource and verify the server pods are created according to the spec and comesup


Jenkins Results
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2222/