### PR TITLE
disable ItTwoDomainsLoadBalancers.testApacheLoadBalancingCustomSample

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
@@ -75,6 +75,7 @@ import org.awaitility.core.ConditionFactory;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -582,6 +583,7 @@ public class ItTwoDomainsLoadBalancers {
    * For more details, please check:
    * https://github.com/oracle/weblogic-kubernetes-operator/tree/master/kubernetes/samples/charts/apache-samples/custom-sample
    */
+  @Disabled("Disabled the test due to intermittent test failure, see JIRA OWLS-84928")
   @Order(12)
   @Test
   @DisplayName("verify Apache load balancer custom sample through HTTP and HTTPS channel")


### PR DESCRIPTION
We see the test failed intermittently in nightly run both on sequential and parallel run. 

https://build.weblogick8s.org:8443/job/wko-kind-nightly-seqential/4/
https://build.weblogick8s.org:8443/job/wko-kind-nightly-parallel/124/

disable it for now. Once the debug is done and the test is stable, re-enable it. 