### PR TITLE
add Calico networking

### DIFF
--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -19,7 +19,8 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
 For the current production release 3.0.2:
 
 * Kubernetes 1.14.8+, 1.15.7+, 1.16.0+, 1.17.0+, and 1.18.0+ (check with `kubectl version`).
-* Flannel networking v0.9.1-amd64 or later (check with `docker images | grep flannel`) *or* OpenShift SDN on OpenShift 4.3 systems.
+* Flannel networking v0.9.1-amd64 or later (check with `docker images | grep flannel`), Calico networking (Calico v3.16.1 or Calico Enterprise v3.2.0),
+ *or* OpenShift SDN on OpenShift 4.3 systems.
 * Docker 18.9.1 or 19.03.1 (check with `docker version`) *or* CRI-O 1.14.7 (check with `crictl version | grep RuntimeVersion`).
 * Helm 3.1.3+ (check with `helm version --client --short`).
 * Either Oracle WebLogic Server 12.2.1.3.0 with patch 29135930, Oracle WebLogic Server 12.2.1.4.0, or Oracle WebLogic Server 14.1.1.0.0.

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -19,7 +19,7 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
 For the current production release 3.0.2:
 
 * Kubernetes 1.14.8+, 1.15.7+, 1.16.0+, 1.17.0+, and 1.18.0+ (check with `kubectl version`).
-* Flannel networking v0.9.1-amd64 or later (check with `docker images | grep flannel`), Calico networking (Calico v3.16.1 or Calico Enterprise v3.2.0),
+* Flannel networking v0.9.1-amd64 or later (check with `docker images | grep flannel`), Calico networking (Calico v3.16.1),
  *or* OpenShift SDN on OpenShift 4.3 systems.
 * Docker 18.9.1 or 19.03.1 (check with `docker version`) *or* CRI-O 1.14.7 (check with `crictl version | grep RuntimeVersion`).
 * Helm 3.1.3+ (check with `helm version --client --short`).

--- a/docs-source/content/userguide/managing-fmw-domains/soa-suite/_index.md
+++ b/docs-source/content/userguide/managing-fmw-domains/soa-suite/_index.md
@@ -46,7 +46,7 @@ In this release, SOA Suite domains are supported using the “domain on a persis
 #### Prerequisites for SOA Suite domains
 
 * Kubernetes 1.13.5+, 1.14.3+ and 1.15.2+ (check with `kubectl version`).
-* Flannel networking v0.11.0-amd64 (check with `docker images | grep flannel`).
+* Flannel networking v0.11.0-amd64 (check with `docker images | grep flannel`) or Calico networking (Calico v3.16.1).
 * Docker 18.9.1 (check with `docker version`)
 * Helm 2.14.0+ (check with `helm version`).
 * Oracle Fusion Middleware Infrastructure 12.2.1.3.0 image with patch 29135930.


### PR DESCRIPTION
As per OWLS-84881: Document certification of WebLogic on Kubernetes running in a Calico network fabric, added Calico to the operator prerequisites.