### PR TITLE
Add Tests for DataHome Override in Domain Custom Resource

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -440,15 +440,18 @@ class ItParameterizedDomain {
         .isTrue();
   }
 
+  /**
+   * Verify dataHome override in a domain with domain in image type.
+   * In this domain, set dataHome to /u01/oracle/mydata in domain custom resource
+   * The domain contains JMS and File Store configuration
+   * File store directory is set to /u01/oracle/customFileStore in the model file which should be overridden by dataHome
+   * File store and JMS server are targeted to the WebLogic cluster cluster-1
+   * see resource/wdt-models/wdt-singlecluster-multiapps-usingprop-wls.yaml
+   */
   @Test
   @DisplayName("Test dataHome override in a domain with domain in image type")
   public void testDataHomeOverrideDomainInImage() {
-    // in this domain, set dataHome to /u01/oracle/mydata in domain custom resource
-    // the domain contains JMS and File Store configuration
-    // File store directory is set to /u01/oracle/customFileStore/ in the model file which should be overridden
-    // by dataHome
-    // File store and JMS server are target to cluster-1
-    // see resource/wdt-models/wdt-singlecluster-multiapps-usingprop-wls.yaml
+
     assertDomainNotNull(domainInImage);
     String domainUid = domainInImage.getSpec().getDomainUid();
     String domainNamespace = domainInImage.getMetadata().getNamespace();
@@ -494,15 +497,19 @@ class ItParameterizedDomain {
     }
   }
 
+  /**
+   * Verify dataHome override in a domain with model in image type.
+   * In this domain, dataHome is not specified in the domain custom resource
+   * The domain contains JMS and File Store configuration
+   * File store directory is set to /u01/oracle/customFileStore in the model file which should not be overridden
+   * by dataHome
+   * File store and JMS server are targeted to the WebLogic admin server
+   * see resource/wdt-models/model-multiclusterdomain-sampleapp-wls.yaml
+   */
   @Test
   @DisplayName("Test dataHome override in a domain with model in image type")
   public void testDataHomeOverrideMiiDomain() {
-    // in this domain, dataHome is not specified
-    // the domain contains JMS and File Store configuration
-    // File store directory is set to /u01/oracle/customFileStore/ in the model file which should not be overridden
-    // by dataHome
-    // File store and JMS server are target to admin server
-    // see resource/wdt-models/model-multiclusterdomain-sampleapp-wls.yaml
+
     assertDomainNotNull(miiDomain);
     String domainUid = miiDomain.getSpec().getDomainUid();
     String domainNamespace = miiDomain.getMetadata().getNamespace();
@@ -551,15 +558,19 @@ class ItParameterizedDomain {
     }
   }
 
+  /**
+   * Verify dataHome override in a domain with domain on PV type.
+   * In this domain, dataHome is set to empty string in the domain custom resource
+   * The domain contains JMS and File Store configuration
+   * File store directory is set to /u01/oracle/customFileStore in the model file which should not be overridden
+   * by dataHome
+   * File store and JMS server are targeted to the WebLogic admin server
+   * see resource/wdt-models/domain-onpv-wdt-model.yaml
+   */
   @Test
   @DisplayName("Test dataHome override in a domain with domain on PV type")
   public void testDataHomeOverrideDomainOnPV() {
-    // in this domain, dataHome is set to empty string
-    // the domain contains JMS and File Store configuration
-    // File store directory is set to /u01/oracle/customFileStore/ in the model file which should not be overridden
-    // by dataHome
-    // File store and JMS server are target to admin server
-    // see resource/wdt-models/domain-onpv-wdt-model.yaml
+
     assertDomainNotNull(domainOnPV);
     String domainUid = domainOnPV.getSpec().getDomainUid();
     String domainNamespace = domainOnPV.getMetadata().getNamespace();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -124,6 +124,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyN
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.scaleAndVerifyCluster;
 import static oracle.weblogic.kubernetes.utils.DeployUtil.deployUsingWlst;
+import static oracle.weblogic.kubernetes.utils.FileUtils.doesFileExistInPod;
 import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndCheckForServerNameInResponse;
 import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndWaitTillReady;
 import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
@@ -131,6 +132,7 @@ import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -155,6 +157,7 @@ class ItParameterizedDomain {
   private static final String WLDF_OPENSESSION_APP = "opensessionapp";
   private static final String WLDF_OPENSESSION_APP_CONTEXT_ROOT = "opensession";
   private static final String wlSecretName = "weblogic-credentials";
+  private static final String DATA_HOME_OVERRIDE = "/u01/oracle/mydata";
 
   private static String wlsBaseImage = WLS_BASE_IMAGE_NAME + ":" + WLS_BASE_IMAGE_TAG;
   private static String opNamespace = null;
@@ -166,6 +169,9 @@ class ItParameterizedDomain {
   private static List<Domain> domains = new ArrayList<>();
   private static LoggingFacade logger = null;
   private static Domain miiDomain = null;
+  private static Domain domainInImage = null;
+  private static Domain domainOnPV = null;
+  private static int t3ChannelPort = 0;
 
   private String curlCmd = null;
 
@@ -196,7 +202,7 @@ class ItParameterizedDomain {
     assertNotNull(namespaces.get(2));
     String miiDomainNamespace = namespaces.get(2);
     assertNotNull(namespaces.get(3));
-    String domainInPVNamespace = namespaces.get(3);
+    String domainOnPVNamespace = namespaces.get(3);
     assertNotNull(namespaces.get(4));
     String domainInImageNamespace = namespaces.get(4);
 
@@ -213,7 +219,7 @@ class ItParameterizedDomain {
 
     // install and verify operator with REST API
     installAndVerifyOperator(opNamespace, opServiceAccount, true, 0,
-        miiDomainNamespace, domainInPVNamespace, domainInImageNamespace);
+        miiDomainNamespace, domainOnPVNamespace, domainInImageNamespace);
 
     externalRestHttpsPort = getServiceNodePort(opNamespace, "external-weblogic-operator-svc");
 
@@ -227,13 +233,13 @@ class ItParameterizedDomain {
     // create model in image domain with multiple clusters
     miiDomain = createMiiDomainWithMultiClusters(miiDomainNamespace);
     // create domain in image
-    Domain domainInImage = createAndVerifyDomainInImageUsingWdt(domainInImageNamespace);
+    domainInImage = createAndVerifyDomainInImageUsingWdt(domainInImageNamespace);
     // create domain in pv
-    Domain domainInPV = createDomainInPvUsingWdt(domainInPVNamespace);
+    domainOnPV = createDomainOnPvUsingWdt(domainOnPVNamespace);
 
     domains.add(miiDomain);
     domains.add(domainInImage);
-    domains.add(domainInPV);
+    domains.add(domainOnPV);
 
     // create ingress for each domain
     for (Domain domain: domains) {
@@ -442,6 +448,172 @@ class ItParameterizedDomain {
         .as("Verify NGINX can access the test web app from all managed servers in the domain")
         .withFailMessage("NGINX can not access the test web app from one or more of the managed servers")
         .isTrue();
+  }
+
+  @Test
+  @DisplayName("Test dataHome override in a domain with domain in image type")
+  public void testDataHomeOverrideDomainInImage() {
+    // in this domain, set dataHome to /u01/oracle/mydata in domain custom resource
+    // the domain contains JMS and File Store configuration
+    // File store directory is set to /u01/oracle/customFileStore/ in the model file which should be overridden
+    // by dataHome
+    // File store and JMS server are target to cluster-1
+    // see resource/wdt-models/wdt-singlecluster-multiapps-usingprop-wls.yaml
+    assertDomainNotNull(domainInImage);
+    String domainUid = domainInImage.getSpec().getDomainUid();
+    String domainNamespace = domainInImage.getMetadata().getNamespace();
+
+    // check in admin server pod, there is no data file for JMS server created
+    String dataFileToCheck = DATA_HOME_OVERRIDE + "/" + domainUid + "/FILESTORE-0000000.DAT";
+    String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+    assertFalse(assertDoesNotThrow(
+        () -> doesFileExistInPod(domainNamespace, adminServerPodName, dataFileToCheck),
+        String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace)),
+        String.format("%s exists in pod %s in namespace %s, expects not exist",
+            dataFileToCheck, adminServerPodName, domainNamespace));
+
+    // check in admin server pod, the default admin server data file moved to DATA_HOME_OVERRIDE
+    String defaultAdminDataFile = DATA_HOME_OVERRIDE + "/" + domainUid + "/_WLS_ADMIN-SERVER000000.DAT";
+    assertTrue(assertDoesNotThrow(() ->
+        doesFileExistInPod(domainNamespace, adminServerPodName, defaultAdminDataFile),
+        String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace)),
+        String.format("can not find file %s in pod %s in namespace %s",
+            defaultAdminDataFile, adminServerPodName, domainNamespace));
+
+    // check in managed server pod, the custom data file for JMS and default managed server datafile are created
+    // in DATA_HOME_OVERRIDE
+    for (int i = 1; i <= replicaCount; i++) {
+      String managedServerPodName = domainUid + "-" + MANAGED_SERVER_NAME_BASE + i;
+      String customDataFile = DATA_HOME_OVERRIDE + "/" + domainUid + "/FILESTORE-0@MANAGED-SERVER" + i + "000000.DAT";
+      assertTrue(assertDoesNotThrow(() ->
+              doesFileExistInPod(domainNamespace, managedServerPodName, customDataFile),
+          String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+              customDataFile, managedServerPodName, domainNamespace)),
+          String.format("can not find file %s in pod %s in namespace %s",
+              customDataFile, managedServerPodName, domainNamespace));
+
+      String defaultMSDataFile = DATA_HOME_OVERRIDE + "/" + domainUid + "/_WLS_MANAGED-SERVER" + i + "000000.DAT";
+      assertTrue(assertDoesNotThrow(() ->
+              doesFileExistInPod(domainNamespace, managedServerPodName, defaultMSDataFile),
+          String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+              defaultMSDataFile, managedServerPodName, domainNamespace)),
+          String.format("can not find file %s in pod %s in namespace %s",
+              defaultMSDataFile, managedServerPodName, domainNamespace));
+    }
+  }
+
+  @Test
+  @DisplayName("Test dataHome override in a domain with model in image type")
+  public void testDataHomeOverrideMiiDomain() {
+    // in this domain, dataHome is not specified
+    // the domain contains JMS and File Store configuration
+    // File store directory is set to /u01/oracle/customFileStore/ in the model file which should not be overridden
+    // by dataHome
+    // File store and JMS server are target to admin server
+    // see resource/wdt-models/model-multiclusterdomain-sampleapp-wls.yaml
+    assertDomainNotNull(miiDomain);
+    String domainUid = miiDomain.getSpec().getDomainUid();
+    String domainNamespace = miiDomain.getMetadata().getNamespace();
+
+    // check in admin server pod, there is a data file for JMS server created in /u01/oracle/customFileStore
+    String dataFileToCheck = "/u01/oracle/customFileStore/FILESTORE-0000000.DAT";
+    String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+    assertTrue(assertDoesNotThrow(
+        () -> doesFileExistInPod(domainNamespace, adminServerPodName, dataFileToCheck),
+        String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace)),
+        String.format("did not find file %s in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace));
+
+    // check in admin server pod, the default admin server data file is in default data store
+    String defaultAdminDataFile =
+        "/u01/domains/" + domainUid + "/servers/admin-server/data/store/default/_WLS_ADMIN-SERVER000000.DAT";
+    assertTrue(assertDoesNotThrow(() ->
+            doesFileExistInPod(domainNamespace, adminServerPodName, defaultAdminDataFile),
+        String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace)),
+        String.format("did not find file %s in pod %s in namespace %s",
+            defaultAdminDataFile, adminServerPodName, domainNamespace));
+
+    // check in managed server pod, there is no custom data file for JMS is created
+    for (int i = 1; i <= replicaCount; i++) {
+      for (int j = 1; j <= NUMBER_OF_CLUSTERS_MIIDOMAIN; j++) {
+        String managedServerPodName = domainUid + "-cluster-" + j + "-" + MANAGED_SERVER_NAME_BASE + i;
+        String customDataFile = "/u01/oracle/customFileStore/FILESTORE-0@MANAGED-SERVER" + i + "000000.DAT";
+        assertFalse(assertDoesNotThrow(() ->
+                doesFileExistInPod(domainNamespace, managedServerPodName, customDataFile),
+            String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+                customDataFile, managedServerPodName, domainNamespace)),
+            String.format("found file %s in pod %s in namespace %s, expect not exist",
+                customDataFile, managedServerPodName, domainNamespace));
+
+        String defaultMSDataFile = "/u01/domains/" + domainUid + "/servers/cluster-" + j + "-managed-server" + i
+            + "/data/store/default/_WLS_CLUSTER-" + j + "-MANAGED-SERVER" + i + "000000.DAT";
+        assertTrue(assertDoesNotThrow(() ->
+                doesFileExistInPod(domainNamespace, managedServerPodName, defaultMSDataFile),
+            String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+                defaultMSDataFile, managedServerPodName, domainNamespace)),
+            String.format("can not find file %s in pod %s in namespace %s",
+                defaultMSDataFile, managedServerPodName, domainNamespace));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Test dataHome override in a domain with domain on PV type")
+  public void testDataHomeOverrideDomainOnPV() {
+    // in this domain, dataHome is set to empty string
+    // the domain contains JMS and File Store configuration
+    // File store directory is set to /u01/oracle/customFileStore/ in the model file which should not be overridden
+    // by dataHome
+    // File store and JMS server are target to admin server
+    // see resource/wdt-models/domain-onpv-wdt-model.yaml
+    assertDomainNotNull(domainOnPV);
+    String domainUid = domainOnPV.getSpec().getDomainUid();
+    String domainNamespace = domainOnPV.getMetadata().getNamespace();
+
+    // check in admin server pod, there is a data file for JMS server created in /u01/oracle/customFileStore
+    String dataFileToCheck = "/u01/oracle/customFileStore/FILESTORE-0000000.DAT";
+    String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+    assertTrue(assertDoesNotThrow(
+        () -> doesFileExistInPod(domainNamespace, adminServerPodName, dataFileToCheck),
+        String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace)),
+        String.format("did not find file %s in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace));
+
+    // check in admin server pod, the default admin server data file is in default data store
+    String defaultAdminDataFile =
+        "/u01/shared/domains/" + domainUid + "/servers/admin-server/data/store/default/_WLS_ADMIN-SERVER000000.DAT";
+    assertTrue(assertDoesNotThrow(() ->
+            doesFileExistInPod(domainNamespace, adminServerPodName, defaultAdminDataFile),
+        String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+            dataFileToCheck, adminServerPodName, domainNamespace)),
+        String.format("did not find file %s in pod %s in namespace %s",
+            defaultAdminDataFile, adminServerPodName, domainNamespace));
+
+    // check in managed server pod, there is no custom data file for JMS is created
+    for (int i = 1; i <= replicaCount; i++) {
+      String managedServerPodName = domainUid + "-" + MANAGED_SERVER_NAME_BASE + i;
+      String customDataFile = "/u01/oracle/customFileStore/FILESTORE-0@MANAGED-SERVER" + i + "000000.DAT";
+      assertFalse(assertDoesNotThrow(() ->
+              doesFileExistInPod(domainNamespace, managedServerPodName, customDataFile),
+          String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+              customDataFile, managedServerPodName, domainNamespace)),
+          String.format("found file %s in pod %s in namespace %s, expect not exist",
+              customDataFile, managedServerPodName, domainNamespace));
+
+      String defaultMSDataFile = "/u01/shared/domains/" + domainUid + "/servers/managed-server" + i
+          + "/data/store/default/_WLS_MANAGED-SERVER" + i + "000000.DAT";
+      assertTrue(assertDoesNotThrow(() ->
+              doesFileExistInPod(domainNamespace, managedServerPodName, defaultMSDataFile),
+          String.format("exception thrown when checking file %s exists in pod %s in namespace %s",
+              defaultMSDataFile, managedServerPodName, domainNamespace)),
+          String.format("can not find file %s in pod %s in namespace %s",
+              defaultMSDataFile, managedServerPodName, domainNamespace));
+    }
   }
 
   /**
@@ -719,12 +891,12 @@ class ItParameterizedDomain {
    * @param domainNamespace namespace in which the domain will be created
    * @return oracle.weblogic.domain.Domain objects
    */
-  private static Domain createDomainInPvUsingWdt(String domainNamespace) {
-    final String domainUid = "domaininpv" + "-" + domainNamespace.substring(3);
+  private static Domain createDomainOnPvUsingWdt(String domainNamespace) {
+    final String domainUid = "domainonpv" + "-" + domainNamespace.substring(3);
     final String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
     String managedServerPodNamePrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
 
-    int t3ChannelPort = getNextFreePort(31111, 32767);  // the port range has to be between 30,000 to 32,767
+    t3ChannelPort = getNextFreePort(31111, 32767);  // the port range has to be between 30,000 to 32,767
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
@@ -779,7 +951,7 @@ class ItParameterizedDomain {
     createPVPVCAndVerify(v1pv, v1pvc, labelSelector, domainNamespace);
 
     // create a temporary WebLogic domain property file as a input for WDT model file
-    File domainPropertiesFile = assertDoesNotThrow(() -> createTempFile("domaininpv", "properties"),
+    File domainPropertiesFile = assertDoesNotThrow(() -> createTempFile("domainonpv", "properties"),
         "Failed to create domain properties file");
 
     Properties p = new Properties();
@@ -804,7 +976,7 @@ class ItParameterizedDomain {
     Path wdtModelFile = get(RESOURCE_DIR, "wdt-models", "domain-onpv-wdt-model.yaml");
 
     // create configmap and domain in persistent volume using WDT
-    runCreateDomainInPVJobUsingWdt(wdtScript, wdtModelFile, domainPropertiesFile.toPath(),
+    runCreateDomainOnPVJobUsingWdt(wdtScript, wdtModelFile, domainPropertiesFile.toPath(),
         domainUid, pvName, pvcName, domainNamespace);
 
     // create the domain custom resource
@@ -949,7 +1121,7 @@ class ItParameterizedDomain {
    * @param pvcName name of the persistent volume claim
    * @param namespace name of the domain namespace in which the job is created
    */
-  private static void runCreateDomainInPVJobUsingWdt(Path domainCreationScriptFile,
+  private static void runCreateDomainOnPVJobUsingWdt(Path domainCreationScriptFile,
                                                      Path modelFile,
                                                      Path domainPropertiesFile,
                                                      String domainUid,
@@ -1165,6 +1337,7 @@ class ItParameterizedDomain {
         .spec(new DomainSpec()
             .domainUid(domainUid)
             .domainHome(WDT_IMAGE_DOMAINHOME_BASE_DIR + "/" + domainUid)
+            .dataHome("/u01/oracle/mydata")
             .domainHomeSourceType("Image")
             .image(domainInImageWithWDTImage)
             .addImagePullSecretsItem(new V1LocalObjectReference()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
@@ -271,4 +271,28 @@ public class FileUtils {
     logger.info("to {0}", src.toString());
     Files.write(src, content.getBytes(charset));
   }
+
+  /**
+   * Check whether a file exists in a pod in the given namespace.
+   *
+   * @param namespace the Kubernetes namespace that the pod is in
+   * @param podName the name of the Kubernetes pod in which the command is expected to run
+   * @param filename the filename to check
+   * @return true if the file exists, otherwise return false
+   * @throws IOException if an I/O error occurs.
+   * @throws ApiException if Kubernetes client API call fails
+   * @throws InterruptedException if any thread has interrupted the current thread
+   */
+  public static boolean doesFileExistInPod(String namespace, String podName, String filename)
+      throws IOException, ApiException, InterruptedException {
+
+    ExecResult result = execCommand(namespace, podName, null, true,
+        "/bin/sh", "-c", "find " + filename);
+
+    if (result.exitValue() == 0 && result.stdout().contains(filename)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/integration-tests/src/test/resources/wdt-models/domain-onpv-wdt-model.yaml
+++ b/integration-tests/src/test/resources/wdt-models/domain-onpv-wdt-model.yaml
@@ -30,3 +30,15 @@ topology:
             ListenPort: '@@PROP:managedServerPort@@'
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'
+
+resources:
+    FileStore:
+        'FileStore-0':
+            Directory: '/u01/oracle/customFileStore/'
+            Target: '@@PROP:adminServerName@@'
+    JMSServer:
+        'JMSServer-0':
+            PersistentStore: 'FileStore-0'
+            Target: '@@PROP:adminServerName@@'
+            MessagesMaximum: 100000
+            BlockingSendPolicy: FIFO

--- a/integration-tests/src/test/resources/wdt-models/model-multiclusterdomain-sampleapp-wls.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-multiclusterdomain-sampleapp-wls.yaml
@@ -35,6 +35,18 @@ topology:
             Cluster: "cluster-2"
             ListenPort: 8001
 
+resources:
+    FileStore:
+        'FileStore-0':
+            Directory: '/u01/oracle/customFileStore/'
+            Target: 'admin-server'
+    JMSServer:
+        'JMSServer-0':
+            PersistentStore: 'FileStore-0'
+            Target: 'admin-server'
+            MessagesMaximum: 100000
+            BlockingSendPolicy: FIFO
+
 appDeployments:
     Application:
         myear:

--- a/integration-tests/src/test/resources/wdt-models/wdt-singlecluster-multiapps-usingprop-wls.yaml
+++ b/integration-tests/src/test/resources/wdt-models/wdt-singlecluster-multiapps-usingprop-wls.yaml
@@ -24,6 +24,19 @@ topology:
         "cluster-1-template":
             Cluster: "cluster-1"
             ListenPort : 8001
+
+resources:
+    FileStore:
+        'FileStore-0':
+            Directory: '/u01/oracle/customFileStore/'
+            Target: 'cluster-1'
+    JMSServer:
+        'JMSServer-0':
+            PersistentStore: 'FileStore-0'
+            Target: 'cluster-1'
+            MessagesMaximum: 100000
+            BlockingSendPolicy: FIFO
+
 appDeployments:
     Application:
         myear:


### PR DESCRIPTION
Add test cases for dataHome override in domain custom resource.

Three use cases are added:
1) dataHome is not specified
2) dataHome is set to empty string
3) dataHome is set to a custom location

Jenkins test result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2244/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2250/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2251/