### PR TITLE
re-enable ItTwoDomainsLoadBalancers.testApacheLoadBalancingCustomSample

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
@@ -73,9 +73,8 @@ import oracle.weblogic.kubernetes.utils.ExecCommand;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
 import org.joda.time.DateTime;
-//import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -176,7 +175,10 @@ public class ItTwoDomainsLoadBalancers {
   private static final int numberOfDomains = 2;
   private static final int numberOfOperators = 2;
   private static final String wlSecretName = "weblogic-credentials";
-  private static final String defaultSharingPVCName = "default-sharing-pvc";
+  private static final String defaultSharingPvcName = "default-sharing-pvc";
+  private static final String defaultSharingPvName = "default-sharing-pv";
+  private static final String apachePvcName = "apache-custom-file-pvc";
+  private static final String apachePvName = "apache-custom-file-pv";
 
   private static String defaultNamespace = "default";
   private static String domain1Uid = null;
@@ -412,17 +414,19 @@ public class ItTwoDomainsLoadBalancers {
     createVoyagerIngressPathRoutingRules();
     createNginxIngressPathRoutingForTwoDomains();
 
-    // install and verify Apache
+    // install and verify Apache for default sample
     apacheHelmParams1 = assertDoesNotThrow(
         () -> installAndVerifyApache(domain1Namespace, kindRepoApacheImage, 0, 0, domain1Uid));
 
+    // install and verify Apache for custom sample
     LinkedHashMap<String, String> clusterNamePortMap = new LinkedHashMap<>();
     for (int i = 0; i < numberOfDomains; i++) {
       clusterNamePortMap.put(domainUids.get(i) + "-cluster-cluster-1", "" + MANAGED_SERVER_PORT);
     }
+    createPVPVCForApacheCustomConfiguration(defaultNamespace);
     apacheHelmParams2 = assertDoesNotThrow(
         () -> installAndVerifyApache(defaultNamespace, kindRepoApacheImage, 0, 0, domain1Uid,
-            defaultSharingPVCName, "apache-sample-host", clusterNamePortMap));
+            apachePvcName, "apache-sample-host", ADMIN_SERVER_PORT, clusterNamePortMap));
   }
 
   /**
@@ -574,7 +578,6 @@ public class ItTwoDomainsLoadBalancers {
    * For more details, please check:
    * https://github.com/oracle/weblogic-kubernetes-operator/tree/master/kubernetes/samples/charts/apache-samples/custom-sample
    */
-  @Disabled("Disabled the test due to intermittent test failure, see JIRA OWLS-84928")
   @Order(12)
   @Test
   @DisplayName("verify Apache load balancer custom sample through HTTP and HTTPS channel")
@@ -652,7 +655,7 @@ public class ItTwoDomainsLoadBalancers {
   /**
    * Cleanup all the remaining artifacts in default namespace created by the test.
    */
-  //@AfterAll
+  @AfterAll
   public void tearDownAll() {
     // uninstall Traefik loadbalancer
     if (traefikHelmParams != null) {
@@ -747,10 +750,14 @@ public class ItTwoDomainsLoadBalancers {
     }
 
     // delete pv and pvc in default namespace
-    logger.info("deleting pvc {0}", defaultSharingPVCName );
-    logger.info("deleting pv default-sharing-pv");
-    assertTrue(deletePersistentVolumeClaim(defaultSharingPVCName, defaultNamespace));
-    assertTrue(deletePersistentVolume("default-sharing-pv"));
+    logger.info("deleting pvc {0}", defaultSharingPvcName);
+    assertTrue(deletePersistentVolumeClaim(defaultSharingPvcName, defaultNamespace));
+    logger.info("deleting pv {0}", defaultSharingPvName);
+    assertTrue(deletePersistentVolume(defaultSharingPvName));
+    logger.info("deleting pvc {0}", apachePvcName);
+    assertTrue(deletePersistentVolumeClaim(apachePvcName, defaultNamespace));
+    logger.info("deleting pv {0}", apachePvName);
+    assertTrue(deletePersistentVolume(apachePvName));
 
     // delete ingressroute in namespace
     if (dstFile != null) {
@@ -1259,8 +1266,6 @@ public class ItTwoDomainsLoadBalancers {
    */
   private void createTwoDomainsSharingPVUsingWlstAndVerify() {
 
-    String pvName = "default-sharing-pv";
-
     // create pull secrets for WebLogic image
     // this secret is used only for non-kind cluster
     createSecretForBaseImages(defaultNamespace);
@@ -1285,7 +1290,7 @@ public class ItTwoDomainsLoadBalancers {
             .hostPath(new V1HostPathVolumeSource()
                 .path(pvHostPath.toString())))
         .metadata(new V1ObjectMetaBuilder()
-            .withName(pvName)
+            .withName(defaultSharingPvName)
             .build()
             .putLabelsItem("sharing-pv", "true"));
 
@@ -1293,11 +1298,11 @@ public class ItTwoDomainsLoadBalancers {
         .spec(new V1PersistentVolumeClaimSpec()
             .addAccessModesItem("ReadWriteMany")
             .storageClassName("default-sharing-weblogic-domain-storage-class")
-            .volumeName(pvName)
+            .volumeName(defaultSharingPvName)
             .resources(new V1ResourceRequirements()
                 .putRequestsItem("storage", Quantity.fromString("6Gi"))))
         .metadata(new V1ObjectMetaBuilder()
-            .withName(defaultSharingPVCName)
+            .withName(defaultSharingPvcName)
             .withNamespace(defaultNamespace)
             .build()
             .putLabelsItem("sharing-pvc", "true"));
@@ -1315,13 +1320,13 @@ public class ItTwoDomainsLoadBalancers {
       logger.info("t3ChannelPort for domain {0} is {1}", domainUid, t3ChannelPort);
 
       // run create a domain on PV job using WLST
-      runCreateDomainOnPVJobUsingWlst(pvName, defaultSharingPVCName, domainUid, defaultNamespace, domainScriptConfigMapName,
-          createDomainInPVJobName);
+      runCreateDomainOnPVJobUsingWlst(defaultSharingPvName, defaultSharingPvcName, domainUid, defaultNamespace,
+          domainScriptConfigMapName, createDomainInPVJobName);
 
       // create the domain custom resource configuration object
       logger.info("Creating domain custom resource");
-      Domain domain =
-          createDomainCustomResource(domainUid, defaultNamespace, pvName, defaultSharingPVCName, t3ChannelPort);
+      Domain domain = createDomainCustomResource(domainUid, defaultNamespace, defaultSharingPvName,
+          defaultSharingPvcName, t3ChannelPort);
 
       logger.info("Creating domain custom resource {0} in namespace {1}", domainUid, defaultNamespace);
       createDomainAndVerify(domain, defaultNamespace);
@@ -1940,5 +1945,47 @@ public class ItTwoDomainsLoadBalancers {
       logger.info("Executing curl command {0}", curlCmd);
       assertTrue(callWebAppAndWaitTillReady(curlCmd, 60));
     }
+  }
+
+  /**
+   * Create PV and PVC for Apache custom configuration file in specified namespace.
+   * @param apacheNamespace namespace in which to create PVC
+   */
+  private void createPVPVCForApacheCustomConfiguration(String apacheNamespace) {
+    Path pvHostPath = get(PV_ROOT, this.getClass().getSimpleName(), "apache-persistentVolume");
+
+    logger.info("Creating PV directory {0}", pvHostPath);
+    assertDoesNotThrow(() -> deleteDirectory(pvHostPath.toFile()), "deleteDirectory failed with IOException");
+    assertDoesNotThrow(() -> createDirectories(pvHostPath), "createDirectories failed with IOException");
+
+    V1PersistentVolume v1pv = new V1PersistentVolume()
+        .spec(new V1PersistentVolumeSpec()
+            .addAccessModesItem("ReadWriteMany")
+            .storageClassName("apache-storage-class")
+            .volumeMode("Filesystem")
+            .putCapacityItem("storage", Quantity.fromString("1Gi"))
+            .persistentVolumeReclaimPolicy("Retain")
+            .hostPath(new V1HostPathVolumeSource()
+                .path(pvHostPath.toString())))
+        .metadata(new V1ObjectMetaBuilder()
+            .withName(apachePvName)
+            .build()
+            .putLabelsItem("apacheLabel", "apache-custom-config"));
+
+    V1PersistentVolumeClaim v1pvc = new V1PersistentVolumeClaim()
+        .spec(new V1PersistentVolumeClaimSpec()
+            .addAccessModesItem("ReadWriteMany")
+            .storageClassName("apache-storage-class")
+            .volumeName(apachePvName)
+            .resources(new V1ResourceRequirements()
+                .putRequestsItem("storage", Quantity.fromString("1Gi"))))
+        .metadata(new V1ObjectMetaBuilder()
+            .withName(apachePvcName)
+            .withNamespace(apacheNamespace)
+            .build()
+            .putLabelsItem("apacheLabel", "apache-custom-config"));
+
+    String labelSelector = String.format("apacheLabel in (%s)", "apache-custom-config");
+    createPVPVCAndVerify(v1pv, v1pvc, labelSelector, apacheNamespace);
   }
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -96,7 +96,7 @@ public interface TestConstants {
 
   // Apache constants
   public static final String APACHE_IMAGE_NAME = "phx.ocir.io/weblogick8s/oracle/apache";
-  public static final String APACHE_IMAGE_VERSION = "12.2.1.3";
+  public static final String APACHE_IMAGE_VERSION = "12.2.1.4";
   public static final String APACHE_IMAGE = APACHE_IMAGE_NAME + ":" + APACHE_IMAGE_VERSION;
   public static final String APACHE_RELEASE_NAME = "apache-release" + BUILD_ID;
   public static final String APACHE_SAMPLE_CHART_DIR = "../kubernetes/samples/charts/apache-webtier";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -650,9 +650,9 @@ public class TestActions {
 
   // -------------------------   pv/pvc  ---------------------------------
   /**
-   * Get the persistent volumes in the Kubernetes cluster with specified name.
-   * @param pvname the name of the PV
-   * @return V1PersistentVolume the Persistent Volume with specified name in Kubernetes cluster
+   * Get the V1PersistentVolume object in the Kubernetes cluster with specified Persistent Volume name.
+   * @param pvname the name of the Persistent Volume
+   * @return V1PersistentVolume the Persistent Volume object with specified name in Kubernetes cluster
    */
   public static V1PersistentVolume getPersistentVolumes(String pvname) {
     return Kubernetes.getPersistentVolumes(pvname);
@@ -681,10 +681,10 @@ public class TestActions {
   }
 
   /**
-   * Get persistent volume claims in the namespace.
-   * @param namespace name of the namespace in which to get the PVC
-   * @param pvcname the name of PVC
-   * @return V1PersistentVolumeClaim the Persistent Volume Claims in namespace
+   * Get V1PersistentVolumeClaim object in the namespace with the specified Persistent Volume Claim name .
+   * @param namespace namespace in which to get the Persistent Volume Claim
+   * @param pvcname the name of Persistent Volume Claim
+   * @return V1PersistentVolumeClaim the Persistent Volume Claims Object in specified namespace
    */
   public static V1PersistentVolumeClaim getPersistentVolumeClaims(String namespace, String pvcname) {
     return Kubernetes.getPersistentVolumeClaims(namespace, pvcname);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -649,6 +649,14 @@ public class TestActions {
   }
 
   // -------------------------   pv/pvc  ---------------------------------
+  /**
+   * Get the persistent volumes in the Kubernetes cluster with specified name.
+   * @param pvname the name of the PV
+   * @return V1PersistentVolume the Persistent Volume with specified name in Kubernetes cluster
+   */
+  public static V1PersistentVolume getPersistentVolumes(String pvname) {
+    return Kubernetes.getPersistentVolumes(pvname);
+  }
 
   /**
    * Create a Kubernetes Persistent Volume.
@@ -670,6 +678,16 @@ public class TestActions {
    */
   public static boolean deletePersistentVolume(String name) {
     return PersistentVolume.delete(name);
+  }
+
+  /**
+   * Get persistent volume claims in the namespace.
+   * @param namespace name of the namespace in which to get the PVC
+   * @param pvcname the name of PVC
+   * @return V1PersistentVolumeClaim the Persistent Volume Claims in namespace
+   */
+  public static V1PersistentVolumeClaim getPersistentVolumeClaims(String namespace, String pvcname) {
+    return Kubernetes.getPersistentVolumeClaims(namespace, pvcname);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -654,8 +654,8 @@ public class TestActions {
    * @param pvname the name of the Persistent Volume
    * @return V1PersistentVolume the Persistent Volume object with specified name in Kubernetes cluster
    */
-  public static V1PersistentVolume getPersistentVolumes(String pvname) {
-    return Kubernetes.getPersistentVolumes(pvname);
+  public static V1PersistentVolume getPersistentVolume(String pvname) {
+    return Kubernetes.getPersistentVolume(pvname);
   }
 
   /**
@@ -686,8 +686,8 @@ public class TestActions {
    * @param pvcname the name of Persistent Volume Claim
    * @return V1PersistentVolumeClaim the Persistent Volume Claims Object in specified namespace
    */
-  public static V1PersistentVolumeClaim getPersistentVolumeClaims(String namespace, String pvcname) {
-    return Kubernetes.getPersistentVolumeClaims(namespace, pvcname);
+  public static V1PersistentVolumeClaim getPersistentVolumeClaim(String namespace, String pvcname) {
+    return Kubernetes.getPersistentVolumeClaim(namespace, pvcname);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/ApacheParams.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/ApacheParams.java
@@ -19,7 +19,7 @@ public class ApacheParams {
   private static final String IMAGE = "image";
   private static final String IMAGE_PULL_POLICY = "imagePullPolicy";
   private static final String IMAGE_PULL_SECRETS = "imagePullSecrets";
-  private static final String VOLUME_PATH = "volumePath";
+  private static final String PVC_NAME = "persistentVolumeClaimName";
   private static final String HTTP_NODEPORT = "httpNodePort";
   private static final String HTTPS_NODEPORT = "httpsNodePort";
   private static final String VIRTUAL_HOSTNAME = "virtualHostName";
@@ -30,7 +30,7 @@ public class ApacheParams {
   private String image = null;
   private String imagePullPolicy = null;
   private Map<String, Object> imagePullSecrets = null;
-  private String volumePath = null;
+  private String pvcName = null;
   private int httpNodePort = 0;
   private int httpsNodePort = 0;
   private String virtualHostName = null;
@@ -54,8 +54,8 @@ public class ApacheParams {
     return this;
   }
 
-  public ApacheParams volumePath(String volumePath) {
-    this.volumePath = volumePath;
+  public ApacheParams pvcName(String pvcName) {
+    this.pvcName = pvcName;
     return this;
   }
 
@@ -109,7 +109,7 @@ public class ApacheParams {
     values.put(IMAGE, image);
     values.put(IMAGE_PULL_POLICY, imagePullPolicy);
     values.put(IMAGE_PULL_SECRETS, imagePullSecrets);
-    values.put(VOLUME_PATH, volumePath);
+    values.put(PVC_NAME, pvcName);
 
     if (httpNodePort >= 0) {
       values.put(HTTP_NODEPORT, httpNodePort);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1559,6 +1559,22 @@ public class Kubernetes {
   }
 
   /**
+   * Get the persistent volumes in the Kubernetes cluster with specified name.
+   * @param pvname the name of the PV
+   * @return V1PersistentVolume the Persistent Volume with specified name in Kubernetes cluster
+   */
+  public static V1PersistentVolume getPersistentVolumes(String pvname) {
+    KubernetesApiResponse<V1PersistentVolume> response = pvClient.get(pvname);
+    if (response.isSuccess()) {
+      return response.getObject();
+    } else {
+      getLogger().warning("Failed to get Persistent Volume {0},"
+          + " status code {1}", pvname, response.getHttpStatusCode());
+      return null;
+    }
+  }
+
+  /**
    * List persistent volume claims in the namespace.
    * @param namespace name of the namespace in which to list
    * @return V1PersistentVolumeClaimList of Persistent Volume Claims in namespace
@@ -1570,6 +1586,23 @@ public class Kubernetes {
     } else {
       getLogger().warning("Failed to list Persistent Volumes claims,"
           + " status code {0}", list.getHttpStatusCode());
+      return null;
+    }
+  }
+
+  /**
+   * Get persistent volume claims in the namespace.
+   * @param namespace name of the namespace in which to get the PVC
+   * @param pvcname the name of PVC
+   * @return V1PersistentVolumeClaim the Persistent Volume Claims in namespace
+   */
+  public static V1PersistentVolumeClaim getPersistentVolumeClaims(String namespace, String pvcname) {
+    KubernetesApiResponse<V1PersistentVolumeClaim> response = pvcClient.get(namespace, pvcname);
+    if (response.isSuccess()) {
+      return response.getObject();
+    } else {
+      getLogger().warning("Failed to get Persistent Volumes claim {0},"
+          + " status code {1}", pvcname, response.getHttpStatusCode());
       return null;
     }
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1563,7 +1563,7 @@ public class Kubernetes {
    * @param pvname the name of the Persistent Volume
    * @return V1PersistentVolume the Persistent Volume object with specified name in Kubernetes cluster
    */
-  public static V1PersistentVolume getPersistentVolumes(String pvname) {
+  public static V1PersistentVolume getPersistentVolume(String pvname) {
     KubernetesApiResponse<V1PersistentVolume> response = pvClient.get(pvname);
     if (response.isSuccess()) {
       return response.getObject();
@@ -1596,7 +1596,7 @@ public class Kubernetes {
    * @param pvcname the name of Persistent Volume Claim
    * @return V1PersistentVolumeClaim the Persistent Volume Claims Object in specified namespace
    */
-  public static V1PersistentVolumeClaim getPersistentVolumeClaims(String namespace, String pvcname) {
+  public static V1PersistentVolumeClaim getPersistentVolumeClaim(String namespace, String pvcname) {
     KubernetesApiResponse<V1PersistentVolumeClaim> response = pvcClient.get(namespace, pvcname);
     if (response.isSuccess()) {
       return response.getObject();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1559,9 +1559,9 @@ public class Kubernetes {
   }
 
   /**
-   * Get the persistent volumes in the Kubernetes cluster with specified name.
-   * @param pvname the name of the PV
-   * @return V1PersistentVolume the Persistent Volume with specified name in Kubernetes cluster
+   * Get the V1PersistentVolume object in the Kubernetes cluster with specified Persistent Volume name.
+   * @param pvname the name of the Persistent Volume
+   * @return V1PersistentVolume the Persistent Volume object with specified name in Kubernetes cluster
    */
   public static V1PersistentVolume getPersistentVolumes(String pvname) {
     KubernetesApiResponse<V1PersistentVolume> response = pvClient.get(pvname);
@@ -1591,10 +1591,10 @@ public class Kubernetes {
   }
 
   /**
-   * Get persistent volume claims in the namespace.
-   * @param namespace name of the namespace in which to get the PVC
-   * @param pvcname the name of PVC
-   * @return V1PersistentVolumeClaim the Persistent Volume Claims in namespace
+   * Get V1PersistentVolumeClaim object in the namespace with the specified Persistent Volume Claim name .
+   * @param namespace namespace in which to get the Persistent Volume Claim
+   * @param pvcname the name of Persistent Volume Claim
+   * @return V1PersistentVolumeClaim the Persistent Volume Claims Object in specified namespace
    */
   public static V1PersistentVolumeClaim getPersistentVolumeClaims(String namespace, String pvcname) {
     KubernetesApiResponse<V1PersistentVolumeClaim> response = pvcClient.get(namespace, pvcname);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -152,8 +152,8 @@ import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorImageName;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPersistentVolumeClaims;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPersistentVolumes;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPersistentVolume;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPersistentVolumeClaim;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodCreationTimestamp;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
@@ -726,13 +726,13 @@ public class CommonTestUtils {
       // create a custom Apache plugin configuration file named custom_mod_wl_apache.conf
       // and put it under the directory specified in pv hostPath
       // this file provides a custom Apache plugin configuration to fine tune the behavior of Apache
-      V1PersistentVolumeClaim v1pvc = getPersistentVolumeClaims(apacheNamespace, pvcName);
+      V1PersistentVolumeClaim v1pvc = getPersistentVolumeClaim(apacheNamespace, pvcName);
       assertNotNull(v1pvc);
       assertNotNull(v1pvc.getSpec());
       String pvName = v1pvc.getSpec().getVolumeName();
       logger.info("Got PV {0} from PVC {1} in namespace {2}", pvName, pvcName, apacheNamespace);
 
-      V1PersistentVolume v1pv = getPersistentVolumes(pvName);
+      V1PersistentVolume v1pv = getPersistentVolume(pvName);
       assertNotNull(v1pv);
       assertNotNull(v1pv.getSpec());
       assertNotNull(v1pv.getSpec().getHostPath());


### PR DESCRIPTION
ItTwoDomainsLoadBalancers.testApacheLoadBalancingCustomSample failed recently due to the change in Apache custom sample chart. 

When we have custom Apache plugin configuration file custom_mod_wl_apache.conf, we used to specify the path of the file in the chart using volumePath. Couple of days ago it was changed to use persistentVolumeClaimName:
persistentVolumeClaimName: pv-claim-name

Updated this in test and re-enable the test.

Jenkins run result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2225/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2228/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2229/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2230/