### PR TITLE
correct image name construction of DB and FMW

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -125,10 +125,12 @@ public interface TestConstants {
   public static final String WEBLOGIC_IMAGE_TO_USE_IN_SPEC = KIND_REPO != null ? KIND_REPO
       + (WEBLOGIC_IMAGE_NAME + ":" + WEBLOGIC_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
       : WEBLOGIC_IMAGE_NAME + ":" + WEBLOGIC_IMAGE_TAG;
-  public static final String FMWINFRA_IMAGE_TO_USE_IN_SPEC = KIND_REPO
-      + (FMWINFRA_IMAGE_NAME + ":" + FMWINFRA_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1);
-  public static final String DB_IMAGE_TO_USE_IN_SPEC = KIND_REPO
-      + (DB_IMAGE_NAME + ":" + DB_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1);
+  public static final String FMWINFRA_IMAGE_TO_USE_IN_SPEC = KIND_REPO != null ? KIND_REPO
+      + (FMWINFRA_IMAGE_NAME + ":" + FMWINFRA_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
+      : FMWINFRA_IMAGE_NAME + ":" + FMWINFRA_IMAGE_TAG;
+  public static final String DB_IMAGE_TO_USE_IN_SPEC = KIND_REPO != null ? KIND_REPO
+      + (DB_IMAGE_NAME + ":" + DB_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
+      : DB_IMAGE_NAME + ":" + DB_IMAGE_TAG;
 
   // ----------------------------- base images constants - end -------------------
 


### PR DESCRIPTION
Without change when repo is OCR or OCIR both image names of DB and FMW image are wrong. This PR is to correct image name construction for them.
Jenkin kind cluster test result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2293/testReport/
 1 failure: ItParameterizedDomain.testParamsScaleClustersWithWLDF{Domain}[1] (from oracle.weblogic.kubernetes.ItMiiDomain)