### PR TITLE
OWLS-82012 Reduce job delete timeout value to avoid unexpected gap in time during retry of failed job

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -525,6 +525,11 @@ public class CallBuilder {
     return this;
   }
 
+  public CallBuilder withTimeoutSeconds(int timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
+    return this;
+  }
+
   private void tuning(int limit, int timeoutSeconds, int maxRetryCount) {
     this.limit = limit;
     this.timeoutSeconds = timeoutSeconds;
@@ -1339,7 +1344,8 @@ public class CallBuilder {
       V1DeleteOptions deleteOptions,
       ResponseStep<V1Status> responseStep) {
     return createRequestAsync(
-        responseStep, new RequestParams("deleteJob", namespace, name, deleteOptions, domainUid), deleteJob);
+        responseStep, new RequestParams("deleteJob", namespace, name, deleteOptions, domainUid),
+            deleteJob, timeoutSeconds);
   }
 
   /**
@@ -1866,6 +1872,21 @@ public class CallBuilder {
 
   private <T> Step createRequestAsync(
           ResponseStep<T> next, RequestParams requestParams, CallFactory<T> factory, RetryStrategy retryStrategy) {
+    return STEP_FACTORY.createRequestAsync(
+            next,
+            requestParams,
+            factory,
+            retryStrategy,
+            helper,
+            timeoutSeconds,
+            maxRetryCount,
+            fieldSelector,
+            labelSelector,
+            resourceVersion);
+  }
+
+  private <T> Step createRequestAsync(
+          ResponseStep<T> next, RequestParams requestParams, CallFactory<T> factory, int timeoutSeconds) {
     return STEP_FACTORY.createRequestAsync(
             next,
             requestParams,

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -362,6 +362,8 @@ public class JobHelper {
 
   private static class DeleteIntrospectorJobStep extends Step {
 
+    public static final int JOB_DELETE_TIMEOUT_SECONDS = 1;
+
     DeleteIntrospectorJobStep(Step next) {
       super(next);
     }
@@ -395,7 +397,7 @@ public class JobHelper {
       java.lang.String namespace = info.getNamespace();
       String jobName = JobHelper.createJobName(domainUid);
       logJobDeleted(domainUid, namespace, jobName, packet);
-      return new CallBuilder()
+      return new CallBuilder().withTimeoutSeconds(JOB_DELETE_TIMEOUT_SECONDS)
             .deleteJobAsync(
                   jobName,
                   namespace,


### PR DESCRIPTION
This PR reduces the timeout value of async delete job call from default value of 10 seconds to 1 second. This is to avoid the unexpected gap in time when job is deleted and recreated following a failure (as a result of retry operation).

Integration test results are at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2367/