### PR TITLE
Improve nightly stability for ItIntrospectVersion.testUpdateImageName

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -906,6 +906,26 @@ public class ItIntrospectVersion {
     assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
+    // verify the admin server service created
+    checkServiceExists(adminServerPodName, domainNamespace);
+
+    // verify admin server pod is ready
+    checkPodReady(adminServerPodName, domainUid, domainNamespace);
+
+    // verify new cluster managed server services created
+    for (int i = 1; i <= replicaCount; i++) {
+      logger.info("Checking managed server service {0} is created in namespace {1}",
+          managedServerPodNamePrefix + i, domainNamespace);
+      checkServiceExists(managedServerPodNamePrefix + i, domainNamespace);
+    }
+
+    // verify cluster managed server pods are ready
+    for (int i = 1; i <= replicaCount; i++) {
+      logger.info("Waiting for managed server pod {0} to be ready in namespace {1}",
+          managedServerPodNamePrefix + i, domainNamespace);
+      checkPodReady(managedServerPodNamePrefix + i, domainUid, domainNamespace);
+    }
+
     //verify admin server accessibility and the health of cluster members
     verifyMemberHealth(adminServerPodName, managedServerNames, ADMIN_USERNAME_PATCH, ADMIN_PASSWORD_PATCH);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -82,6 +82,7 @@ import static oracle.weblogic.kubernetes.utils.CommonPatchTestUtils.patchDomainR
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
@@ -906,24 +907,12 @@ public class ItIntrospectVersion {
     assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
         String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
 
-    // verify the admin server service created
-    checkServiceExists(adminServerPodName, domainNamespace);
+    checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
 
-    // verify admin server pod is ready
-    checkPodReady(adminServerPodName, domainUid, domainNamespace);
-
-    // verify new cluster managed server services created
     for (int i = 1; i <= replicaCount; i++) {
       logger.info("Checking managed server service {0} is created in namespace {1}",
           managedServerPodNamePrefix + i, domainNamespace);
-      checkServiceExists(managedServerPodNamePrefix + i, domainNamespace);
-    }
-
-    // verify cluster managed server pods are ready
-    for (int i = 1; i <= replicaCount; i++) {
-      logger.info("Waiting for managed server pod {0} to be ready in namespace {1}",
-          managedServerPodNamePrefix + i, domainNamespace);
-      checkPodReady(managedServerPodNamePrefix + i, domainUid, domainNamespace);
+      checkPodReadyAndServiceExists(managedServerPodNamePrefix + i, domainUid, domainNamespace);
     }
 
     //verify admin server accessibility and the health of cluster members


### PR DESCRIPTION
Add  logic to make sure all the Services/Pods are ready after rolling start.

With this PR change the first 3 jobs on the KIND Jenkins passed in a row without any failure

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2379/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2380/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2381/

The second 3 jobs in a row
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2391/   -- all passed
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2392/ -- 1 failure
oracle.weblogic.kubernetes.ItMiiUpdateDomainConfig.testMiiUpdateWebLogicCredential
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2393/testReport/ -- no failure but 1 skipped. ItIntrospectVersion.testUpdateImageName passed though.

After addressing the review comment Jenkins job passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2419/