### PR TITLE
Minor doc update on upgrading operator using helm upgrade

### DIFF
--- a/docs-source/content/userguide/managing-operators/installation/_index.md
+++ b/docs-source/content/userguide/managing-operators/installation/_index.md
@@ -109,7 +109,9 @@ Then install the 3.x operator using the [installation](#install-the-operator-hel
 The following instructions will be applicable to upgrade operators within the 3.x release family
 as additional versions are released.
 
-To upgrade the operator, use the `helm upgrade` command. When upgrading the operator,
+To upgrade the operator, use the `helm upgrade` command. Make sure that the
+`weblogic-kubernetes-operator` repository in your local machine is at the
+operator release that you are upgrading to. When upgrading the operator,
 the `helm upgrade` command requires that you supply a new Helm chart and image. For example:
 
 ```

--- a/docs-source/content/userguide/managing-operators/installation/_index.md
+++ b/docs-source/content/userguide/managing-operators/installation/_index.md
@@ -110,8 +110,8 @@ The following instructions will be applicable to upgrade operators within the 3.
 as additional versions are released.
 
 To upgrade the operator, use the `helm upgrade` command. Make sure that the
-`weblogic-kubernetes-operator` repository in your local machine is at the
-operator release that you are upgrading to. When upgrading the operator,
+`weblogic-kubernetes-operator` repository on your local machine is at the
+operator release to which you are upgrading. When upgrading the operator,
 the `helm upgrade` command requires that you supply a new Helm chart and image. For example:
 
 ```


### PR DESCRIPTION
Using `helm upgrade --set image=` to upgrade operator to a newer operator version should be performed from the "upgrade to" branch of the source repository, which would contain fixes to helm templates that might not be present in the "upgrade from" branch.