### PR TITLE
Fix ItOperatorUpgrade failures 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
@@ -211,7 +211,8 @@ public class ItOperatorUpgrade {
         0, opHelmParams, domainNamespace);
 
     // create domain
-    createDomainHomeInImageAndVerify(domainNamespace, operatorVersion);
+    createDomainHomeInImageAndVerify(
+        domainNamespace, operatorVersion, TestConstants.OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
 
     if (useHelmUpgrade) {
       // upgrade to latest operator
@@ -282,7 +283,8 @@ public class ItOperatorUpgrade {
         false, "", "", 0, "", "", null, null);
   }
 
-  private void createDomainHomeInImageAndVerify(String domainNamespace, String operatorVersion) {
+  private void createDomainHomeInImageAndVerify(
+      String domainNamespace, String operatorVersion, String externalServiceNameSuffix) {
 
     // Create the repo secret to pull the image
     // this secret is used only for non-kind cluster
@@ -325,7 +327,7 @@ public class ItOperatorUpgrade {
 
     logger.info("Getting node port for default channel");
     int serviceNodePort = assertDoesNotThrow(() -> getServiceNodePort(
-        domainNamespace, getExternalServicePodName(adminServerPodName), "default"),
+        domainNamespace, getExternalServicePodName(adminServerPodName, externalServiceNameSuffix), "default"),
         "Getting admin server node port failed");
 
     logger.info("Validating WebLogic admin server access by login to console");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -266,4 +266,5 @@ public interface TestConstants {
   // default name suffixes
   public String DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX = "-ext";
   public String DEFAULT_INTROSPECTOR_JOB_NAME_SUFFIX = "-introspector";
+  public String OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX = "-external";
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -3144,7 +3144,11 @@ public class CommonTestUtils {
   }
 
   public static String getExternalServicePodName(String adminServerPodName) {
-    return adminServerPodName + TestConstants.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX;
+    return getExternalServicePodName(adminServerPodName, TestConstants.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
+  }
+
+  public static String getExternalServicePodName(String adminServerPodName, String suffix) {
+    return adminServerPodName + suffix;
   }
 
   public static String getIntrospectJobName(String domainUid) {


### PR DESCRIPTION
Changed the test case to use the old default suffix when running older releases.

ITOperatorUpgrade tests passed in https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2462/