### PR TITLE
Refactoring: extract domain namespaces code from main

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainNamespaces.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainNamespaces.java
@@ -1,0 +1,219 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ConfigMapList;
+import io.kubernetes.client.openapi.models.V1Event;
+import io.kubernetes.client.openapi.models.V1EventList;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobList;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1ServiceList;
+import oracle.kubernetes.operator.TuningParameters.WatchTuning;
+import oracle.kubernetes.operator.watcher.WatchListener;
+import oracle.kubernetes.operator.work.ThreadFactorySingleton;
+import oracle.kubernetes.weblogic.domain.model.Domain;
+import oracle.kubernetes.weblogic.domain.model.DomainList;
+
+import static oracle.kubernetes.operator.helpers.KubernetesUtils.getResourceVersion;
+
+/**
+ * This class represents the information the operator maintains for a namespace used to maintain
+ * one or more domains.
+ */
+@SuppressWarnings("SameParameterValue")
+public class DomainNamespaces {
+  private static final Map<String, NamespaceStatus> namespaceStatuses = new ConcurrentHashMap<>();
+  private static final Map<String, AtomicBoolean> namespaceStoppingMap = new ConcurrentHashMap<>();
+  private static final WatchListener<V1Job> NULL_LISTENER = w -> { };
+
+  private static final WatcherControl<V1ConfigMap, ConfigMapWatcher> configMapWatchers
+        = new WatcherControl<>(ConfigMapWatcher::create, d -> d::dispatchConfigMapWatch);
+  private static final WatcherControl<Domain, DomainWatcher> domainWatchers
+        = new WatcherControl<>(DomainWatcher::create, d -> d::dispatchDomainWatch);
+  private static final WatcherControl<V1Event, EventWatcher> eventWatchers
+        = new WatcherControl<>(EventWatcher::create, d -> d::dispatchEventWatch);
+  private static final WatcherControl<V1Job, JobWatcher> jobWatchers
+        = new WatcherControl<>(JobWatcher::create, d -> NULL_LISTENER);
+  private static final WatcherControl<V1Pod, PodWatcher> podWatchers
+        = new WatcherControl<>(PodWatcher::create, d -> d::dispatchPodWatch);
+  private static final WatcherControl<V1Service, ServiceWatcher> serviceWatchers
+        = new WatcherControl<>(ServiceWatcher::create, d -> d::dispatchServiceWatch);
+
+  static AtomicBoolean isStopping(String ns) {
+    return namespaceStoppingMap.computeIfAbsent(ns, (key) -> new AtomicBoolean(false));
+  }
+
+  /**
+   * Returns a collection of the names of the namespaces currently being managed by the operator.
+   */
+  @Nonnull
+  static Set<String> getNamespaces() {
+    return new TreeSet<>(namespaceStoppingMap.keySet());
+  }
+
+  /**
+   * Requests all active namespaced-watchers to stop.
+   */
+  static void stopAllWatchers() {
+    namespaceStoppingMap.forEach((key, value) -> value.set(true));
+  }
+
+  /**
+   * Stop the specified namespace and discard its in-memory resources.
+   * @param ns a namespace name
+   */
+  static void stopNamespace(String ns) {
+    namespaceStoppingMap.remove(ns).set(true);
+    namespaceStatuses.remove(ns);
+
+    domainWatchers.removeWatcher(ns);
+    eventWatchers.removeWatcher(ns);
+    podWatchers.removeWatcher(ns);
+    serviceWatchers.removeWatcher(ns);
+    configMapWatchers.removeWatcher(ns);
+    jobWatchers.removeWatcher(ns);
+  }
+
+  static ConfigMapWatcher getConfigMapWatcher(String namespace) {
+    return configMapWatchers.getWatcher(namespace);
+  }
+
+  static DomainWatcher getDomainWatcher(String namespace) {
+    return domainWatchers.getWatcher(namespace);
+  }
+
+  static EventWatcher getEventWatcher(String namespace) {
+    return eventWatchers.getWatcher(namespace);
+  }
+
+  public static JobWatcher getJobWatcher(String namespace) {
+    return jobWatchers.getWatcher(namespace);
+  }
+
+  static PodWatcher getPodWatcher(String namespace) {
+    return podWatchers.getWatcher(namespace);
+  }
+
+  static ServiceWatcher getServiceWatcher(String namespace) {
+    return serviceWatchers.getWatcher(namespace);
+  }
+
+  /**
+   * Returns the internal status object for the specified namespace.
+   * @param ns the name of the namespace.
+   */
+  @Nonnull
+  static NamespaceStatus getNamespaceStatus(@Nonnull String ns) {
+    return namespaceStatuses.computeIfAbsent(ns, (key) -> new NamespaceStatus());
+  }
+
+  static void startConfigMapWatcher(String ns, String initialResourceVersion, DomainProcessor processor) {
+    configMapWatchers.startWatcher(ns, initialResourceVersion, processor);
+  }
+
+  private static WatchTuning getWatchTuning() {
+    return TuningParameters.getInstance().getWatchTuning();
+  }
+
+  private static ThreadFactory getThreadFactory() {
+    return ThreadFactorySingleton.getInstance();
+  }
+
+  interface WatcherFactory<T, W extends Watcher<T>> {
+    W create(
+          ThreadFactory threadFactory,
+          String namespace,
+          String initialResourceVersion,
+          WatchTuning watchTuning,
+          WatchListener<T> dispatchMethod,
+          AtomicBoolean stopping);
+  }
+
+  interface ListenerSelector<T> extends Function<DomainProcessor, WatchListener<T>> { }
+
+  static class WatcherControl<T, W extends Watcher<T>> {
+    private final Map<String, W> watchers = new ConcurrentHashMap<>();
+    private final WatcherFactory<T,W> factory;
+    private final ListenerSelector<T> selector;
+
+    public WatcherControl(WatcherFactory<T, W> factory, ListenerSelector<T> selector) {
+      this.factory = factory;
+      this.selector = selector;
+    }
+
+    void startWatcher(String namespace, String resourceVersion, DomainProcessor domainProcessor) {
+      watchers.computeIfAbsent(namespace, n -> createWatcher(n, resourceVersion, selector.apply(domainProcessor)));
+    }
+
+    W createWatcher(String ns, String resourceVersion, WatchListener<T> listener) {
+      return factory.create(getThreadFactory(), ns, resourceVersion, getWatchTuning(), listener, isStopping(ns));
+    }
+
+    W getWatcher(String ns) {
+      return watchers.get(ns);
+    }
+
+    void removeWatcher(String ns) {
+      watchers.remove(ns);
+    }
+  }
+
+  static NamespacedResources.Processors createWatcherStartupProcessing(String ns, DomainProcessor domainProcessor) {
+    return new WatcherStartupProcessing(ns, domainProcessor);
+  }
+
+  static class WatcherStartupProcessing extends NamespacedResources.Processors {
+    private final String ns;
+    private final DomainProcessor domainProcessor;
+
+    WatcherStartupProcessing(String ns, DomainProcessor domainProcessor) {
+      this.ns = ns;
+      this.domainProcessor = domainProcessor;
+    }
+
+    @Override
+    Consumer<V1ConfigMapList> getConfigMapListProcessing() {
+      return l -> configMapWatchers.startWatcher(ns, getResourceVersion(l), domainProcessor);
+    }
+
+    @Override
+    Consumer<V1EventList> getEventListProcessing() {
+      return l -> eventWatchers.startWatcher(ns, getResourceVersion(l), domainProcessor);
+    }
+
+    @Override
+    Consumer<V1JobList> getJobListProcessing() {
+      return l -> jobWatchers.startWatcher(ns, getResourceVersion(l), domainProcessor);
+    }
+
+    @Override
+    Consumer<V1PodList> getPodListProcessing() {
+      return l -> podWatchers.startWatcher(ns, getResourceVersion(l), domainProcessor);
+    }
+
+    @Override
+    Consumer<V1ServiceList> getServiceListProcessing() {
+      return l -> serviceWatchers.startWatcher(ns, getResourceVersion(l), domainProcessor);
+    }
+
+    @Override
+    Consumer<DomainList> getDomainListProcessing() {
+      return l -> domainWatchers.startWatcher(ns, getResourceVersion(l), domainProcessor);
+    }
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -11,23 +11,50 @@ import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
+/**
+ * An abstraction for processing a domain.
+ */
 public interface DomainProcessor {
 
+  /**
+   * Ensures that the domain is up-to-date. This may involve validation and introspection of the domain itself,
+   * changes to Kubernetes resources such as pods and services.
+   * @param liveInfo an info object that tracks what is know about the domain
+   */
   MakeRightDomainOperation createMakeRightOperation(DomainPresenceInfo liveInfo);
 
-  MakeRightDomainOperation createMakeRightOperation(Domain liveDomain);
+  /**
+   * Handles a watch event for domains in the managed namespaces.
+   * @param item a Kubernetes watch even
+   */
+  void dispatchDomainWatch(Watch.Response<Domain> item);
 
-  public void dispatchDomainWatch(Watch.Response<Domain> item);
+  /**
+   * Handles a watch event for pods in the managed namespaces.
+   * @param item a Kubernetes watch even
+   */
+  void dispatchPodWatch(Watch.Response<V1Pod> item);
 
-  public void dispatchPodWatch(Watch.Response<V1Pod> item);
+  /**
+   * Handles a watch event for services in the managed namespaces.
+   * @param item a Kubernetes watch even
+   */
+  void dispatchServiceWatch(Watch.Response<V1Service> item);
 
-  public void dispatchServiceWatch(Watch.Response<V1Service> item);
+  /**
+   * Handles a watch event for config maps in the managed namespaces.
+   * @param item a Kubernetes watch even
+   */
+  void dispatchConfigMapWatch(Watch.Response<V1ConfigMap> item);
 
-  public void dispatchConfigMapWatch(Watch.Response<V1ConfigMap> item);
+  /**
+   * Handles a watch event for events in the managed namespaces.
+   * @param item a Kubernetes watch even
+   */
+  void dispatchEventWatch(Watch.Response<V1Event> item);
 
-  public void dispatchEventWatch(Watch.Response<V1Event> item);
-
-  public void stopNamespace(String ns);
-
-  public void reportSuspendedFibers();
+  /**
+   * If the logging level is high enough, reports on any fibers which may currently be suspended.
+   */
+  void reportSuspendedFibers();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -998,7 +998,7 @@ public class DomainProcessorImpl implements DomainProcessor {
     private Step getRecordExistingResourcesSteps() {
       NamespacedResources resources = new NamespacedResources(info.getNamespace(), info.getDomainUid());
 
-      resources.addProcessor(new NamespacedResources.Processors() {
+      resources.addProcessing(new NamespacedResources.Processors() {
         @Override
         Consumer<V1PodList> getPodListProcessing() {
           return list -> list.getItems().forEach(this::addPod);

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -208,30 +208,6 @@ public class DomainProcessorImpl implements DomainProcessor {
   }
 
   /**
-   * Stop namespace.
-   * @param ns namespace
-   */
-  public void stopNamespace(String ns) {
-    try (LoggingContext stack = LoggingContext.setThreadContext().namespace(ns)) {
-      Map<String, DomainPresenceInfo> map = DOMAINS.get(ns);
-      if (map != null) {
-        for (DomainPresenceInfo dpi : map.values()) {
-          stack.domainUid(dpi.getDomainUid());
-
-          Domain dom = dpi.getDomain();
-          DomainPresenceInfo value =
-              (dom != null)
-                  ? new DomainPresenceInfo(dom)
-                  : new DomainPresenceInfo(dpi.getNamespace(), dpi.getDomainUid());
-          value.setDeleting(true);
-          value.setPopulated(true);
-          createMakeRightOperation(value).withExplicitRecheck().forDeletion().execute();
-        }
-      }
-    }
-  }
-
-  /**
    * Report on currently suspended fibers. This is the first step toward diagnosing if we need special handling
    * to kill or kick these fibers.
    */
@@ -528,11 +504,6 @@ public class DomainProcessorImpl implements DomainProcessor {
   @Override
   public MakeRightDomainOperationImpl createMakeRightOperation(DomainPresenceInfo liveInfo) {
     return new MakeRightDomainOperationImpl(liveInfo);
-  }
-
-  @Override
-  public MakeRightDomainOperation createMakeRightOperation(Domain liveDomain) {
-    return createMakeRightOperation(new DomainPresenceInfo(liveDomain));
   }
 
   public Step createPopulatePacketServerMapsStep(oracle.kubernetes.operator.work.Step next) {

--- a/operator/src/main/java/oracle/kubernetes/operator/EventWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/EventWatcher.java
@@ -19,26 +19,24 @@ import oracle.kubernetes.operator.watcher.WatchListener;
  * for processing.
  */
 public class EventWatcher extends Watcher<V1Event> {
+  private static final String FIELD_SELECTOR = ProcessingConstants.READINESS_PROBE_FAILURE_EVENT_FILTER;
+  
   private final String ns;
-  private final String fieldSelector;
 
   private EventWatcher(
-      String ns,
-      String fieldSelector,
-      String initialResourceVersion,
-      WatchTuning tuning,
-      WatchListener<V1Event> listener,
-      AtomicBoolean isStopping) {
+        String ns,
+        String initialResourceVersion,
+        WatchTuning tuning,
+        WatchListener<V1Event> listener,
+        AtomicBoolean isStopping) {
     super(initialResourceVersion, tuning, isStopping, listener);
     this.ns = ns;
-    this.fieldSelector = fieldSelector;
   }
 
   /**
    * Create and start a new EventWatcher.
    * @param factory thread factory to use for this watcher's threads
    * @param ns namespace
-   * @param fieldSelector value for the fieldSelector parameter
    * @param initialResourceVersion the oldest version to return for this watch
    * @param tuning Watch tuning parameters
    * @param listener a listener to which to dispatch watch events
@@ -46,22 +44,21 @@ public class EventWatcher extends Watcher<V1Event> {
    * @return the domain watcher
    */
   public static EventWatcher create(
-      ThreadFactory factory,
-      String ns,
-      String fieldSelector,
-      String initialResourceVersion,
-      WatchTuning tuning,
-      WatchListener<V1Event> listener,
-      AtomicBoolean isStopping) {
+        ThreadFactory factory,
+        String ns,
+        String initialResourceVersion,
+        WatchTuning tuning,
+        WatchListener<V1Event> listener,
+        AtomicBoolean isStopping) {
     EventWatcher watcher =
-        new EventWatcher(ns, fieldSelector, initialResourceVersion, tuning, listener, isStopping);
+        new EventWatcher(ns, initialResourceVersion, tuning, listener, isStopping);
     watcher.start(factory);
     return watcher;
   }
 
   @Override
   public Watchable<V1Event> initiateWatch(WatchBuilder watchBuilder) throws ApiException {
-    return watchBuilder.withFieldSelector(fieldSelector).createEventWatch(ns);
+    return watchBuilder.withFieldSelector(FIELD_SELECTOR).createEventWatch(ns);
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Job;
@@ -35,9 +34,9 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 
 /** Watches for Jobs to become Ready or leave Ready state. */
 public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
+  public static final WatchListener<V1Job> NULL_LISTENER = r -> {};
+
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-  private static final Map<String, JobWatcher> JOB_WATCHERS = new ConcurrentHashMap<>();
-  private static JobWatcherFactory factory;
 
   private final String namespace;
 
@@ -66,20 +65,6 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
     completeCallbackRegistrations.remove(jobName, callback);
   }
 
-  /**
-   * Returns a cached JobWatcher, if present; otherwise, creates a new one.
-   *
-   * @param domain the domain for which the job watcher is to be returned
-   * @return a cached jobwatcher.
-   */
-  public static @Nonnull JobWatcher getOrCreateFor(Domain domain) {
-    return JOB_WATCHERS.computeIfAbsent(getNamespace(domain), n -> factory.createFor(domain));
-  }
-
-  static void removeNamespace(String ns) {
-    JOB_WATCHERS.remove(ns);
-  }
-
   private static String getNamespace(Domain domain) {
     return domain.getMetadata().getNamespace();
   }
@@ -96,31 +81,26 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
   }
 
   /**
-   * Creates a new JobWatcher and caches it by namespace.
+   * Creates a new JobWatcher.
    *
    * @param factory thread factory
    * @param ns Namespace
    * @param initialResourceVersion Initial resource version or empty string
    * @param tuning Tuning parameters for the watch, for example watch lifetime
+   * @param listener a null listener to keep the same signature as other watcher create methods
    * @param isStopping Stop signal
    * @return Job watcher for the namespace
    */
   public static JobWatcher create(
-      ThreadFactory factory,
-      String ns,
-      String initialResourceVersion,
-      WatchTuning tuning,
-      AtomicBoolean isStopping) {
+        ThreadFactory factory,
+        String ns,
+        String initialResourceVersion,
+        WatchTuning tuning,
+        @SuppressWarnings("unused") WatchListener<V1Job> listener,
+        AtomicBoolean isStopping) {
     JobWatcher watcher = new JobWatcher(ns, initialResourceVersion, tuning, isStopping);
     watcher.start(factory);
     return watcher;
-  }
-
-  static void defineFactory(
-      ThreadFactory threadFactory,
-      WatchTuning tuning,
-      Function<String, AtomicBoolean> isNamespaceStopping) {
-    factory = new JobWatcherFactory(threadFactory, tuning, isNamespaceStopping);
   }
 
   /**
@@ -245,6 +225,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job> {
           namespace,
           domain.getMetadata().getResourceVersion(),
           watchTuning,
+          NULL_LISTENER,
           isNamespaceStopping.apply(namespace));
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -278,7 +278,7 @@ public class Main {
     NamespacedResources resources = new NamespacedResources(ns, null);
     resources.addProcessing(new DomainResourcesValidation(ns, processor).getProcessors());
     resources.addProcessing(DomainNamespaces.createWatcherStartupProcessing(ns, processor));
-    return resources.createListSteps();
+    return Step.chain(ConfigMapHelper.createScriptConfigMapStep(ns), resources.createListSteps());
   }
 
 

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -18,9 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
@@ -34,16 +32,10 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
-import io.kubernetes.client.common.KubernetesListObject;
-import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
-import io.kubernetes.client.openapi.models.V1EventList;
-import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1NamespaceList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1PodList;
-import io.kubernetes.client.openapi.models.V1ServiceList;
 import io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatus;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.calls.CallResponse;
@@ -54,8 +46,8 @@ import oracle.kubernetes.operator.helpers.ConfigMapHelper;
 import oracle.kubernetes.operator.helpers.CrdHelper;
 import oracle.kubernetes.operator.helpers.HealthCheckHelper;
 import oracle.kubernetes.operator.helpers.HelmAccess;
+import oracle.kubernetes.operator.helpers.KubernetesUtils;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
-import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.NamespaceHelper;
 import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.logging.LoggingContext;
@@ -76,7 +68,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
-import oracle.kubernetes.weblogic.domain.model.DomainList;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 
@@ -86,19 +77,10 @@ import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorName
 public class Main {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
-  private static final String DPI_MAP = "DPI_MAP";
-
   private static final Container container = new Container();
   private static final ThreadFactory threadFactory = new WrappedThreadFactory();
   private static final ScheduledExecutorService wrappedExecutorService =
       Engine.wrappedExecutorService("operator", container);
-  private static Map<String, NamespaceStatus> namespaceStatuses = new ConcurrentHashMap<>();
-  private static Map<String, AtomicBoolean> namespaceStoppingMap = new ConcurrentHashMap<>();
-  private static final Map<String, ConfigMapWatcher> configMapWatchers = new ConcurrentHashMap<>();
-  private static final Map<String, DomainWatcher> domainWatchers = new ConcurrentHashMap<>();
-  private static final Map<String, EventWatcher> eventWatchers = new ConcurrentHashMap<>();
-  private static final Map<String, ServiceWatcher> serviceWatchers = new ConcurrentHashMap<>();
-  private static final Map<String, PodWatcher> podWatchers = new ConcurrentHashMap<>();
   private static NamespaceWatcher namespaceWatcher = null;
   private static final AtomicReference<DateTime> lastFullRecheck =
       new AtomicReference<>(DateTime.now());
@@ -190,8 +172,6 @@ public class Main {
     principal = "system:serviceaccount:" + getOperatorNamespace() + ":" + serviceAccountName;
 
     LOGGER.info(MessageKeys.OP_CONFIG_NAMESPACE, getOperatorNamespace());
-    JobWatcher.defineFactory(
-        threadFactory, tuningAndConfig().getWatchTuning(), Main::isNamespaceStopping);
 
     Namespaces namespaces = new Namespaces(false);
     Namespaces.SelectionStrategy selectionStrategy = Namespaces.getSelectionStrategy();
@@ -224,7 +204,7 @@ public class Main {
   private static void completeBegin() {
     try {
       // start the REST server
-      startRestServer(principal, namespaceStoppingMap.keySet());
+      startRestServer(principal, DomainNamespaces.getNamespaces());
 
       // start periodic retry and recheck
       int recheckInterval = tuningAndConfig().getMainTuning().domainNamespaceRecheckIntervalSeconds;
@@ -242,43 +222,6 @@ public class Main {
     } catch (Throwable e) {
       LOGGER.warning(MessageKeys.EXCEPTION, e);
     }
-  }
-
-  private static void stopNamespace(String ns, boolean inDomainNamespaceList) {
-    AtomicBoolean isNamespaceStopping = isNamespaceStopping(ns);
-
-    // Remove if namespace not in domainNamespace list
-    if (!inDomainNamespaceList) {
-      namespaceStoppingMap.remove(ns);
-    }
-
-    // stop all Domains for namespace being stopped (not active)
-    if (isNamespaceStopping.get()) {
-      processor.stopNamespace(ns);
-    }
-
-    // set flag to indicate namespace is stopping.
-    isNamespaceStopping.set(true);
-
-    // unsubscribe from resource events for given namespace
-    namespaceStatuses.remove(ns);
-    domainWatchers.remove(ns);
-    eventWatchers.remove(ns);
-    podWatchers.remove(ns);
-    serviceWatchers.remove(ns);
-    configMapWatchers.remove(ns);
-    JobWatcher.removeNamespace(ns);
-  }
-
-  private static void stopNamespaces(Collection<String> domainNamespaces,
-                                     Collection<String> namespacesToStop) {
-    for (String ns : namespacesToStop) {
-      stopNamespace(ns, domainNamespaces.contains(ns));
-    }
-  }
-
-  private static AtomicBoolean isNamespaceStopping(String ns) {
-    return namespaceStoppingMap.computeIfAbsent(ns, (key) -> new AtomicBoolean(false));
   }
 
   private static void runSteps(Step firstStep, Packet packet) {
@@ -333,95 +276,11 @@ public class Main {
 
   static Step readExistingResources(String ns) {
     NamespacedResources resources = new NamespacedResources(ns, null);
-    DomainResourcesValidation dpis = new DomainResourcesValidation(ns, processor);
-    resources.addProcessor(dpis.getProcessors());
-    resources.addProcessor(new NamespacedResources.Processors() {
-      @Override
-      Consumer<Packet> getConfigMapProcessing() {
-        return p -> main.startConfigMapWatcher(ns, getResourceVersion(getScriptConfigMap(p)));
-      }
-
-      private V1ConfigMap getScriptConfigMap(Packet packet) {
-        return (V1ConfigMap) packet.get(ProcessingConstants.SCRIPT_CONFIG_MAP);
-      }
-
-      @Override
-      Consumer<V1EventList> getEventListProcessing() {
-        return l -> main.startEventWatcher(ns, getResourceVersion(l));
-      }
-
-      @Override
-      Consumer<V1PodList> getPodListProcessing() {
-        return l -> main.startPodWatcher(ns, getResourceVersion(l));
-      }
-
-      @Override
-      Consumer<V1ServiceList> getServiceListProcessing() {
-        return l -> main.startServiceWatcher(ns, getResourceVersion(l));
-      }
-
-      @Override
-      Consumer<DomainList> getDomainListProcessing() {
-        return l -> main.startDomainWatcher(ns, getResourceVersion(l));
-      }
-    });
+    resources.addProcessing(new DomainResourcesValidation(ns, processor).getProcessors());
+    resources.addProcessing(DomainNamespaces.createWatcherStartupProcessing(ns, processor));
     return resources.createListSteps();
   }
 
-  private static ConfigMapAfterStep createConfigMapStep(String ns) {
-    return new ConfigMapAfterStep(ns);
-  }
-
-  private void startEventWatcher(String ns, String initialResourceVersion) {
-    if (!eventWatchers.containsKey(ns)) {
-      eventWatchers.put(ns, createEventWatcher(ns, initialResourceVersion));
-    }
-  }
-
-  private void startConfigMapWatcher(String ns, String initialResourceVersion) {
-    if (!configMapWatchers.containsKey(ns)) {
-      configMapWatchers.put(ns, createConfigMapWatcher(ns, initialResourceVersion));
-    }
-  }
-
-  private void startServiceWatcher(String ns, String initialResourceVersion) {
-    if (!serviceWatchers.containsKey(ns)) {
-      serviceWatchers.put(ns, createServiceWatcher(ns, initialResourceVersion));
-    }
-  }
-
-  private void startDomainWatcher(String ns, String initialResourceVersion) {
-    if (!domainWatchers.containsKey(ns)) {
-      domainWatchers.put(ns, createDomainWatcher(ns, initialResourceVersion));
-    }
-  }
-
-  private void startPodWatcher(String ns, String initialResourceVersion) {
-    if (!podWatchers.containsKey(ns)) {
-      podWatchers.put(ns, createPodWatcher(ns, initialResourceVersion));
-    }
-  }
-
-
-  ConfigMapWatcher getConfigMapWatcher(String namespace) {
-    return configMapWatchers.get(namespace);
-  }
-
-  DomainWatcher getDomainWatcher(String namespace) {
-    return domainWatchers.get(namespace);
-  }
-
-  EventWatcher getEventWatcher(String namespace) {
-    return eventWatchers.get(namespace);
-  }
-
-  PodWatcher getPodWatcher(String namespace) {
-    return podWatchers.get(namespace);
-  }
-
-  ServiceWatcher getServiceWatcher(String namespace) {
-    return serviceWatchers.get(namespace);
-  }
 
   /**
    * Returns true if the operator is configured to use a single dedicated namespace for both itself any any domains.
@@ -436,7 +295,6 @@ public class Main {
     static final String ALL_DOMAIN_NAMESPACES = "ALL_DOMAIN_NAMESPACES";
 
     SelectionStrategy selectionStrategy = getSelectionStrategy();
-    private Collection<String> configuredDomainNamespaces = selectionStrategy.getConfiguredDomainNamespaces();
     boolean isFullRecheck;
 
     public Namespaces(boolean isFullRecheck) {
@@ -522,7 +380,7 @@ public class Main {
         return null;
       }
 
-      private static Map<String,Pattern> compiledPatterns = new WeakHashMap<>();
+      private static final Map<String,Pattern> compiledPatterns = new WeakHashMap<>();
     }
 
     static @Nonnull Collection<String> getAllDomainNamespaces(Packet packet) {
@@ -560,38 +418,9 @@ public class Main {
     }
 
     @Nonnull Collection<String> getConfiguredDomainNamespaces() {
-      return Optional.ofNullable(configuredDomainNamespaces).orElse(Collections.emptyList());
+      return Optional.ofNullable(selectionStrategy.getConfiguredDomainNamespaces()).orElse(Collections.emptyList());
     }
 
-    /**
-     * Gets the configured domain introspector job name suffix.
-     * @return String suffix
-     */
-    public static String getIntrospectorJobNameSuffix() {
-      return Optional.ofNullable(tuningAndConfig()
-          .get(LegalNames.INTROSPECTOR_JOB_NAME_SUFFIX_PARAM))
-          .orElse(LegalNames.DEFAULT_INTROSPECTOR_JOB_NAME_SUFFIX);
-    }
-
-    /**
-     * Gets the configured external service name suffix.
-     * @return String suffix
-     */
-    public static String getExternalServiceNameSuffix() {
-      return Optional.ofNullable(tuningAndConfig()
-          .get(LegalNames.EXTERNAL_SERVICE_NAME_SUFFIX_PARAM))
-          .orElse(LegalNames.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
-    }
-
-    /**
-     * Gets the configured boolean for enabling cluster size padding validation.
-     * @return boolean enabled
-     */
-    public static boolean isClusterSizePaddingValidationEnabled() {
-      return "true".equalsIgnoreCase(Optional.ofNullable(tuningAndConfig()
-          .get(LegalNames.CLUSTER_SIZE_PADDING_VALIDATION_ENABLED_PARAM))
-          .orElse(LegalNames.DEFAULT_CLUSTER_SIZE_PADDING_VALIDATION_ENABLED));
-    }
 
     /**
      * Reads the existing namespaces from Kubernetes and performs appropriate processing on those
@@ -624,11 +453,11 @@ public class Main {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1NamespaceList> callResponse) {
-        final String intialResourceVersion = getResourceVersion(callResponse.getResult());
-        final Set<String> namespacesToStartNow = getNamespacesToStart(getNames(callResponse.getResult()));
-        getFoundDomainNamespaces(packet).addAll(namespacesToStartNow);
+        final String intialResourceVersion = KubernetesUtils.getResourceVersion(callResponse.getResult());
+        final Set<String> domainNamespaces = getNamespacesToStart(getNames(callResponse.getResult()));
+        getFoundDomainNamespaces(packet).addAll(domainNamespaces);
 
-        return doContinueListOrNext(callResponse, packet, createNextSteps(intialResourceVersion, namespacesToStartNow));
+        return doContinueListOrNext(callResponse, packet, createNextSteps(intialResourceVersion, domainNamespaces));
       }
 
       private Step createNextSteps(String intialResourceVersion, Set<String> namespacesToStartNow) {
@@ -672,20 +501,16 @@ public class Main {
       public NextAction apply(Packet packet) {
         NamespaceValidationContext validationContext = new NamespaceValidationContext(packet);
         getConfiguredDomainNamespaces().forEach(validationContext::validateConfiguredNamespace);
-
-        // Check for namespaces that are removed from the operator's
-        // domainNamespaces list, or that are deleted from the Kubernetes cluster.
-        Set<String> namespacesToStop = new TreeSet<>(namespaceStoppingMap.keySet());
-        for (String ns : validationContext.allDomainNamespaces) {
-          // the active namespaces are the ones that will not be stopped
-          if (delegate.isNamespaceRunning(ns)) {
-            namespacesToStop.remove(ns);
-          }
-        }
-
-        stopNamespaces(validationContext.allDomainNamespaces, namespacesToStop);
-
+        stopRemovedNamespaces(validationContext);
         return doNext(packet);
+      }
+
+      // Halts processing of any managed namespaces that are no longer to be managed, either because
+      // they have been deleted from the Kubernetes cluster or because the operator is no longer configured for them.
+      private void stopRemovedNamespaces(NamespaceValidationContext validationContext) {
+        DomainNamespaces.getNamespaces().stream()
+              .filter(validationContext::isNoLongerActiveDomainNamespace)
+              .forEach(DomainNamespaces::stopNamespace);
       }
 
     }
@@ -730,58 +555,7 @@ public class Main {
       Thread.currentThread().interrupt();
     }
 
-    namespaceStoppingMap.forEach((key, value) -> value.set(true));
-  }
-
-  private static EventWatcher createEventWatcher(String ns, String initialResourceVersion) {
-    return EventWatcher.create(
-        threadFactory,
-        ns,
-        ProcessingConstants.READINESS_PROBE_FAILURE_EVENT_FILTER,
-        initialResourceVersion,
-        tuningAndConfig().getWatchTuning(),
-        processor::dispatchEventWatch,
-        isNamespaceStopping(ns));
-  }
-
-  private static PodWatcher createPodWatcher(String ns, String initialResourceVersion) {
-    return PodWatcher.create(
-        threadFactory,
-        ns,
-        initialResourceVersion,
-        tuningAndConfig().getWatchTuning(),
-        processor::dispatchPodWatch,
-        isNamespaceStopping(ns));
-  }
-
-  private static ServiceWatcher createServiceWatcher(String ns, String initialResourceVersion) {
-    return ServiceWatcher.create(
-        threadFactory,
-        ns,
-        initialResourceVersion,
-        tuningAndConfig().getWatchTuning(),
-        processor::dispatchServiceWatch,
-        isNamespaceStopping(ns));
-  }
-
-  private static ConfigMapWatcher createConfigMapWatcher(String namespace, String initialResourceVersion) {
-    return ConfigMapWatcher.create(
-        threadFactory,
-        namespace,
-        initialResourceVersion,
-        tuningAndConfig().getWatchTuning(),
-        processor::dispatchConfigMapWatch,
-        isNamespaceStopping(namespace));
-  }
-
-  private static DomainWatcher createDomainWatcher(String ns, String initialResourceVersion) {
-    return DomainWatcher.create(
-        threadFactory,
-        ns,
-        initialResourceVersion,
-        tuningAndConfig().getWatchTuning(),
-        processor::dispatchDomainWatch,
-        isNamespaceStopping(ns));
+    DomainNamespaces.stopAllWatchers();
   }
 
   private static NamespaceWatcher createNamespaceWatcher(Namespaces.SelectionStrategy selectionStrategy,
@@ -809,7 +583,7 @@ public class Main {
 
         Namespaces namespaces = new Namespaces(true);
         Step strategy = new StartNamespacesStep(namespaces, Collections.singletonList(ns));
-        if (!isNamespaceStopping(ns).getAndSet(false)) {
+        if (!DomainNamespaces.isStopping(ns).getAndSet(false)) {
           strategy = Step.chain(getScriptCreationSteps(ns), strategy);
         }
         runSteps(strategy, createPacketWithLoggingContext(ns));
@@ -818,7 +592,7 @@ public class Main {
       case "DELETED":
         // Mark the namespace as isStopping, which will cause the namespace be stopped
         // the next time when recheckDomains is triggered
-        isNamespaceStopping(ns).set(true);
+        DomainNamespaces.isStopping(ns).set(true);
 
         break;
 
@@ -841,6 +615,10 @@ public class Main {
       return Step.chain(
           ConfigMapHelper.createScriptConfigMapStep(ns), createConfigMapStep(ns));
     }
+  }
+
+  private static ConfigMapAfterStep createConfigMapStep(String ns) {
+    return new ConfigMapAfterStep(ns);
   }
 
   private static class WrappedThreadFactory implements ThreadFactory {
@@ -911,7 +689,7 @@ public class Main {
   }
 
   private static class StartNamespaceBeforeStep extends Step {
-    private Namespaces namespaces;
+    private final Namespaces namespaces;
     private final String ns;
 
     StartNamespaceBeforeStep(Namespaces namespaces, String ns) {
@@ -921,11 +699,12 @@ public class Main {
 
     @Override
     public NextAction apply(Packet packet) {
-      NamespaceStatus nss = namespaceStatuses.computeIfAbsent(ns, (key) -> new NamespaceStatus());
+      NamespaceStatus nss = DomainNamespaces.getNamespaceStatus(ns);
       if (namespaces.isFullRecheck || !nss.isNamespaceStarting().getAndSet(true)) {
         return doNext(packet);
+      } else {
+        return doEnd(packet);
       }
-      return doEnd(packet);
     }
   }
 
@@ -952,24 +731,18 @@ public class Main {
     }
 
     NamespaceRulesReviewStep(String ns) {
-      this.ns = ns;
+      this.ns = ns != null ? ns : getOperatorNamespace();
     }
 
     @Override
     public NextAction apply(Packet packet) {
-      // Looking up namespace status. If ns is null, then this step will check the status of the
-      // operator's own namespace. If the namespace status is missing, then generate it with
-      // the health check helper.
-      NamespaceStatus nss = namespaceStatuses.computeIfAbsent(
-          ns != null ? ns : getOperatorNamespace(), (key) -> new NamespaceStatus());
+      NamespaceStatus nss = DomainNamespaces.getNamespaceStatus(ns);
 
       // we don't have the domain presence information yet
       // we add a logging context to pass the namespace information to the LoggingFormatter
-      if (ns != null) {
-        packet.getComponents().put(
-            LoggingContext.LOGGING_CONTEXT_KEY,
-            Component.createFor(new LoggingContext().namespace(ns)));
-      }
+      packet.getComponents().put(
+          LoggingContext.LOGGING_CONTEXT_KEY,
+          Component.createFor(new LoggingContext().namespace(ns)));
 
       V1SubjectRulesReviewStatus srrs = nss.getRulesReviewStatus().updateAndGet(prev -> {
         if (prev != null) {
@@ -990,22 +763,9 @@ public class Main {
 
       return doNext(packet);
     }
+
   }
 
-
-  private static String getResourceVersion(KubernetesListObject list) {
-    return Optional.ofNullable(list)
-          .map(KubernetesListObject::getMetadata)
-          .map(V1ListMeta::getResourceVersion)
-          .orElse("");
-  }
-
-  private static String getResourceVersion(KubernetesObject resource) {
-    return Optional.ofNullable(resource)
-          .map(KubernetesObject::getMetadata)
-          .map(V1ObjectMeta::getResourceVersion)
-          .orElse("");
-  }
 
   static class NamespaceValidationContext {
     Collection<String> allDomainNamespaces;
@@ -1014,8 +774,12 @@ public class Main {
       allDomainNamespaces = Namespaces.getAllDomainNamespaces(packet);
     }
 
+    private boolean isNoLongerActiveDomainNamespace(String ns) {
+      return !allDomainNamespaces.contains(ns);
+    }
+
     private void validateConfiguredNamespace(String namespace) {
-      if (!this.allDomainNamespaces.contains(namespace)) {
+      if (isNoLongerActiveDomainNamespace(namespace)) {
         try (LoggingContext ignored = LoggingContext.setThreadContext().namespace(namespace)) {
           LOGGER.warning(MessageKeys.NAMESPACE_IS_MISSING, namespace);
         }
@@ -1074,19 +838,17 @@ public class Main {
 
     @Override
     public PodAwaiterStepFactory getPodAwaiterStepFactory(String namespace) {
-      return podWatchers.get(namespace);
+      return DomainNamespaces.getPodWatcher(namespace);
     }
 
     @Override
     public V1SubjectRulesReviewStatus getSubjectRulesReviewStatus(String namespace) {
-      NamespaceStatus namespaceStatus = namespaceStatuses.get(namespace);
-      return namespaceStatus != null ? namespaceStatus.getRulesReviewStatus().get() : null;
+      return DomainNamespaces.getNamespaceStatus(namespace).getRulesReviewStatus().get();
     }
 
     @Override
     public boolean isNamespaceRunning(String namespace) {
-      // make sure the map entry is initialized the value to "false" if absent
-      return !isNamespaceStopping(namespace).get();
+      return !DomainNamespaces.isStopping(namespace).get();
     }
 
     @Override
@@ -1124,12 +886,13 @@ public class Main {
      * @param ns namespace
      */
     ConfigMapAfterStep(String ns) {
-      this(Collections.singletonList(packet -> main.startConfigMapWatcher(ns, getInitialResourceVersion(packet))));
+      this(Collections.singletonList(
+          packet -> DomainNamespaces.startConfigMapWatcher(ns, getInitialResourceVersion(packet), processor)));
     }
 
     @Nonnull
     private static String getInitialResourceVersion(Packet packet) {
-      return getResourceVersion(getScriptConfigMap(packet));
+      return KubernetesUtils.getResourceVersion(getScriptConfigMap(packet));
     }
 
     public ConfigMapAfterStep(List<Consumer<Packet>> processors) {

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -30,6 +30,7 @@ import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.KubernetesUtils;
+import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.logging.LoggingFacade;
@@ -161,7 +162,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
     switch (item.type) {
       case "ADDED":
       case "MODIFIED":
-        if (getPodName(pod).contains(Main.Namespaces.getIntrospectorJobNameSuffix()) && isFailed(pod)) {
+        if (getPodName(pod).contains(LegalNames.getIntrospectorJobNameSuffix()) && isFailed(pod)) {
           LOGGER.info(MessageKeys.INTROSPECTOR_POD_FAILED, getPodName(pod), getPodNamespace(pod), pod.getStatus());
         }
         copyOf(getOnModifiedCallbacks(getPodName(pod))).forEach(c -> c.accept(pod));

--- a/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
@@ -3,7 +3,6 @@
 
 package oracle.kubernetes.operator;
 
-import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -25,16 +24,15 @@ public class TuningParametersImpl extends ConfigMapConsumer implements TuningPar
   private WatchTuning watch = null;
   private PodTuning pod = null;
 
-  private TuningParametersImpl(ScheduledExecutorService executorService, String mountPoint)
-      throws IOException {
-    super(executorService, mountPoint, TuningParametersImpl::updateTuningParameters);
-    update();
+  private TuningParametersImpl(ScheduledExecutorService executorService) {
+    super(executorService);
   }
 
-  static synchronized TuningParameters initializeInstance(
-      ScheduledExecutorService executorService, String mountPoint) throws IOException {
+  static synchronized TuningParameters initializeInstance(ScheduledExecutorService executorService, String mountPoint) {
     if (INSTANCE == null) {
-      INSTANCE = new TuningParametersImpl(executorService, mountPoint);
+      final TuningParametersImpl impl = new TuningParametersImpl(executorService);
+      INSTANCE = impl;
+      impl.scheduleUpdates(mountPoint, TuningParametersImpl::updateTuningParameters);
     }
     return INSTANCE;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.helpers;
 
 import java.util.Optional;
 import java.util.function.Consumer;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiCallback;
@@ -607,7 +608,7 @@ public class CallBuilder {
    * @return Domain list
    * @throws ApiException API exception
    */
-  public DomainList listDomain(String namespace) throws ApiException {
+  public @Nonnull DomainList listDomain(String namespace) throws ApiException {
     RequestParams requestParams = new RequestParams("listDomain", namespace, null, null, callParams);
     return executeSynchronousCall(requestParams, listDomainCall);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -23,6 +23,7 @@ import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1EventList;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobList;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1NamespaceList;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
@@ -1261,6 +1262,40 @@ public class CallBuilder {
         responseStep,
         new RequestParams("deletePodCollection", namespace, null, null, callParams),
         deletecollectionPod);
+  }
+
+  private Call listJobAsync(
+      ApiClient client, String namespace, String cont, ApiCallback<V1JobList> callback)
+      throws ApiException {
+    return new BatchV1Api(client)
+        .listNamespacedJobAsync(
+            namespace,
+            pretty,
+            allowWatchBookmarks,
+            cont,
+            fieldSelector,
+            labelSelector,
+            limit,
+            resourceVersion,
+            timeoutSeconds,
+            watch,
+            callback);
+  }
+
+  private final CallFactory<V1JobList> listJob =
+      (requestParams, usage, cont, callback) ->
+          wrap(listJobAsync(usage, requestParams.namespace, cont, callback));
+
+  /**
+   * Asynchronous step for listing jobs.
+   *
+   * @param namespace Namespace
+   * @param responseStep Response step for when call completes
+   * @return Asynchronous step
+   */
+  public Step listJobAsync(String namespace, ResponseStep<V1JobList> responseStep) {
+    return createRequestAsync(
+        responseStep, new RequestParams("listJob", namespace, null, null, callParams), listJob);
   }
 
   private Call createJobAsync(

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
@@ -10,6 +10,9 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.json.JsonPatchBuilder;
 
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.LabelConstants;
 import org.apache.commons.collections.MapUtils;
@@ -172,6 +175,28 @@ public class KubernetesUtils {
       }
     }
     return BigInteger.ZERO;
+  }
+
+  /**
+   * Returns the resource version associated with the specified list.
+   * @param list the result of a Kubernetes list operation.
+   */
+  public static String getResourceVersion(KubernetesListObject list) {
+    return Optional.ofNullable(list)
+          .map(KubernetesListObject::getMetadata)
+          .map(V1ListMeta::getResourceVersion)
+          .orElse("");
+  }
+
+  /**
+   * Returns the resource version associated with the specified resource.
+   * @param resource a Kubernetes resource
+   */
+  public static String getResourceVersion(KubernetesObject resource) {
+    return Optional.ofNullable(resource)
+          .map(KubernetesObject::getMetadata)
+          .map(V1ObjectMeta::getResourceVersion)
+          .orElse("");
   }
 
   public static V1ObjectMeta withOperatorLabels(String uid, V1ObjectMeta meta) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -9,15 +9,12 @@ import java.util.Optional;
 import java.util.StringTokenizer;
 
 import com.google.common.base.Strings;
-import oracle.kubernetes.operator.Main;
 import oracle.kubernetes.operator.TuningParameters;
 
 /** A class to create DNS-1123 legal names for Kubernetes objects. */
 public class LegalNames {
 
   public static final String DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX = "-ext";
-  public static final String DEFAULT_CLUSTER_SIZE_PADDING_VALIDATION_ENABLED = "true";
-  public static final String CLUSTER_SIZE_PADDING_VALIDATION_ENABLED_PARAM = "clusterSizePaddingValidationEnabled";
   private static final String SERVER_PATTERN = "%s-%s";
   private static final String CLUSTER_SERVICE_PATTERN = "%s-cluster-%s";
   public static final String DEFAULT_INTROSPECTOR_JOB_NAME_SUFFIX = "-introspector";
@@ -87,7 +84,17 @@ public class LegalNames {
     return toDns1123LegalName(String.format(
         DOMAIN_INTROSPECTOR_JOB_PATTERN,
         domainUid,
-        Main.Namespaces.getIntrospectorJobNameSuffix()));
+        getIntrospectorJobNameSuffix()));
+  }
+
+  /**
+   * Gets the configured domain introspector job name suffix.
+   * @return String suffix
+   */
+  public static String getIntrospectorJobNameSuffix() {
+    return Optional.ofNullable(TuningParameters.getInstance())
+          .map(t -> t.get(INTROSPECTOR_JOB_NAME_SUFFIX_PARAM))
+          .orElse(LegalNames.DEFAULT_INTROSPECTOR_JOB_NAME_SUFFIX);
   }
 
   /**
@@ -102,7 +109,17 @@ public class LegalNames {
         EXTERNAL_SERVICE_PATTERN,
         domainUid,
         serverName,
-        Main.Namespaces.getExternalServiceNameSuffix()));
+        getExternalServiceNameSuffix()));
+  }
+
+  /**
+   * Gets the configured external service name suffix.
+   * @return String suffix
+   */
+  private static String getExternalServiceNameSuffix() {
+    return Optional.ofNullable(TuningParameters.getInstance())
+        .map(t -> t.get(LegalNames.EXTERNAL_SERVICE_NAME_SUFFIX_PARAM))
+        .orElse(LegalNames.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/RestConfigImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/RestConfigImpl.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator.rest;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
@@ -16,20 +17,17 @@ public class RestConfigImpl implements RestConfig {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private final String principal;
-  private final Collection<String> domainNamespaces;
+  private final Supplier<Collection<String>> domainNamespaces;
 
   /**
    * Constructs a RestConfigImpl.
-   *
-   * @param principal is the name of the Kubernetes User or Service Account to use when calling the
+   *  @param principal is the name of the Kubernetes User or Service Account to use when calling the
    *     Kubernetes REST API.
-   * @param domainNamespaces is a list of the Kubernetes Namespaces covered by this Operator.
+   * @param domainNamespaces returns a list of the Kubernetes Namespaces covered by this Operator.
    */
-  public RestConfigImpl(String principal, Collection<String> domainNamespaces) {
-    LOGGER.entering(principal, domainNamespaces);
-    this.principal = principal;
+  public RestConfigImpl(String principal, Supplier<Collection<String>> domainNamespaces) {
     this.domainNamespaces = domainNamespaces;
-    LOGGER.exiting();
+    this.principal = principal;
   }
 
   @Override
@@ -89,9 +87,6 @@ public class RestConfigImpl implements RestConfig {
 
   @Override
   public RestBackend getBackend(String accessToken) {
-    LOGGER.entering();
-    RestBackend result = new RestBackendImpl(principal, accessToken, domainNamespaces);
-    LOGGER.exiting();
-    return result;
+    return new RestBackendImpl(principal, accessToken, domainNamespaces);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/WatchDomainIntrospectorJobReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/WatchDomainIntrospectorJobReadyStep.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator.steps;
 
 import io.kubernetes.client.openapi.models.V1Job;
+import oracle.kubernetes.operator.DomainNamespaces;
 import oracle.kubernetes.operator.JobWatcher;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
@@ -25,7 +26,7 @@ public class WatchDomainIntrospectorJobReadyStep extends Step {
 
     // No need to spawn a watcher if the job is already complete
     if (domainIntrospectorJob != null && !JobWatcher.isComplete(domainIntrospectorJob)) {
-      JobWatcher jw = JobWatcher.getOrCreateFor(info.getDomain());
+      JobWatcher jw = DomainNamespaces.getJobWatcher(info.getNamespace());
 
       return doNext(jw.waitForReady(domainIntrospectorJob, getNext()), packet);
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -58,6 +58,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
 
   private final List<Memento> mementos = new ArrayList<>();
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final DomainProcessorStub dp = createStub(DomainProcessorStub.class);
   private Map<String, AtomicBoolean> namespaceStoppingMap;
 
   private static Memento installStub(Class<?> containingClass, String fieldName, Object newValue)
@@ -95,10 +96,8 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
 
   @Test
   public void whenNoPreexistingDomains_createEmptyDomainPresenceInfoMap() {
-    DomainProcessorStub dp = createStub(DomainProcessorStub.class);
     testSupport.addComponent("DP", DomainProcessor.class, dp);
-
-    readExistingResources();
+    testSupport.runSteps(DomainNamespaces.readExistingResources(NS, dp));
 
     assertThat(dp.getDomainPresenceInfos(), is(anEmptyMap()));
   }
@@ -108,16 +107,10 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
     Domain domain = createDomain(UID, NS);
     testSupport.defineResources(domain);
 
-    DomainProcessorStub dp = createStub(DomainProcessorStub.class);
     testSupport.addComponent("DP", DomainProcessor.class, dp);
-
-    readExistingResources();
+    testSupport.runSteps(DomainNamespaces.readExistingResources(NS, dp));
 
     assertThat(getDomainPresenceInfo(dp, UID).getDomain(), equalTo(domain));
-  }
-
-  private void readExistingResources() {
-    testSupport.runSteps(Main.readExistingResources(NS));
   }
 
   private void addDomainResource(String uid, String namespace) {
@@ -177,10 +170,8 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
     V1Service service = createServerService(UID, NS, "admin");
     testSupport.defineResources(service);
 
-    DomainProcessorStub dp = createStub(DomainProcessorStub.class);
     testSupport.addComponent("DP", DomainProcessor.class, dp);
-
-    readExistingResources();
+    testSupport.runSteps(DomainNamespaces.readExistingResources(NS, dp));
 
     assertThat(getDomainPresenceInfo(dp, UID).getServerService("admin"), equalTo(service));
   }
@@ -191,10 +182,8 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
     V1Pod pod = createPodResource(UID, NS, "admin");
     testSupport.defineResources(pod);
 
-    DomainProcessorStub dp = createStub(DomainProcessorStub.class);
     testSupport.addComponent("DP", DomainProcessor.class, dp);
-
-    readExistingResources();
+    testSupport.runSteps(DomainNamespaces.readExistingResources(NS, dp));
 
     assertThat(getDomainPresenceInfo(dp, UID).getServerPod("admin"), equalTo(pod));
   }
@@ -213,10 +202,8 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
     addPodResource(UID, NS, "admin");
     addEventResource(UID, "admin", "ignore this event");
 
-    DomainProcessorStub dp = createStub(DomainProcessorStub.class);
     testSupport.addComponent("DP", DomainProcessor.class, dp);
-
-    readExistingResources();
+    testSupport.runSteps(DomainNamespaces.readExistingResources(NS, dp));
 
     assertThat(getDomainPresenceInfo(dp, UID).getLastKnownServerStatus("admin"), nullValue());
   }
@@ -243,7 +230,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
 
     namespaceStoppingMap.get(NS).set(false);
 
-    readExistingResources();
+    testSupport.runSteps(Main.readExistingResources(NS));
 
     assertThat(testSupport.getResources(SERVICE), empty());
   }
@@ -256,8 +243,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
     testSupport.defineResources(service1, service2);
 
     namespaceStoppingMap.get(NS).set(false);
-
-    readExistingResources();
+    testSupport.runSteps(Main.readExistingResources(NS));
 
     assertThat(testSupport.getResources(SERVICE), both(hasItem(service1)).and(hasItem(service2)));
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -81,7 +81,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   private Map<String, AtomicBoolean> getStoppingVariable() throws NoSuchFieldException {
-    Memento stoppingMemento = StaticStubSupport.preserve(Main.class, "namespaceStoppingMap");
+    Memento stoppingMemento = StaticStubSupport.preserve(DomainNamespaces.class, "namespaceStoppingMap");
     return stoppingMemento.getOriginalValue();
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -110,7 +110,8 @@ public class DomainProcessorTest {
   private final Domain domain = DomainProcessorTestSetup.createTestDomain();
   private final Domain newDomain = DomainProcessorTestSetup.createTestDomain();
   private final DomainConfigurator domainConfigurator = configureDomain(newDomain);
-  private final MakeRightDomainOperation makeRightOperation = processor.createMakeRightOperation(newDomain);
+  private final MakeRightDomainOperation makeRightOperation
+        = processor.createMakeRightOperation(new DomainPresenceInfo(newDomain));
   private final WlsDomainConfig domainConfig = createDomainConfig();
 
   private static WlsDomainConfig createDomainConfig() {

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -18,20 +18,18 @@ import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.watcher.WatchListener;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
-import oracle.kubernetes.weblogic.domain.model.Domain;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static oracle.kubernetes.operator.JobWatcher.NULL_LISTENER;
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -96,11 +94,11 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
 
   @Override
   protected JobWatcher createWatcher(String ns, AtomicBoolean stopping, BigInteger rv) {
-    return JobWatcher.create(this, ns, rv.toString(), tuning, stopping);
+    return JobWatcher.create(this, ns, rv.toString(), tuning, NULL_LISTENER, stopping);
   }
 
   private JobWatcher createWatcher(AtomicBoolean stopping) {
-    return JobWatcher.create(this, "ns", INITIAL_RESOURCE_VERSION.toString(), tuning, stopping);
+    return createWatcher("ns", stopping, INITIAL_RESOURCE_VERSION);
   }
 
   @Test
@@ -362,26 +360,6 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
     } finally {
       stopping.set(true);
     }
-  }
-
-  @Test
-  public void afterFactoryDefined_createWatcherForDomain() {
-    AtomicBoolean stopping = new AtomicBoolean(true);
-    JobWatcher.defineFactory(this, tuning, s -> stopping);
-    Domain domain = new Domain().withMetadata(new V1ObjectMeta().namespace(NS).resourceVersion(VERSION));
-
-    assertThat(JobWatcher.getOrCreateFor(domain), notNullValue());
-  }
-
-  @Test
-  public void afterWatcherCreated_itIsCached() {
-    AtomicBoolean stopping = new AtomicBoolean(true);
-    JobWatcher.defineFactory(this, tuning, ns -> stopping);
-    Domain domain =
-        new Domain().withMetadata(new V1ObjectMeta().namespace(NS).resourceVersion(VERSION));
-    JobWatcher firstWatcher = JobWatcher.getOrCreateFor(domain);
-
-    assertThat(JobWatcher.getOrCreateFor(domain), sameInstance(firstWatcher));
   }
 
   public void receivedEvents_areSentToListeners() {

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -99,8 +99,8 @@ public class MainTest extends ThreadFactoryTestBase {
     mementos.add(StaticStubSupport.install(Main.class, "version", new KubernetesVersion(1, 16)));
     mementos.add(StaticStubSupport.install(ThreadFactorySingleton.class, "INSTANCE", this));
     mementos.add(StaticStubSupport.install(Main.class, "engine", testSupport.getEngine()));
-    mementos.add(StaticStubSupport.install(Main.class, NAMESPACE_STATUS_MAP, createNamespaceStatuses()));
-    mementos.add(StaticStubSupport.install(Main.class, NAMESPACE_STOPPING_MAP, createNamespaceFlags()));
+    mementos.add(StaticStubSupport.install(DomainNamespaces.class, NAMESPACE_STATUS_MAP, createNamespaceStatuses()));
+    mementos.add(StaticStubSupport.install(DomainNamespaces.class, NAMESPACE_STOPPING_MAP, createNamespaceFlags()));
     mementos.add(NoopWatcherStarter.install());
   }
 
@@ -116,7 +116,7 @@ public class MainTest extends ThreadFactoryTestBase {
   @SuppressWarnings("unchecked")
   private Map<String, NamespaceStatus> getNamespaceStatusMap()
           throws NoSuchFieldException, IllegalAccessException {
-    Field field = Main.class.getDeclaredField(NAMESPACE_STATUS_MAP);
+    Field field = DomainNamespaces.class.getDeclaredField(NAMESPACE_STATUS_MAP);
     field.setAccessible(true);
     return (Map<String, NamespaceStatus>) field.get(null);
   }
@@ -300,13 +300,17 @@ public class MainTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  public void afterReadingExistingResourcesForNamespace_WatcheraAreDefined() {
+  public void afterReadingExistingResourcesForNamespace_WatchersAreDefined() {
     testSupport.runSteps(main.readExistingResources(NS));
 
-    assertThat(main.getConfigMapWatcher(NS), notNullValue());
-    assertThat(main.getDomainWatcher(NS), notNullValue());
-    assertThat(main.getEventWatcher(NS), notNullValue());
-    assertThat(main.getPodWatcher(NS), notNullValue());
-    assertThat(main.getServiceWatcher(NS), notNullValue());
+    assertThat(DomainNamespaces.getConfigMapWatcher(NS), notNullValue());
+    assertThat(DomainNamespaces.getDomainWatcher(NS), notNullValue());
+    assertThat(DomainNamespaces.getEventWatcher(NS), notNullValue());
+    assertThat(DomainNamespaces.getPodWatcher(NS), notNullValue());
+    assertThat(DomainNamespaces.getServiceWatcher(NS), notNullValue());
   }
+
+
+  // after reading existing resources, script config map is defined
+  // when namespace added, resources defined, config map is defined and watchers are started (?)
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -196,10 +196,6 @@ public class NamespaceTest {
   abstract static class DomainProcessorStub implements DomainProcessor {
     List<String> nameSpaces = new ArrayList<>();
 
-    @Override
-    public void stopNamespace(String ns) {
-      throw new RuntimeException("Should not be calling this");
-    }
   }
 
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -3,50 +3,44 @@
 
 package oracle.kubernetes.operator;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import com.meterware.simplestub.Stub;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.helpers.HelmAccessStub;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
+import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.util.function.Function.identity;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.helpers.HelmAccess.OPERATOR_DOMAIN_NAMESPACES;
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class NamespaceTest {
 
-  private static final String NAMESPACES_PROPERTY = "OPERATOR_DOMAIN_NAMESPACES";
-  private static final String ADDITIONAL_NAMESPACE = "NS3";
+  private static final String ADDITIONAL_NS1 = "EXTRA_NS1";
+  private static final String ADDITIONAL_NS2 = "EXTRA_NS2";
   public static final String NAMESPACE_STOPPING_MAP = "namespaceStoppingMap";
 
   KubernetesTestSupport testSupport = new KubernetesTestSupport();
@@ -55,19 +49,17 @@ public class NamespaceTest {
   private final List<Memento> mementos = new ArrayList<>();
   private final Set<String> currentNamespaces = new HashSet<>();
   private final DomainProcessorStub dp = Stub.createStub(DomainProcessorStub.class);
-  private Method stopNamespace = null;
 
   @Before
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger());
-    mementos.add(StaticStubSupport.preserve(Main.class, "namespaceStatuses"));
-    mementos.add(StaticStubSupport.preserve(Main.class, NAMESPACE_STOPPING_MAP));
+    mementos.add(StaticStubSupport.preserve(DomainNamespaces.class, "namespaceStatuses"));
+    mementos.add(StaticStubSupport.preserve(DomainNamespaces.class, NAMESPACE_STOPPING_MAP));
     mementos.add(HelmAccessStub.install());
     mementos.add(TuningParametersStub.install());
     mementos.add(StaticStubSupport.install(Main.class, "processor", dp));
     mementos.add(testSupport.install());
     AtomicBoolean stopping = new AtomicBoolean(true);
-    JobWatcher.defineFactory(r -> createDaemonThread(), tuning, ns -> stopping);
   }
 
   private Thread createDaemonThread() {
@@ -82,95 +74,112 @@ public class NamespaceTest {
   }
 
   @Test
-  public void givenJobWatcherForNamespace_afterNamespaceDeletedAndRecreatedHaveDifferentWatcher()
-      throws NoSuchFieldException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    addDomainNamespace(NS);
-    addDomainNamespace(ADDITIONAL_NAMESPACE);
-    cacheStartedNamespaces();
-    JobWatcher oldWatcher = JobWatcher.getOrCreateFor(domain);
+  public void givenJobWatcherForNamespace_afterNamespaceDeletedAndRecreatedHaveDifferentWatcher() {
+    initializeNamespaces();
+    JobWatcher oldWatcher = DomainNamespaces.getJobWatcher(NS);
 
-    // Stop the namespace before removing as a domain namespace so operator will stop it.
-    invoke_stopNamespace(NS, true);
-    deleteDomainNamespace(NS);
+    deleteNamespace(NS);
+    processNamespaces();
+    defineNamespaces(NS);
+
     testSupport.runSteps(Main.createDomainRecheckSteps(DateTime.now()));
-
-    assertThat(JobWatcher.getOrCreateFor(domain), not(sameInstance(oldWatcher)));
+    assertThat(DomainNamespaces.getJobWatcher(NS), not(sameInstance(oldWatcher)));
   }
 
   @Test
-  public void whenNamespaceNotInDomainNamespaceList_namespaceRemovedFromNamespaceStoppingMap()
-      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, NoSuchFieldException {
-    addDomainNamespace(NS);
-    cacheStartedNamespaces();
+  public void whenDomainNamespaceRemovedFromDomainNamespaces_stopDomainWatchers() {
+    initializeNamespaces();
+    AtomicBoolean stopping = DomainNamespaces.isStopping(NS);
 
-    // Stop the namespace that is not in domainNamespace list
-    invoke_stopNamespace(NS, false);
+    unspecifyDomainNamespace(NS);
+    processNamespaces();
 
-    Map<String, AtomicBoolean> namespaceStoppingMap = getNamespaceStoppingMap();
+    assertThat(stopping.get(), is(true));
+  }
 
-    // Verify 'namespace' removed from 'namespaceStoppingMap'
-    assertThat(namespaceStoppingMap, anEmptyMap());
+  private void initializeNamespaces() {
+    defineNamespaces(NS, ADDITIONAL_NS1, ADDITIONAL_NS2);
+    specifyDomainNamespaces(NS, ADDITIONAL_NS2);
+    processNamespaces();
+  }
+
+  private void defineNamespaces(String... namespaces) {
+    Arrays.stream(namespaces).forEach(ns -> testSupport.defineResources(createNamespace(ns), createDomain(ns)));
+  }
+
+  private V1Namespace createNamespace(String n) {
+    return new V1Namespace().metadata(new V1ObjectMeta().name(n));
+  }
+
+  private Domain createDomain(String ns) {
+    return new Domain().withMetadata(new V1ObjectMeta().namespace(ns).name(createUid(ns)));
+  }
+
+  @NotNull
+  private String createUid(String ns) {
+    return "uid-" + ns;
+  }
+
+  private void specifyDomainNamespaces(String... namespaces) {
+    Arrays.stream(namespaces).forEach(this::addDomainNamespace);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private void deleteNamespace(String namespaceName) {
+    testSupport.deleteNamespace(namespaceName);
+  }
+
+  private void processNamespaces() {
+    testSupport.withClearPacket().runSteps(new Main.Namespaces(false).readExistingNamespaces());
   }
 
   @Test
-  public void whenNamespaceInDomainNamespaceList_namespaceExistsInNamespaceStoppingMap()
-      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, NoSuchFieldException {
-    addDomainNamespace(NS);
-    addDomainNamespace(ADDITIONAL_NAMESPACE);
-    cacheStartedNamespaces();
+  public void whenDomainNamespaceRemovedFromDomainNamespaces_isNoLongerInManagedNamespaces() {
+    initializeNamespaces();
 
-    // Stop the namespace that is in domainNamespace list
-    invoke_stopNamespace(ADDITIONAL_NAMESPACE, true);
+    unspecifyDomainNamespace(NS);
+    processNamespaces();
 
-    // Stop the namespace that is NOT in domainNamespace list
-    invoke_stopNamespace(NS, false);
-
-    Map<String, AtomicBoolean> namespaceStoppingMap = getNamespaceStoppingMap();
-
-    // Verify that 'namespaceStoppingMap' has only namespace that was in domainNamespace list
-    assertThat(namespaceStoppingMap, aMapWithSize(1));
-    assertThat(namespaceStoppingMap, hasKey(ADDITIONAL_NAMESPACE));
+    assertThat(DomainNamespaces.getNamespaces(), not(contains(NS)));
   }
 
   @Test
-  public void whenNamespaceStopping_domainProcessorStopNamespaceInvoked()
-      throws NoSuchFieldException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    addDomainNamespace(NS);
-    addDomainNamespace(ADDITIONAL_NAMESPACE);
-    cacheStartedNamespaces();
+  public void whenDomainNamespaceRemovedFromDomainNamespaces_doNotShutdownDomain() {
+    initializeNamespaces();
 
-    Map<String, AtomicBoolean> namespaceStoppingMap = getNamespaceStoppingMap();
+    unspecifyDomainNamespace(NS);
+    processNamespaces();
 
-    // set 'namespace' to stopping
-    namespaceStoppingMap.put(NS, new AtomicBoolean(true));
+    assertThat(getDomainsInNamespace(NS), notNullValue());
+  }
 
-    // Stop the namespace
-    invoke_stopNamespace(NS, false);
-
-    assertThat(dp.nameSpaces, hasSize(1));
-    assertThat(NS, equalTo(dp.nameSpaces.get(0)));
+  @SuppressWarnings("SameParameterValue")
+  private Domain getDomainsInNamespace(String namespace) {
+    return testSupport.<Domain>getResources(DOMAIN).stream()
+          .filter(d -> d.getDomainUid().equals(createUid(namespace)))
+          .findFirst()
+          .orElse(null);
   }
 
   @Test
-  public void whenNamespaceNotStopping_domainProcessorStopNamespaceNotInvoked()
-      throws NoSuchFieldException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    addDomainNamespace(NS);
-    cacheStartedNamespaces();
+  public void whenDomainNamespaceDeleted_stopDomainWatchers() {
+    initializeNamespaces();
+    AtomicBoolean stopping = DomainNamespaces.isStopping(NS);
 
-    Map<String, AtomicBoolean> namespaceStoppingMap = getNamespaceStoppingMap();
+    deleteNamespace(NS);
+    processNamespaces();
 
-    // Stop the namespace not in domainNamespace list
-    invoke_stopNamespace(NS, false);
-
-    // Verify DomainProcessor::stopNamespace not called since namespace is active (i.e. not stopping)
-    assertThat(dp.nameSpaces, is(empty()));
+    assertThat(stopping.get(), is(true));
   }
 
-  private Map<String, AtomicBoolean> getNamespaceStoppingMap()
-      throws NoSuchFieldException, IllegalAccessException {
-    Field field = Main.class.getDeclaredField(NAMESPACE_STOPPING_MAP);
-    field.setAccessible(true);
-    return (Map<String, AtomicBoolean>) field.get(null);
+  @Test
+  public void whenDomainNamespaceDeleted_isNoLongerInManagedNamespaces() {
+    initializeNamespaces();
+
+    deleteNamespace(NS);
+    processNamespaces();
+
+    assertThat(DomainNamespaces.getNamespaces(), not(contains(NS)));
   }
 
   private void addDomainNamespace(String namespace) {
@@ -179,42 +188,18 @@ public class NamespaceTest {
   }
 
   @SuppressWarnings("SameParameterValue")
-  private void deleteDomainNamespace(String namespace) {
+  private void unspecifyDomainNamespace(String namespace) {
     currentNamespaces.remove(namespace);
     HelmAccessStub.defineVariable(OPERATOR_DOMAIN_NAMESPACES, String.join(",", currentNamespaces));
   }
 
-  private void cacheStartedNamespaces() throws NoSuchFieldException {
-    StaticStubSupport.install(Main.class, "namespaceStatuses", createNamespaceStatuses());
-    StaticStubSupport.install(Main.class, NAMESPACE_STOPPING_MAP, createNamespaceFlags());
-  }
-
-  private Map<String, NamespaceStatus> createNamespaceStatuses() {
-    return currentNamespaces.stream()
-        .collect(Collectors.toMap(identity(), a -> new NamespaceStatus()));
-  }
-
-  private Map<String, AtomicBoolean> createNamespaceFlags() {
-    return currentNamespaces.stream()
-        .collect(Collectors.toMap(identity(), a -> new AtomicBoolean()));
-  }
-
-  private void invoke_stopNamespace(String namespace, boolean inDomainNamespaceList)
-      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    if (stopNamespace == null) {
-      stopNamespace =
-          Main.class.getDeclaredMethod("stopNamespace", String.class, Boolean.TYPE);
-      stopNamespace.setAccessible(true);
-    }
-    stopNamespace.invoke(null, namespace, inDomainNamespaceList);
-  }
-
   abstract static class DomainProcessorStub implements DomainProcessor {
-    ArrayList<String> nameSpaces = new ArrayList<>();
+    List<String> nameSpaces = new ArrayList<>();
 
     @Override
     public void stopNamespace(String ns) {
-      Optional.ofNullable(ns).ifPresent(nspace -> nameSpaces.add(nspace));
+      throw new RuntimeException("Should not be calling this");
     }
   }
+
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/HealthCheckHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/HealthCheckHelperTest.java
@@ -106,6 +106,7 @@ public class HealthCheckHelperTest {
    */
   @Before
   public void setUp() throws Exception {
+    mementos.add(TuningParametersStub.install());
     mementos.add(TestUtils.silenceOperatorLogger().collectLogMessages(logRecords, LOG_KEYS));
     mementos.add(ClientFactoryStub.install());
     mementos.add(testSupport.installSynchronousCallDispatcher());

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -297,6 +297,17 @@ public class KubernetesTestSupport extends FiberTestSupport {
     repositories.get(PODLOG).createResourceInNamespace(name, namespace, contents);
   }
 
+  /**
+   * Deletes the specified namespace and all resources in that namespace.
+   * @param namespaceName the name of the namespace to delete
+   */
+  public void deleteNamespace(String namespaceName) {
+    repositories.get(NAMESPACE).data.remove(namespaceName);
+    repositories.values().stream()
+          .filter(r -> r instanceof NamespacedDataRepository)
+          .forEach(r -> ((NamespacedDataRepository<?>) r).deleteNamespace(namespaceName));
+  }
+
   @SuppressWarnings("unchecked")
   private <T> DataRepository<T> getDataRepository(T resource) {
     return (DataRepository<T>) repositories.get(dataTypes.get(resource.getClass()));
@@ -594,7 +605,7 @@ public class KubernetesTestSupport extends FiberTestSupport {
     private final Map<String, T> data = new HashMap<>();
     private final Class<?> resourceType;
     private Function<List<T>, Object> listFactory;
-    private Map<String, List<T>> continuations = new HashMap<>();
+    private final Map<String, List<T>> continuations = new HashMap<>();
     private List<Consumer<T>> onCreateActions = new ArrayList<>();
     private List<Consumer<T>> onUpdateActions = new ArrayList<>();
     private Method getStatusMethod;
@@ -935,6 +946,10 @@ public class KubernetesTestSupport extends FiberTestSupport {
     NamespacedDataRepository(Class<?> resourceType, Function<List<T>, Object> listFactory) {
       super(resourceType, listFactory);
       this.resourceType = resourceType;
+    }
+
+    void deleteNamespace(String namespace) {
+      repositories.remove(namespace);
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
@@ -54,6 +54,15 @@ public abstract class TuningParametersStub implements TuningParameters {
         INTROSPECTOR_JOB_ACTIVE_DEADLINE_SECONDS);
   }
 
+  /**
+   * Sets a tuning parameter for testing purposes.
+   * @param key the parameter to set
+   * @param value its test value
+   */
+  public static void setParameter(String key, String value) {
+    namedParameters.put(key, value);
+  }
+
   @Override
   public MainTuning getMainTuning() {
     return new MainTuning(2, 2, 2, 2, 2, 2, 2L, 2L);

--- a/operator/src/test/java/oracle/kubernetes/operator/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/rest/RestBackendImplTest.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator.rest;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,7 @@ import javax.ws.rs.WebApplicationException;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1SubjectAccessReview;
 import io.kubernetes.client.openapi.models.V1SubjectAccessReviewStatus;
@@ -53,19 +55,27 @@ public class RestBackendImplTest {
 
   private static final int REPLICA_LIMIT = 4;
   private static final String NS = "namespace1";
-  private static final String NAME1 = "domain";
-  private static final String NAME2 = "domain2";
+  private static final String DOMAIN1 = "domain";
+  private static final String DOMAIN2 = "domain2";
+  private static final String DOMAIN3 = "domain3";
+  private static final String DOMAIN4 = "domain4";
   public static final String INITIAL_VERSION = "1";
-  private final WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport(NAME1);
+  private final WlsDomainConfigSupport domain1ConfigSupport = new WlsDomainConfigSupport(DOMAIN1);
 
   private final List<Memento> mementos = new ArrayList<>();
   private RestBackend restBackend;
-  private final Domain domain = createDomain(NS, NAME1);
-  private final Domain domain2 = createDomain(NS, NAME2);
+  private final V1Namespace namespace = createNamespace(NS);
+  private final Domain domain1 = createDomain(NS, DOMAIN1);
+  private final Domain domain2 = createDomain(NS, DOMAIN2);
+  private final Collection<String> namespaces = new ArrayList<>(Collections.singletonList(NS));
   private Domain updatedDomain;
-  private final DomainConfigurator configurator = DomainConfiguratorFactory.forDomain(domain);
+  private final DomainConfigurator configurator = DomainConfiguratorFactory.forDomain(domain1);
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private WlsDomainConfig config;
+
+  private static V1Namespace createNamespace(String name) {
+    return new V1Namespace().metadata(new V1ObjectMeta().name(name));
+  }
 
   private static Domain createDomain(String namespace, String name) {
     return new Domain()
@@ -85,14 +95,18 @@ public class RestBackendImplTest {
     mementos.add(
         StaticStubSupport.install(RestBackendImpl.class, "INSTANCE", new TopologyRetrieverStub()));
 
-    testSupport.defineResources(domain, domain2);
+    testSupport.defineResources(namespace, domain1, domain2);
     testSupport.doOnCreate(TOKEN_REVIEW, r -> authenticate((V1TokenReview) r));
     testSupport.doOnCreate(SUBJECT_ACCESS_REVIEW, s -> allow((V1SubjectAccessReview) s));
     testSupport.doOnUpdate(DOMAIN, d -> updatedDomain = (Domain) d);
-    configSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3", "ms4", "ms5", "ms6");
-    restBackend = new RestBackendImpl("", "", Collections.singletonList(NS));
+    domain1ConfigSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3", "ms4", "ms5", "ms6");
+    restBackend = new RestBackendImpl("", "", this::getDomainNamespaces);
 
     setupScanCache();
+  }
+
+  Collection<String> getDomainNamespaces() {
+    return namespaces;
   }
 
   private void authenticate(V1TokenReview tokenReview) {
@@ -112,14 +126,24 @@ public class RestBackendImplTest {
 
   @Test
   public void retrieveRegisteredDomainIds() {
-    assertThat(restBackend.getDomainUids(), containsInAnyOrder(NAME1, NAME2));
+    createNamespaceWithDomains("ns2", DOMAIN3, DOMAIN4);
+    namespaces.add("ns2");
+    
+    assertThat(restBackend.getDomainUids(), containsInAnyOrder(DOMAIN1, DOMAIN2, DOMAIN3, DOMAIN4));
+  }
+
+  private void createNamespaceWithDomains(String ns, String... domainNames) {
+    testSupport.defineResources(createNamespace(ns));
+    for (String domainName : domainNames) {
+      testSupport.defineResources(createDomain(ns, domainName));
+    }
   }
 
   // functionality needed for Domain resource
 
   @Test
   public void validateKnownUid() {
-    assertThat(restBackend.isDomainUid(NAME2), is(true));
+    assertThat(restBackend.isDomainUid(DOMAIN2), is(true));
   }
 
   @Test
@@ -134,12 +158,12 @@ public class RestBackendImplTest {
 
   @Test(expected = WebApplicationException.class)
   public void whenUnknownDomainUpdateCommand_throwException() {
-    restBackend.performDomainAction(NAME1, new DomainAction(null));
+    restBackend.performDomainAction(DOMAIN1, new DomainAction(null));
   }
 
   @Test
   public void whenIntrospectionRequestedWhileNoIntrospectVersionDefined_setIntrospectVersion() {
-    restBackend.performDomainAction(NAME1, createIntrospectRequest());
+    restBackend.performDomainAction(DOMAIN1, createIntrospectRequest());
 
     assertThat(getUpdatedIntrospectVersion(), equalTo(INITIAL_VERSION));
   }
@@ -162,14 +186,14 @@ public class RestBackendImplTest {
   }
 
   private boolean isDomain1Meta(V1ObjectMeta meta) {
-    return meta != null && NS.equals(meta.getNamespace()) && NAME1.equals(meta.getName());
+    return meta != null && NS.equals(meta.getNamespace()) && DOMAIN1.equals(meta.getName());
   }
 
   @Test
   public void whenIntrospectionRequestedWhileIntrospectVersionNonNumeric_setNumericVersion() {
     configurator.withIntrospectVersion("zork");
 
-    restBackend.performDomainAction(NAME1, createIntrospectRequest());
+    restBackend.performDomainAction(DOMAIN1, createIntrospectRequest());
 
     assertThat(getUpdatedIntrospectVersion(), equalTo(INITIAL_VERSION));
   }
@@ -178,14 +202,14 @@ public class RestBackendImplTest {
   public void whenIntrospectionRequestedWhileIntrospectVersionDefined_incrementIntrospectVersion() {
     configurator.withIntrospectVersion("17");
 
-    restBackend.performDomainAction(NAME1, createIntrospectRequest());
+    restBackend.performDomainAction(DOMAIN1, createIntrospectRequest());
 
     assertThat(getUpdatedIntrospectVersion(), equalTo("18"));
   }
 
   @Test
   public void whenClusterRestartRequestedWhileNoRestartVersionDefined_setRestartVersion() {
-    restBackend.performDomainAction(NAME1, createDomainRestartRequest());
+    restBackend.performDomainAction(DOMAIN1, createDomainRestartRequest());
 
     assertThat(getUpdatedRestartVersion(), equalTo(INITIAL_VERSION));
   }
@@ -202,7 +226,7 @@ public class RestBackendImplTest {
   public void whenRestartRequestedWhileRestartVersionDefined_incrementIntrospectVersion() {
     configurator.withRestartVersion("23");
 
-    restBackend.performDomainAction(NAME1, createDomainRestartRequest());
+    restBackend.performDomainAction(DOMAIN1, createDomainRestartRequest());
 
     assertThat(getUpdatedRestartVersion(), equalTo("24"));
   }
@@ -211,36 +235,36 @@ public class RestBackendImplTest {
 
   @Test
   public void retrieveDefinedClusters() {
-    configSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3");
-    configSupport.addWlsCluster("cluster2", "ms4", "ms5", "ms6");
+    domain1ConfigSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3");
+    domain1ConfigSupport.addWlsCluster("cluster2", "ms4", "ms5", "ms6");
     setupScanCache();
 
-    assertThat(restBackend.getClusters(NAME1), containsInAnyOrder("cluster1", "cluster2"));
+    assertThat(restBackend.getClusters(DOMAIN1), containsInAnyOrder("cluster1", "cluster2"));
   }
 
   // functionality needed for cluster resource
 
   @Test
   public void acceptDefinedClusterName() {
-    configSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3");
-    configSupport.addWlsCluster("cluster2", "ms4", "ms5", "ms6");
+    domain1ConfigSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3");
+    domain1ConfigSupport.addWlsCluster("cluster2", "ms4", "ms5", "ms6");
     setupScanCache();
 
-    assertThat(restBackend.isCluster(NAME1, "cluster1"), is(true));
+    assertThat(restBackend.isCluster(DOMAIN1, "cluster1"), is(true));
   }
 
   @Test
   public void rejectUndefinedClusterName() {
-    configSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3");
-    configSupport.addWlsCluster("cluster2", "ms4", "ms5", "ms6");
+    domain1ConfigSupport.addWlsCluster("cluster1", "ms1", "ms2", "ms3");
+    domain1ConfigSupport.addWlsCluster("cluster2", "ms4", "ms5", "ms6");
     setupScanCache();
 
-    assertThat(restBackend.isCluster(NAME1, "cluster3"), is(false));
+    assertThat(restBackend.isCluster(DOMAIN1, "cluster3"), is(false));
   }
 
   @Test
   public void whenDomainRestartRequestedWhileNoRestartVersionDefined_setRestartVersion() {
-    restBackend.performDomainAction(NAME1, createDomainRestartRequest());
+    restBackend.performDomainAction(DOMAIN1, createDomainRestartRequest());
 
     assertThat(getUpdatedRestartVersion(), equalTo(INITIAL_VERSION));
   }
@@ -249,14 +273,14 @@ public class RestBackendImplTest {
 
   @Test(expected = WebApplicationException.class)
   public void whenNegativeScaleSpecified_throwException() {
-    restBackend.scaleCluster(NAME1, "cluster1", -1);
+    restBackend.scaleCluster(DOMAIN1, "cluster1", -1);
   }
 
   @Test
   public void whenPerClusterReplicaSettingMatchesScaleRequest_doNothing() {
     configureCluster("cluster1").withReplicas(5);
 
-    restBackend.scaleCluster(NAME1, "cluster1", 5);
+    restBackend.scaleCluster(DOMAIN1, "cluster1", 5);
 
     assertThat(getUpdatedDomain(), nullValue());
   }
@@ -273,7 +297,7 @@ public class RestBackendImplTest {
   public void whenPerClusterReplicaSetting_scaleClusterUpdatesSetting() {
     configureCluster("cluster1").withReplicas(1);
 
-    restBackend.scaleCluster(NAME1, "cluster1", 5);
+    restBackend.scaleCluster(DOMAIN1, "cluster1", 5);
 
     assertThat(getUpdatedDomain().getReplicaCount("cluster1"), equalTo(5));
   }
@@ -281,7 +305,7 @@ public class RestBackendImplTest {
   @Test
   @Ignore
   public void whenNoPerClusterReplicaSetting_scaleClusterCreatesOne() {
-    restBackend.scaleCluster(NAME1, "cluster1", 5);
+    restBackend.scaleCluster(DOMAIN1, "cluster1", 5);
 
     assertThat(getUpdatedDomain().getReplicaCount("cluster1"), equalTo(5));
   }
@@ -290,25 +314,25 @@ public class RestBackendImplTest {
   public void whenNoPerClusterReplicaSettingAndDefaultMatchesRequest_doNothing() {
     configureDomain().withDefaultReplicaCount(REPLICA_LIMIT);
 
-    restBackend.scaleCluster(NAME1, "cluster1", REPLICA_LIMIT);
+    restBackend.scaleCluster(DOMAIN1, "cluster1", REPLICA_LIMIT);
 
     assertThat(getUpdatedDomain(), nullValue());
   }
 
   @Test(expected = WebApplicationException.class)
   public void whenReplaceDomainReturnsError_scaleClusterThrowsException() {
-    testSupport.failOnResource(DOMAIN, NAME2, NS, HTTP_CONFLICT);
+    testSupport.failOnResource(DOMAIN, DOMAIN2, NS, HTTP_CONFLICT);
 
     DomainConfiguratorFactory.forDomain(domain2).configureCluster("cluster1").withReplicas(2);
 
-    restBackend.scaleCluster(NAME2, "cluster1", 3);
+    restBackend.scaleCluster(DOMAIN2, "cluster1", 3);
   }
 
   @Test
   public void verify_getWlsDomainConfig_returnsWlsDomainConfig() {
-    WlsDomainConfig wlsDomainConfig = ((RestBackendImpl) restBackend).getWlsDomainConfig(NAME1);
+    WlsDomainConfig wlsDomainConfig = ((RestBackendImpl) restBackend).getWlsDomainConfig(DOMAIN1);
 
-    assertThat(wlsDomainConfig.getName(), equalTo(NAME1));
+    assertThat(wlsDomainConfig.getName(), equalTo(DOMAIN1));
   }
 
   @Test
@@ -323,7 +347,7 @@ public class RestBackendImplTest {
   public void verify_getWlsDomainConfig_doesNotReturnNull_whenScanIsNull() {
     config = null;
 
-    WlsDomainConfig wlsDomainConfig = ((RestBackendImpl) restBackend).getWlsDomainConfig(NAME1);
+    WlsDomainConfig wlsDomainConfig = ((RestBackendImpl) restBackend).getWlsDomainConfig(DOMAIN1);
 
     assertThat(wlsDomainConfig, notNullValue());
   }
@@ -333,7 +357,7 @@ public class RestBackendImplTest {
   }
 
   private void setupScanCache() {
-    config = configSupport.createDomainConfig();
+    config = domain1ConfigSupport.createDomainConfig();
   }
 
   private class TopologyRetrieverStub implements TopologyRetriever {

--- a/operator/src/test/java/oracle/kubernetes/operator/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/rest/RestBackendImplTest.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.openapi.models.V1TokenReview;
 import io.kubernetes.client.openapi.models.V1TokenReviewStatus;
 import io.kubernetes.client.openapi.models.V1UserInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.operator.rest.RestBackendImpl.TopologyRetriever;
 import oracle.kubernetes.operator.rest.backend.RestBackend;
 import oracle.kubernetes.operator.rest.model.DomainAction;
@@ -79,6 +80,7 @@ public class RestBackendImplTest {
   @Before
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(TuningParametersStub.install());
     mementos.add(testSupport.install());
     mementos.add(
         StaticStubSupport.install(RestBackendImpl.class, "INSTANCE", new TopologyRetrieverStub()));

--- a/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
@@ -123,6 +123,11 @@ public class FiberTestSupport {
     return packet;
   }
 
+  public FiberTestSupport withClearPacket() {
+    packet.clear();
+    return this;
+  }
+
   public FiberTestSupport addToPacket(String key, Object value) {
     packet.put(key, value);
     return this;

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -13,7 +13,6 @@ import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
-import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
@@ -45,10 +44,9 @@ public class DomainValidationTest extends DomainValidationBaseTest {
   private static final String BAD_MOUNT_PATH_2 = "$(DOMAIN_HOME/servers/$(SERVER_NAME";
   private static final String BAD_MOUNT_PATH_3 = "$()DOMAIN_HOME/servers/SERVER_NAME";
 
-  private Domain domain = createTestDomain();
-  private final WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("mydomain");
-  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
-  private List<Memento> mementos = new ArrayList<>();
+  private final Domain domain = createTestDomain();
+  private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final List<Memento> mementos = new ArrayList<>();
 
   private static final String ADMIN_SERVER_NAME = "admin";
   private static final String CLUSTER = "cluster";
@@ -1029,7 +1027,7 @@ public class DomainValidationTest extends DomainValidationBaseTest {
         .configureAdminService()
         .withChannel("default");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, domainConfigWithCluster);
-    TuningParameters.getInstance().put(LegalNames.CLUSTER_SIZE_PADDING_VALIDATION_ENABLED_PARAM, "false");
+    TuningParametersStub.setParameter(Domain.CLUSTER_SIZE_PADDING_VALIDATION_ENABLED_PARAM, "false");
     assertThat(myDomain.getAfterIntrospectValidationFailures(testSupport.getPacket()),  empty());
   }
 
@@ -1056,7 +1054,7 @@ public class DomainValidationTest extends DomainValidationBaseTest {
         .configureAdminService()
         .withChannel("default");
     testSupport.addToPacket(DOMAIN_TOPOLOGY, domainConfigWithCluster);
-    TuningParameters.getInstance().put(LegalNames.CLUSTER_SIZE_PADDING_VALIDATION_ENABLED_PARAM, "false");
+    TuningParametersStub.setParameter(Domain.CLUSTER_SIZE_PADDING_VALIDATION_ENABLED_PARAM, "false");
     assertThat(myDomain.getAfterIntrospectValidationFailures(testSupport.getPacket()),  empty());
   }
 


### PR DESCRIPTION
This refactoring eliminates a lot of duplicate code and centralizes much of the processing of domain namespaces, including management of watchers. It also addresses some misuse of Kubernetes resource versions: according to the documentation, the initial reference version for a watcher should be taken from the result of a list operation. In two cases, configmaps and jobs, we were using resource versions from other resources.

In the current K8s implementation, that doesn't matter, as it currently uses the etcd modifiedIndex which is consistent for a server; however, that is subject to change.

This cleanup has highlighted some additional issues I hope to address in the next PR, including the fact that we do different processing for a namespace that was in existence before the operator started than for one created while the operator is running. For example, the ADDED event handling of the Namespace watcher has special handling for the script map, while it should be handled by common namespace startup code.

Successful integration test run at https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2548/