### PR TITLE
remove "if __name__ == 'main':" in the python scripts used in test 

### DIFF
--- a/integration-tests/src/test/resources/python-scripts/application_deployment.py
+++ b/integration-tests/src/test/resources/python-scripts/application_deployment.py
@@ -9,8 +9,6 @@ from java.util import Base64
 from org.apache.commons.io import FileUtils
 from java.io import File
 
-
-
 script_name = 'application_deployment.py'
 print 'script_name: ' + script_name
 
@@ -65,8 +63,8 @@ def deploy_application():
     print dumpStack()
     apply(traceback.print_exception, sys.exc_info())
     exit(exitcode=1)
- 
-if __name__== "main": 
-  decode_archive()
-  deploy_application()
-  exit()
+
+decode_archive()
+deploy_application()
+exit()
+

--- a/integration-tests/src/test/resources/python-scripts/changeListenPort.py
+++ b/integration-tests/src/test/resources/python-scripts/changeListenPort.py
@@ -48,6 +48,5 @@ def change_listenportenabled():
     apply(traceback.print_exception, sys.exc_info())
     exit(exitcode=1)
 
-if __name__== "main":
-  change_listenportenabled()
-  exit()
+change_listenportenabled()
+exit()

--- a/integration-tests/src/test/resources/python-scripts/create-jdbc-resource.py
+++ b/integration-tests/src/test/resources/python-scripts/create-jdbc-resource.py
@@ -34,18 +34,18 @@ def createDataSource(dsName, dsURL, dsDriver, dsUser, dsPassword, dsTarget):
     cd('/JDBCSystemResources/'+dsName)
     set('Targets',jarray.array([ObjectName('com.bea:Name=' + dsTarget + ',Type=Cluster')], ObjectName))
 
-if __name__== "main":
-  admin_t3_url = 't3://'+admin_host+':'+admin_port
-  try:
-    connect(admin_username, admin_password, admin_t3_url)
-    edit()
-    startEdit()
-    createDataSource(dsName, dsUrl, dsDriver, dsUser, dsPassword, dsTarget)
-    activate()
-    disconnect()
-    exit()
-  except:
-    print 'Creating JDBC datasource failed'
-    print dumpStack()
-    apply(traceback.print_exception, sys.exc_info())
-    exit(exitcode=1)
+
+admin_t3_url = 't3://'+admin_host+':'+admin_port
+try:
+  connect(admin_username, admin_password, admin_t3_url)
+  edit()
+  startEdit()
+  createDataSource(dsName, dsUrl, dsDriver, dsUser, dsPassword, dsTarget)
+  activate()
+  disconnect()
+  exit()
+except:
+  print 'Creating JDBC datasource failed'
+  print dumpStack()
+  apply(traceback.print_exception, sys.exc_info())
+  exit(exitcode=1)

--- a/integration-tests/src/test/resources/python-scripts/introspect_version_script.py
+++ b/integration-tests/src/test/resources/python-scripts/introspect_version_script.py
@@ -123,13 +123,12 @@ def get_admin_server_name():
   serverConfig()
   return admin_server_name
 
-if __name__== "main":
-  if(test_name == 'change_server_count'):
-    change_server_count()
-  if(test_name == 'change_admin_port'):
-    change_admin_port()
-  if(test_name == 'create_cluster'):
-    create_static_cluster()
-  if(test_name == 'replace_admin_user'):
-    replace_admin_user()
-  exit()
+if(test_name == 'change_server_count'):
+  change_server_count()
+if(test_name == 'change_admin_port'):
+  change_admin_port()
+if(test_name == 'create_cluster'):
+  create_static_cluster()
+if(test_name == 'replace_admin_user'):
+  replace_admin_user()
+exit()


### PR DESCRIPTION
With WLS 14.1.1.0 image, the test ItParameterizedDomain#testParamsScaleClustersWithRestApi failed in the domain type domain on pv. The root cause is that in WLS 1411 the usage of "main" of python script got changed. This change caused the application failed to deploy using  the file integration-tests/src/test/resources/python-scripts/application-deployment.py.

See the release note: https://docs.oracle.com/en/middleware/standalone/weblogic-server/14.1.1.0/wlsrn/issues.html#GUID-2F716208-D9A4-4586-91E8-A340DCD0CBF0

This PR removed "if __name__ == 'main':" clause in the python scripts used in test.

Jenkins run:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2571/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2574/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2648/

with 14.1.1.0-8 image:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2652/ (test failures are due to a known bug)
with 14.1.1.0-11 image:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2651/ (test failures are due to a known bug)