### PR TITLE
Change the domain name to be unique

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
@@ -93,7 +93,7 @@ public class ItSystemResOverrides {
 
   private static String opNamespace = null;
   private static String domainNamespace = null;
-  final String domainUid = "mydomain";
+  final String domainUid = "mysitconfigdomain";
   final String clusterName = "mycluster";
   final String adminServerName = "admin-server";
   final String adminServerPodName = domainUid + "-" + adminServerName;


### PR DESCRIPTION
The ItConfigDistributionStrategy and ItSystemResOverrides uses the same pv name for the domain. This results in a pv name clash when both these tests are running at the same time in parallel runs.

Fix is to change the domain name to be unique in both tests so that pv name which is derived from domainUID can be unique.