### PR TITLE
Owls 84815

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
@@ -12,12 +12,6 @@ import oracle.kubernetes.operator.work.Step;
 
 /** A set of underlying services required during domain processing. */
 public interface DomainProcessorDelegate {
-  /**
-   * Returns the namespace associated with the operator itself.
-   *
-   * @return a namespace string
-   */
-  String getOperatorNamespace();
 
   /**
    * Returns a factory that creates a step to wait for a pod in the specified namespace to be ready.

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
@@ -6,9 +6,7 @@ package oracle.kubernetes.operator;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatus;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
-import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.work.FiberGate;
 import oracle.kubernetes.operator.work.Step;
 
@@ -37,8 +35,6 @@ public interface DomainProcessorDelegate {
    */
   JobAwaiterStepFactory getJobAwaiterStepFactory(String namespace);
 
-  V1SubjectRulesReviewStatus getSubjectRulesReviewStatus(String namespace);
-
   /**
    * Returns true if the namespace is running.
    *
@@ -53,13 +49,6 @@ public interface DomainProcessorDelegate {
    * @return an object that represents the Kubernetes version
    */
   KubernetesVersion getVersion();
-
-  /**
-   * Returns the version of the operator.
-   *
-   * @return an object that represents the semantic version
-   */
-  SemanticVersion getProductVersion();
 
   /**
    * Creates a new FiberGate.

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
@@ -29,6 +29,14 @@ public interface DomainProcessorDelegate {
    */
   PodAwaiterStepFactory getPodAwaiterStepFactory(String namespace);
 
+  /**
+   * Returns a factory that creates a step to wait for a pod in the specified namespace to be ready.
+   *
+   * @param namespace the namespace for the pod
+   * @return a step-creating factory
+   */
+  JobAwaiterStepFactory getJobAwaiterStepFactory(String namespace);
+
   V1SubjectRulesReviewStatus getSubjectRulesReviewStatus(String namespace);
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -698,6 +698,7 @@ public class DomainProcessorImpl implements DomainProcessor {
               ProcessingConstants.DOMAIN_COMPONENT_NAME,
               Component.createFor(liveInfo, delegate.getVersion(),
                   PodAwaiterStepFactory.class, delegate.getPodAwaiterStepFactory(getNamespace()),
+                  JobAwaiterStepFactory.class, delegate.getJobAwaiterStepFactory(getNamespace()),
                   V1SubjectRulesReviewStatus.class, delegate.getSubjectRulesReviewStatus(getNamespace())));
       runDomainPlan(
             getDomain(),

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -28,7 +28,6 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceList;
-import io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatus;
 import io.kubernetes.client.util.Watch;
 import oracle.kubernetes.operator.TuningParameters.MainTuning;
 import oracle.kubernetes.operator.calls.FailureStatusSourceException;
@@ -438,15 +437,13 @@ public class DomainProcessorImpl implements DomainProcessor {
         delegate.scheduleWithFixedDelay(
             () -> {
               try {
-                V1SubjectRulesReviewStatus srrs =
-                    delegate.getSubjectRulesReviewStatus(info.getNamespace());
                 Packet packet = new Packet();
                 packet
                     .getComponents()
                     .put(
                         ProcessingConstants.DOMAIN_COMPONENT_NAME,
                         Component.createFor(
-                            info, delegate.getVersion(), V1SubjectRulesReviewStatus.class, srrs));
+                            info, delegate.getVersion()));
                 packet.put(LoggingFilter.LOGGING_FILTER_PACKET_KEY, loggingFilter);
                 Step strategy =
                     ServerStatusReader.createStatusStep(main.statusUpdateTimeoutSeconds, null);
@@ -698,8 +695,7 @@ public class DomainProcessorImpl implements DomainProcessor {
               ProcessingConstants.DOMAIN_COMPONENT_NAME,
               Component.createFor(liveInfo, delegate.getVersion(),
                   PodAwaiterStepFactory.class, delegate.getPodAwaiterStepFactory(getNamespace()),
-                  JobAwaiterStepFactory.class, delegate.getJobAwaiterStepFactory(getNamespace()),
-                  V1SubjectRulesReviewStatus.class, delegate.getSubjectRulesReviewStatus(getNamespace())));
+                  JobAwaiterStepFactory.class, delegate.getJobAwaiterStepFactory(getNamespace())));
       runDomainPlan(
             getDomain(),
             getDomainUid(),

--- a/operator/src/main/java/oracle/kubernetes/operator/JobAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobAwaiterStepFactory.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import io.kubernetes.client.openapi.models.V1Job;
+import oracle.kubernetes.operator.work.Step;
+
+public interface JobAwaiterStepFactory {
+
+  Step waitForReady(V1Job job, Step next);
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -838,6 +838,11 @@ public class Main {
     }
 
     @Override
+    public JobAwaiterStepFactory getJobAwaiterStepFactory(String namespace) {
+      return DomainNamespaces.getJobWatcher(namespace);
+    }
+
+    @Override
     public V1SubjectRulesReviewStatus getSubjectRulesReviewStatus(String namespace) {
       return DomainNamespaces.getNamespaceStatus(namespace).getRulesReviewStatus().get();
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -449,11 +449,11 @@ public class Main {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1NamespaceList> callResponse) {
-        final String intialResourceVersion = KubernetesUtils.getResourceVersion(callResponse.getResult());
+        final String initialResourceVersion = KubernetesUtils.getResourceVersion(callResponse.getResult());
         final Set<String> domainNamespaces = getNamespacesToStart(getNames(callResponse.getResult()));
         getFoundDomainNamespaces(packet).addAll(domainNamespaces);
 
-        return doContinueListOrNext(callResponse, packet, createNextSteps(intialResourceVersion, domainNamespaces));
+        return doContinueListOrNext(callResponse, packet, createNextSteps(initialResourceVersion, domainNamespaces));
       }
 
       private Step createNextSteps(String intialResourceVersion, Set<String> namespacesToStartNow) {
@@ -565,7 +565,7 @@ public class Main {
         new AtomicBoolean(false));
   }
 
-  private static void dispatchNamespaceWatch(Watch.Response<V1Namespace> item) {
+  static void dispatchNamespaceWatch(Watch.Response<V1Namespace> item) {
     String ns = Optional.ofNullable(item.object).map(V1Namespace::getMetadata).map(V1ObjectMeta::getName).orElse(null);
     if (ns == null) {
       return;

--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -6,6 +6,9 @@ package oracle.kubernetes.operator;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.work.Engine;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
 
 /**
  * Definition of an interface that returns values that the Main class requires.
@@ -14,11 +17,19 @@ interface MainDelegate {
 
   void logStartup(LoggingFacade loggingFacade);
 
-  abstract SemanticVersion getProductVersion();
+  SemanticVersion getProductVersion();
 
   String getServiceAccountName();
 
   String getPrincipal();
+
+  Engine getEngine();
+
+  default void runSteps(Step firstStep) {
+    runSteps(new Packet(), firstStep, null);
+  }
+
+  void runSteps(Packet packet, Step firstStep, Runnable completionAction);
 
   DomainProcessor getProcessor();
 

--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -3,9 +3,15 @@
 
 package oracle.kubernetes.operator;
 
+import oracle.kubernetes.operator.helpers.SemanticVersion;
+
 /**
  * Definition of an interface that returns values that the Main class requires.
  */
 interface MainDelegate {
 
+  /**
+   * Returns the version of the operator.
+   */
+  SemanticVersion getProductVersion();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -1,0 +1,11 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+/**
+ * Definition of an interface that returns values that the Main class requires.
+ */
+interface MainDelegate {
+
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -4,14 +4,20 @@
 package oracle.kubernetes.operator;
 
 import oracle.kubernetes.operator.helpers.SemanticVersion;
+import oracle.kubernetes.operator.logging.LoggingFacade;
 
 /**
  * Definition of an interface that returns values that the Main class requires.
  */
 interface MainDelegate {
 
-  /**
-   * Returns the version of the operator.
-   */
-  SemanticVersion getProductVersion();
+  void logStartup(LoggingFacade loggingFacade);
+
+  abstract SemanticVersion getProductVersion();
+
+  String getServiceAccountName();
+
+  String getPrincipal();
+
+  DomainProcessor getProcessor();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 
@@ -20,4 +21,6 @@ interface MainDelegate {
   String getPrincipal();
 
   DomainProcessor getProcessor();
+
+  KubernetesVersion getKubernetesVersion();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/NamespaceStrategyVisitor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/NamespaceStrategyVisitor.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+/**
+ * A class which implements different behavior based on the strategy defined for finding domain namespaces.
+ * Uses the Visitor pattern (see https://en.wikipedia.org/wiki/Visitor_pattern)
+ */
+public interface NamespaceStrategyVisitor<T> {
+
+  default T getDefaultSelection() {
+    return null;
+  }
+
+  default T getListStrategySelection() {
+    return getDefaultSelection();
+  }
+
+  default T getDedicatedStrategySelection() {
+    return getDefaultSelection();
+  }
+
+  default T getRegexpStrategySelection() {
+    return getDefaultSelection();
+  }
+
+  default T getLabelSelectorStrategySelection() {
+    return getDefaultSelection();
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/NamespaceStrategyVisitor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/NamespaceStrategyVisitor.java
@@ -5,13 +5,10 @@ package oracle.kubernetes.operator;
 
 /**
  * A class which implements different behavior based on the strategy defined for finding domain namespaces.
- * Uses the Visitor pattern (see https://en.wikipedia.org/wiki/Visitor_pattern)
+ * Uses the Visitor pattern (see https://en.wikipedia.org/wiki/Visitor_pattern). Implementations should
+ * either define all of the strategy-specific methods or at least one of them as well as the default selection.
  */
 public interface NamespaceStrategyVisitor<T> {
-
-  default T getDefaultSelection() {
-    return null;
-  }
 
   default T getListStrategySelection() {
     return getDefaultSelection();
@@ -27,5 +24,9 @@ public interface NamespaceStrategyVisitor<T> {
 
   default T getLabelSelectorStrategySelection() {
     return getDefaultSelection();
+  }
+
+  default T getDefaultSelection() {
+    return null;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/Namespaces.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Namespaces.java
@@ -1,0 +1,268 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import oracle.kubernetes.operator.helpers.HelmAccess;
+import oracle.kubernetes.operator.helpers.NamespaceHelper;
+import oracle.kubernetes.operator.logging.LoggingContext;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.logging.MessageKeys;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+
+import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
+
+/**
+ * A class which manages the strategy for recognizing the namespaces in which the operator will manage
+ * domains.
+ */
+public class Namespaces {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  public static final String SELECTION_STRATEGY_KEY = "domainNamespaceSelectionStrategy";
+  /**
+   * The key in a Packet of the collection of existing namespaces that are designated as domain namespaces.
+   */
+  static final String ALL_DOMAIN_NAMESPACES = "ALL_DOMAIN_NAMESPACES";
+
+  boolean isFullRecheck;
+
+  public Namespaces(boolean isFullRecheck) {
+    this.isFullRecheck = isFullRecheck;
+  }
+
+  /**
+   * Returns true if the specified string is the name of a domain namespace.
+   * @param ns a namespace name
+   */
+  static boolean isDomainNamespace(String ns) {
+    return getSelectionStrategy().isDomainNamespace(ns);
+  }
+
+  /**
+   * Returns a (possibly empty) collection of strings which designate namespaces for the operator to manage.
+   */
+  static @Nullable Collection<String> getConfiguredDomainNamespaces() {
+    return getSelectionStrategy().getConfiguredDomainNamespaces();
+  }
+
+
+  /**
+   * Returns an array of the label selectors that will determine that a namespace is being used to manage domains.
+   */
+  static String[] getLabelSelectors() {
+    return getSelectionStrategy().getLabelSelectors();
+  }
+
+  static <R> R getSelection(NamespaceStrategyVisitor<R> visitor) {
+    return getSelectionStrategy().getSelection(visitor);
+  }
+
+  public enum SelectionStrategy {
+    List {
+      @Override
+      public boolean isDomainNamespace(@Nonnull String namespaceName) {
+        return getConfiguredDomainNamespaces().contains(namespaceName);
+      }
+
+      @Override
+      public @Nonnull Collection<String> getConfiguredDomainNamespaces() {
+        return NamespaceHelper.parseNamespaceList(getNamespaceList());
+      }
+
+      @Override
+      public <V> V getSelection(NamespaceStrategyVisitor<V> visitor) {
+        return visitor.getListStrategySelection();
+      }
+
+      private String getNamespaceList() {
+        return Optional.ofNullable(HelmAccess.getHelmSpecifiedNamespaceList()).orElse(getInternalNamespaceList());
+      }
+
+      private String getInternalNamespaceList() {
+        return Optional.ofNullable(getConfiguredNamespaceList()).orElse(getOperatorNamespace());
+      }
+
+      private String getConfiguredNamespaceList() {
+        return Optional.ofNullable(TuningParameters.getInstance().get("domainNamespaces"))
+              .orElse(TuningParameters.getInstance().get("targetNamespaces"));
+      }
+    },
+    LabelSelector {
+      @Override
+      public String[] getLabelSelectors() {
+        return new String[]{TuningParameters.getInstance().get("domainNamespaceLabelSelector")};
+      }
+
+      @Override
+      public <V> V getSelection(NamespaceStrategyVisitor<V> visitor) {
+        return visitor.getLabelSelectorStrategySelection();
+      }
+
+      @Override
+      public boolean isDomainNamespace(@Nonnull String namespaceName) {
+        return true;  // filtering is done by Kubernetes list call
+      }
+    },
+    RegExp {
+      @Override
+      public boolean isDomainNamespace(@Nonnull String namespaceName) {
+        try {
+          return getCompiledPattern(getRegExp()).matcher(namespaceName).find();
+        } catch (PatternSyntaxException e) {
+          LOGGER.severe(MessageKeys.EXCEPTION, e);
+          return false;
+        }
+      }
+
+      @Override
+      public <V> V getSelection(NamespaceStrategyVisitor<V> visitor) {
+        return visitor.getRegexpStrategySelection();
+      }
+
+      private String getRegExp() {
+        return TuningParameters.getInstance().get("domainNamespaceRegExp");
+      }
+
+      private Pattern getCompiledPattern(String regExp) {
+        return compiledPatterns.computeIfAbsent(regExp, Pattern::compile);
+      }
+    },
+    Dedicated {
+      @Override
+      public boolean isDomainNamespace(@Nonnull String namespaceName) {
+        return namespaceName.equals(getOperatorNamespace());
+      }
+
+      @Override
+      public Collection<String> getConfiguredDomainNamespaces() {
+        return Collections.singleton(getOperatorNamespace());
+      }
+
+      @Override
+      public <V> V getSelection(NamespaceStrategyVisitor<V> visitor) {
+        return visitor.getDedicatedStrategySelection();
+      }
+    };
+
+    static final String[] NO_SELECTORS = new String[0];
+
+    public abstract boolean isDomainNamespace(@Nonnull String namespaceName);
+
+    public String[] getLabelSelectors() {
+      return NO_SELECTORS;
+    }
+
+    public @Nullable Collection<String> getConfiguredDomainNamespaces() {
+      return null;
+    }
+
+    public abstract <V> V getSelection(NamespaceStrategyVisitor<V> visitor);
+
+    private static final Map<String, Pattern> compiledPatterns = new WeakHashMap<>();
+  }
+
+  /**
+   * Returns a modifiable collection of found namespace names in a packet.
+   * Callers should use this to add to the collection.
+   *
+   * @param packet the packet passed to a step
+   */
+  @SuppressWarnings("unchecked")
+  static Collection<String> getFoundDomainNamespaces(Packet packet) {
+    if (!packet.containsKey(ALL_DOMAIN_NAMESPACES)) {
+      packet.put(ALL_DOMAIN_NAMESPACES, new HashSet<>());
+    }
+    return (Collection<String>) packet.get(ALL_DOMAIN_NAMESPACES);
+  }
+
+  /**
+   * Gets the configured domain namespace selection strategy.
+   *
+   * @return Selection strategy
+   */
+  static SelectionStrategy getSelectionStrategy() {
+    SelectionStrategy strategy =
+          Optional.ofNullable(TuningParameters.getInstance().get(SELECTION_STRATEGY_KEY))
+                .map(SelectionStrategy::valueOf)
+                .orElse(SelectionStrategy.List);
+
+    if (SelectionStrategy.List.equals(strategy) && isDeprecatedDedicated()) {
+      return SelectionStrategy.Dedicated;
+    }
+    return strategy;
+  }
+
+  // Returns true if the deprecated way to specify the dedicated namespace strategy is being used.
+  // This value will only be used if the 'list' namespace strategy is specified or defaulted.
+  private static boolean isDeprecatedDedicated() {
+    return "true".equalsIgnoreCase(getDeprecatedDedicatedSetting());
+  }
+
+  private static String getDeprecatedDedicatedSetting() {
+    return Optional.ofNullable(TuningParameters.getInstance().get("dedicated")).orElse("false");
+  }
+
+
+  // checks the list of namespace names collected above. If any configured namespaces are not found, logs a warning.
+  static class NamespaceListAfterStep extends Step {
+
+    @Override
+    public NextAction apply(Packet packet) {
+      NamespaceValidationContext validationContext = new NamespaceValidationContext(packet);
+      getNonNullConfiguredDomainNamespaces().forEach(validationContext::validateConfiguredNamespace);
+      stopRemovedNamespaces(validationContext);
+      return doNext(packet);
+    }
+
+    @Nonnull
+    static Collection<String> getNonNullConfiguredDomainNamespaces() {
+      return Optional.ofNullable(getConfiguredDomainNamespaces()).orElse(Collections.emptyList());
+    }
+
+    // Halts processing of any managed namespaces that are no longer to be managed, either because
+    // they have been deleted from the Kubernetes cluster or because the operator is no longer configured for them.
+    private void stopRemovedNamespaces(NamespaceValidationContext validationContext) {
+      DomainNamespaces.getNamespaces().stream()
+            .filter(validationContext::isNoLongerActiveDomainNamespace)
+            .forEach(DomainNamespaces::stopNamespace);
+    }
+  }
+
+
+  private static class NamespaceValidationContext {
+
+    Collection<String> allDomainNamespaces;
+
+    NamespaceValidationContext(Packet packet) {
+      allDomainNamespaces = Optional.ofNullable(getFoundDomainNamespaces(packet)).orElse(Collections.emptyList());
+    }
+
+    private boolean isNoLongerActiveDomainNamespace(String ns) {
+      return !allDomainNamespaces.contains(ns);
+    }
+
+    private void validateConfiguredNamespace(String namespace) {
+      if (isNoLongerActiveDomainNamespace(namespace)) {
+        try (LoggingContext ignored = LoggingContext.setThreadContext().namespace(namespace)) {
+          LOGGER.warning(MessageKeys.NAMESPACE_IS_MISSING, namespace);
+        }
+      }
+    }
+  }
+
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -10,6 +10,7 @@ public interface ProcessingConstants {
   String DOMAIN_COMPONENT_NAME = "domain";
   String FIBER_COMPONENT_NAME = "fiber";
   String PODWATCHER_COMPONENT_NAME = "podWatcher";
+  String JOBWATCHER_COMPONENT_NAME = "jobWatcher";
 
   /** key to an object of type WlsServerConfig. */
   String SERVER_SCAN = "serverScan";

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -29,7 +29,8 @@ abstract class WaitForReadyStep<T> extends Step {
 
   static int getWatchBackstopRecheckDelaySeconds() {
     return Optional.ofNullable(TuningParameters.getInstance())
-            .map(parameters -> parameters.getWatchTuning().watchBackstopRecheckDelay)
+            .map(TuningParameters::getWatchTuning)
+            .map(t -> t.watchBackstopRecheckDelay)
             .orElse(DEFAULT_RECHECK_SECONDS);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/HealthCheckHelper.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.helpers;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ResourceRule;
@@ -18,6 +19,8 @@ import oracle.kubernetes.operator.helpers.AuthorizationProxy.Resource;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
+
+import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
 
 /** A Helper Class for checking the health of the WebLogic Operator. */
 public final class HealthCheckHelper {
@@ -106,42 +109,36 @@ public final class HealthCheckHelper {
   /**
    * Verify Access.
    *
-   * @param version Kubernetes version
-   * @param operatorNamespace operator namespace
    * @param namespace domain namespace
    * @return self subject rules review for the domain namespace
    */
-  public static V1SubjectRulesReviewStatus performSecurityChecks(
-      KubernetesVersion version, String operatorNamespace, String namespace) {
-    String ns = namespace != null ? namespace : operatorNamespace;
-
+  public static V1SubjectRulesReviewStatus getAccessAuthorizations(@Nonnull String namespace) {
     // Validate namespace
-    if (DEFAULT_NAMESPACE.equals(operatorNamespace)) {
+    if (DEFAULT_NAMESPACE.equals(getOperatorNamespace())) {
       LOGGER.fine(MessageKeys.NAMESPACE_IS_DEFAULT);
     }
 
     // Validate policies allow service account to perform required operations
     AuthorizationProxy ap = new AuthorizationProxy();
-    LOGGER.fine(MessageKeys.VERIFY_ACCESS_START, ns);
+    LOGGER.fine(MessageKeys.VERIFY_ACCESS_START, namespace);
 
-    V1SelfSubjectRulesReview review = ap.review(ns);
+    V1SelfSubjectRulesReview review = ap.review(namespace);
     if (review != null) {
       V1SubjectRulesReviewStatus status = review.getStatus();
 
       if (status != null) {
         List<V1ResourceRule> rules = status.getResourceRules();
 
-        if (namespace != null) {
-          for (Resource r : namespaceAccessChecks.keySet()) {
-            for (Operation op : namespaceAccessChecks.get(r)) {
-              check(rules, r, op, namespace);
-            }
+        for (Resource r : namespaceAccessChecks.keySet()) {
+          for (Operation op : namespaceAccessChecks.get(r)) {
+            check(rules, r, op, namespace);
           }
         }
-        if (!Main.isDedicated() && operatorNamespace.equals(ns)) {
+
+        if (!Main.isDedicated() && getOperatorNamespace().equals(namespace)) {
           for (Resource r : clusterAccessChecks.keySet()) {
             for (Operation op : clusterAccessChecks.get(r)) {
-              check(rules, r, op, ns);
+              check(rules, r, op, namespace);
             }
           }
         }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesVersion.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesVersion.java
@@ -7,7 +7,8 @@ import io.kubernetes.client.openapi.models.VersionInfo;
 
 /** Major and minor version of Kubernetes API Server. */
 public class KubernetesVersion extends SemanticVersion {
-  public static final KubernetesVersion TEST_VERSION = new KubernetesVersion(1, 10);
+  public static final VersionInfo TEST_VERSION_INFO = new VersionInfo().major("1").minor("18").gitVersion("0");
+  public static final KubernetesVersion TEST_VERSION = new KubernetesVersion(TEST_VERSION_INFO);
   private static final String[] MINIMUM_K8S_VERSIONS = {"1.14.8", "1.15.7", "1.16.0", "1.17.0", "1.18.0"};
   static final KubernetesVersion UNREADABLE = new KubernetesVersion(0, 0);
   private final String version;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/SemanticVersion.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/SemanticVersion.java
@@ -8,6 +8,8 @@ import javax.validation.constraints.NotNull;
 
 /** Major, minor and revision version specification for a product. */
 public class SemanticVersion implements Comparable<SemanticVersion> {
+  public static final SemanticVersion TEST_VERSION = new SemanticVersion(3,1);
+
   private final int major;
   private final int minor;
   private final int revision;

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -133,6 +133,7 @@ public class MessageKeys {
   public static final String INTROSPECTOR_JOB_FAILED = "WLSKO-0175";
   public static final String INTROSPECTOR_JOB_FAILED_DETAIL = "WLSKO-0176";
   public static final String INTROSPECTOR_POD_FAILED = "WLSKO-0177";
+  public static final String CRD_NOT_INSTALLED = "WLSKO-0180";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -187,6 +187,7 @@ WLSKO-0175=Job {0} in namespace {1} failed with status {2}. Check log messages \
   copied from the introspector pod {3} log for additional information.
 WLSKO-0176=Job {1} in namespace {0} failed, job details are {2}
 WLSKO-0177=Pod {0} in namespace {1} failed, the pod status is {2}
+WLSKO-0180=Operator cannot start. 'Dedicated' namespace strategy selected, but the CRD is not installed
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatus;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.work.FiberGate;
@@ -47,11 +46,6 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
   @Override
   public JobAwaiterStepFactory getJobAwaiterStepFactory(String namespace) {
     return new PassthroughJobAwaiterStepFactory();
-  }
-
-  @Override
-  public V1SubjectRulesReviewStatus getSubjectRulesReviewStatus(String namespace) {
-    return null;
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.IntStream;
@@ -22,6 +23,8 @@ import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobCondition;
+import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1Secret;
@@ -31,6 +34,7 @@ import io.kubernetes.client.openapi.models.V1ServiceSpec;
 import oracle.kubernetes.operator.helpers.AnnotationHelper;
 import oracle.kubernetes.operator.helpers.ConfigMapHelper;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.IntrospectionTestUtils;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.KubernetesUtils;
 import oracle.kubernetes.operator.helpers.LegalNames;
@@ -105,14 +109,26 @@ public class DomainProcessorTest {
   private final List<LogRecord> logRecords = new ArrayList<>();
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final Map<String, Map<String, DomainPresenceInfo>> presenceInfoMap = new HashMap<>();
-  private final DomainProcessorImpl processor =
-      new DomainProcessorImpl(DomainProcessorDelegateStub.createDelegate(testSupport));
+  private final DomainProcessorDelegateStub processorDelegate = DomainProcessorDelegateStub.createDelegate(testSupport);
+  private final DomainProcessorImpl processor = new DomainProcessorImpl(processorDelegate);
   private final Domain domain = DomainProcessorTestSetup.createTestDomain();
   private final Domain newDomain = DomainProcessorTestSetup.createTestDomain();
   private final DomainConfigurator domainConfigurator = configureDomain(newDomain);
   private final MakeRightDomainOperation makeRightOperation
         = processor.createMakeRightOperation(new DomainPresenceInfo(newDomain));
   private final WlsDomainConfig domainConfig = createDomainConfig();
+
+  private V1JobStatus jobStatus = createCompletedStatus();
+  private final Supplier<V1JobStatus> jobStatusSupplier = () -> jobStatus;
+
+  V1JobStatus createCompletedStatus() {
+    return new V1JobStatus()
+          .addConditionsItem(new V1JobCondition().type("Complete").status("True"));
+  }
+
+  V1JobStatus createNotCompletedStatus() {
+    return new V1JobStatus();
+  }
 
   private static WlsDomainConfig createDomainConfig() {
     WlsClusterConfig clusterConfig = new WlsClusterConfig(CLUSTER);
@@ -124,10 +140,6 @@ public class DomainProcessorTest {
         .withCluster(clusterConfig);
   }
 
-  /**
-   * Setup test environment.
-   * @throws Exception if StaticStubSupport fails to install
-   */
   @Before
   public void setUp() throws Exception {
     mementos.add(TestUtils.silenceOperatorLogger()
@@ -140,18 +152,13 @@ public class DomainProcessorTest {
     mementos.add(ScanCacheStub.install());
 
     testSupport.defineResources(newDomain);
-    new DomainProcessorTestSetup(testSupport).defineKubernetesResources(createDomainConfig());
+    IntrospectionTestUtils.defineResources(testSupport, createDomainConfig(), jobStatusSupplier);
     DomainProcessorTestSetup.defineRequiredResources(testSupport);
   }
 
-  /**
-   * Cleanup test environment.
-   */
   @After
   public void tearDown() {
-    for (Memento memento : mementos) {
-      memento.revert();
-    }
+    mementos.forEach(Memento::revert);
   }
 
   @Test
@@ -350,6 +357,19 @@ public class DomainProcessorTest {
     assertThat(makeRight.wasInspectionRun(), is(true));
   }
 
+  @Test
+  public void whenIntrospectionJobNotComplete_waitForIt() throws Exception {
+    establishPreviousIntrospection(null);
+    jobStatus = createNotCompletedStatus();
+
+    domainConfigurator.withIntrospectVersion(NEW_INTROSPECTION_STATE);
+    MakeRightDomainOperation makeRight = this.processor.createMakeRightOperation(
+          new DomainPresenceInfo(newDomain)).interrupt();
+    makeRight.execute();
+
+    assertThat(processorDelegate.waitedForIntrospection(), is(true));
+  }
+
   private void establishPreviousIntrospection(Consumer<Domain> domainSetup) throws JsonProcessingException {
     if (domainSetup != null) {
       domainSetup.accept(domain);
@@ -387,7 +407,7 @@ public class DomainProcessorTest {
   }
 
   private String defineTopology() throws JsonProcessingException {
-    return DomainProcessorTestSetup.createTopologyYaml(createDomainConfig());
+    return IntrospectionTestUtils.createTopologyYaml(createDomainConfig());
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
@@ -3,24 +3,13 @@
 
 package oracle.kubernetes.operator;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.kubernetes.client.openapi.models.V1Job;
-import io.kubernetes.client.openapi.models.V1JobCondition;
-import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretReference;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
-import oracle.kubernetes.operator.helpers.LegalNames;
-import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import org.joda.time.DateTime;
-
-import static oracle.kubernetes.operator.ProcessingConstants.JOB_POD_NAME;
 
 /**
  * Setup for tests that will involve running the main domain processor functionality. Such tests
@@ -33,37 +22,6 @@ public class DomainProcessorTestSetup {
   public static final String SECRET_NAME = "secret-name";
   public static final String KUBERNETES_UID = "12345";
   public static final String NODE_NAME = "Node1";
-
-  private static final String INTROSPECTION_JOB = LegalNames.toJobIntrospectorName(UID);
-  private static final String INTROSPECT_RESULT =
-      ">>>  /u01/introspect/domain1/userConfigNodeManager.secure\n"
-          + "#WebLogic User Configuration File; 2\n"
-          + "#Thu Oct 04 21:07:06 GMT 2018\n"
-          + "weblogic.management.username={AES}fq11xKVoE927O07IUKhQ00d4A8QY598Dvd+KSnHNTEA\\=\n"
-          + "weblogic.management.password={AES}LIxVY+aqI8KBkmlBTwkvAnQYQs4PS0FX3Ili4uLBggo\\=\n"
-          + "\n"
-          + ">>> EOF\n"
-          + "\n"
-          + "@[2018-10-04T21:07:06.864 UTC][introspectDomain.py:105] Printing file "
-          + "/u01/introspect/domain1/userKeyNodeManager.secure\n"
-          + "\n"
-          + ">>>  /u01/introspect/domain1/userKeyNodeManager.secure\n"
-          + "BPtNabkCIIc2IJp/TzZ9TzbUHG7O3xboteDytDO3XnwNhumdSpaUGKmcbusdmbOUY+4J2kteu6xJPWTzmNRAtg==\n"
-          + "\n"
-          + ">>> EOF\n"
-          + "\n"
-          + "@[2018-10-04T21:07:06.867 UTC][introspectDomain.py:105] Printing file "
-          + "/u01/introspect/domain1/topology.yaml\n"
-          + "\n"
-          + ">>>  /u01/introspect/domain1/topology.yaml\n"
-          + "%s\n"
-          + ">>> EOF";
-
-  private final KubernetesTestSupport testSupport;
-
-  public DomainProcessorTestSetup(KubernetesTestSupport testSupport) {
-    this.testSupport = testSupport;
-  }
 
   public static void defineRequiredResources(KubernetesTestSupport testSupport) {
     testSupport.defineResources(createSecret());
@@ -111,56 +69,4 @@ public class DomainProcessorTestSetup {
         .withSpec(ds);
   }
 
-  /**
-   * Set up the in-memory Kubernetes environment for the domain processor, so that it can run
-   * against what appears to be a domain job that includes the domain topology.
-   *
-   * @param domainConfig the configuration from which the topology should be computed
-   * @throws JsonProcessingException if an error occurs in creating the topology
-   */
-  public void defineKubernetesResources(WlsDomainConfig domainConfig)
-      throws JsonProcessingException {
-    defineKubernetesResources(getIntrospectResult(domainConfig));
-  }
-
-  /**
-   * Set up the in-memory Kubernetes environment for the domain processor, specifying the pod log.
-   * This allows testing of log messages in the case of failures.
-   *
-   * @param introspectResult the log to be returned from the job pod
-   */
-  public void defineKubernetesResources(String introspectResult) {
-    testSupport.addToPacket(JOB_POD_NAME, INTROSPECTION_JOB);
-    testSupport.doOnCreate(
-        KubernetesTestSupport.JOB,
-        job ->
-            ((V1Job) job)
-                .setStatus(
-                    new V1JobStatus()
-                        .addConditionsItem(new V1JobCondition().type("Complete").status("True"))));
-    testSupport.definePodLog(LegalNames.toJobIntrospectorName(UID), NS, introspectResult);
-    testSupport.defineResources(
-        new V1Pod()
-            .metadata(
-                new V1ObjectMeta()
-                    .putLabelsItem("job-name", "")
-                    .name(LegalNames.toJobIntrospectorName(UID))
-                    .namespace(NS)));
-  }
-
-  private String getIntrospectResult(WlsDomainConfig domainConfig) throws JsonProcessingException {
-    return String.format(INTROSPECT_RESULT, createTopologyYaml(domainConfig));
-  }
-
-  /**
-   * Create a topologyYaml similar to that produced by the introspector.
-   * @param domainConfig the domain configuration used as a basis for the produced YAML..
-   * @throws JsonProcessingException if unable to convert the configuration to YAML.
-   */
-  public static String createTopologyYaml(WlsDomainConfig domainConfig) throws JsonProcessingException {
-    ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-    return yamlMapper
-        .writerWithDefaultPrettyPrinter()
-        .writeValueAsString(domainConfig.toTopology());
-  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
@@ -14,7 +14,6 @@ import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatus;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
@@ -284,9 +283,5 @@ public class DomainUpPlanTest {
       return new NullPodWaiter();
     }
 
-    @Override
-    public V1SubjectRulesReviewStatus getSubjectRulesReviewStatus(String namespace) {
-      return null;
-    }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -87,7 +87,7 @@ public class MainTest extends ThreadFactoryTestBase {
   private static final String GIT_BUILD_VERSION = "3.1.0";
   private static final String GIT_BRANCH = "master";
   private static final String GIT_COMMIT = "a987654";
-  private static final String GIT_BUILD_TIME = "Jan-27-2018";
+  private static final String GIT_BUILD_TIME = "Sep-10-2015";
   private static final String IMPL = GIT_BRANCH + "." + GIT_COMMIT;
 
   private static final String LABEL = "weblogic-operator";
@@ -257,7 +257,7 @@ public class MainTest extends ThreadFactoryTestBase {
     testSupport.defineResources(NAMESPACE_WEBLOGIC1, NAMESPACE_WEBLOGIC2, NAMESPACE_WEBLOGIC3,
                                 NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
-    testSupport.runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC1), isNamespaceStarting()),
@@ -297,7 +297,7 @@ public class MainTest extends ThreadFactoryTestBase {
           NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
     TuningParameters.getInstance().put("domainNamespaceRegExp", REGEXP);
-    testSupport.runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC2), isNamespaceStarting()),
@@ -313,7 +313,7 @@ public class MainTest extends ThreadFactoryTestBase {
           NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
     TuningParameters.getInstance().put("domainNamespaceLabelSelector", LABEL + "=" + VALUE);
-    testSupport.runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC1), isNamespaceStarting()),
@@ -339,7 +339,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM - 1);
 
-    testSupport.runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
 
     assertThat(logRecords, containsWarning(MessageKeys.NAMESPACE_IS_MISSING));
   }
@@ -353,7 +353,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM);
 
-    testSupport.runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
   }
 
   private void defineSelectionStrategy(SelectionStrategy selectionStrategy) {
@@ -369,7 +369,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(MULTICHUNK_LAST_NAMESPACE_NUM);
 
-    testSupport.runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
   }
 
   private void createNamespaces(int lastNamespaceNum) {

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -257,7 +257,7 @@ public class MainTest extends ThreadFactoryTestBase {
     testSupport.defineResources(NAMESPACE_WEBLOGIC1, NAMESPACE_WEBLOGIC2, NAMESPACE_WEBLOGIC3,
                                 NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
-    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC1), isNamespaceStarting()),
@@ -297,7 +297,7 @@ public class MainTest extends ThreadFactoryTestBase {
           NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
     TuningParameters.getInstance().put("domainNamespaceRegExp", REGEXP);
-    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC2), isNamespaceStarting()),
@@ -313,7 +313,7 @@ public class MainTest extends ThreadFactoryTestBase {
           NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
     TuningParameters.getInstance().put("domainNamespaceLabelSelector", LABEL + "=" + VALUE);
-    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC1), isNamespaceStarting()),
@@ -339,7 +339,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM - 1);
 
-    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
 
     assertThat(logRecords, containsWarning(MessageKeys.NAMESPACE_IS_MISSING));
   }
@@ -353,7 +353,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM);
 
-    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
   }
 
   private void defineSelectionStrategy(SelectionStrategy selectionStrategy) {
@@ -369,7 +369,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(MULTICHUNK_LAST_NAMESPACE_NUM);
 
-    testSupport.runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
   }
 
   private void createNamespaces(int lastNamespaceNum) {

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -22,7 +22,7 @@ import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import oracle.kubernetes.operator.Main.Namespaces.SelectionStrategy;
+import oracle.kubernetes.operator.Namespaces.SelectionStrategy;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.builders.WatchEvent;
 import oracle.kubernetes.operator.helpers.HelmAccess;
@@ -257,7 +257,7 @@ public class MainTest extends ThreadFactoryTestBase {
     testSupport.defineResources(NAMESPACE_WEBLOGIC1, NAMESPACE_WEBLOGIC2, NAMESPACE_WEBLOGIC3,
                                 NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
-    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.runSteps(new Main.DomainRecheck().readExistingNamespaces());
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC1), isNamespaceStarting()),
@@ -297,7 +297,7 @@ public class MainTest extends ThreadFactoryTestBase {
           NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
     TuningParameters.getInstance().put("domainNamespaceRegExp", REGEXP);
-    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.runSteps(new Main.DomainRecheck().readExistingNamespaces());
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC2), isNamespaceStarting()),
@@ -313,7 +313,7 @@ public class MainTest extends ThreadFactoryTestBase {
           NAMESPACE_WEBLOGIC4, NAMESPACE_WEBLOGIC5);
 
     TuningParameters.getInstance().put("domainNamespaceLabelSelector", LABEL + "=" + VALUE);
-    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.runSteps(new Main.DomainRecheck().readExistingNamespaces());
 
     assertThat(getNamespaceStatusMap(),
                allOf(hasEntry(is(NS_WEBLOGIC1), isNamespaceStarting()),
@@ -339,7 +339,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM - 1);
 
-    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.runSteps(new Main.DomainRecheck().readExistingNamespaces());
 
     assertThat(logRecords, containsWarning(MessageKeys.NAMESPACE_IS_MISSING));
   }
@@ -353,11 +353,11 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM);
 
-    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.runSteps(new Main.DomainRecheck().readExistingNamespaces());
   }
 
   private void defineSelectionStrategy(SelectionStrategy selectionStrategy) {
-    TuningParameters.getInstance().put(Main.Namespaces.SELECTION_STRATEGY_KEY, selectionStrategy.toString());
+    TuningParameters.getInstance().put(Namespaces.SELECTION_STRATEGY_KEY, selectionStrategy.toString());
   }
 
   @Test
@@ -369,7 +369,7 @@ public class MainTest extends ThreadFactoryTestBase {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(MULTICHUNK_LAST_NAMESPACE_NUM);
 
-    testSupport.runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.runSteps(new Main.DomainRecheck().readExistingNamespaces());
   }
 
   private void createNamespaces(int lastNamespaceNum) {

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -362,6 +362,7 @@ public class MainTest extends ThreadFactoryTestBase {
 
     verifyWatchersNotDefined(ns);
   }
+  
   @Test
   public void afterNonDomainNamespaceAdded_WatchersAreNotDefined() {
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, NS_WEBLOGIC1);

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -15,9 +15,9 @@ import com.meterware.simplestub.StaticStubSupport;
 import com.meterware.simplestub.Stub;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.helpers.HelmAccessStub;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
@@ -44,11 +44,10 @@ public class NamespaceTest {
   public static final String NAMESPACE_STOPPING_MAP = "namespaceStoppingMap";
 
   KubernetesTestSupport testSupport = new KubernetesTestSupport();
-  private final Domain domain = DomainProcessorTestSetup.createTestDomain();
-  private final WatchTuning tuning = new WatchTuning(30, 0, 5);
   private final List<Memento> mementos = new ArrayList<>();
   private final Set<String> currentNamespaces = new HashSet<>();
   private final DomainProcessorStub dp = Stub.createStub(DomainProcessorStub.class);
+
 
   @Before
   public void setUp() throws Exception {
@@ -59,13 +58,6 @@ public class NamespaceTest {
     mementos.add(TuningParametersStub.install());
     mementos.add(StaticStubSupport.install(Main.class, "processor", dp));
     mementos.add(testSupport.install());
-    AtomicBoolean stopping = new AtomicBoolean(true);
-  }
-
-  private Thread createDaemonThread() {
-    Thread thread = new Thread();
-    thread.setDaemon(true);
-    return thread;
   }
 
   @After
@@ -82,7 +74,7 @@ public class NamespaceTest {
     processNamespaces();
     defineNamespaces(NS);
 
-    testSupport.runSteps(Main.createDomainRecheckSteps(DateTime.now()));
+    testSupport.runSteps(new Main(null).createDomainRecheckSteps(DateTime.now()));
     assertThat(DomainNamespaces.getJobWatcher(NS), not(sameInstance(oldWatcher)));
   }
 
@@ -196,6 +188,14 @@ public class NamespaceTest {
   abstract static class DomainProcessorStub implements DomainProcessor {
     List<String> nameSpaces = new ArrayList<>();
 
+  }
+
+  class MainDelegateImpl implements MainDelegate {
+
+    @Override
+    public SemanticVersion getProductVersion() {
+      return null;
+    }
   }
 
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -124,7 +124,7 @@ public class NamespaceTest {
   }
 
   private void processNamespaces() {
-    testSupport.withClearPacket().runSteps(Main.Namespaces.readExistingNamespaces(false));
+    testSupport.withClearPacket().runSteps(new Main.DomainRecheck().readExistingNamespaces());
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -17,6 +17,8 @@ import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.helpers.HelmAccessStub;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.KubernetesVersion;
+import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
@@ -26,7 +28,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.meterware.simplestub.Stub.createNiceStub;
 import static com.meterware.simplestub.Stub.createStrictStub;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.helpers.HelmAccess.OPERATOR_DOMAIN_NAMESPACES;
@@ -75,7 +76,7 @@ public class NamespaceTest {
     processNamespaces();
     defineNamespaces(NS);
 
-    testSupport.runSteps(new Main(createNiceStub(MainDelegate.class)).createDomainRecheckSteps(DateTime.now()));
+    testSupport.runSteps(new Main(delegate).createDomainRecheckSteps(DateTime.now()));
     assertThat(DomainNamespaces.getJobWatcher(NS), not(sameInstance(oldWatcher)));
   }
 
@@ -123,7 +124,7 @@ public class NamespaceTest {
   }
 
   private void processNamespaces() {
-    testSupport.withClearPacket().runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.withClearPacket().runSteps(Main.Namespaces.readExistingNamespaces(false));
   }
 
   @Test
@@ -187,10 +188,26 @@ public class NamespaceTest {
   }
 
   abstract static class DomainProcessorStub implements DomainProcessor {
+    @Override
+    public void reportSuspendedFibers() {
+    }
   }
 
   abstract static class MainDelegateStub implements MainDelegate {
+    @Override
+    public DomainProcessor getProcessor() {
+      return createStrictStub(DomainProcessorStub.class);
+    }
 
+    @Override
+    public KubernetesVersion getKubernetesVersion() {
+      return KubernetesVersion.TEST_VERSION;
+    }
+
+    @Override
+    public SemanticVersion getProductVersion() {
+      return SemanticVersion.TEST_VERSION;
+    }
   }
 
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -17,7 +17,6 @@ import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.helpers.HelmAccessStub;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
-import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
@@ -27,6 +26,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.meterware.simplestub.Stub.createNiceStub;
+import static com.meterware.simplestub.Stub.createStrictStub;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.helpers.HelmAccess.OPERATOR_DOMAIN_NAMESPACES;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
@@ -47,7 +48,7 @@ public class NamespaceTest {
   private final List<Memento> mementos = new ArrayList<>();
   private final Set<String> currentNamespaces = new HashSet<>();
   private final DomainProcessorStub dp = Stub.createStub(DomainProcessorStub.class);
-
+  private final MainDelegateStub delegate = createStrictStub(MainDelegateStub.class);
 
   @Before
   public void setUp() throws Exception {
@@ -74,7 +75,7 @@ public class NamespaceTest {
     processNamespaces();
     defineNamespaces(NS);
 
-    testSupport.runSteps(new Main(null).createDomainRecheckSteps(DateTime.now()));
+    testSupport.runSteps(new Main(createNiceStub(MainDelegate.class)).createDomainRecheckSteps(DateTime.now()));
     assertThat(DomainNamespaces.getJobWatcher(NS), not(sameInstance(oldWatcher)));
   }
 
@@ -122,7 +123,7 @@ public class NamespaceTest {
   }
 
   private void processNamespaces() {
-    testSupport.withClearPacket().runSteps(new Main.Namespaces(false).readExistingNamespaces());
+    testSupport.withClearPacket().runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
   }
 
   @Test
@@ -186,16 +187,10 @@ public class NamespaceTest {
   }
 
   abstract static class DomainProcessorStub implements DomainProcessor {
-    List<String> nameSpaces = new ArrayList<>();
-
   }
 
-  class MainDelegateImpl implements MainDelegate {
+  abstract static class MainDelegateStub implements MainDelegate {
 
-    @Override
-    public SemanticVersion getProductVersion() {
-      return null;
-    }
   }
 
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -123,7 +123,7 @@ public class NamespaceTest {
   }
 
   private void processNamespaces() {
-    testSupport.withClearPacket().runSteps(new Main.Namespaces(delegate, false).readExistingNamespaces());
+    testSupport.withClearPacket().runSteps(new Main.Namespaces(false).readExistingNamespaces());
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceWatcherTest.java
@@ -4,7 +4,6 @@
 package oracle.kubernetes.operator;
 
 import java.math.BigInteger;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.kubernetes.client.openapi.models.V1Namespace;
@@ -45,7 +44,6 @@ public class NamespaceWatcherTest extends WatcherTestBase
 
   @Override
   protected NamespaceWatcher createWatcher(String ns, AtomicBoolean stopping, BigInteger rv) {
-    return NamespaceWatcher.create((ThreadFactory)this, rv.toString(), null,
-        tuning, (WatchListener<V1Namespace>)this, stopping);
+    return NamespaceWatcher.create(this, rv.toString(), null, tuning, this, stopping);
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
@@ -65,9 +65,8 @@ public class IntrospectionLoggingTest {
 
   @Test
   public void logIntrospectorMessages() {
-    new DomainProcessorTestSetup(testSupport)
-        .defineKubernetesResources(
-            onSeparateLines(SEVERE_MESSAGE_1, WARNING_MESSAGE, INFO_MESSAGE));
+    IntrospectionTestUtils.defineResources(testSupport,
+          onSeparateLines(SEVERE_MESSAGE_1, WARNING_MESSAGE, INFO_MESSAGE));
 
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
 
@@ -84,7 +83,7 @@ public class IntrospectionLoggingTest {
   @Test
   public void whenIntrospectorMessageContainsAdditionalLines_logThem() {
     String extendedInfoMessage = onSeparateLines(INFO_MESSAGE, INFO_EXTRA1, INFO_EXTRA_2);
-    new DomainProcessorTestSetup(testSupport).defineKubernetesResources(extendedInfoMessage);
+    IntrospectionTestUtils.defineResources(testSupport, extendedInfoMessage);
 
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
 
@@ -94,7 +93,7 @@ public class IntrospectionLoggingTest {
 
   @Test
   public void whenJobLogContainsSevereError_copyToDomainStatus() {
-    new DomainProcessorTestSetup(testSupport).defineKubernetesResources(SEVERE_MESSAGE_1);
+    IntrospectionTestUtils.defineResources(testSupport, SEVERE_MESSAGE_1);
 
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
     logRecords.clear();
@@ -106,8 +105,7 @@ public class IntrospectionLoggingTest {
 
   @Test
   public void whenJobLogContainsMultipleSevereErrors_copyToDomainStatus() {
-    new DomainProcessorTestSetup(testSupport)
-        .defineKubernetesResources(
+    IntrospectionTestUtils.defineResources(testSupport,
             onSeparateLines(SEVERE_MESSAGE_1, INFO_MESSAGE, INFO_EXTRA1, SEVERE_MESSAGE_2));
 
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionTestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionTestUtils.java
@@ -1,0 +1,123 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobCondition;
+import io.kubernetes.client.openapi.models.V1JobStatus;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
+
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
+import static oracle.kubernetes.operator.ProcessingConstants.JOB_POD_NAME;
+
+public class IntrospectionTestUtils {
+
+
+  private static final String INTROSPECTION_JOB = LegalNames.toJobIntrospectorName(UID);
+  private static final String INTROSPECT_RESULT =
+      ">>>  /u01/introspect/domain1/userConfigNodeManager.secure\n"
+          + "#WebLogic User Configuration File; 2\n"
+          + "#Thu Oct 04 21:07:06 GMT 2018\n"
+          + "weblogic.management.username={AES}fq11xKVoE927O07IUKhQ00d4A8QY598Dvd+KSnHNTEA\\=\n"
+          + "weblogic.management.password={AES}LIxVY+aqI8KBkmlBTwkvAnQYQs4PS0FX3Ili4uLBggo\\=\n"
+          + "\n"
+          + ">>> EOF\n"
+          + "\n"
+          + "@[2018-10-04T21:07:06.864 UTC][introspectDomain.py:105] Printing file "
+          + "/u01/introspect/domain1/userKeyNodeManager.secure\n"
+          + "\n"
+          + ">>>  /u01/introspect/domain1/userKeyNodeManager.secure\n"
+          + "BPtNabkCIIc2IJp/TzZ9TzbUHG7O3xboteDytDO3XnwNhumdSpaUGKmcbusdmbOUY+4J2kteu6xJPWTzmNRAtg==\n"
+          + "\n"
+          + ">>> EOF\n"
+          + "\n"
+          + "@[2018-10-04T21:07:06.867 UTC][introspectDomain.py:105] Printing file "
+          + "/u01/introspect/domain1/topology.yaml\n"
+          + "\n"
+          + ">>>  /u01/introspect/domain1/topology.yaml\n"
+          + "%s\n"
+          + ">>> EOF";
+
+  /**
+   * Define in-memory kubernetes resources to represent an introspector job.
+   *
+   * @param testSupport a kubernetes test support instance
+   * @param domainConfig the configuration from which the topology should be computed
+   * @throws JsonProcessingException if an error occurs in creating the topology
+   */
+  static void defineResources(KubernetesTestSupport testSupport, WlsDomainConfig domainConfig)
+      throws JsonProcessingException {
+    defineResources(testSupport, domainConfig, IntrospectionTestUtils::createCompletedStatus);
+  }
+
+  /**
+   * Define in-memory kubernetes resources to represent an introspector job.
+   *
+   * @param testSupport a kubernetes test support instance
+   * @param domainConfig the configuration from which the topology should be computed
+   * @param jobStatus a supplier for a job status to be applied to the introspector job
+   * @throws JsonProcessingException if an error occurs in creating the topology
+   */
+  public static void defineResources(KubernetesTestSupport testSupport,
+                                     WlsDomainConfig domainConfig,
+                                     Supplier<V1JobStatus> jobStatus)
+        throws JsonProcessingException {
+    defineResources(testSupport, getIntrospectResult(domainConfig), jobStatus);
+  }
+
+  /**
+   * Set up the in-memory Kubernetes environment for the domain processor, specifying the pod log.
+   * This allows testing of log messages in the case of failures.
+   *
+   * @param testSupport a kubernetes test support instance
+   * @param introspectResult the log to be returned from the job pod
+   */
+  static void defineResources(KubernetesTestSupport testSupport, String introspectResult) {
+    defineResources(testSupport, introspectResult, IntrospectionTestUtils::createCompletedStatus);
+  }
+
+  private static void defineResources(KubernetesTestSupport testSupport,
+                              String introspectResult,
+                              Supplier<V1JobStatus> jobStatus) {
+    testSupport.addToPacket(JOB_POD_NAME, INTROSPECTION_JOB);
+    testSupport.doOnCreate(KubernetesTestSupport.JOB, job -> ((V1Job) job).setStatus(jobStatus.get()));
+    testSupport.definePodLog(LegalNames.toJobIntrospectorName(UID), NS, introspectResult);
+    testSupport.defineResources(
+        new V1Pod()
+            .metadata(
+                new V1ObjectMeta()
+                    .putLabelsItem("job-name", "")
+                    .name(LegalNames.toJobIntrospectorName(UID))
+                    .namespace(NS)));
+  }
+
+  private static V1JobStatus createCompletedStatus() {
+    return new V1JobStatus()
+          .addConditionsItem(new V1JobCondition().type("Complete").status("True"));
+  }
+
+  private static String getIntrospectResult(WlsDomainConfig domainConfig) throws JsonProcessingException {
+    return String.format(INTROSPECT_RESULT, createTopologyYaml(domainConfig));
+  }
+
+  /**
+   * Create a topologyYaml similar to that produced by the introspector.
+   * @param domainConfig the domain configuration used as a basis for the produced YAML..
+   * @throws JsonProcessingException if unable to convert the configuration to YAML.
+   */
+  public static String createTopologyYaml(WlsDomainConfig domainConfig) throws JsonProcessingException {
+    ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+    return yamlMapper
+        .writerWithDefaultPrettyPrinter()
+        .writeValueAsString(domainConfig.toTopology());
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -27,6 +27,7 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Toleration;
+import oracle.kubernetes.operator.JobAwaiterStepFactory;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.TuningParameters;
@@ -49,10 +50,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.meterware.simplestub.Stub.createNiceStub;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.createTestDomain;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
+import static oracle.kubernetes.operator.ProcessingConstants.JOBWATCHER_COMPONENT_NAME;
 import static oracle.kubernetes.operator.helpers.Matchers.hasContainer;
 import static oracle.kubernetes.operator.helpers.Matchers.hasEnvVar;
 import static oracle.kubernetes.operator.helpers.Matchers.hasEnvVarRegEx;
@@ -98,8 +101,8 @@ public class JobHelperTest extends DomainValidationBaseTest {
   private final V1EnvVar configMapKeyRefEnvVar = createConfigMapKeyRefEnvVar("VARIABLE1", "my-env", "VAR1");
   private final V1EnvVar secretKeyRefEnvVar = createSecretKeyRefEnvVar("VARIABLE2", "my-secret", "VAR2");
   private final V1EnvVar fieldRefEnvVar = createFieldRefEnvVar("MY_NODE_IP", "status.hostIP");
-  private List<Memento> mementos = new ArrayList<>();
-  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final List<Memento> mementos = new ArrayList<>();
+  private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
 
   /**
    * Setup test environment.
@@ -114,6 +117,9 @@ public class JobHelperTest extends DomainValidationBaseTest {
     domain.getSpec().setNodeName(null);
     testSupport.defineResources(domain);
     testSupport.addDomainPresenceInfo(domainPresenceInfo);
+    testSupport.addComponent(JOBWATCHER_COMPONENT_NAME,
+          JobAwaiterStepFactory.class,
+          createNiceStub(JobAwaiterStepFactory.class));
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -86,6 +86,7 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
+import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -467,6 +468,12 @@ public class KubernetesTestSupport extends FiberTestSupport {
       @Override
       <T> Object execute(CallContext callContext, DataRepository<T> dataRepository) {
         return callContext.deleteCollection(dataRepository);
+      }
+    },
+    getVersion {
+      @Override
+      <T> Object execute(CallContext callContext, DataRepository<T> dataRepository) {
+        return KubernetesVersion.TEST_VERSION_INFO;
       }
     };
 
@@ -1047,15 +1054,22 @@ public class KubernetesTestSupport extends FiberTestSupport {
     private void parseCallName(String callName) {
       int i = indexOfFirstCapital(callName);
       resourceType = callName.substring(i);
-      String operationName = callName.substring(0, i);
-      if (callName.endsWith("Status")) {
-        operationName = operationName + "Status";
-      }
-      operation = Operation.valueOf(operationName);
+      operation = getOperation(callName, i);
 
       if (isDeleteCollection()) {
         selectDeleteCollectionOperation();
       }
+    }
+
+    @NotNull
+    private Operation getOperation(String callName, int numChars) {
+      String operationName = callName.substring(0, numChars);
+      if (callName.endsWith("Status")) {
+        operationName = operationName + "Status";
+      } else if (callName.equals("getVersion")) {
+        return Operation.getVersion;
+      }
+      return Operation.valueOf(operationName);
     }
 
     private boolean isDeleteCollection() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -60,15 +60,15 @@ public class PodPresenceTest {
   private static final String POD_NAME = SERVER;
   private static final String RESOURCE_VERSION = "1233489";
   private static final String ADMIN_SERVER_NAME = "admin";
-  private DomainPresenceInfo info = new DomainPresenceInfo(NS, UID);
-  private List<Memento> mementos = new ArrayList<>();
-  private Map<String, Map<String, DomainPresenceInfo>> domains = new HashMap<>();
-  private KubernetesTestSupport testSupport = new KubernetesTestSupport();
-  private DomainProcessorImpl processor =
+  private final DomainPresenceInfo info = new DomainPresenceInfo(NS, UID);
+  private final List<Memento> mementos = new ArrayList<>();
+  private final Map<String, Map<String, DomainPresenceInfo>> domains = new HashMap<>();
+  private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final DomainProcessorImpl processor =
       new DomainProcessorImpl(DomainProcessorDelegateStub.createDelegate(testSupport));
   private long clock;
-  private Packet packet = new Packet();
-  private V1Pod pod =
+  private final Packet packet = new Packet();
+  private final V1Pod pod =
       new V1Pod()
           .metadata(
               KubernetesUtils.withOperatorLabels(
@@ -99,8 +99,7 @@ public class PodPresenceTest {
         new WlsDomainConfigSupport(UID).withAdminServerName(ADMIN_SERVER_NAME);
     configSupport.addWlsServer("admin", 8001);
     configSupport.addWlsServer(SERVER, 7001);
-    new DomainProcessorTestSetup(testSupport)
-        .defineKubernetesResources(configSupport.createDomainConfig());
+    IntrospectionTestUtils.defineResources(testSupport, configSupport.createDomainConfig());
 
     packet.put(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
     packet.put(CLUSTER_NAME, CLUSTER);
@@ -117,14 +116,9 @@ public class PodPresenceTest {
     info.setDeleting(false);
   }
 
-  /**
-   * Tear down test.
-   */
   @After
   public void tearDown() {
-    for (Memento memento : mementos) {
-      memento.revert();
-    }
+    mementos.forEach(Memento::revert);
   }
 
   @Test
@@ -195,12 +189,14 @@ public class PodPresenceTest {
     MatcherAssert.assertThat(PodHelper.isFailed(pod), is(true));
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test
   public void whenPodHasNoDomainUid_returnNull() {
     pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
     MatcherAssert.assertThat(PodHelper.getPodDomainUid(pod), nullValue());
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test
   public void whenPodHasDomainUid_returnIt() {
     pod.getMetadata().labels(ImmutableMap.of(DOMAINUID_LABEL, "domain1"));
@@ -213,6 +209,7 @@ public class PodPresenceTest {
     MatcherAssert.assertThat(PodHelper.getPodServerName(pod), nullValue());
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test
   public void whenPodHasServerName_returnIt() {
     pod.getMetadata().labels(ImmutableMap.of(SERVERNAME_LABEL, "myserver"));
@@ -405,6 +402,7 @@ public class PodPresenceTest {
     return withTimeAndVersion(PodHelper.createManagedServerPodModel(packet));
   }
 
+  @SuppressWarnings("ConstantConditions")
   private V1Pod withTimeAndVersion(V1Pod pod) {
     pod.getMetadata().creationTimestamp(getDateTime()).resourceVersion(RESOURCE_VERSION);
     return pod;

--- a/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
@@ -40,7 +40,7 @@ public class FiberTestSupport {
   private final CompletionCallbackStub completionCallback = new CompletionCallbackStub();
   private final ScheduledExecutorStub schedule = ScheduledExecutorStub.create();
   private final Engine engine = new Engine(schedule);
-  private final Packet packet = new Packet();
+  private Packet packet = new Packet();
 
   private Fiber fiber = engine.createFiber();
 
@@ -167,6 +167,20 @@ public class FiberTestSupport {
    */
   public static void doOnExit(NextAction nextAction, AsyncFiber fiber) {
     Optional.ofNullable(nextAction.onExit).orElse(f -> {}).accept(fiber);
+  }
+
+  /**
+   * Specifies a predefined packet to use for the next run.
+   * @param packet the new packet
+   */
+  public FiberTestSupport withPacket(@Nonnull Packet packet) {
+    this.packet = packet;
+    return this;
+  }
+
+  public FiberTestSupport withCompletionAction(Runnable completionAction) {
+    completionCallback.setCompletionAction(completionAction);
+    return this;
   }
 
   /**
@@ -358,9 +372,15 @@ public class FiberTestSupport {
 
   static class CompletionCallbackStub implements Fiber.CompletionCallback {
     private Throwable throwable;
+    private Runnable completionAction;
+
+    void setCompletionAction(Runnable completionAction) {
+      this.completionAction = completionAction;
+    }
 
     @Override
     public void onCompletion(Packet packet) {
+      Optional.ofNullable(completionAction).ifPresent(Runnable::run);
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/utils/LogMatcher.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/LogMatcher.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -18,7 +19,7 @@ public class LogMatcher
 
   private String expectedMessage;
   private Level expectedLevel;
-  private Object expectedParameter;
+  private Object[] expectedParameters;
   private LogMatcher[] logMatchers;
 
   private LogMatcher(LogMatcher[] logMatchers) {
@@ -29,26 +30,26 @@ public class LogMatcher
     this(expectedLevel, expectedMessage, null);
   }
 
-  private LogMatcher(Level expectedLevel, String expectedMessage, Object expectedParameter) {
+  private LogMatcher(Level expectedLevel, String expectedMessage, Object[] expectedParameters) {
     this.expectedMessage = expectedMessage;
     this.expectedLevel = expectedLevel;
-    this.expectedParameter = expectedParameter;
+    this.expectedParameters = expectedParameters;
   }
 
   public static LogMatcher containsInfo(String expectedMessage) {
     return new LogMatcher(Level.INFO, expectedMessage);
   }
 
-  public static LogMatcher containsInfo(String expectedMessage, Object expectedParameter) {
-    return new LogMatcher(Level.INFO, expectedMessage, expectedParameter);
+  public static LogMatcher containsInfo(String expectedMessage, Object... expectedParameters) {
+    return new LogMatcher(Level.INFO, expectedMessage, expectedParameters);
   }
 
   public static LogMatcher containsWarning(String expectedMessage) {
     return new LogMatcher(Level.WARNING, expectedMessage);
   }
 
-  public static LogMatcher containsWarning(String expectedMessage, Object expectedParameter) {
-    return new LogMatcher(Level.WARNING, expectedMessage, expectedParameter);
+  public static LogMatcher containsWarning(String expectedMessage, Object... expectedParameters) {
+    return new LogMatcher(Level.WARNING, expectedMessage, expectedParameters);
   }
 
   public static LogMatcher containsSevere(String expectedMessage) {
@@ -59,8 +60,8 @@ public class LogMatcher
     return new LogMatcher(Level.FINE, expectedMessage);
   }
 
-  public static LogMatcher containsFine(String expectedMessage, Object expectedParameter) {
-    return new LogMatcher(Level.FINE, expectedMessage, expectedParameter);
+  public static LogMatcher containsFine(String expectedMessage, Object... expectedParameters) {
+    return new LogMatcher(Level.FINE, expectedMessage, expectedParameters);
   }
 
   public static LogMatcher containsInOrder(LogMatcher... logMatchers) {
@@ -109,8 +110,11 @@ public class LogMatcher
   private boolean matches(LogRecord item) {
     return item.getLevel() == expectedLevel
         && item.getMessage().equals(expectedMessage)
-        && (expectedParameter == null
-            || Arrays.stream(item.getParameters()).anyMatch(expectedParameter::equals));
+        && (expectedParameters == null || containsAll(Arrays.asList(item.getParameters()), expectedParameters));
+  }
+
+  private boolean containsAll(List<Object> actualParameters, Object[] expectedParameters) {
+    return Arrays.stream(expectedParameters).allMatch(actualParameters::contains);
   }
 
   private boolean noLogMessageFound(Description mismatchDescription) {
@@ -133,8 +137,8 @@ public class LogMatcher
         .appendValue(expectedLevel)
         .appendText(" log message with value ")
         .appendValue(expectedMessage);
-    if (expectedParameter != null) {
-      description.appendText(" with parameter(s) ").appendValue(expectedParameter);
+    if (expectedParameters != null) {
+      description.appendText(" with parameter(s) ").appendValue(expectedParameters);
     }
     description.appendText(" ");
   }


### PR DESCRIPTION
1. Major refactoring of the Main class which creates DomainCheck nested class and extracts Namespaces to top level
2. Unit testing of operator startup
3. Addresses OWLS-84815 to abort operator startup if `dedicated` strategy is selected, but CRD is not installed (detected by attempting to list domains)
4. Fix for intermittent failures in unit test `PodWatcherTest.whenPodNotReadyLaterAndThenReadyButNoWatchEvent_runNextStep`

Jenkins run https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/2671/

several of the tests failed due to OutOfMemory conditions, and I reran them as individual jobs, where they passed.