### PR TITLE
OWLS 85530: OPERATOR INTROSPECTOR THROWS VALIDATION ERRORS FOR STATIC CLUSTER

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -381,8 +381,9 @@ class TopologyGenerator(Generator):
     try:
       ret = cluster.getDynamicServers()
       # Dynamic Servers must be configured with a ServerTemplate
-      if ret.getServerTemplate() is None:
-        ret = None
+      if ret is not None:
+        if ret.getServerTemplate() is None:
+          ret = None
     except:
       trace("Ignoring getDynamicServers() exception, this is expected.")
       ret = None

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -380,6 +380,8 @@ class TopologyGenerator(Generator):
   def getDynamicServersOrNone(self,cluster):
     try:
       ret = cluster.getDynamicServers()
+      if ret.getDynamicClusterSize() == 0:
+        ret = None
     except:
       trace("Ignoring getDynamicServers() exception, this is expected.")
       ret = None

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -380,7 +380,8 @@ class TopologyGenerator(Generator):
   def getDynamicServersOrNone(self,cluster):
     try:
       ret = cluster.getDynamicServers()
-      if ret.getDynamicClusterSize() == 0:
+      # Dynamic Servers must be configured with a ServerTemplate
+      if ret.getServerTemplate() is None:
         ret = None
     except:
       trace("Ignoring getDynamicServers() exception, this is expected.")

--- a/src/integration-tests/introspector/README
+++ b/src/integration-tests/introspector/README
@@ -21,9 +21,21 @@ Usage:
 (2) Optionally specify values for input env vars (see introspectTest.sh for the list).
 (3) For a non Model In Image domain type.
         Run introspectTest.sh
+
     For a Model In Image domain type.
         export DOMAIN_SOURCE_TYPE=FromModel
         Run introspectTest.sh
+
+    To check for ISTIO
+        export ISTIO_ENABELD=true - this only test for Non Model in Image
+
+    To check for introspection of configured clusters with WebLogic 14.1.1.0 image.
+    NOTE: Test for introspection of configured clusters only for Non Model in Image
+          and for verifying OWLS 85530.
+
+        export WEBLOGIC_IMAGE_TAG=14.1.1.0
+        introspectTest.sh
+
 -------------------
 Internal Test Flow:
 -------------------
@@ -85,3 +97,14 @@ Internal Test Flow:
    wl-pod.yamlt
    <operator-src>/operator/src/main/resources/scripts/startServer.sh
    <operator-src>/operator/src/main/resources/scripts/start-server.py
+
+() Various test verifications (WebLogic version, configuration overrides, etc) are executed.
+
+() For domain types other than Model in Image, a verification test for JIRA OWLS-85530 is executed:
+
+   1. a static configured cluster is created using WLST in online mode.
+   2. a minor cleanup of the test environment is performed in preparation for a rerun of the
+      introspection job.  The minor cleanup function leaves the existing
+      domain-home/pv/pvc/secret/etc, deletes wl pods, deletes the introspect job, then
+      redeploys the custom overrides.
+   3. reruns the introspect job

--- a/src/integration-tests/introspector/createStaticCluster.py
+++ b/src/integration-tests/introspector/createStaticCluster.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+#
+# purpose:
+#
+#    invoke on-line WLST to create a configured static cluster and two managed
+#      servers that reference it.
+#
+#    assumes the admin user/pass was encoded to a userConfig/userKey by the
+#      introspector these files have been mounted to /weblogic-operator/introspector
+#
+# usage:
+#    wlst.sh createStaticCluster.py <url> <cluster_name>
+#
+# sample usage:
+#    wlst.sh createStaticCluster.py t3://domain1-admin-server:7001 c1
+#
+
+import sys
+
+url = sys.argv[1]
+cluster_name = sys.argv[2]
+
+connect(userConfigFile='/weblogic-operator/introspector/userConfigNodeManager.secure',userKeyFile='/tmp/userKeyNodeManager.secure.bin',url=url)
+
+edit()
+startEdit()
+
+cl=cmo.createCluster(cluster_name)
+
+# Create managed servers
+for index in range(0, 2):
+  cd('/')
+
+  msIndex = index+1
+  name = '%s%s' % ('ms', msIndex)
+
+  create(name, 'Server')
+  cd('/Servers/%s/' % name )
+  print('managed server name is %s' % name);
+  set('ListenPort', 8001)
+  set('ListenAddress', '')
+  set('Cluster', cl)
+
+save()
+activate()
+
+print 'ok'
+exit(exitcode=0)

--- a/src/integration-tests/introspector/createStaticCluster.py
+++ b/src/integration-tests/introspector/createStaticCluster.py
@@ -7,6 +7,18 @@
 #    invoke on-line WLST to create a configured static cluster and two managed
 #      servers that reference it.
 #
+#    NOTE: The static cluster must be configured using on-line WLST instead of
+#    off-line WLST in order to reproduce OWLS 85530. On-line WLST produces the
+#    following cluster configuration:
+#
+#    <cluster>
+#      <name>c1</name>
+#      <cluster-messaging-mode>unicast</cluster-messaging-mode>
+#      <dynamic-servers>
+#        <maximum-dynamic-server-count>0</maximum-dynamic-server-count>
+#      </dynamic-servers>
+#    </cluster>
+#
 #    assumes the admin user/pass was encoded to a userConfig/userKey by the
 #      introspector these files have been mounted to /weblogic-operator/introspector
 #

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -40,7 +40,8 @@
 #         export ISTIO_ENABELD=true - this only test for Non Model in Image
 #
 #     To check for introspection of configured clusters with WebLogic 14.1.1.0 image.
-#     NOTE: Test for introspection of configured clusters only for Non Model in Image.
+#     NOTE: Test for introspection of configured clusters only for Non Model in Image
+#           and for verifying OWLS 85530.
 #
 #         export WEBLOGIC_IMAGE_TAG=14.1.1.0
 #         introspectTest.sh
@@ -1025,8 +1026,10 @@ function checkNodeManagerJavaOptions() {
 
 #############################################################################
 #
-# Create static cluster using on-line WLST.  This creates a static cluster entry
-# of the form:
+# Create static cluster using on-line WLST.
+# NOTE: The static cluster must be configured using on-line WLST instead of
+#       off-line WLST in order to reproduce OWLS 85530. This creates a static
+#       cluster entry of the form:
 #
 # <cluster>
 #   <name>c1</name>
@@ -1146,7 +1149,9 @@ checkManagedServer1MemArg
 checkNodeManagerJavaOptions
 
 if [ ${DOMAIN_SOURCE_TYPE} != "FromModel" ] ; then
-  # Create static cluster using WLST on-line mode
+  # Create static cluster using WLST on-line mode.
+  # NOTE: The static cluster must be configured using on-line WLST instead of
+  #       off-line WLST in order to reproduce OWLS 85530.
   createStaticCluster 'c1' ${DOMAIN_UID}-${ADMIN_NAME?} t3://${DOMAIN_UID}-${ADMIN_NAME}:${ADMIN_PORT}
 
   # Re-run introspector to introspect the static cluster

--- a/src/integration-tests/introspector/introspectTest.sh
+++ b/src/integration-tests/introspector/introspectTest.sh
@@ -39,6 +39,12 @@
 #     To check for ISTIO
 #         export ISTIO_ENABELD=true - this only test for Non Model in Image
 #
+#     To check for introspection of configured clusters with WebLogic 14.1.1.0 image.
+#     NOTE: Test for introspection of configured clusters only for Non Model in Image.
+#
+#         export WEBLOGIC_IMAGE_TAG=14.1.1.0
+#         introspectTest.sh
+#
 #############################################################################
 #
 # Initialize basic globals


### PR DESCRIPTION
With 14.1.1.0 WebLogic image, static/configured clusters are being mis-identified as dynamic clusters.  The workaround bug, where WLST throws an exception when there are no 'real' DynamicServers, may not occur as a DynamicServerMBean is returned although it is not configured with any dynamic servers:
```
<cluster>
   <name>c1</name>
   <dynamic-servers>
     <maximum-dynamic-server-count>0</maximum-dynamic-server-count>
   </dynamic-servers>
</cluster>
```
The above <cluster> configuration gets generated when running online WLST.  Validation errors similar to the following can be seen when a configured cluster is mis-identified as a dynamic cluster:

validationErrors:
- "The WebLogic dynamic cluster \"c1\"' is not referenced by any server template."
- "The WebLogic dynamic cluster \"c1\"'s dynamic servers use calculated listen ports."
- "The WebLogic dynamic cluster \"c1\" is referenced by configured server \"ms1\", the operator does not support 'mixed clusters' that host both dynamic (templated) servers and configured servers."
- "The WebLogic dynamic cluster \"c1\" is referenced by configured server \"ms2\", the operator does not support 'mixed clusters' that host both dynamic (templated) servers and configured servers."
