### PR TITLE
Detect and shut down stuck server pods

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -3,6 +3,9 @@
 
 package oracle.kubernetes.operator;
 
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.logging.LoggingFacade;
@@ -36,4 +39,6 @@ interface MainDelegate {
   DomainNamespaces getDomainNamespaces();
 
   KubernetesVersion getKubernetesVersion();
+
+  ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
@@ -100,7 +100,7 @@ public class StuckPodProcessing {
         Collection<StepAndPacket> startDetails = new ArrayList<>();
 
         for (V1Pod pod : stuckPodList) {
-          startDetails.add(new StepAndPacket(createDeletePodStep(pod), packet.clone()));
+          startDetails.add(new StepAndPacket(createForcedDeletePodStep(pod), packet.clone()));
         }
         return doForkJoin(readExistingNamespaces(), packet, startDetails);
       }
@@ -111,8 +111,9 @@ public class StuckPodProcessing {
       return mainDelegate.getDomainNamespaces().readExistingResources(namespace, mainDelegate.getDomainProcessor());
     }
 
-    private Step createDeletePodStep(V1Pod pod) {
+    private Step createForcedDeletePodStep(V1Pod pod) {
       return new CallBuilder()
+            .withGracePeriodSeconds(0)
             .deletePodAsync(getName(pod), getNamespace(pod), getDomainUid(pod), null, new DefaultResponseStep<>());
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
@@ -1,0 +1,131 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import oracle.kubernetes.operator.calls.CallResponse;
+import oracle.kubernetes.operator.helpers.CallBuilder;
+import oracle.kubernetes.operator.helpers.PodHelper;
+import oracle.kubernetes.operator.steps.DefaultResponseStep;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
+import org.joda.time.DateTime;
+
+public class StuckPodProcessing {
+
+
+  private final MainDelegate mainDelegate;
+
+  public StuckPodProcessing(MainDelegate mainDelegate) {
+    this.mainDelegate = mainDelegate;
+  }
+
+  void checkStuckPods(String namespace) {
+    Step step = new CallBuilder()
+          .withLabelSelectors(LabelConstants.getCreatedbyOperatorSelector())
+          .listPodAsync(namespace, new PodListProcessing(namespace, SystemClock.now()));
+    mainDelegate.runSteps(step);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<V1Pod> getStuckPodList(Packet packet) {
+    return (List<V1Pod>) packet.computeIfAbsent("STUCK_PODS", k -> new ArrayList<>());
+  }
+
+  class PodListProcessing extends DefaultResponseStep<V1PodList> {
+
+    private final DateTime now;
+
+    public PodListProcessing(String namespace, DateTime dateTime) {
+      super(new PodActionsStep(namespace));
+      now = dateTime;
+    }
+
+    @Override
+    public NextAction onSuccess(Packet packet, CallResponse<V1PodList> callResponse) {
+      callResponse.getResult().getItems().stream()
+            .filter(pod -> isStuck(pod, now))
+            .forEach(pod -> addStuckPodToPacket(packet, pod));
+      
+      return doContinueListOrNext(callResponse, packet);
+    }
+
+    private boolean isStuck(V1Pod pod, DateTime now)  {
+      return getExpectedDeleteTime(pod).isBefore(now);
+    }
+
+    private DateTime getExpectedDeleteTime(V1Pod pod) {
+      return getDeletionTimeStamp(pod).plusSeconds((int) getDeletionGracePeriodSeconds(pod));
+    }
+
+    private long getDeletionGracePeriodSeconds(V1Pod pod) {
+      return Optional.of(pod).map(V1Pod::getMetadata).map(V1ObjectMeta::getDeletionGracePeriodSeconds).orElse(1L);
+    }
+
+    private DateTime getDeletionTimeStamp(V1Pod pod) {
+      return Optional.of(pod).map(V1Pod::getMetadata).map(V1ObjectMeta::getDeletionTimestamp).orElse(SystemClock.now());
+    }
+
+    private void addStuckPodToPacket(Packet packet, V1Pod stuckPod) {
+      getStuckPodList(packet).add(stuckPod);
+    }
+  }
+
+  class PodActionsStep extends Step {
+
+    private final String namespace;
+
+    public PodActionsStep(String namespace) {
+      this.namespace = namespace;
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      final List<V1Pod> stuckPodList = getStuckPodList(packet);
+      if (stuckPodList.isEmpty()) {
+        return doNext(packet);
+      } else {
+        Collection<StepAndPacket> startDetails = new ArrayList<>();
+
+        for (V1Pod pod : stuckPodList) {
+          startDetails.add(new StepAndPacket(createDeletePodStep(pod), packet.clone()));
+        }
+        return doForkJoin(readExistingNamespaces(), packet, startDetails);
+      }
+    }
+
+    @Nonnull
+    private Step readExistingNamespaces() {
+      return mainDelegate.getDomainNamespaces().readExistingResources(namespace, mainDelegate.getDomainProcessor());
+    }
+
+    private Step createDeletePodStep(V1Pod pod) {
+      return new CallBuilder()
+            .deletePodAsync(getName(pod), getNamespace(pod), getDomainUid(pod), null, new DefaultResponseStep<>());
+    }
+
+    private String getName(V1Pod pod) {
+      return Objects.requireNonNull(pod.getMetadata()).getName();
+    }
+
+    private String getNamespace(V1Pod pod) {
+      return Objects.requireNonNull(pod.getMetadata()).getNamespace();
+    }
+
+    private String getDomainUid(V1Pod pod) {
+      return PodHelper.getPodDomainUid(pod);
+    }
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/TuningParameters.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/TuningParameters.java
@@ -37,6 +37,7 @@ public interface TuningParameters extends Map<String, String> {
     public final int domainNamespaceRecheckIntervalSeconds;
     public final int statusUpdateTimeoutSeconds;
     public final int unchangedCountToDelayStatusRecheck;
+    public final int stuckPodRecheckSeconds;
     public final long initialShortDelay;
     public final long eventualLongDelay;
 
@@ -48,24 +49,27 @@ public interface TuningParameters extends Map<String, String> {
      * @param domainNamespaceRecheckIntervalSeconds domain namespace recheck interval
      * @param statusUpdateTimeoutSeconds status update timeout
      * @param unchangedCountToDelayStatusRecheck unchanged count to delay status recheck
+     * @param stuckPodRecheckSeconds time between checks for stuck pods
      * @param initialShortDelay initial short delay
      * @param eventualLongDelay eventual long delay
      */
     public MainTuning(
-        int domainPresenceFailureRetrySeconds,
-        int domainPresenceFailureRetryMaxCount,
-        int domainPresenceRecheckIntervalSeconds,
-        int domainNamespaceRecheckIntervalSeconds,
-        int statusUpdateTimeoutSeconds,
-        int unchangedCountToDelayStatusRecheck,
-        long initialShortDelay,
-        long eventualLongDelay) {
+          int domainPresenceFailureRetrySeconds,
+          int domainPresenceFailureRetryMaxCount,
+          int domainPresenceRecheckIntervalSeconds,
+          int domainNamespaceRecheckIntervalSeconds,
+          int statusUpdateTimeoutSeconds,
+          int unchangedCountToDelayStatusRecheck,
+          int stuckPodRecheckSeconds,
+          long initialShortDelay,
+          long eventualLongDelay) {
       this.domainPresenceFailureRetrySeconds = domainPresenceFailureRetrySeconds;
       this.domainPresenceFailureRetryMaxCount = domainPresenceFailureRetryMaxCount;
       this.domainPresenceRecheckIntervalSeconds = domainPresenceRecheckIntervalSeconds;
       this.domainNamespaceRecheckIntervalSeconds = domainNamespaceRecheckIntervalSeconds;
       this.statusUpdateTimeoutSeconds = statusUpdateTimeoutSeconds;
       this.unchangedCountToDelayStatusRecheck = unchangedCountToDelayStatusRecheck;
+      this.stuckPodRecheckSeconds = stuckPodRecheckSeconds;
       this.initialShortDelay = initialShortDelay;
       this.eventualLongDelay = eventualLongDelay;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
@@ -54,6 +54,7 @@ public class TuningParametersImpl extends ConfigMapConsumer implements TuningPar
             (int) readTuningParameter("domainNamespaceRecheckIntervalSeconds", 3),
             (int) readTuningParameter("statusUpdateTimeoutSeconds", 10),
             (int) readTuningParameter("statusUpdateUnchangedCountToDelayStatusRecheck", 10),
+            (int) readTuningParameter("stuckPodRecheckSeconds", 30),
             readTuningParameter("statusUpdateInitialShortDelay", 5),
             readTuningParameter("statusUpdateEventualLongDelay", 30));
 

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
@@ -83,7 +83,7 @@ public class AsyncRequestStep<T> extends Step implements RetryStrategyListener {
       String labelSelector,
       String resourceVersion) {
     this(next, requestParams, factory, null, helper, timeoutSeconds, maxRetryCount,
-            fieldSelector, labelSelector, resourceVersion);
+            null, fieldSelector, labelSelector, resourceVersion);
   }
 
   /**
@@ -108,6 +108,7 @@ public class AsyncRequestStep<T> extends Step implements RetryStrategyListener {
           ClientPool helper,
           int timeoutSeconds,
           int maxRetryCount,
+          Integer gracePeriodSeconds,
           String fieldSelector,
           String labelSelector,
           String resourceVersion) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AsyncRequestStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AsyncRequestStepFactory.java
@@ -17,6 +17,7 @@ public interface AsyncRequestStepFactory {
       ClientPool helper,
       int timeoutSeconds,
       int maxRetryCount,
+      Integer gracePeriodSeconds,
       String fieldSelector,
       String labelSelector,
       String resourceVersion);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -303,7 +303,7 @@ public class CallBuilder {
   private final CallFactory<V1Secret> readSecret =
       (requestParams, usage, cont, callback) ->
           wrap(readSecretAsync(usage, requestParams.name, requestParams.namespace, callback));
-  private final Integer gracePeriodSeconds = null;
+  private Integer gracePeriodSeconds = null;
   private final Boolean orphanDependents = null;
   private final String propagationPolicy = null;
 
@@ -537,6 +537,11 @@ public class CallBuilder {
 
   public CallBuilder withTimeoutSeconds(int timeoutSeconds) {
     this.timeoutSeconds = timeoutSeconds;
+    return this;
+  }
+
+  public CallBuilder withGracePeriodSeconds(int gracePeriodSeconds) {
+    this.gracePeriodSeconds = gracePeriodSeconds;
     return this;
   }
 
@@ -1909,6 +1914,7 @@ public class CallBuilder {
         helper,
         timeoutSeconds,
         maxRetryCount,
+        gracePeriodSeconds,
         fieldSelector,
         labelSelector,
         resourceVersion);
@@ -1924,6 +1930,7 @@ public class CallBuilder {
             helper,
             timeoutSeconds,
             maxRetryCount,
+            gracePeriodSeconds,
             fieldSelector,
             labelSelector,
             resourceVersion);
@@ -1939,6 +1946,7 @@ public class CallBuilder {
             helper,
             timeoutSeconds,
             maxRetryCount,
+            gracePeriodSeconds,
             fieldSelector,
             labelSelector,
             resourceVersion);

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -134,6 +134,7 @@ public class MessageKeys {
   public static final String INTROSPECTOR_JOB_FAILED_DETAIL = "WLSKO-0176";
   public static final String INTROSPECTOR_POD_FAILED = "WLSKO-0177";
   public static final String CRD_NOT_INSTALLED = "WLSKO-0178";
+  public static final String POD_FORCE_DELETED = "WLSKO-0179";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/java/oracle/kubernetes/utils/SystemClock.java
+++ b/operator/src/main/java/oracle/kubernetes/utils/SystemClock.java
@@ -8,8 +8,9 @@ import org.joda.time.DateTime;
 /** A wrapper for the system clock that facilitates unit testing of time. */
 public abstract class SystemClock {
 
-  private static SystemClock DELEGATE =
-      new SystemClock() {
+  // Leave as non-final; unit tests may replace this value
+  @SuppressWarnings("FieldMayBeFinal")
+  private static SystemClock DELEGATE = new SystemClock() {
         @Override
         public DateTime getCurrentTime() {
           return DateTime.now();

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -188,6 +188,7 @@ WLSKO-0175=Job {0} in namespace {1} failed with status {2}. Check log messages \
 WLSKO-0176=Job {1} in namespace {0} failed, job details are {2}
 WLSKO-0177=Pod {0} in namespace {1} failed, the pod status is {2}
 WLSKO-0178=Operator cannot proceed, as the Custom Resource Definition for ''domains.weblogic.oracle'' is not installed.
+WLSKO-0179=Pod {0} in namespace {1} detected as stuck, and force-deleted
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
@@ -1,0 +1,206 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.meterware.simplestub.Memento;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.TuningParametersStub;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
+import oracle.kubernetes.utils.SystemClockTestSupport;
+import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.weblogic.domain.model.Domain;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.meterware.simplestub.Stub.createStrictStub;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.createTestDomain;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.POD;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class StuckPodTest {
+
+  private static final long DELETION_GRACE_PERIOD_SECONDS = 5L;
+  private static final String SERVER_POD_1 = "name1";
+  private static final String SERVER_POD_2 = "name2";
+  private static final String FOREIGN_POD = "foreign";
+  private final List<Memento> mementos = new ArrayList<>();
+  private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final Domain domain = createTestDomain();
+  private final MainDelegateStub mainDelegate = createStrictStub(MainDelegateStub.class, testSupport);
+  private final StuckPodProcessing processing = new StuckPodProcessing(mainDelegate);
+  private final V1Pod managedPod1 = defineManagedPod(SERVER_POD_1);
+  private final V1Pod managedPod2 = defineManagedPod(SERVER_POD_2);
+  private final V1Pod foreignPod = defineForeignPod(FOREIGN_POD);
+
+  @Before
+  public void setUp() throws Exception {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(testSupport.install());
+    mementos.add(SystemClockTestSupport.installClock());
+    mementos.add(TuningParametersStub.install());
+    mementos.add(NoopWatcherStarter.install());
+
+    testSupport.defineResources(domain, managedPod1, managedPod2, foreignPod);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    testSupport.throwOnCompletionFailure();
+    
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  public void whenServerPodNotDeleted_ignoreIt() {
+    SystemClockTestSupport.increment(DELETION_GRACE_PERIOD_SECONDS);
+
+    processing.checkStuckPods(NS);
+
+    assertThat(getSelectedPod(SERVER_POD_1), notNullValue());
+  }
+
+  @Test
+  public void whenServerPodNotStuck_ignoreIt() {
+    markAsDelete(getSelectedPod(SERVER_POD_1));
+    SystemClockTestSupport.increment(DELETION_GRACE_PERIOD_SECONDS - 1);
+
+    processing.checkStuckPods(NS);
+
+    assertThat(getSelectedPod(SERVER_POD_1), notNullValue());
+  }
+
+  @Test
+  public void whenServerPodStuck_deleteIt() {
+    markAsDelete(getSelectedPod(SERVER_POD_1));
+    SystemClockTestSupport.increment(DELETION_GRACE_PERIOD_SECONDS + 1);
+
+    processing.checkStuckPods(NS);
+
+    assertThat(getSelectedPod(SERVER_POD_1), nullValue());
+  }
+
+  @Test
+  public void whenServerPodStuck_initiateMakeRightProcessing() {
+    markAsDelete(getSelectedPod(SERVER_POD_2));
+    SystemClockTestSupport.increment(DELETION_GRACE_PERIOD_SECONDS + 1);
+
+    processing.checkStuckPods(NS);
+
+    assertThat(mainDelegate.makeRightInvoked(domain), is(true));
+  }
+
+  @Test
+  public void whenForeignPodStuck_ignoreIt() {
+    markAsDelete(getSelectedPod(FOREIGN_POD));
+    SystemClockTestSupport.increment(DELETION_GRACE_PERIOD_SECONDS + 1);
+
+    processing.checkStuckPods(NS);
+
+    assertThat(getSelectedPod(FOREIGN_POD), notNullValue());
+  }
+
+  private V1Pod getSelectedPod(String name) {
+    return testSupport.getResourceWithName(POD, name);
+  }
+
+  private V1Pod defineManagedPod(String name) {
+    return new V1Pod().metadata(createManagedPodMetadata(name));
+  }
+
+  private V1ObjectMeta createManagedPodMetadata(String name) {
+    return createPodMetadata(name)
+          .putLabelsItem(LabelConstants.CREATEDBYOPERATOR_LABEL,"true")
+          .putLabelsItem(LabelConstants.DOMAINNAME_LABEL, UID)
+          .putLabelsItem(LabelConstants.SERVERNAME_LABEL, name);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private V1Pod defineForeignPod(String name) {
+    return new V1Pod().metadata(createPodMetadata(name));
+  }
+
+  private V1ObjectMeta createPodMetadata(String name) {
+    return new V1ObjectMeta()
+          .name(name)
+          .namespace(NS);
+  }
+
+  private void markAsDelete(V1Pod pod) {
+    Objects.requireNonNull(pod.getMetadata())
+          .deletionGracePeriodSeconds(DELETION_GRACE_PERIOD_SECONDS)
+          .deletionTimestamp(SystemClock.now());
+  }
+
+  abstract static class MainDelegateStub implements MainDelegate {
+    private final List<Domain> invocations = new ArrayList<>();
+    private final DomainProcessorStub domainProcessor = createStrictStub(DomainProcessorStub.class, this);
+    private final DomainNamespaces domainNamespaces = new DomainNamespaces();
+    private final KubernetesTestSupport testSupport;
+
+    MainDelegateStub(KubernetesTestSupport testSupport) {
+      this.testSupport = testSupport;
+    }
+
+    boolean makeRightInvoked(Domain domain) {
+      return invocations.contains(domain);
+    }
+
+    @Override
+    public void runSteps(Step firstStep) {
+      testSupport.runSteps(firstStep);
+    }
+
+    @Override
+    public DomainProcessor getDomainProcessor() {
+      return domainProcessor;
+    }
+
+    @Override
+    public DomainNamespaces getDomainNamespaces() {
+      return domainNamespaces;
+    }
+
+    abstract static class DomainProcessorStub implements DomainProcessor {
+      private final MainDelegateStub delegateStub;
+
+      DomainProcessorStub(MainDelegateStub delegateStub) {
+        this.delegateStub = delegateStub;
+      }
+
+      @Override
+      public MakeRightDomainOperation createMakeRightOperation(DomainPresenceInfo info) {
+        Optional.ofNullable(info).map(DomainPresenceInfo::getDomain).ifPresent(delegateStub.invocations::add);
+        return createStrictStub(MakeRightDomainOperationStub.class);
+      }
+    }
+
+    abstract static class MakeRightDomainOperationStub implements MakeRightDomainOperation {
+
+      @Override
+      public MakeRightDomainOperation withExplicitRecheck() {
+        return this;
+      }
+
+      @Override
+      public void execute() {
+        
+      }
+    }
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
@@ -65,7 +65,7 @@ public abstract class TuningParametersStub implements TuningParameters {
 
   @Override
   public MainTuning getMainTuning() {
-    return new MainTuning(2, 2, 2, 2, 2, 2, 2L, 2L);
+    return new MainTuning(2, 2, 2, 2, 2, 2, 30, 2L, 2L);
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/utils/SystemClockTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/SystemClockTestSupport.java
@@ -21,12 +21,23 @@ public class SystemClockTestSupport {
     return new DuringTestTimeMatcher();
   }
 
+  /**
+   * Increments the system clock by the specified number of seconds.
+   * @param numSeconds the number of seconds by which to advance the system clock
+   */
+  public static void increment(long numSeconds) {
+    clock.increment(numSeconds);
+  }
+
+  /**
+   * Increments the system clock by one second.
+   */
   public static void increment() {
-    clock.increment();
+    clock.increment(1L);
   }
 
   static class TestSystemClock extends SystemClock {
-    private long testStartTime = 0;
+    private final long testStartTime = 0;
     private long currentTime = testStartTime;
 
     @Override
@@ -34,8 +45,8 @@ public class SystemClockTestSupport {
       return new DateTime(currentTime);
     }
 
-    void increment() {
-      currentTime = currentTime + 1000;
+    void increment(long numSeconds) {
+      currentTime = currentTime + 1000 * numSeconds;
     }
   }
 


### PR DESCRIPTION
This code looks for stuck pods, which is detects by comparing the current time with any deleted time stamp, allowing for the specified grace period. If any pods managed by the operator is terminated, but are still present after the grace period, the operator will force-delete them and run a new make-right on their domain(s).

Note: we need to do some code cleanup on the async calls. Adding new parameters to be checked by unit tests is increasingly difficult. It is time to introduce an object rather than passing in a list (see Clean Code, chapter 3, regarding function parameters).