### PR TITLE
fix K8s setup doc

### DIFF
--- a/docs-source/content/userguide/overview/k8s-setup.md
+++ b/docs-source/content/userguide/overview/k8s-setup.md
@@ -208,7 +208,7 @@ These instructions are for Oracle Linux 7u2+.  If you are using a different flav
 1. Set an environment variable with the Docker version you want to install:
 
     ```
-    docker_version="17.03.1.ce"
+    docker_version="18.09.1.ol"
     ```
 
 1. Install Docker, removing any previously installed version:
@@ -273,7 +273,7 @@ These instructions are for Oracle Linux 7u2+.  If you are using a different flav
 
     setenforce 0
     # install kube* packages
-    v=${1:-1.8.4-0}
+    v=${1:-1.17.0-0}
     old_ver=`echo $v | egrep "^1.7"`
     yum install -y kubelet-$v kubeadm-$v kubectl-$v kubernetes-cni
 


### PR DESCRIPTION
Update Docker and Kubernetes versions in the K8s setup doc, according to JIRA (OWLS-80570 K8S INSTALL STEP AND PRE-REQUISITE FOR KUBCTL AND DOCKER VERSION ARE NOT IN SYNC