### PR TITLE
owls-85910 - display correct minimumReplicas status for dynamic clusters

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -602,7 +602,8 @@ public class DomainStatusUpdater {
       }
 
       private Integer getClusterMinimumSize(String clusterName) {
-        return getDomainConfig()
+        return getDomain().isAllowReplicasBelowMinDynClusterSize(clusterName)
+              ? 0 : getDomainConfig()
               .map(config -> config.getClusterConfig(clusterName))
               .map(WlsClusterConfig::getMinClusterSize)
               .orElse(0);


### PR DESCRIPTION
OWLS-85910 - Display correct value of `domain.status.clusters[].minimumReplicas`  for dynamic clusters when `domain.spec.allowReplicasBelowMinDynClusterSize` is at its default (true).