### PR TITLE
Owls85476 attempt to fix intermittent integration test issues in nightlies

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -83,7 +83,6 @@ import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPodKubectl;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.appNotAccessibleInPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
@@ -982,7 +981,7 @@ class ItMiiDomain {
             namespace,
             condition.getElapsedTimeInMS(),
             condition.getRemainingTimeInMS()))
-        .until(() -> appAccessibleInPod(
+        .until(() -> appAccessibleInPodKubectl(
                 namespace,
                 podName, 
                 internalPort, 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -123,6 +123,7 @@ class ItMiiDomain {
   private String miiImageAddSecondApp = null;
   private String miiImage = null;
   private static LoggingFacade logger = null;
+  private static boolean mainThreadDone = false;
 
   /**
    * Install Operator.
@@ -395,7 +396,7 @@ class ItMiiDomain {
             MII_APP_RESPONSE_V2 + i);
       } 
     } finally {
-    
+      mainThreadDone = true;
       if (accountingThread != null) {
         try {
           accountingThread.join();
@@ -1125,7 +1126,7 @@ class ItMiiDomain {
       }
 
       logger.fine("YYYYYYYYYYY: application available YYYYYYYY count = " + count);
-      return v2AppAvailable;
+      return v2AppAvailable || mainThreadDone;
     };
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -83,7 +83,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.dockerLogin;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPodKubectl;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.appNotAccessibleInPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainResourceImagePatched;
@@ -981,7 +981,7 @@ class ItMiiDomain {
             namespace,
             condition.getElapsedTimeInMS(),
             condition.getRemainingTimeInMS()))
-        .until(() -> appAccessibleInPodKubectl(
+        .until(() -> appAccessibleInPod(
                 namespace,
                 podName, 
                 internalPort, 
@@ -1098,7 +1098,7 @@ class ItMiiDomain {
       boolean v2AppAvailable = true;
       
       for (int i = 1; i <= replicaCount; i++) {
-        v2AppAvailable = v2AppAvailable && appAccessibleInPodKubectl(
+        v2AppAvailable = v2AppAvailable && appAccessibleInPod(
                             namespace,
                             managedServerPrefix + i,
                             internalPort,
@@ -1108,7 +1108,7 @@ class ItMiiDomain {
 
       int count = 0;
       for (int i = 1; i <= replicaCount; i++) {
-        if (appAccessibleInPodKubectl(
+        if (appAccessibleInPod(
             namespace,
             managedServerPrefix + i,
             internalPort,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -1121,7 +1121,7 @@ class ItMiiDomain {
       appAvailability.add(count);
 
       if (count == 0) {
-        logger.info("XXXXXXXXXXX: application not available XXXXXXXX");
+        logger.info("NNNNNNNNNNN: application not available NNNNNNNN");
         return true;
       }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -123,7 +123,7 @@ class ItMiiDomain {
   private String miiImageAddSecondApp = null;
   private String miiImage = null;
   private static LoggingFacade logger = null;
-  private static boolean mainThreadDone = false;
+  private static volatile boolean mainThreadDone = false;
 
   /**
    * Install Operator.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
@@ -83,6 +84,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPod;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPodKubectl;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.appNotAccessibleInPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainResourceImagePatched;
@@ -137,9 +139,9 @@ class ItMiiDomain {
         .atMost(6, MINUTES).await();
 
     // create a reusable quick retry policy
-    withQuickRetryPolicy = with().pollDelay(0, SECONDS)
-        .and().with().pollInterval(4, SECONDS)
-        .atMost(10, SECONDS).await();
+    withQuickRetryPolicy = with().pollDelay(1, SECONDS)
+        .and().with().pollInterval(2, SECONDS)
+        .atMost(15, SECONDS).await();
 
     // get a new unique opNamespace
     logger.info("Creating unique namespace for Operator");
@@ -334,7 +336,7 @@ class ItMiiDomain {
     accountingThread =
         new Thread(
             () -> {
-              collectAppAvaiability(
+              collectAppAvailability(
                   domainNamespace,
                   appAvailability,
                   managedServerPrefix,
@@ -1060,7 +1062,7 @@ class ItMiiDomain {
                namespace)));
   }
   
-  private static void collectAppAvaiability(
+  private static void collectAppAvailability(
       String namespace,
       List<Integer> appAvailability,
       String managedServerPrefix,
@@ -1068,48 +1070,66 @@ class ItMiiDomain {
       String internalPort,
       String appPath
   ) {
-    boolean v2AppAvailable = false;
+    with().pollDelay(2, SECONDS)
+        .and().with().pollInterval(200, MILLISECONDS)
+        .atMost(15, MINUTES)
+        .await()
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for patched application running on all managed servers in namespace {1} "
+                + "(elapsed time {2}ms, remaining time {3}ms)",
+            namespace,
+            condition.getElapsedTimeInMS(),
+            condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> checkContinuousAvailability(
+            namespace, appAvailability, managedServerPrefix, replicaCount, internalPort, appPath),
+            String.format(
+                "App is not available on all managed servers in namespace %s.",
+                namespace)));
 
-    // Access the pod periodically to check application's availability across the duration
-    // of patching the domain with newer version of the application.
-    while (!v2AppAvailable)  {
-      v2AppAvailable = true;
+  }
+
+  private static Callable<Boolean> checkContinuousAvailability(
+      String namespace,
+      List<Integer> appAvailability,
+      String managedServerPrefix,
+      int replicaCount,
+      String internalPort,
+      String appPath) {
+    return () -> {
+      boolean v2AppAvailable = true;
+      
       for (int i = 1; i <= replicaCount; i++) {
-        v2AppAvailable = v2AppAvailable && appAccessibleInPod(
+        v2AppAvailable = v2AppAvailable && appAccessibleInPodKubectl(
                             namespace,
-                            managedServerPrefix + i, 
-                            internalPort, 
-                            appPath, 
+                            managedServerPrefix + i,
+                            internalPort,
+                            appPath,
                             MII_APP_RESPONSE_V2 + i);
       }
 
       int count = 0;
       for (int i = 1; i <= replicaCount; i++) {
-        if (appAccessibleInPod(
+        if (appAccessibleInPodKubectl(
             namespace,
-            managedServerPrefix + i, 
-            internalPort, 
-            appPath, 
-            "Hello World")) {  
+            managedServerPrefix + i,
+            internalPort,
+            appPath,
+            "Hello World")) {
           count++;
         }
       }
       appAvailability.add(count);
-      
+
       if (count == 0) {
         logger.info("XXXXXXXXXXX: application not available XXXXXXXX");
-        break;
-      } else {
-        logger.fine("YYYYYYYYYYY: application available YYYYYYYY count = " + count);   
+        return true;
       }
-      try {
-        TimeUnit.MILLISECONDS.sleep(200);
-      } catch (InterruptedException ie) {
-        // do nothing
-      }
-    }
+
+      logger.fine("YYYYYYYYYYY: application available YYYYYYYY count = " + count);
+      return v2AppAvailable;
+    };
   }
-  
+
   private static boolean appAlwaysAvailable(List<Integer> appAvailability) {
     for (Integer count: appAvailability) {
       if (count == 0) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -489,7 +489,7 @@ public class TestAssertions {
       String appPath,
       String expectedResponse
   ) {
-    return !Application.appAccessibleInPod(namespace, podName, port, appPath, expectedResponse);
+    return !Application.appAccessibleInPodKubectl(namespace, podName, port, appPath, expectedResponse);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -431,8 +431,7 @@ public class TestAssertions {
   }
 
   /**
-   * Check if an application is accessible inside a WebLogic server pod using
-   * Kubernetes Java client API.
+   * Check if an application is accessible inside a WebLogic server pod.
    *
    * @param namespace Kubernetes namespace where the WebLogic server pod is running
    * @param podName name of the WebLogic server pod
@@ -442,27 +441,6 @@ public class TestAssertions {
    * @return true if the command succeeds
    */
   public static boolean appAccessibleInPod(
-      String namespace,
-      String podName,
-      String port,
-      String appPath,
-      String expectedResponse
-  ) {
-    return Application.appAccessibleInPod(namespace, podName, port, appPath, expectedResponse);
-  }
-
-  /**
-   * Check if an application is accessible inside a WebLogic server pod using
-   * "kubectl exec" command.
-   *
-   * @param namespace Kubernetes namespace where the WebLogic server pod is running
-   * @param podName name of the WebLogic server pod
-   * @param port internal port of the managed server running in the pod
-   * @param appPath path to access the application
-   * @param expectedResponse the expected response from the application
-   * @return true if the command succeeds
-   */
-  public static boolean appAccessibleInPodKubectl(
       String namespace,
       String podName,
       String port,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Application.java
@@ -83,7 +83,7 @@ public class Application {
   }
 
   /**
-   * Check if an application is accessible inside a WebLogic server pod.
+   * Check if an application is accessible inside a WebLogic server pod using "kubectl exec" command.
    *
    * @param namespace Kubernetes namespace where the WebLogic server pod is running
    * @param podName name of the WebLogic server pod


### PR DESCRIPTION
1. Use "kubectl exec" instead of Kubernetes Java client exec call to verify application accessibility.
2. Use Awaitility utilities instead of a while loop for retries.
3. Sync up with the completion of the main thread from the accounting thread.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3043/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3044/