### PR TITLE
Response from pod delete REST call can be Pod or Status

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
@@ -139,7 +139,7 @@ public class StuckPodProcessing {
     }
   }
 
-  static class ForcedDeleteResponseStep extends DefaultResponseStep<V1Pod> {
+  static class ForcedDeleteResponseStep extends DefaultResponseStep<Object> {
 
     private final String name;
     private final String namespace;
@@ -150,7 +150,7 @@ public class StuckPodProcessing {
     }
 
     @Override
-    public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
+    public NextAction onSuccess(Packet packet, CallResponse<Object> callResponse) {
       LOGGER.info(POD_FORCE_DELETED, name, namespace);
       return super.onSuccess(packet, callResponse);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -4,22 +4,28 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 
 import com.google.common.base.Strings;
+import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Pair;
 import io.kubernetes.client.openapi.apis.ApiextensionsV1Api;
 import io.kubernetes.client.openapi.apis.ApiextensionsV1beta1Api;
 import io.kubernetes.client.openapi.apis.AuthenticationV1Api;
 import io.kubernetes.client.openapi.apis.AuthorizationV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.apis.VersionApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
@@ -70,7 +76,6 @@ import static oracle.kubernetes.operator.helpers.KubernetesUtils.getDomainUidLab
 /** Simplifies synchronous and asynchronous call patterns to the Kubernetes API Server. */
 @SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
 public class CallBuilder {
-
   /** HTTP status code for "Not Found". */
   public static final int NOT_FOUND = 404;
 
@@ -1185,19 +1190,8 @@ public class CallBuilder {
       V1DeleteOptions deleteOptions,
       ApiCallback<Object> callback)
       throws ApiException {
-    return new CustomObjectsApi(client)
-        .deleteNamespacedCustomObjectAsync(
-            "",
-            "v1",
-            namespace,
-            "pods",
-            name,
-            gracePeriodSeconds,
-            orphanDependents,
-            propagationPolicy,
-            dryRun,
-            deleteOptions,
-            callback);
+    return deleteNamespacedPodAsync(client, name, namespace, pretty, dryRun, gracePeriodSeconds,
+        orphanDependents, propagationPolicy, deleteOptions, callback);
   }
 
   /**
@@ -1211,14 +1205,87 @@ public class CallBuilder {
    * @return Asynchronous step
    */
   public Step deletePodAsync(
-      String name,
-      String namespace,
-      String domainUid,
-      V1DeleteOptions deleteOptions,
-      ResponseStep<Object> responseStep) {
+          String name,
+          String namespace,
+          String domainUid,
+          V1DeleteOptions deleteOptions,
+          ResponseStep<Object> responseStep) {
     return createRequestAsync(
-        responseStep, new RequestParams("deletePod", namespace, name, deleteOptions, domainUid),
+            responseStep, new RequestParams("deletePod", namespace, name, deleteOptions, domainUid),
             deletePod, retryStrategy);
+  }
+
+  private Call deleteNamespacedPodAsync(ApiClient client, String name, String namespace, String pretty, String dryRun,
+                                       Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy,
+                                       V1DeleteOptions body, ApiCallback<Object> callback) throws ApiException {
+    Call localVarCall = this.deleteNamespacedPodValidateBeforeCall(client, name, namespace, pretty, dryRun,
+        gracePeriodSeconds, orphanDependents, propagationPolicy, body, callback);
+    Type localVarReturnType = (new TypeToken<Object>() {
+    }).getType();
+    client.executeAsync(localVarCall, localVarReturnType, callback);
+    return localVarCall;
+  }
+
+  private Call deleteNamespacedPodValidateBeforeCall(ApiClient client, String name, String namespace, String pretty,
+                                                     String dryRun, Integer gracePeriodSeconds,
+                                                     Boolean orphanDependents, String propagationPolicy,
+                                                     V1DeleteOptions body, ApiCallback callback) throws ApiException {
+    if (name == null) {
+      throw new ApiException("Missing the required parameter 'name' when calling deleteNamespacedPod(Async)");
+    } else if (namespace == null) {
+      throw new ApiException("Missing the required parameter 'namespace' when calling deleteNamespacedPod(Async)");
+    } else {
+      Call localVarCall = this.deleteNamespacedPodCall(client, name, namespace, pretty, dryRun, gracePeriodSeconds,
+          orphanDependents, propagationPolicy, body, callback);
+      return localVarCall;
+    }
+  }
+
+  private Call deleteNamespacedPodCall(ApiClient client, String name, String namespace, String pretty, String dryRun,
+                                      Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy,
+                                      V1DeleteOptions body, ApiCallback callback) throws ApiException {
+    String localVarPath = "/api/v1/namespaces/{namespace}/pods/{name}".replaceAll("\\{name\\}",
+            client.escapeString(name.toString())).replaceAll("\\{namespace\\}",
+            client.escapeString(namespace.toString()));
+    List<Pair> localVarQueryParams = new ArrayList();
+    List<Pair> localVarCollectionQueryParams = new ArrayList();
+    if (pretty != null) {
+      localVarQueryParams.addAll(client.parameterToPair("pretty", pretty));
+    }
+
+    if (dryRun != null) {
+      localVarQueryParams.addAll(client.parameterToPair("dryRun", dryRun));
+    }
+
+    if (gracePeriodSeconds != null) {
+      localVarQueryParams.addAll(client.parameterToPair("gracePeriodSeconds", gracePeriodSeconds));
+    }
+
+    if (orphanDependents != null) {
+      localVarQueryParams.addAll(client.parameterToPair("orphanDependents", orphanDependents));
+    }
+
+    if (propagationPolicy != null) {
+      localVarQueryParams.addAll(client.parameterToPair("propagationPolicy", propagationPolicy));
+    }
+
+    Map<String, String> localVarHeaderParams = new HashMap();
+    Map<String, String> localVarCookieParams = new HashMap();
+    Map<String, Object> localVarFormParams = new HashMap();
+    String[] localVarAccepts = new String[]{
+        "application/json", "application/yaml", "application/vnd.kubernetes.protobuf"
+    };
+    String localVarAccept = client.selectHeaderAccept(localVarAccepts);
+    if (localVarAccept != null) {
+      localVarHeaderParams.put("Accept", localVarAccept);
+    }
+
+    String[] localVarContentTypes = new String[0];
+    String localVarContentType = client.selectHeaderContentType(localVarContentTypes);
+    localVarHeaderParams.put("Content-Type", localVarContentType);
+    String[] localVarAuthNames = new String[]{"BearerToken"};
+    return client.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, body,
+            localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, callback);
   }
 
   private Call patchPodAsync(

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.openapi.apis.AuthenticationV1Api;
 import io.kubernetes.client.openapi.apis.AuthorizationV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.apis.VersionApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
@@ -317,7 +318,7 @@ public class CallBuilder {
                   requestParams.namespace,
                   (V1DeleteOptions) requestParams.body,
                   callback));
-  private final CallFactory<V1Pod> deletePod =
+  private final CallFactory<Object> deletePod =
       (requestParams, usage, cont, callback) ->
           wrap(
               deletePodAsync(
@@ -1182,17 +1183,19 @@ public class CallBuilder {
       String name,
       String namespace,
       V1DeleteOptions deleteOptions,
-      ApiCallback<V1Pod> callback)
+      ApiCallback<Object> callback)
       throws ApiException {
-    return new CoreV1Api(client)
-        .deleteNamespacedPodAsync(
-            name,
+    return new CustomObjectsApi(client)
+        .deleteNamespacedCustomObjectAsync(
+            "api",
+            "v1",
             namespace,
-            pretty,
-            dryRun,
+            "pods",
+            name,
             gracePeriodSeconds,
             orphanDependents,
             propagationPolicy,
+            dryRun,
             deleteOptions,
             callback);
   }
@@ -1212,7 +1215,7 @@ public class CallBuilder {
       String namespace,
       String domainUid,
       V1DeleteOptions deleteOptions,
-      ResponseStep<V1Pod> responseStep) {
+      ResponseStep<Object> responseStep) {
     return createRequestAsync(
         responseStep, new RequestParams("deletePod", namespace, name, deleteOptions, domainUid),
             deletePod, retryStrategy);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -1187,7 +1187,7 @@ public class CallBuilder {
       throws ApiException {
     return new CustomObjectsApi(client)
         .deleteNamespacedCustomObjectAsync(
-            "api",
+            "",
             "v1",
             namespace,
             "pods",

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -1190,8 +1190,17 @@ public class CallBuilder {
       V1DeleteOptions deleteOptions,
       ApiCallback<Object> callback)
       throws ApiException {
-    return deleteNamespacedPodAsync(client, name, namespace, pretty, dryRun, gracePeriodSeconds,
-        orphanDependents, propagationPolicy, deleteOptions, callback);
+    return deleteNamespacedPodAsync(
+        client,
+        name,
+        namespace,
+        pretty,
+        dryRun,
+        gracePeriodSeconds,
+        orphanDependents,
+        propagationPolicy,
+        deleteOptions,
+        callback);
   }
 
   /**
@@ -1205,11 +1214,11 @@ public class CallBuilder {
    * @return Asynchronous step
    */
   public Step deletePodAsync(
-          String name,
-          String namespace,
-          String domainUid,
-          V1DeleteOptions deleteOptions,
-          ResponseStep<Object> responseStep) {
+      String name,
+      String namespace,
+      String domainUid,
+      V1DeleteOptions deleteOptions,
+      ResponseStep<Object> responseStep) {
     return createRequestAsync(
             responseStep, new RequestParams("deletePod", namespace, name, deleteOptions, domainUid),
             deletePod, retryStrategy);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -282,11 +282,11 @@ public class PodHelper {
     }
 
     @Override
-    Step replaceCurrentPod(Step next) {
+    Step replaceCurrentPod(V1Pod pod, Step next) {
       if (MakeRightDomainOperation.isInspectionRequired(packet)) {
         return createProgressingStep(MakeRightDomainOperation.createStepsToRerunWithIntrospection(packet));
       } else {
-        return createProgressingStep(createCyclePodStep(next));
+        return createProgressingStep(createCyclePodStep(pod, next));
       }
     }
 
@@ -409,8 +409,8 @@ public class PodHelper {
 
     @Override
     // let the pod rolling step update the pod
-    Step replaceCurrentPod(Step next) {
-      return deferProcessing(createCyclePodStep(next));
+    Step replaceCurrentPod(V1Pod pod, Step next) {
+      return deferProcessing(createCyclePodStep(pod, next));
     }
 
     private Step deferProcessing(Step deferredStep) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
@@ -373,7 +373,7 @@ public class KubernetesTestSupportTest {
     V1Pod pod3 = createPod("ns3", "another");
     testSupport.defineResources(pod1, pod2, pod3);
 
-    TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
+    TestResponseStep<Object> responseStep = new TestResponseStep<>();
     testSupport.runSteps(new CallBuilder().deletePodAsync("mycrd", "ns2", "", null, responseStep));
 
     assertThat(testSupport.getResources(POD), containsInAnyOrder(pod1, pod3));
@@ -383,7 +383,7 @@ public class KubernetesTestSupportTest {
   public void whenHttpErrorAssociatedWithResource_callResponseIsError() {
     testSupport.failOnResource(POD, "pod1", "ns2", HTTP_BAD_REQUEST);
 
-    TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
+    TestResponseStep<Object> responseStep = new TestResponseStep<>();
     testSupport.runSteps(new CallBuilder().deletePodAsync("pod1", "ns2", "", null, responseStep));
 
     testSupport.verifyCompletionThrowable(FailureStatusSourceException.class);
@@ -394,7 +394,7 @@ public class KubernetesTestSupportTest {
   public void whenHttpErrorNotAssociatedWithResource_ignoreIt() {
     testSupport.failOnResource(POD, "pod1", "ns2", HTTP_BAD_REQUEST);
 
-    TestResponseStep<V1Pod> responseStep = new TestResponseStep<>();
+    TestResponseStep<Object> responseStep = new TestResponseStep<>();
     testSupport.runSteps(new CallBuilder().deletePodAsync("pod2", "ns2", "", null, responseStep));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
@@ -154,7 +154,10 @@ public class RollingHelperTest {
     return new Step.StepAndPacket(DomainStatusUpdater.createProgressingStep(
         DomainStatusUpdater.MANAGED_SERVERS_STARTING_PROGRESS_REASON,
         false,
-        new ManagedPodStepContext(terminalStep, packet).createCyclePodStep(null)), packet);
+        new ManagedPodStepContext(terminalStep, packet).createCyclePodStep(
+            testSupport.getResourceWithName(
+                KubernetesTestSupport.POD,
+                LegalNames.toPodName(UID, serverName)), null)), packet);
   }
 
   private void initializeExistingPods() {


### PR DESCRIPTION
We've had a long-running issue where calls to delete a pod would fail even though the underlying deletion was successful. This failure was due to attempting to deserialize a Pod from the response even though the actual response from the REST call could either be a Pod or a Status depending on the timing of the underlying deletion operation.

The Java API handled this by only handling the Pod response and failing otherwise.

This is causing problems with the "stuck Terminating pod" deletion functionality because that activity is retried repeatedly interleaving with the operator's behavior to create a new pod -- therefore, the customer would see a pod deleted, immediately recreated, and then deleted again in a cycle that would go for five iterations.

This change replaces the pod deletion response code with one that only assumes that the response will be an Object. It turns out that we never really looked at the return value assuming that the call was successful.