### PR TITLE
OWLS 85938 - Server lifecycle script changes to use domain.status.minimumReplicas when stopping/starting server

### DIFF
--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -82,6 +82,7 @@ serverStarted=""
 effectivePolicy=""
 managedServerPolicy=""
 stoppedWhenAlwaysPolicyReset=""
+replicasEqualsMinReplicas=""
 withReplicas="CONSTANT"
 withPolicy="CONSTANT"
 
@@ -150,6 +151,16 @@ else
   if [[ "${effectivePolicy}" == "NEVER" || "${effectivePolicy}" == "ADMIN_ONLY" ]]; then
     printInfo "No changes needed, exiting. Server should be already stopping or stopped because effective sever start policy is 'NEVER' or 'ADMIN_ONLY'."
     exit 0
+  fi
+fi
+
+if [[ -n "${clusterName}" && "${keepReplicaConstant}" == 'false' ]]; then
+  # check if replica count can decrease below current value
+  isReplicaCountEqualToMinReplicas "${domainJson}" "${clusterName}" replicasEqualsMinReplicas
+  if [ "${replicasEqualsMinReplicas}" == 'true' ]; then
+    printInfo "Current replica count value is same as minimum number of replica count. \
+      Not decreasing the replica count value."
+    keepReplicaConstant=true
   fi
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -158,8 +158,9 @@ if [[ -n "${clusterName}" && "${keepReplicaConstant}" == 'false' ]]; then
   # check if replica count can decrease below current value
   isReplicaCountEqualToMinReplicas "${domainJson}" "${clusterName}" replicasEqualsMinReplicas
   if [ "${replicasEqualsMinReplicas}" == 'true' ]; then
-    printInfo "Current replica count value is same as minimum number of replica count. \
-      Not decreasing the replica count value."
+    printInfo "Not decreasing the replica count value: it is at its minimum. \
+      (See 'domain.spec.allowReplicasBelowMinDynClusterSize' and \
+      'domain.status.clusters[].minimumReplicas' for details)."
     keepReplicaConstant=true
   fi
 fi


### PR DESCRIPTION
OWLS 85938 - Server lifecycle script changes to use `domain.status.minimumReplicas` when allowReplicasBelowMinDynClusterSize is set to `false`. It also fixes a minor bug when setting server start policy to ALWAYS.

This change adds a check in stop script to see if replica count value is same as minimum replica count value and prevents script from incorrectly assuming that decreasing the replica count would shut down a server. Additionally, when replica count value of cluster is lower than minimum replica count, it resets the replica count value to minimum replica count value. This helps server start script to know the value of effective replica count.