### PR TITLE
Update the startServer.sh copy functionality to only chmod owned files

### DIFF
--- a/docs-source/content/faq/oci-fss-pv.md
+++ b/docs-source/content/faq/oci-fss-pv.md
@@ -53,7 +53,7 @@ Init Containers:
     Command:
       sh
       -c
-      chown -R 1000:1000 /shared
+      chown -R 1000:0 /shared
     State:          Terminated
       Reason:       Error
       Exit Code:    1
@@ -85,7 +85,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "chown 1000:1000 %DOMAIN_ROOT_DIR%/. && find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown -R 1000:1000"]
+          command: ["sh", "-c", "chown 1000:0 %DOMAIN_ROOT_DIR%/. && find %DOMAIN_ROOT_DIR%/. -maxdepth 1 ! -name '.snapshot' ! -name '.' -print0 | xargs -r -0 chown -R 1000:0"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
@@ -398,7 +398,7 @@ public class ItIstioDomainInPV  {
                         .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                         .addCommandItem("/bin/sh")
                         .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /shared")
+                        .addArgsItem("chown -R 1000:0 /shared")
                         .volumeMounts(Arrays.asList(
                             new V1VolumeMount()
                                 .name(pvName)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -347,7 +347,7 @@ public class ItMiiDomainModelInPV {
                 .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                 .addCommandItem("/bin/sh")
                 .addArgsItem("-c")
-                .addArgsItem("chown -R 1000:1000 " + modelMountPath)
+                .addArgsItem("chown -R 1000:0 " + modelMountPath)
                 .volumeMounts(Arrays.asList(
                     new V1VolumeMount()
                         .name(pvName)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -950,7 +950,7 @@ class ItMiiUpdateDomainConfig {
                         .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                         .addCommandItem("/bin/sh")
                         .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /shared")
+                        .addArgsItem("chown -R 1000:0 /shared")
                         .addVolumeMountsItem(
                             new V1VolumeMount()
                                 .name(pvName)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -1234,7 +1234,7 @@ class ItParameterizedDomain {
                         .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                         .addCommandItem("/bin/sh")
                         .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /u01/shared")
+                        .addArgsItem("chown -R 1000:0 /u01/shared")
                         .addVolumeMountsItem(
                             new V1VolumeMount()
                                 .name(pvName)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
@@ -1069,7 +1069,7 @@ public class ItTwoDomainsLoadBalancers {
                         .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                         .addCommandItem("/bin/sh")
                         .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /shared")
+                        .addArgsItem("chown -R 1000:0 /shared")
                         .volumeMounts(Collections.singletonList(
                             new V1VolumeMount()
                                 .name(pvName)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -3120,7 +3120,7 @@ public class CommonTestUtils {
                         .image(image)
                         .addCommandItem("/bin/sh")
                         .addArgsItem("-c")
-                        .addArgsItem("chown -R 1000:1000 /shared")
+                        .addArgsItem("chown -R 1000:0 /shared")
                         .volumeMounts(Arrays.asList(
                             new V1VolumeMount()
                                 .name(pvName)

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -20,7 +20,7 @@ spec:
       initContainers:
         - name: fix-pvc-owner
           image: %WEBLOGIC_IMAGE%
-          command: ["sh", "-c", "chown -R 1000:1000 %DOMAIN_ROOT_DIR%"]
+          command: ["sh", "-c", "chown -R 1000:0 %DOMAIN_ROOT_DIR%"]
           volumeMounts:
           - name: weblogic-sample-domain-storage-volume
             mountPath: %DOMAIN_ROOT_DIR%

--- a/operator/src/main/resources/scripts/livenessProbe.sh
+++ b/operator/src/main/resources/scripts/livenessProbe.sh
@@ -36,7 +36,9 @@ if [ ! "${DYNAMIC_CONFIG_OVERRIDE:-notset}" = notset ]; then
       [ -f "$tgt_file" ] && [ -z "$(diff $local_fname $tgt_file 2>&1)" ] && continue  # nothing changed
       trace "Copying file '$local_fname' to '$tgt_file'."
       cp $local_fname $tgt_file # TBD ignore any error?
-      chmod 750 $tgt_file # TBD ignore any error?
+      if [ -O "$tgt_file" ]; then
+        chmod 770 $tgt_file # TBD ignore any error?
+      fi
     done
     for local_fname in ${tgt_dir}/*.xml ; do
       if [ -f "$src_dir/${fil_prefix}$(basename ${local_fname})" ]; then

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -34,8 +34,6 @@ function copyIfChanged() {
     trace "Copying '$1' to '$2'."
     cp $1 $2
     [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
-    chmod 750 $2 
-    [ $? -ne 0 ] && trace SEVERE "failed chmod 750 $2" && exitOrLoop
   else
     trace "Skipping copy of '$1' to '$2' -- these files already match."
   fi

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -33,22 +33,14 @@ function copyIfChanged() {
   if [ ! -f "${2?}" ] || [ ! -z "`diff $1 $2 2>&1`" ]; then
     trace "Copying '$1' to '$2'."
     cp $1 $2
-    [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && diagnoseCopyFailure $1 $2 && exitOrLoop
+    [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
     if [ -O "$2" ]; then
       chmod 770 $2
-      [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && diagnoseCopyFailure $1 $2 && exitOrLoop
+      [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && exitOrLoop
     fi
   else
     trace "Skipping copy of '$1' to '$2' -- these files already match."
   fi
-}
-
-function diagnoseCopyFailure() {
-  ls -l $1
-  ls -l $2
-  ls -l `dirname $2`
-  whoami
-  groups
 }
 
 #

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -30,16 +30,14 @@ exportInstallHomes
 
 function copyIfChanged() {
   [ ! -f "${1?}" ] && trace SEVERE "File '$1' not found." && exit 1
-  if [ ! -f "${2?}" ]; then
+  if [ ! -f "${2?}" ] || [ ! -z "`diff $1 $2 2>&1`" ]; then
     trace "Copying '$1' to '$2'."
     cp $1 $2
     [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
-    chmod 770 $2
-    [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && exitOrLoop
-  else if [ ! -z "`diff $1 $2 2>&1`" ]; then
-    trace "Copying '$1' to '$2'."
-    cp $1 $2
-    [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
+    if [ -O "$2" ]; then
+      chmod 770 $2
+      [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && exitOrLoop
+    fi
   else
     trace "Skipping copy of '$1' to '$2' -- these files already match."
   fi

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -30,7 +30,13 @@ exportInstallHomes
 
 function copyIfChanged() {
   [ ! -f "${1?}" ] && trace SEVERE "File '$1' not found." && exit 1
-  if [ ! -f "${2?}" ] || [ ! -z "`diff $1 $2 2>&1`" ]; then
+  if [ ! -f "${2?}" ]; then
+    trace "Copying '$1' to '$2'."
+    cp $1 $2
+    [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
+    chmod 770 $2
+    [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && exitOrLoop
+  else if [ ! -z "`diff $1 $2 2>&1`" ]; then
     trace "Copying '$1' to '$2'."
     cp $1 $2
     [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
@@ -40,7 +46,7 @@ function copyIfChanged() {
 }
 
 #
-# Define function to start weblogic
+# Define function to start WebLogic
 #
 
 function startWLS() {

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -33,14 +33,22 @@ function copyIfChanged() {
   if [ ! -f "${2?}" ] || [ ! -z "`diff $1 $2 2>&1`" ]; then
     trace "Copying '$1' to '$2'."
     cp $1 $2
-    [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && exitOrLoop
+    [ $? -ne 0 ] && trace SEVERE "failed cp $1 $2" && diagnoseCopyFailure $1 $2 && exitOrLoop
     if [ -O "$2" ]; then
       chmod 770 $2
-      [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && exitOrLoop
+      [ $? -ne 0 ] && trace SEVERE "failed chmod 770 $2" && diagnoseCopyFailure $1 $2 && exitOrLoop
     fi
   else
     trace "Skipping copy of '$1' to '$2' -- these files already match."
   fi
+}
+
+function diagnoseCopyFailure() {
+  ls -l $1
+  ls -l $2
+  ls -l `dirname $2`
+  whoami
+  groups
 }
 
 #


### PR DESCRIPTION
This is part of making restrictive SCC work on OpenShift. In addition to the specific change to startServer.sh to only chmod when permitted, I noticed that many of the integration tests were initializing PV's with chown oracle:oracle rather than with oracle:root. I've updated those references too.