### PR TITLE
OWLS-86038: Helm upgrade error missing internalOperatorKey

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-cm.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-cm.tpl
@@ -12,6 +12,13 @@ data:
   externalOperatorCert: {{ .externalOperatorCert | quote }}
     {{- end }}
   {{- end }}
+  {{- $configmap := (lookup "v1" "ConfigMap" .Release.Namespace "weblogic-operator-cm") }}
+  {{- if (and $configmap $configmap.data) }}
+  {{- $internalOperatorCert := index $configmap.data "internalOperatorCert" }}
+  {{- if $internalOperatorCert }}
+  internalOperatorCert: {{ $internalOperatorCert }}
+  {{- end }}
+  {{- end }}
   serviceaccount: {{ .serviceAccount | quote }}
   domainNamespaceSelectionStrategy: {{ (default "List" .domainNamespaceSelectionStrategy) | quote }}
   domainNamespaces: {{ .domainNamespaces | uniq | sortAlpha | join "," | quote }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-secret.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-secret.tpl
@@ -10,7 +10,7 @@ data:
   externalOperatorKey: {{ .externalOperatorKey | quote }}
   {{- end }}
   {{- $secret := (lookup "v1" "Secret" .Release.Namespace "weblogic-operator-secrets") }}
-  {{- if $secret }}
+  {{- if (and $secret $secret.data) }}
   {{- $internalOperatorKey := index $secret.data "internalOperatorKey" }}
   {{- if $internalOperatorKey }}
   internalOperatorKey: {{ $internalOperatorKey }}

--- a/src/scripts/initialize-internal-operator-identity.sh
+++ b/src/scripts/initialize-internal-operator-identity.sh
@@ -146,7 +146,7 @@ trap "cleanup" EXIT
 
 mkdir ${INTERNAL_IDENTITY_DIR}
 
-if [ -f "${OPERATOR_DIR}/config/${CERT_PROPERTY}" ]; then
+if [ -f "${OPERATOR_DIR}/config/${CERT_PROPERTY}" ] && [ -f "${OPERATOR_DIR}/secrets/${KEY_PROPERTY}" ]; then
   # The operator's internal ssl identity has already been created.
   reuseInternalIdentity
 else


### PR DESCRIPTION
When using 'helm upgrade' command for the operator, the 'weblogic-operator-secrets' data field is nil (empty or null) if there are no key/value pairs defined in the 'data' dictionary.  In this specific scenario, the 'internalOperatorKey' key is not defined and so the 'data' field of the 'weblogic-operator-secrets' Secret resource has no defined key/value pairs hence it is defined as 'nil' (null or empty).  The 'index' function cannot operate on a 'nil' object.  The fix was to add a condition check for '$secret.data'.

When doing an upgrade, if either the key or certificate of the operator's internal SSL identity is missing then the operator will generate a new one when the operator is re-started.  