### PR TITLE
owls85464 - add MII dynamic update tests for changing work manager config

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/domain/Model.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/Model.java
@@ -21,6 +21,8 @@ public class Model {
   @ApiModelProperty("Location of the WebLogic Deploy Tooling model home. Defaults to /u01/wdt/models.")
   private String modelHome;
 
+  @ApiModelProperty("Online update option for Model In Image dynamic update.")
+  private OnlineUpdate onlineUpdate;
 
   @ApiModelProperty(
       "Runtime encryption secret. Required when domainHomeSourceType is set to FromModel.")
@@ -90,6 +92,23 @@ public class Model {
     return this;
   }
 
+  public OnlineUpdate getOnlineUpdate() {
+    return onlineUpdate;
+  }
+
+  public OnlineUpdate onlineUpdate() {
+    return onlineUpdate;
+  }
+
+  public Model onlineUpdate(OnlineUpdate onlineUpdate) {
+    this.onlineUpdate = onlineUpdate;
+    return this;
+  }
+
+  public void setOnlineUpdate(OnlineUpdate onlineUpdate) {
+    this.onlineUpdate = onlineUpdate;
+  }
+
   @Override
   public String toString() {
     ToStringBuilder builder =
@@ -97,7 +116,8 @@ public class Model {
             .append("domainType", domainType)
             .append("configMap", configMap)
             .append("modelHome", modelHome)
-            .append("runtimeEncryptionSecret", runtimeEncryptionSecret);
+            .append("runtimeEncryptionSecret", runtimeEncryptionSecret)
+            .append("onlineUpdate", onlineUpdate);
 
     return builder.toString();
   }
@@ -125,7 +145,8 @@ public class Model {
             .append(domainType, rhs.domainType)
             .append(configMap, rhs.configMap)
             .append(modelHome,rhs.modelHome)
-            .append(runtimeEncryptionSecret, rhs.runtimeEncryptionSecret);
+            .append(runtimeEncryptionSecret, rhs.runtimeEncryptionSecret)
+            .append(onlineUpdate, rhs.onlineUpdate);
 
     return builder.isEquals();
   }

--- a/integration-tests/src/test/java/oracle/weblogic/domain/OnlineUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/OnlineUpdate.java
@@ -1,0 +1,242 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.domain;
+
+import io.swagger.annotations.ApiModelProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class OnlineUpdate {
+
+  @ApiModelProperty("Enable online update.")
+  private Boolean enabled = false;
+
+  @ApiModelProperty("If set to true, it will rollback the changes if the update require domain restart. "
+      + "All changes are rolled back, the domain continues to run without interruption. "
+      + "It is the user responsibility to revert the content changes in the configmap specified in "
+      + "`domain.spec.configuration.model.configmap` or secrets. User can detect the changes have been "
+      + "rolled back when describing the domain `kubectl -n <ns> describe domain <domain name>"
+      + " under the condition `OnlineUpdateRolledback`")
+  private Boolean rollBackIfRestartRequired = false;
+
+  @ApiModelProperty("WLST deploy application or libraries timout in milliseconds. Default: 180000.")
+  private Long deployTimeoutMilliSeconds = 180000L;
+
+  @ApiModelProperty("WLST redeploy application or libraries timout in milliseconds. Default: 180000.")
+  private Long redeployTimeoutMilliSeconds = 180000L;
+
+  @ApiModelProperty("WLST undeploy application or libraries timout in milliseconds. Default: 180000.")
+  private Long undeployTimeoutMilliSeconds = 180000L;
+
+  @ApiModelProperty("WLST startApplication timout in milliseconds. Default: 180000.")
+  private Long startApplicationTimeoutMilliSeconds = 180000L;
+
+  @ApiModelProperty("WLST stopApplication timout in milliseconds. Default: 180000.")
+  private Long stopApplicationTimeoutMilliSeconds = 180000L;
+
+  @ApiModelProperty("WLST connect to running domain timout in milliseconds. Default: 120000.")
+  private Long connectTimeoutMilliSeconds = 120000L;
+
+  @ApiModelProperty("WLST activate changes timout in milliseconds. Default: 180000.")
+  private Long activateTimeoutMilliSeconds = 180000L;
+
+  @ApiModelProperty("WLST set server groups timout in milliseconds. Default: 180000.")
+  private Long setServerGroupsTimeoutMilliSeconds = 180000L;
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public OnlineUpdate withEnabled(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  public OnlineUpdate enabled(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  public Boolean getRollBackIfRestartRequired() {
+    return rollBackIfRestartRequired;
+  }
+
+  public void setRollBackIfRestartRequired(boolean rollBackIfRestartRequired) {
+    this.rollBackIfRestartRequired = rollBackIfRestartRequired;
+  }
+
+  public OnlineUpdate withRollBackIfRestartRequired(boolean rollBackIfRestartRequired) {
+    this.rollBackIfRestartRequired = rollBackIfRestartRequired;
+    return this;
+  }
+
+  public Long getDeployTimeoutMilliSeconds() {
+    return deployTimeoutMilliSeconds;
+  }
+
+  public void setDeployTimeoutMilliSeconds(Long deployTimeoutMilliSeconds) {
+    this.deployTimeoutMilliSeconds = deployTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withDeployTimeoutSeconds(Long deployTimeoutSeconds) {
+    this.deployTimeoutMilliSeconds = deployTimeoutSeconds;
+    return this;
+  }
+
+  public Long getRedeployTimeoutMilliSeconds() {
+    return redeployTimeoutMilliSeconds;
+  }
+
+  public void setRedeployTimeoutMilliSeconds(Long redeployTimeoutMilliSeconds) {
+    this.redeployTimeoutMilliSeconds = redeployTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withRedeployTimeoutSeconds(Long redeployTimeoutSeconds) {
+    this.redeployTimeoutMilliSeconds = redeployTimeoutSeconds;
+    return this;
+  }
+
+  public Long getUndeployTimeoutMilliSeconds() {
+    return undeployTimeoutMilliSeconds;
+  }
+
+  public void setUndeployTimeoutMilliSeconds(Long undeployTimeoutMilliSeconds) {
+    this.undeployTimeoutMilliSeconds = undeployTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withUndeployTimeoutSeconds(Long undeployTimeoutSeconds) {
+    this.undeployTimeoutMilliSeconds = undeployTimeoutSeconds;
+    return this;
+  }
+
+  public Long getStartApplicationTimeoutMilliSeconds() {
+    return startApplicationTimeoutMilliSeconds;
+  }
+
+  public void setStartApplicationTimeoutMilliSeconds(Long startApplicationTimeoutMilliSeconds) {
+    this.startApplicationTimeoutMilliSeconds = startApplicationTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withStartApplicationTimeoutSeconds(Long startApplicationTimeoutSeconds) {
+    this.startApplicationTimeoutMilliSeconds = startApplicationTimeoutSeconds;
+    return this;
+  }
+
+  public Long getStopApplicationTimeoutMilliSeconds() {
+    return stopApplicationTimeoutMilliSeconds;
+  }
+
+  public void setStopApplicationTimeoutMilliSeconds(Long stopApplicationTimeoutMilliSeconds) {
+    this.stopApplicationTimeoutMilliSeconds = stopApplicationTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withStopApplicationTimeoutSeconds(Long stopApplicationTimeoutSeconds) {
+    this.stopApplicationTimeoutMilliSeconds = stopApplicationTimeoutSeconds;
+    return this;
+  }
+
+  public Long getConnectTimeoutMilliSeconds() {
+    return connectTimeoutMilliSeconds;
+  }
+
+  public void setConnectTimeoutMilliSeconds(Long connectTimeoutMilliSeconds) {
+    this.connectTimeoutMilliSeconds = connectTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withConnectTimeoutSeconds(Long connectTimeoutSeconds) {
+    this.connectTimeoutMilliSeconds = connectTimeoutSeconds;
+    return this;
+  }
+
+  public Long getActivateTimeoutMilliSeconds() {
+    return activateTimeoutMilliSeconds;
+  }
+
+  public void setActivateTimeoutMilliSeconds(Long activateTimeoutMilliSeconds) {
+    this.activateTimeoutMilliSeconds = activateTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withActivateTimeoutSeconds(Long activateTimeoutSeconds) {
+    this.activateTimeoutMilliSeconds = activateTimeoutSeconds;
+    return this;
+  }
+
+  public Long getSetServerGroupsTimeoutMilliSeconds() {
+    return setServerGroupsTimeoutMilliSeconds;
+  }
+
+  public void setSetServerGroupsTimeoutMilliSeconds(Long setServerGroupsTimeoutMilliSeconds) {
+    this.setServerGroupsTimeoutMilliSeconds = setServerGroupsTimeoutMilliSeconds;
+  }
+
+  public OnlineUpdate withSetServerGroupsTimeoutSeconds(Long setServerGroupsTimeoutSeconds) {
+    this.setServerGroupsTimeoutMilliSeconds = setServerGroupsTimeoutSeconds;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    ToStringBuilder builder =
+        new ToStringBuilder(this)
+            .append("enabled", enabled)
+            .append("rollBackIfRestartRequired", rollBackIfRestartRequired)
+            .append("deployTimeoutMilliSeconds", deployTimeoutMilliSeconds)
+            .append("redeployTimeoutMilliSeconds", redeployTimeoutMilliSeconds)
+            .append("undeployTimeoutMilliSeconds", undeployTimeoutMilliSeconds)
+            .append("startApplicationTimeoutMilliSeconds", startApplicationTimeoutMilliSeconds)
+            .append("stopApplicationTimeoutMilliSeconds", stopApplicationTimeoutMilliSeconds)
+            .append("activateTimeoutMilliSeconds", activateTimeoutMilliSeconds)
+            .append("connectTimeoutMilliSeconds", connectTimeoutMilliSeconds)
+            .append("setServerGroupsTimeoutMilliSeconds", setServerGroupsTimeoutMilliSeconds);
+
+    return builder.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder()
+        .append(enabled)
+        .append(rollBackIfRestartRequired)
+        .append(deployTimeoutMilliSeconds)
+        .append(redeployTimeoutMilliSeconds)
+        .append(undeployTimeoutMilliSeconds)
+        .append(startApplicationTimeoutMilliSeconds)
+        .append(stopApplicationTimeoutMilliSeconds)
+        .append(connectTimeoutMilliSeconds)
+        .append(setServerGroupsTimeoutMilliSeconds)
+        .append(activateTimeoutMilliSeconds);
+
+    return builder.toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (!(other instanceof OnlineUpdate)) {
+      return false;
+    }
+
+    OnlineUpdate rhs = ((OnlineUpdate) other);
+    EqualsBuilder builder =
+        new EqualsBuilder()
+            .append(enabled, rhs.enabled)
+            .append(rollBackIfRestartRequired, rhs.rollBackIfRestartRequired)
+            .append(deployTimeoutMilliSeconds, rhs.deployTimeoutMilliSeconds)
+            .append(redeployTimeoutMilliSeconds, rhs.redeployTimeoutMilliSeconds)
+            .append(undeployTimeoutMilliSeconds, rhs.undeployTimeoutMilliSeconds)
+            .append(startApplicationTimeoutMilliSeconds, rhs.startApplicationTimeoutMilliSeconds)
+            .append(stopApplicationTimeoutMilliSeconds, rhs.stopApplicationTimeoutMilliSeconds)
+            .append(connectTimeoutMilliSeconds, rhs.connectTimeoutMilliSeconds)
+            .append(setServerGroupsTimeoutMilliSeconds, rhs.setServerGroupsTimeoutMilliSeconds)
+            .append(activateTimeoutMilliSeconds, rhs.activateTimeoutMilliSeconds);
+
+    return builder.isEquals();
+  }
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -12,7 +12,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonMiiTestUtils;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +27,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
-import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVolume;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkLogsOnPV;
@@ -178,11 +176,6 @@ class ItMiiDynamicUpdate {
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
         .until(domainExists(domainUid, DOMAIN_VERSION, domainNamespace));
-  }
-
-  @AfterAll
-  public void tearDownAll() {
-    deletePersistentVolume(pvName);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -1,0 +1,386 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes;
+
+import java.util.Arrays;
+import java.util.List;
+
+import oracle.weblogic.kubernetes.annotations.IntegrationTest;
+import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import oracle.weblogic.kubernetes.utils.ExecResult;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVolume;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkLogsOnPV;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkSystemResource;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkWorkManagerRuntime;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDatabaseSecret;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResourceWithLogHome;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainSecret;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createJobToChangePermissionsOnPvHostPath;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.readJdbcRuntime;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.readMaxThreadsConstraintRuntimeForWorkManager;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.readMinThreadsConstraintRuntimeForWorkManager;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.replaceConfigMapWithModelFiles;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodDoesNotExist;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createOcirRepoSecret;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPV;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretForBaseImages;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getIntrospectJobName;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
+import static org.awaitility.Awaitility.with;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This test class verifies the following scenarios
+ *
+ * <p>testServerLogsAreOnPV
+ * domain logHome is on PV, check server logs are on PV
+ *
+ * <p>testMiiCheckSystemResources
+ *  Check the System Resources in a pre-configured ConfigMap
+ *
+ * <p>testAddWorkManager
+ *  Add a new work manager to a running WebLogic domain
+ *
+ * <p>testUpdateWorkManager
+ *  Update dynamic work manager configurations in a running WebLogic domain.
+ *
+ */
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Test dynamic updates to a model in image domain")
+@IntegrationTest
+class ItMiiDynamicUpdate {
+
+  private static String opNamespace = null;
+  private static String domainNamespace = null;
+  private static ConditionFactory withStandardRetryPolicy = null;
+  private static int replicaCount = 1;
+  private static final String domainUid = "mii-dynamic-update";
+  private static String pvName = domainUid + "-pv"; // name of the persistent volume
+  private static String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+  private static final String initialModelYamlFileName = "model.sysresources.yaml";
+  private static final String configMapName = "dynamicupdate-test-configmap";//"wmconfigmap";
+  private final String adminServerPodName = domainUid + "-admin-server";
+  private final String managedServerPrefix = domainUid + "-managed-server";
+  private final String adminServerName = "admin-server";
+  private final String workManagerName = "newWM";
+
+  private static LoggingFacade logger = null;
+
+  /**
+   * Install Operator.
+   * Create domain resource defintion.
+   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
+   JUnit engine parameter resolution mechanism
+   */
+  @BeforeAll
+  public static void initAll(@Namespaces(2) List<String> namespaces) {
+    logger = getLogger();
+    // create standard, reusable retry/backoff policy
+    withStandardRetryPolicy = with().pollDelay(2, SECONDS)
+        .and().with().pollInterval(10, SECONDS)
+        .atMost(5, MINUTES).await();
+
+    // get a new unique opNamespace
+    logger.info("Creating unique namespace for Operator");
+    assertNotNull(namespaces.get(0), "Namespace list is null");
+    opNamespace = namespaces.get(0);
+
+    logger.info("Creating unique namespace for Domain");
+    assertNotNull(namespaces.get(1), "Namespace list is null");
+    domainNamespace = namespaces.get(1);
+
+    // install and verify operator
+    installAndVerifyOperator(opNamespace, domainNamespace);
+
+    // Create the repo secret to pull the image
+    // this secret is used only for non-kind cluster
+    createOcirRepoSecret(domainNamespace);
+
+    // create secret for admin credentials
+    logger.info("Create secret for admin credentials");
+    String adminSecretName = "weblogic-credentials";
+    assertDoesNotThrow(() -> createDomainSecret(adminSecretName,"weblogic",
+            "welcome1", domainNamespace),
+            String.format("createSecret failed for %s", adminSecretName));
+
+    // create encryption secret
+    logger.info("Create encryption secret");
+    String encryptionSecretName = "encryptionsecret";
+    assertDoesNotThrow(() -> createDomainSecret(encryptionSecretName, "weblogicenc",
+            "weblogicenc", domainNamespace),
+             String.format("createSecret failed for %s", encryptionSecretName));
+
+    logger.info("Create database secret");
+    final String dbSecretName = domainUid  + "-db-secret";
+    assertDoesNotThrow(() -> createDatabaseSecret(dbSecretName, "scott",
+            "tiger", "jdbc:oracle:thin:localhost:/ORCLCDB", domainNamespace),
+             String.format("createSecret failed for %s", dbSecretName));
+
+    createConfigMapAndVerify(
+        configMapName, domainUid, domainNamespace,
+        Arrays.asList(initialModelYamlFileName));
+
+
+    // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
+    // this secret is used only for non-kind cluster
+    createSecretForBaseImages(domainNamespace);
+
+    // create PV, PVC for logs
+    createPV(pvName, domainUid, ItMiiDynamicUpdate.class.getSimpleName());
+    createPVC(pvName, pvcName, domainUid, domainNamespace);
+
+    // create job to change permissions on PV hostPath
+    createJobToChangePermissionsOnPvHostPath(pvName, pvcName, domainNamespace);
+
+    // create the domain CR with a pre-defined configmap
+    createDomainResourceWithLogHome(domainUid, domainNamespace,
+        MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
+        adminSecretName, OCIR_SECRET_NAME, encryptionSecretName,
+        replicaCount, pvName, pvcName, "cluster-1", configMapName, dbSecretName, true);
+
+    // wait for the domain to exist
+    logger.info("Check for domain custom resource in namespace {0}", domainNamespace);
+    withStandardRetryPolicy
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for domain {0} to be created in namespace {1} "
+                    + "(elapsed time {2}ms, remaining time {3}ms)",
+                domainUid,
+                domainNamespace,
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(domainExists(domainUid, DOMAIN_VERSION, domainNamespace));
+  }
+
+  @AfterAll
+  public void tearDownAll() {
+    deletePersistentVolume(pvName);
+  }
+
+  /**
+   * Verify all server pods are running.
+   * Verify all k8s services for all servers are created.
+   */
+  @BeforeEach
+  public void beforeEach() {
+
+    logger.info("Check admin service and pod {0} is created in namespace {1}",
+        adminServerPodName, domainNamespace);
+    checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+
+    // check managed server services and pods are ready
+    for (int i = 1; i <= replicaCount; i++) {
+      logger.info("Wait for managed server services and pods are created in namespace {0}",
+          domainNamespace);
+      checkPodReadyAndServiceExists(managedServerPrefix + i, domainUid, domainNamespace);
+    }
+  }
+
+  /**
+   * Check server logs are written on PV.
+   */
+  @Test
+  @Order(1)
+  @DisplayName("Check the server logs are written on PV, look for string RUNNING in server log")
+  public void testServerLogsAreOnPV() {
+
+    // check server logs are written on PV and look for string RUNNING in log
+    checkLogsOnPV(domainNamespace, "grep RUNNING /shared/logs/" + adminServerName + ".log", adminServerPodName);
+  }
+
+  /**
+   * Create a WebLogic domain with a defined configmap in configuration/model 
+   * section of the domain resource.
+   * The configmap has multiple sparse WDT model files that define 
+   * a JDBCSystemResource, a JMSSystemResource and a WLDFSystemResource.
+   * Verify all the SystemResource configurations using the rest API call 
+   * using the public nodeport of the administration server.
+   */
+  @Test
+  @Order(2)
+  @DisplayName("Verify the pre-configured SystemResources in a model-in-image domain")
+  public void testMiiCheckSystemResources() {
+
+    assertTrue(checkSystemResourceConfiguration("JDBCSystemResources", 
+        "TestDataSource", "200"), "JDBCSystemResource not found");
+    logger.info("Found the JDBCSystemResource configuration");
+
+    assertTrue(checkSystemResourceConfiguration("JMSSystemResources", 
+        "TestClusterJmsModule", "200"), "JMSSystemResources not found");
+    logger.info("Found the JMSSystemResource configuration");
+
+    assertTrue(checkSystemResourceConfiguration("WLDFSystemResources", 
+        "TestWldfModule", "200"), "WLDFSystemResources not found");
+    logger.info("Found the WLDFSystemResource configuration");
+
+    ExecResult result = null;
+    result = readJdbcRuntime(domainNamespace, adminServerPodName,"TestDataSource");
+    logger.info("checkJdbcRuntime: returned {0}", result.toString());
+    assertTrue(result.stdout().contains("jdbc:oracle:thin:localhost"),
+         String.format("DB URL does not match with RuntimeMBean Info"));
+    assertTrue(result.stdout().contains("scott"),
+         String.format("DB user name does not match with RuntimeMBean Info"));
+    logger.info("Found the JDBCSystemResource configuration");
+
+  }
+
+  /**
+   * Create a configmap containing both the model yaml, and a sparse model file to add
+   * a new work manager, a min threads constraint, and a max threads constraint
+   * Patch the domain resource with the configmap.
+   * Update the introspect version of the domain resource.
+   * Verify rolling restart of the domain by comparing PodCreationTimestamp
+   * before and after rolling restart.
+   * Verify new work manager is configured.
+   */
+  @Test
+  @Order(3)
+  @DisplayName("Add a work manager to a model-in-image domain using dynamic update")
+  public void testMiiAddWorkManager() {
+
+    // This test uses the WebLogic domain created in BeforeAll method
+    // BeforeEach method ensures that the server pods are running
+
+    replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
+        Arrays.asList(initialModelYamlFileName, "model.config.wm.yaml"), withStandardRetryPolicy);
+
+    assertTrue(assertDoesNotThrow(() ->
+            patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace),
+        "Patch domain with new IntrospectVersion threw ApiException"),
+        "Failed to patch domain with new IntrospectVersion");
+
+    verifyIntrospectorRuns();
+
+    withStandardRetryPolicy.conditionEvaluationListener(
+        condition ->
+            logger.info("Waiting for work manager configuration to be updated. Elapsed time{1}, remaining time {2}",
+                condition.getElapsedTimeInMS(), condition.getRemainingTimeInMS())).until(
+                    () -> checkWorkManagerRuntime(domainNamespace, adminServerPodName,
+                        MANAGED_SERVER_NAME_BASE + "1",
+                        workManagerName, "200"));
+    logger.info("Found new work manager configuration");
+  }
+
+  /**
+   * Recreate configmap containing both the model yaml, and a sparse model file with
+   * updated min and max threads constraints that was added in {@link #testMiiAddWorkManager()}
+   * test.
+   * Patch the domain resource with the configmap.
+   * Update the introspect version of the domain resource.
+   * Wait for introspector to complete
+   * Verify work manager configuration is updated.
+   */
+  @Test
+  @Order(4)
+  @DisplayName("Update work manager min/max threads constraints config to a model-in-image domain using dynamic update")
+  public void testMiiUpdateWorkManager() {
+
+    // This test uses the WebLogic domain created in BeforeAll method
+    // BeforeEach method ensures that the server pods are running
+
+    replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
+        Arrays.asList(initialModelYamlFileName, "model.update.wm.yaml"),
+        withStandardRetryPolicy);
+
+    assertTrue(assertDoesNotThrow(() ->
+            patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace),
+        "Patch domain with new IntrospectVersion threw ApiException"),
+        "Failed to patch domain with new IntrospectVersion");
+
+    verifyIntrospectorRuns();
+
+    withStandardRetryPolicy.conditionEvaluationListener(
+        condition ->
+            logger.info("Waiting for min threads constraint configuration to be updated. "
+                    + "Elapsed time{1}, remaining time {2}",
+                condition.getElapsedTimeInMS(), condition.getRemainingTimeInMS())).until(
+                    () -> checkMinThreadsConstraintRuntime(2));
+
+    withStandardRetryPolicy.conditionEvaluationListener(
+        condition ->
+            logger.info("Waiting for max threads constraint configuration to be updated. "
+                    + "Elapsed time{1}, remaining time {2}",
+                condition.getElapsedTimeInMS(), condition.getRemainingTimeInMS())).until(
+                    () -> checkMaxThreadsConstraintRuntime(20));
+
+    logger.info("Found updated work manager configuration");
+  }
+
+  private void verifyIntrospectorRuns() {
+    //verify the introspector pod is created and runs
+    logger.info("Verifying introspector pod is created, runs and deleted");
+    String introspectPodName = getIntrospectJobName(domainUid);
+    checkPodExists(introspectPodName, domainUid, domainNamespace);
+    checkPodDoesNotExist(introspectPodName, domainUid, domainNamespace);
+  }
+
+  /*
+   * Verify the min threads constraint runtime configuration through rest API.
+   * @param count expected value for min threads constraint count
+   * @returns true if the min threads constraint runtime is read successfully and is configured
+   *          with the provided count value.
+   **/
+  private boolean checkMinThreadsConstraintRuntime(int count) {
+    ExecResult result = readMinThreadsConstraintRuntimeForWorkManager(domainNamespace,
+        adminServerPodName, MANAGED_SERVER_NAME_BASE + "1", workManagerName);
+    if (result != null) {
+      logger.info("readMinThreadsConstraintRuntime read " + result.toString());
+      return (result.stdout() != null && result.stdout().contains("\"count\": " + count));
+    }
+    logger.info("readMinThreadsConstraintRuntime failed to read from WebLogic server ");
+    return false;
+  }
+
+  /*
+   * Verify the max threads constraint runtime configuration through rest API.
+   * @param count expected value for max threads constraint count
+   * @returns true if the max threads constraint runtime is read successfully and is configured
+   *          with the provided count value.
+   **/
+  private boolean checkMaxThreadsConstraintRuntime(int count) {
+    ExecResult result = readMaxThreadsConstraintRuntimeForWorkManager(domainNamespace,
+        adminServerPodName, MANAGED_SERVER_NAME_BASE + "1", workManagerName);
+    if (result != null) {
+      logger.info("readMaxThreadsConstraintRuntime read " + result.toString());
+      return (result.stdout() != null && result.stdout().contains("\"count\": " + count));
+    }
+    logger.info("readMaxThreadsConstraintRuntime failed to read from WebLogic server ");
+    return false;
+  }
+
+  private boolean checkSystemResourceConfiguration(String resourcesType,
+         String resourcesName, String expectedStatusCode) {
+    return checkSystemResource(domainNamespace, adminServerPodName,
+        "/management/weblogic/latest/domainConfig/"
+            + resourcesType + "/" + resourcesName + "/",
+        expectedStatusCode);
+  }
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -9,6 +9,7 @@ import java.util.List;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import oracle.weblogic.kubernetes.utils.CommonMiiTestUtils;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -31,7 +32,6 @@ import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVol
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkLogsOnPV;
-import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkSystemResource;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkWorkManagerRuntime;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDatabaseSecret;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResourceWithLogHome;
@@ -378,9 +378,7 @@ class ItMiiDynamicUpdate {
 
   private boolean checkSystemResourceConfiguration(String resourcesType,
          String resourcesName, String expectedStatusCode) {
-    return checkSystemResource(domainNamespace, adminServerPodName,
-        "/management/weblogic/latest/domainConfig/"
-            + resourcesType + "/" + resourcesName + "/",
-        expectedStatusCode);
+    return CommonMiiTestUtils.checkSystemResourceConfiguration(domainNamespace,
+        adminServerPodName, resourcesType, resourcesName, expectedStatusCode);
   }
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -214,6 +214,7 @@ public interface TestConstants {
   public static final String MII_BASIC_IMAGE_TAG = TestUtils.getDateAndTimeStamp();
   public static final String MII_BASIC_IMAGE_DOMAINTYPE = "mii";
   public static final String MII_BASIC_APP_NAME = "sample-app";
+  public static final String MII_BASIC_APP_DEPLOYMENT_NAME = "myear";
   public static final String MII_TWO_APP_WDT_MODEL_FILE = "model-singlecluster-two-sampleapp-wls.yaml";
 
   // application constants

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -1511,6 +1511,30 @@ public class TestActions {
   }
 
   /**
+   * Patch the domain resource with a new model configMap.
+   *
+   * @param domainResourceName name of the domain resource
+   * @param namespace Kubernetes namespace that the domain is hosted
+   * @param configMapName name of the configMap to be set in spec.configuration.model.configMap
+   */
+  public static void patchDomainResourceWithModelConfigMap(
+      String domainResourceName, String namespace, String configMapName) {
+    LoggingFacade logger = getLogger();
+    StringBuffer patchStr = new StringBuffer("[{");
+    patchStr.append("\"op\": \"replace\",")
+        .append(" \"path\": \"/spec/configuration/model/configMap\",")
+        .append(" \"value\":  \"" + configMapName + "\"")
+        .append(" }]");
+    logger.info("Configmap patch string: {0}", patchStr);
+
+    V1Patch patch = new V1Patch(new String(patchStr));
+    boolean cmPatched = assertDoesNotThrow(() ->
+            patchDomainCustomResource(domainResourceName, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
+        "patchDomainCustomResourceWithModelConfigMap(configMap)  failed ");
+    assertTrue(cmPatched, "patchDomainCustomResourceWithModelConfigMap(configMap) failed");
+  }
+
+  /**
    * Get the name of the operator pod.
    *
    * @param release release name of the operator

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -75,8 +75,6 @@ import static oracle.weblogic.kubernetes.actions.impl.Operator.start;
 import static oracle.weblogic.kubernetes.actions.impl.Operator.stop;
 import static oracle.weblogic.kubernetes.actions.impl.Prometheus.uninstall;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // this class essentially delegates to the impl classes, and "hides" all of the
 // detail impl classes - tests would only ever call methods in here, never
@@ -1484,30 +1482,7 @@ public class TestActions {
    */
   public static String patchDomainResourceWithNewRestartVersion(
       String domainResourceName, String namespace) {
-    LoggingFacade logger = getLogger();
-    String oldVersion = assertDoesNotThrow(
-        () -> getDomainCustomResource(domainResourceName, namespace).getSpec().getRestartVersion(),
-        String.format("Failed to get the restartVersion of %s in namespace %s", domainResourceName, namespace));
-    int newVersion = oldVersion == null ? 1 : Integer.valueOf(oldVersion) + 1;
-    logger.info("Update domain resource {0} in namespace {1} restartVersion from {2} to {3}",
-        domainResourceName, namespace, oldVersion, newVersion);
-
-    StringBuffer patchStr = new StringBuffer("[{");
-    patchStr.append(" \"op\": \"replace\",")
-        .append(" \"path\": \"/spec/restartVersion\",")
-        .append(" \"value\": \"")
-        .append(newVersion)
-        .append("\"")
-        .append(" }]");
-
-    logger.info("Restart version patch string: {0}", patchStr);
-    V1Patch patch = new V1Patch(new String(patchStr));
-    boolean rvPatched = assertDoesNotThrow(() ->
-            patchDomainCustomResource(domainResourceName, namespace, patch, "application/json-patch+json"),
-        "patchDomainCustomResource(restartVersion)  failed ");
-    assertTrue(rvPatched, "patchDomainCustomResource(restartVersion) failed");
-
-    return String.valueOf(newVersion);
+    return Domain.patchDomainResourceWithNewRestartVersion(domainResourceName, namespace);
   }
 
   /**
@@ -1519,19 +1494,8 @@ public class TestActions {
    */
   public static void patchDomainResourceWithModelConfigMap(
       String domainResourceName, String namespace, String configMapName) {
-    LoggingFacade logger = getLogger();
-    StringBuffer patchStr = new StringBuffer("[{");
-    patchStr.append("\"op\": \"replace\",")
-        .append(" \"path\": \"/spec/configuration/model/configMap\",")
-        .append(" \"value\":  \"" + configMapName + "\"")
-        .append(" }]");
-    logger.info("Configmap patch string: {0}", patchStr);
-
-    V1Patch patch = new V1Patch(new String(patchStr));
-    boolean cmPatched = assertDoesNotThrow(() ->
-            patchDomainCustomResource(domainResourceName, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
-        "patchDomainCustomResourceWithModelConfigMap(configMap)  failed ");
-    assertTrue(cmPatched, "patchDomainCustomResourceWithModelConfigMap(configMap) failed");
+    Domain.patchDomainResourceWithModelConfigMap(domainResourceName,
+        namespace, configMapName);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -446,7 +446,7 @@ public class CommonMiiTestUtils {
   public static boolean checkWorkManagerRuntime(
       String domainNamespace, String adminServerPodName,
       String serverName, String workManagerName, String expectedStatusCode) {
-    return checkSystemResource(
+    return checkWeblogicMBean(
         domainNamespace,
         adminServerPodName,
         "/management/weblogic/latest/domainRuntime/serverRuntimes/"
@@ -482,14 +482,15 @@ public class CommonMiiTestUtils {
   }
 
   /**
-   * Use REST APIs to check the system resource runtime mbean from the WebLogic server.
+   * Use REST APIs to check a runtime mbean from the WebLogic server.
+   *
    * @param domainNamespace Kubernetes namespace that the domain is hosted
    * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
    * @param resourcePath Path of the system resource to be used in the REST API call
    * @param expectedStatusCode the expected response to verify
    * @return true if the REST API reply contains the expected response
    */
-  public static boolean checkSystemResource(String domainNamespace,
+  public static boolean checkWeblogicMBean(String domainNamespace,
          String adminServerPodName,  String resourcePath, String expectedStatusCode) {
     LoggingFacade logger = getLogger();
 
@@ -510,7 +511,27 @@ public class CommonMiiTestUtils {
   }
 
   /**
+   * Use REST APIs to check the system resource runtime mbean from the WebLogic server.
+   *
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
+   * @param resourcesType Type of the system resource to be checked
+   * @param resourcesName Name of the system resource to be checked
+   * @param expectedStatusCode the expected response to verify
+   * @return true if the REST API reply contains the expected response
+   */
+  public static boolean checkSystemResourceConfiguration(String domainNamespace,
+      String adminServerPodName, String resourcesType,
+      String resourcesName, String expectedStatusCode) {
+    return checkWeblogicMBean(domainNamespace, adminServerPodName,
+        "/management/weblogic/latest/domainConfig/"
+            + resourcesType + "/" + resourcesName + "/",
+        expectedStatusCode);
+  }
+
+  /**
    * Create a job to change the permissions on the pv host path.
+   *
    * @param pvName Name of the persistent volume
    * @param pvcName Name of the persistent volume claim
    * @param namespace Namespace containing the persistent volume claim and where the job should be created in

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -3,21 +3,75 @@
 
 package oracle.weblogic.kubernetes.utils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobCondition;
+import io.kubernetes.client.openapi.models.V1JobSpec;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1SecretReference;
+import io.kubernetes.client.openapi.models.V1SecurityContext;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+import oracle.weblogic.domain.AdminServer;
+import oracle.weblogic.domain.AdminService;
+import oracle.weblogic.domain.Channel;
+import oracle.weblogic.domain.Cluster;
+import oracle.weblogic.domain.Configuration;
 import oracle.weblogic.domain.Domain;
+import oracle.weblogic.domain.DomainSpec;
+import oracle.weblogic.domain.Model;
+import oracle.weblogic.domain.OnlineUpdate;
+import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
+import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import org.awaitility.core.ConditionFactory;
 
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_DEPLOYMENT_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
+import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
+import static oracle.weblogic.kubernetes.actions.TestActions.deleteConfigMap;
+import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
+import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
+import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
+import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listConfigMaps;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createJobAndWaitUntilComplete;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createOcirRepoSecret;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.setPodAntiAffinity;
+import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * The common utility class for model-in-image tests.
@@ -107,7 +161,8 @@ public class CommonMiiTestUtils {
   }
 
   /**
-   * Create a domain object for a Kubernetes domain custom resource using the basic model-in-image image.
+   * Create a domain object for a Kubernetes domain custom resource using the basic model-in-image
+   * image.
    *
    * @param domainResourceName name of the domain resource
    * @param domNamespace Kubernetes namespace that the domain is hosted
@@ -169,7 +224,429 @@ public class CommonMiiTestUtils {
                     .domainType("WLS")
                     .runtimeEncryptionSecret(encryptionSecretName))
                 .introspectorJobActiveDeadlineSeconds(300L)));
+
     setPodAntiAffinity(domain);
     return domain;
+  }
+
+  /**
+   * Create a domain object for a Kubernetes domain custom resource using the basic model-in-image
+   * image.
+   *
+   * @param domainResourceName name of the domain resource
+   * @param domNamespace Kubernetes namespace that the domain is hosted
+   * @param imageName name of the image including its tag
+   * @param adminSecretName name of the new WebLogic admin credentials secret
+   * @param repoSecretName name of the secret for pulling the WebLogic image
+   * @param encryptionSecretName name of the secret used to encrypt the models
+   * @param replicaCount number of managed servers to start
+   * @param pvName Name of persistent volume
+   * @param pvcName Name of persistent volume claim
+   * @param clusterName name of the cluster to add in domain
+   * @param configMapName name of the configMap containing Weblogic Deploy Tooling model
+   * @param dbSecretName name of the Secret for WebLogic configuration overrides
+   * @param onlineUpdateEnabled whether to enable onlineUpdate feature for mii dynamic update
+   * @return domain object of the domain resource
+   */
+  public static Domain createDomainResourceWithLogHome(
+      String domainResourceName,
+      String domNamespace,
+      String imageName,
+      String adminSecretName,
+      String repoSecretName,
+      String encryptionSecretName,
+      int replicaCount,
+      String pvName,
+      String pvcName,
+      String clusterName,
+      String configMapName,
+      String dbSecretName,
+      boolean onlineUpdateEnabled) {
+    LoggingFacade logger = getLogger();
+
+    List<String> securityList = new ArrayList<>();
+    securityList.add(dbSecretName);
+
+    // create the domain CR
+    Domain domain = new Domain()
+        .apiVersion(DOMAIN_API_VERSION)
+        .kind("Domain")
+        .metadata(new V1ObjectMeta()
+            .name(domainResourceName)
+            .namespace(domNamespace))
+        .spec(new DomainSpec()
+            .domainUid(domainResourceName)
+            .domainHomeSourceType("FromModel")
+            .image(imageName)
+            .addImagePullSecretsItem(new V1LocalObjectReference()
+                .name(repoSecretName))
+            .webLogicCredentialsSecret(new V1SecretReference()
+                .name(adminSecretName)
+                .namespace(domNamespace))
+            .includeServerOutInPodLog(true)
+            .logHomeEnabled(Boolean.TRUE)
+            .logHome("/shared/logs")
+            .serverStartPolicy("IF_NEEDED")
+            .serverPod(new ServerPod()
+                .addEnvItem(new V1EnvVar()
+                    .name("JAVA_OPTIONS")
+                    .value("-Dweblogic.StdoutDebugEnabled=false"))
+                .addEnvItem(new V1EnvVar()
+                    .name("USER_MEM_ARGS")
+                    .value("-Djava.security.egd=file:/dev/./urandom "))
+                .addVolumesItem(new V1Volume()
+                    .name(pvName)
+                    .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
+                        .claimName(pvcName)))
+                .addVolumeMountsItem(new V1VolumeMount()
+                    .mountPath("/shared")
+                    .name(pvName)))
+            .adminServer(new AdminServer()
+                .serverStartState("RUNNING")
+                .adminService(new AdminService()
+                    .addChannelsItem(new Channel()
+                        .channelName("default")
+                        .nodePort(0))))
+            .addClustersItem(new Cluster()
+                .clusterName(clusterName)
+                .replicas(replicaCount)
+                .serverStartState("RUNNING"))
+            .configuration(new Configuration()
+                .secrets(securityList)
+                .model(new Model()
+                    .domainType("WLS")
+                    .configMap(configMapName)
+                    .runtimeEncryptionSecret(encryptionSecretName)
+                    .onlineUpdate(new OnlineUpdate()
+                        .enabled(onlineUpdateEnabled)))
+                .introspectorJobActiveDeadlineSeconds(300L)));
+
+    logger.info("Create domain custom resource for domainUid {0} in namespace {1}",
+        domainResourceName, domNamespace);
+    boolean domCreated = assertDoesNotThrow(() -> createDomainCustomResource(domain),
+        String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
+            domainResourceName, domNamespace));
+    assertTrue(domCreated, String.format("Create domain custom resource failed with ApiException "
+        + "for %s in namespace %s", domainResourceName, domNamespace));
+
+    setPodAntiAffinity(domain);
+    return domain;
+  }
+
+  /**
+   * Replace contents of an existing configMap, by deleting and recreating the configMap
+   * with the provided list of model file(s).
+   *
+   * @param configMapName name of the configMap containing Weblogic Deploy Tooling model to have its
+   *                      contents replaced
+   * @param domainResourceName name of the domain resource
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param modelFiles list of the names of the WDT mode files in the ConfigMap
+   * @param retryPolicy ConditionFactory used for checking if the configMap has been deleted
+   */
+  public static void replaceConfigMapWithModelFiles(
+      String configMapName,
+      String domainResourceName,
+      String domainNamespace,
+      List<String> modelFiles,
+      ConditionFactory retryPolicy) {
+    LoggingFacade logger = getLogger();
+
+    deleteConfigMap(configMapName, domainNamespace);
+    retryPolicy
+        .conditionEvaluationListener(
+            condition ->
+                logger.info(
+                    "Waiting for configmap {0} to be deleted. Elapsed time{1}, remaining time {2}",
+                    configMapName,
+                    condition.getElapsedTimeInMS(),
+                    condition.getRemainingTimeInMS()))
+        .until(
+            () -> {
+              return listConfigMaps(domainNamespace).getItems().stream()
+                  .noneMatch((cm) -> (cm.getMetadata().getName().equals(configMapName)));
+            });
+
+    createConfigMapAndVerify(configMapName, domainResourceName, domainNamespace, modelFiles);
+  }
+
+  /**
+   * Use REST APIs to return the JdbcRuntime mbean from the WebLogic server.
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
+   * @param resourcesName Name of the JDBC system resource for which that mbean data to be queried
+   * @return An ExecResult containing the output of the REST API exec request
+   */
+  public static ExecResult readJdbcRuntime(
+      String domainNamespace, String adminServerPodName, String resourcesName) {
+    return readRuntimeResource(
+        domainNamespace,
+        adminServerPodName,
+        "/management/wls/latest/datasources/id/" + resourcesName,
+        "checkJdbcRuntime");
+  }
+
+  /**
+   * Use REST APIs to return the MinThreadsConstraint runtime mbean associated with
+   * the specified work manager from the WebLogic server.
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
+   * @param serverName Name of the server from which to look for the runtime mbean
+   * @param workManagerName Name of the work manager for which its associated
+   *                       min threads constraint runtime mbean data to be queried
+   * @return An ExecResult containing the output of the REST API exec request
+   */
+  public static ExecResult readMinThreadsConstraintRuntimeForWorkManager(
+      String domainNamespace, String adminServerPodName,
+      String serverName, String workManagerName) {
+    return readRuntimeResource(
+        domainNamespace,
+        adminServerPodName,
+        "/management/weblogic/latest/domainRuntime/serverRuntimes/"
+            + serverName
+            + "/applicationRuntimes/" + MII_BASIC_APP_DEPLOYMENT_NAME
+            + "/workManagerRuntimes/" + workManagerName
+            + "/minThreadsConstraintRuntime",
+        "checkMinThreadsConstraintRuntime");
+  }
+
+  /**
+   * Use REST APIs to return the MaxThreadsConstraint runtime mbean associated with
+   * the specified work manager from the WebLogic server.
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
+   * @param serverName Name of the server from which to look for the runtime mbean
+   * @param workManagerName Name of the work manager for which its associated
+   *                       max threads constraint runtime mbean data to be queried
+   * @return An ExecResult containing the output of the REST API exec request
+   */
+  public static ExecResult readMaxThreadsConstraintRuntimeForWorkManager(
+      String domainNamespace, String adminServerPodName,
+      String serverName, String workManagerName) {
+    return readRuntimeResource(
+        domainNamespace,
+        adminServerPodName,
+        "/management/weblogic/latest/domainRuntime/serverRuntimes/"
+            + serverName
+            + "/applicationRuntimes/" + MII_BASIC_APP_DEPLOYMENT_NAME
+            + "/workManagerRuntimes/" + workManagerName
+            + "/maxThreadsConstraintRuntime",
+        "checkMaxThreadsConstraintRuntime");
+  }
+
+  /**
+   * Use REST APIs to check the WorkManager runtime mbean from the WebLogic server.
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
+   * @param serverName Name of the server from which to look for the runtime mbean
+   * @param workManagerName Name of the work manager for which its runtime mbean is to be verified
+   * @param expectedStatusCode the expected response to verify
+   * @return true if the REST API reply contains the expected response
+   */
+  public static boolean checkWorkManagerRuntime(
+      String domainNamespace, String adminServerPodName,
+      String serverName, String workManagerName, String expectedStatusCode) {
+    return checkSystemResource(
+        domainNamespace,
+        adminServerPodName,
+        "/management/weblogic/latest/domainRuntime/serverRuntimes/"
+            + serverName
+            + "/applicationRuntimes/" + MII_BASIC_APP_DEPLOYMENT_NAME
+            + "/workManagerRuntimes/" + workManagerName,
+        expectedStatusCode);
+  }
+
+  private static ExecResult readRuntimeResource(String domainNamespace, String adminServerPodName,
+      String resourcePath, String callerName) {
+    LoggingFacade logger = getLogger();
+
+    int adminServiceNodePort
+        = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
+    ExecResult result = null;
+
+    StringBuffer curlString = new StringBuffer("curl --user "
+        + ADMIN_USERNAME_DEFAULT + ":" + ADMIN_PASSWORD_DEFAULT + " ");
+    curlString.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
+        .append(resourcePath)
+        .append("/")
+        .append(" --silent --show-error ");
+    logger.info(callerName + ": curl command {0}", new String(curlString));
+    try {
+      result = exec(new String(curlString), true);
+      logger.info(callerName + ": exec curl command {0} got: {1}", new String(curlString), result);
+    } catch (Exception ex) {
+      logger.info(callerName + ": caught unexpected exception {0}", ex);
+      return null;
+    }
+    return result;
+  }
+
+  /**
+   * Use REST APIs to check the system resource runtime mbean from the WebLogic server.
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param adminServerPodName Name of the admin server pod to which the REST requests should be sent to
+   * @param resourcePath Path of the system resource to be used in the REST API call
+   * @param expectedStatusCode the expected response to verify
+   * @return true if the REST API reply contains the expected response
+   */
+  public static boolean checkSystemResource(String domainNamespace,
+         String adminServerPodName,  String resourcePath, String expectedStatusCode) {
+    LoggingFacade logger = getLogger();
+
+    int adminServiceNodePort
+        = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
+    StringBuffer curlString = new StringBuffer("status=$(curl --user weblogic:welcome1 ");
+    curlString.append("http://" + K8S_NODEPORT_HOST + ":" + adminServiceNodePort)
+         .append(resourcePath)
+         .append(" --silent --show-error ")
+         .append(" -o /dev/null ")
+         .append(" -w %{http_code});")
+         .append("echo ${status}");
+    logger.info("checkSystemResource: curl command {0}", new String(curlString));
+    return new Command()
+          .withParams(new CommandParams()
+              .command(curlString.toString()))
+          .executeAndVerify(expectedStatusCode);
+  }
+
+  /**
+   * Create a job to change the permissions on the pv host path.
+   * @param pvName Name of the persistent volume
+   * @param pvcName Name of the persistent volume claim
+   * @param namespace Namespace containing the persistent volume claim and where the job should be created in
+   */
+  public static void createJobToChangePermissionsOnPvHostPath(String pvName, String pvcName, String namespace) {
+    LoggingFacade logger = getLogger();
+
+    logger.info("Running Kubernetes job to create domain");
+    V1Job jobBody = new V1Job()
+        .metadata(
+            new V1ObjectMeta()
+                .name("change-permissions-onpv-job-" + pvName) // name of the job
+                .namespace(namespace))
+        .spec(new V1JobSpec()
+            .backoffLimit(0) // try only once
+            .template(new V1PodTemplateSpec()
+                .spec(new V1PodSpec()
+                    .restartPolicy("Never")
+                    .addContainersItem(new V1Container()
+                        .name("fix-pvc-owner") // change the ownership of the pv to opc:opc
+                        .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
+                        .addCommandItem("/bin/sh")
+                        .addArgsItem("-c")
+                        .addArgsItem("chown -R 1000:1000 /shared")
+                        .addVolumeMountsItem(
+                            new V1VolumeMount()
+                                .name(pvName)
+                                .mountPath("/shared"))
+                        .securityContext(new V1SecurityContext()
+                            .runAsGroup(0L)
+                            .runAsUser(0L))) // mounted under /shared inside pod
+                    .volumes(Arrays.asList(
+                        new V1Volume()
+                            .name(pvName)
+                            .persistentVolumeClaim(
+                                new V1PersistentVolumeClaimVolumeSource()
+                                    .claimName(pvcName))))
+                    .imagePullSecrets(Arrays.asList(
+                        new V1LocalObjectReference()
+                            .name(BASE_IMAGES_REPO_SECRET)))))); // this secret is used only for non-kind cluster
+
+    String jobName = createJobAndWaitUntilComplete(jobBody, namespace);
+
+    // check job status and fail test if the job failed
+    V1Job job = assertDoesNotThrow(() -> getJob(jobName, namespace),
+        "Getting the job failed");
+    if (job != null) {
+      V1JobCondition jobCondition = job.getStatus().getConditions().stream().filter(
+          v1JobCondition -> "Failed".equalsIgnoreCase(v1JobCondition.getType()))
+          .findAny()
+          .orElse(null);
+      if (jobCondition != null) {
+        logger.severe("Job {0} failed to change permissions on PV hostpath", jobName);
+        List<V1Pod> pods = assertDoesNotThrow(() -> listPods(
+            namespace, "job-name=" + jobName).getItems(),
+            "Listing pods failed");
+        if (!pods.isEmpty()) {
+          String podLog = assertDoesNotThrow(() -> getPodLog(pods.get(0).getMetadata().getName(), namespace),
+              "Failed to get pod log");
+          logger.severe(podLog);
+          fail("Change permissions on PV hostpath job failed");
+        }
+      }
+    }
+  }
+
+  /**
+   * Check logs are written on PV by running the specified command on the pod.
+   * @param domainNamespace Kubernetes namespace that the domain is hosted
+   * @param commandToExecuteInsidePod The command to be run inside the pod
+   * @param podName Name of the pod
+   */
+  public static void checkLogsOnPV(String domainNamespace, String commandToExecuteInsidePod, String podName) {
+    LoggingFacade logger = getLogger();
+
+    logger.info("Checking logs are written on PV by running the command {0} on pod {1}, namespace {2}",
+        commandToExecuteInsidePod, podName, domainNamespace);
+    V1Pod serverPod = assertDoesNotThrow(() ->
+            Kubernetes.getPod(domainNamespace, null, podName),
+        String.format("Could not get the server Pod {0} in namespace {1}",
+            podName, domainNamespace));
+
+    ExecResult result = assertDoesNotThrow(() -> Kubernetes.exec(serverPod, null, true,
+        "/bin/sh", "-c", commandToExecuteInsidePod),
+        String.format("Could not execute the command %s in pod %s, namespace %s",
+            commandToExecuteInsidePod, podName, domainNamespace));
+    logger.info("Command {0} returned with exit value {1}, stderr {2}, stdout {3}",
+        commandToExecuteInsidePod, result.exitValue(), result.stderr(), result.stdout());
+
+    // checking for exitValue 0 for success fails sometimes as k8s exec api returns non-zero exit value even on success,
+    // so checking for exitValue non-zero and stderr not empty for failure, otherwise its success
+    assertFalse(result.exitValue() != 0 && result.stderr() != null && !result.stderr().isEmpty(),
+        String.format("Command %s failed with exit value %s, stderr %s, stdout %s",
+            commandToExecuteInsidePod, result.exitValue(), result.stderr(), result.stdout()));
+
+  }
+
+  /**
+   * Create a database secret.
+   * @param secretName Name of the secret
+   * @param username username to be added to the secret
+   * @param password password to be added to the secret
+   * @param dburl url of the database to be added to the secret
+   * @param domNamespace Kubernetes namespace to create the secret in
+   */
+  public static void createDatabaseSecret(
+      String secretName, String username, String password,
+      String dburl, String domNamespace)  {
+    Map<String, String> secretMap = new HashMap();
+    secretMap.put("username", username);
+    secretMap.put("password", password);
+    secretMap.put("url", dburl);
+    boolean secretCreated = assertDoesNotThrow(() -> createSecret(new V1Secret()
+        .metadata(new V1ObjectMeta()
+            .name(secretName)
+            .namespace(domNamespace))
+        .stringData(secretMap)), "Create secret failed with ApiException");
+    assertTrue(secretCreated, String.format("create secret failed for %s in namespace %s", secretName, domNamespace));
+  }
+
+  /**
+   * Create a domain secret.
+   * @param secretName Name of the secret
+   * @param username username to be added to the secret
+   * @param password password to be added to the secret
+   * @param domNamespace Kubernetes namespace to create the secret in
+   */
+  public static void createDomainSecret(String secretName, String username, String password, String domNamespace) {
+    Map<String, String> secretMap = new HashMap();
+    secretMap.put("username", username);
+    secretMap.put("password", password);
+    boolean secretCreated = assertDoesNotThrow(() -> createSecret(new V1Secret()
+        .metadata(new V1ObjectMeta()
+            .name(secretName)
+            .namespace(domNamespace))
+        .stringData(secretMap)), "Create secret failed with ApiException");
+    assertTrue(secretCreated, String.format("create secret failed for %s in namespace %s", secretName, domNamespace));
   }
 }

--- a/integration-tests/src/test/resources/wdt-models/model.config.wm.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model.config.wm.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+resources:
+  SelfTuning:
+    WorkManager:
+      newWM:
+        Target: 'cluster-1'
+        MinThreadsConstraint: 'SampleMinThreads'
+        MaxThreadsConstraint: 'SampleMaxThreads'
+    MinThreadsConstraint:
+      SampleMinThreads:
+        Count: 1
+    MaxThreadsConstraint:
+      SampleMaxThreads:
+        Count: 10

--- a/integration-tests/src/test/resources/wdt-models/model.update.wm.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model.update.wm.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+resources:
+  SelfTuning:
+    WorkManager:
+      newWM:
+        Target: 'cluster-1'
+        MinThreadsConstraint: 'SampleMinThreads'
+        MaxThreadsConstraint: 'SampleMaxThreads'
+    MinThreadsConstraint:
+      SampleMinThreads:
+        Count: 2
+    MaxThreadsConstraint:
+      SampleMaxThreads:
+        Count: 20


### PR DESCRIPTION
This is for merging to `dynamicupdate` branch

Added new integration test `ItMiiDynamicUpdate` under integration-tests/src/test/java/oracle/weblogic/kubernetes/ for testing dynamic update of work manager configurations. First update adds a new work manager, min and max threads constraints, and a second update changes the count of the min and max threads constraint.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3120/
