### PR TITLE
Tanzu sample certification documentation

### DIFF
--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -14,7 +14,7 @@ TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kube
 #### Contents
 
  - [Prerequisites](#prerequisites)
-   - [Create the Tanzu Kubernetes cluster](#create-the-tanzu-kubernetes-cluster)
+   - [Create a Tanzu Kubernetes cluster](#create-a-tanzu-kubernetes-cluster)
    - [Oracle Container Registry](#oracle-container-registry)
  - [Install WebLogic Server Kubernetes Operator](#install-weblogic-server-kubernetes-operator)
  - [Create Docker image](#create-docker-image)
@@ -25,17 +25,17 @@ TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kube
 
 This sample assumes the following prerequisite environment setup.
 
-* WebLogic Server Kubernetes operator: This document was tested with version v3.1.0.
+* WebLogic Server Kubernetes Operator: This document was tested with version v3.1.0.
 * Operating System: GNU/Linux.
 * [Git](https://git-scm.com/downloads); use `git --version` to test if `git` works.  This document was tested with version 2.17.1.
-* TKG CLI; use `tkg version` to test if tkg works. This document was tested with version v1.1.3.
+* TKG CLI; use `tkg version` to test if TKG works. This document was tested with version v1.1.3.
 * [kubectl](https://kubernetes-io-vnext-staging.netlify.com/docs/tasks/tools/install-kubectl/); use `kubectl version` to test if `kubectl` works.  This document was tested with version v1.18.6.
-* [helm](https://helm.sh/docs/intro/install/) version 3.1 or later; use `helm version` to check the `helm` version.  This document was tested with version v3.2.1.
+* [Helm](https://helm.sh/docs/intro/install/) version 3.1 or later; use `helm version` to check the `helm` version.  This document was tested with version v3.2.1.
 
-##### Create the Tanzu Kubernetes cluster
+##### Create a Tanzu Kubernetes cluster
 
 Create the Kubernetes cluster using the TKG CLI. See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) to set up your Kubernetes cluster.
-After your Kubernetes cluster is up and running, run the following commands to make sure `kubectl` can access the Kubernetes cluster.
+After your Kubernetes cluster is up and running, run the following commands to make sure `kubectl` can access the Kubernetes cluster:
 
 ```bash
 $ kubectl get nodes -o wide
@@ -63,8 +63,8 @@ Obtain the WebLogic Server image from the [Oracle Container Registry](https://co
 The Oracle WebLogic Server Kubernetes Operator is an adapter to integrate WebLogic Server and Kubernetes, allowing Kubernetes to serve as a container infrastructure hosting WLS instances.
 The operator runs as a Kubernetes Pod and stands ready to perform actions related to running WLS on Kubernetes.
 
-Clone the Oracle WebLogic Server Kubernetes Operator repository to your machine. We will use several scripts in this repository to create a WebLogic domain. This sample was tested with v3.1.0.
-Kubernetes Operators, use [Helm](https://helm.sh/) to manage Kubernetes applications. The operator’s Helm chart is located in the `kubernetes/charts/weblogic-operator` directory. Install the operator by running the following commands.
+Clone the Oracle WebLogic Server Kubernetes Operator repository to your machine. We will use several scripts in this repository to create a WebLogic domain.
+Kubernetes Operators use [Helm](https://helm.sh/) to manage Kubernetes applications. The operator’s Helm chart is located in the `kubernetes/charts/weblogic-operator` directory. Install the operator by running the following commands.
 
 Clone the repository.
 
@@ -346,8 +346,8 @@ Also, if you run the `docker images` command, then you will see a Docker image n
 
 In this section, you will deploy the new image to namespace `sample-domain1-ns`, including the following steps:
 
-- Create a namespace for WebLogic domain
-- Upgrade the operator to manage the WebLogic domain namespace    
+- Create a namespace for the WebLogic domain.
+- Upgrade the operator to manage the WebLogic domain namespace.   
 - Create a Secret containing your WebLogic administrator user name and password.
 - Create a Secret containing your Model in Image runtime encryption password:
     - All Model in Image domains must supply a runtime encryption Secret with a `password` value.
@@ -365,6 +365,7 @@ $ kubectl create namespace sample-domain1-ns
 ```
 
 ##### Upgrade the operator
+
 Upgrade the operator to manage the WebLogic domains in namespace `sample-domain1-ns`.
 
 ```bash
@@ -577,13 +578,11 @@ service/sample-domain1-managed-server2     ClusterIP   None           <none>    
 
 #### Invoke the web application
 
-##### Create a load balancer
-
 Create a load balancer to access the WebLogic Server Administration Console and applications deployed in the cluster.
 Tanzu supports the MetalLB load balancer and NGINX ingress for routing.
 
 
-##### Install the MetalLB load balancer by running following commands
+Install the MetalLB load balancer by running following commands:
 
 ```bash
 ## create namespace metallb-system
@@ -631,7 +630,7 @@ replicaset.apps/controller-684f5d9b49   1         1         1       2m14s
 ```
 
 
-##### Install NGINX
+Install NGINX.
 
 ```bash
 $ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -640,7 +639,7 @@ $ helm install ingress-nginx ingress-nginx/ingress-nginx
 ```
 
 
-##### Create ingress routing for accessing the application deployed in the cluster
+Create ingress routing for accessing the application deployed in the cluster.
 
 ```bash
 $ cat cluster-ingress.yaml
@@ -665,7 +664,7 @@ spec:
 $ kubectl apply -f cluster-ingress.yaml
 ```
 
-##### Create ingress for Administration Console access
+Create ingress for Administration Console access.
 
 ```bash
 $ cat admin-ingress.yaml
@@ -691,7 +690,7 @@ $ kubectl apply -f admin-ingress.yaml
 
 ```
 
-##### Verify ingresses are running
+Verify ingresses are running.
 
 ```bash
 $ kubectl get ingresses -n sample-domain1-ns
@@ -700,12 +699,9 @@ sample-nginx-ingress-adminconsole   <none>  *                              80   
 sample-nginx-ingress-hostrouting   <none>   domain1.org   192.168.100.50   80      7m18s
 ```
 
-##### Access the Administration Console
-Access the Administration Console using the load balancer IP address (`192.168.100.50`).
+Access the Administration Console using the load balancer IP address, `http://192.168.100.50/console`
 
-`http://192.168.100.50/console`
-
-##### Access the sample application
+Access the sample application.
 
 ```bash
 ## Access the sample application using the load balancer IP (192.168.100.50)

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -110,7 +110,10 @@ Install the operator.
 $ helm install weblogic-operator kubernetes/charts/weblogic-operator \
   --namespace sample-weblogic-operator-ns \
   --set serviceAccount=sample-weblogic-operator-sa \
-  --set "enableClusterRoleBinding=true" --wait
+  --set "enableClusterRoleBinding=true" \
+  --set "domainNamespaceSelectionStrategy=LabelSelector" \
+  --set "domainNamespaceLabelSelector=weblogic-operator\=enabled" \
+  --wait
 
 NAME: weblogic-operator
 LAST DEPLOYED: Tue Nov 17 09:33:58 2020
@@ -639,12 +642,12 @@ $ helm install ingress-nginx ingress-nginx/ingress-nginx
 ```
 
 
-Create ingress for accessing the application deployed in the cluster and to access Administration console.
+Create ingress for accessing the application deployed in the cluster and to access the Administration console.
 
 ```bash
 $ cat ingress.yaml
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: sample-nginx-ingress-pathrouting

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -302,7 +302,7 @@ At this point, you have staged all of the files needed for the image `model-in-i
   - `/tmp/mii-sample/model-images/model-in-image__WLS-v1/model.10.properties`
   - `/tmp/mii-sample/model-images/model-in-image__WLS-v1/archive.zip`
 
-If you don’t see the `weblogic-deploy.zip` file, then you missed a step in the prerequisites.
+If you don’t see the `weblogic-deploy.zip` file, then you missed a step in the [prerequisites](#image-creation-prerequisites).
 
 Now, you use the Image Tool to create an image named `model-in-image:WLS-v1` that’s layered on a base WebLogic image. You’ve already set up this tool during the prerequisite steps.
 
@@ -639,40 +639,15 @@ $ helm install ingress-nginx ingress-nginx/ingress-nginx
 ```
 
 
-Create ingress routing for accessing the application deployed in the cluster.
+Create ingress for accessing the application deployed in the cluster and to access Administration console.
 
 ```bash
-$ cat cluster-ingress.yaml
+$ cat ingress.yaml
 
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: sample-nginx-ingress-hostrouting
-  namespace: sample-domain1-ns
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-  - host: 'domain1.org'
-    http:
-      paths:
-      - path:
-        backend:
-          serviceName: sample-domain1-cluster-cluster-1
-          servicePort: 8001
-
-$ kubectl apply -f cluster-ingress.yaml
-```
-
-Create ingress for Administration Console access.
-
-```bash
-$ cat admin-ingress.yaml
-
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: sample-nginx-ingress-adminconsole
+  name: sample-nginx-ingress-pathrouting
   namespace: sample-domain1-ns
   annotations:
     kubernetes.io/ingress.class: nginx
@@ -681,22 +656,25 @@ spec:
   - host:
     http:
       paths:
-      - path:
+      - path: /
+        backend:
+          serviceName: sample-domain1-cluster-cluster-1
+          servicePort: 8001
+      - path: /console
         backend:
           serviceName: sample-domain1-admin-server
           servicePort: 7001
 
-$ kubectl apply -f admin-ingress.yaml
+$ kubectl apply -f ingress.yaml
 
 ```
 
-Verify ingresses are running.
+Verify ingress is running.
 
 ```bash
 $ kubectl get ingresses -n sample-domain1-ns
-NAME                               CLASS    HOSTS         ADDRESS          PORTS   AGE
-sample-nginx-ingress-adminconsole   <none>  *                              80      7m18s
-sample-nginx-ingress-hostrouting   <none>   domain1.org   192.168.100.50   80      7m18s
+NAME                               CLASS    HOSTS   ADDRESS          PORTS   AGE
+sample-nginx-ingress-pathrouting   <none>   *       192.168.100.50   80      7m18s
 ```
 
 Access the Administration Console using the load balancer IP address, `http://192.168.100.50/console`
@@ -705,7 +683,7 @@ Access the sample application.
 
 ```bash
 ## Access the sample application using the load balancer IP (192.168.100.50)
-$ curl --show-error -H 'Host: domain1.org' http://192.168.100.50/myapp_war/index.jsp
+$ curl http://192.168.100.50/myapp_war/index.jsp
 
 
 <html><body><pre>
@@ -726,7 +704,7 @@ Found 0 local data sources:
 *****************************************************************
 </pre></body></html>
 
-root@cli-vm:~/weblogic-kubernetes-operator# curl --show-error -H 'Host: domain1.org' http://192.168.100.50/myapp_war/index.jsp
+$ curl http://192.168.100.50/myapp_war/index.jsp
 
 
 

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -7,7 +7,7 @@ description: "Sample for using the operator to set up a WLS cluster on the Tanzu
 
 
 This sample demonstrates how to use the Oracle [WebLogic Server Kubernetes Operator](/weblogic-kubernetes-operator/) (hereafter “the operator”) to set up a WebLogic Server (WLS) cluster on the Tanzu Kubernetes Grid (TKG).
-After performing the sample steps,, your WLS domain runs on a TKG Kubernetes cluster instance and you can manage your WLS domain by using the WebLogic Server Administration Console.
+After performing the sample steps, your WLS domain runs on a TKG Kubernetes cluster instance and you can manage your WLS domain by using the WebLogic Server Administration Console.
 
 TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kubernetes clusters. To learn more, see the [Tanzu Kubernetes Grid (TKG)](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) overview page.
 
@@ -30,7 +30,7 @@ This sample assumes the following prerequisite environment setup.
 * [Git](https://git-scm.com/downloads); use `git --version` to test if `git` works.  This document was tested with version 2.17.1.
 * TKG CLI; use `tkg version` to test if tkg works. This document was tested with version v1.1.3.
 * [kubectl](https://kubernetes-io-vnext-staging.netlify.com/docs/tasks/tools/install-kubectl/); use `kubectl version` to test if `kubectl` works.  This document was tested with version v1.18.6.
-* [helm](https://helm.sh/docs/intro/install/); version 3.1 or later; use `helm version` to check the `helm` version.  This document was tested with version v3.2.1.
+* [helm](https://helm.sh/docs/intro/install/) version 3.1 or later; use `helm version` to check the `helm` version.  This document was tested with version v3.2.1.
 
 ##### Create the Tanzu Kubernetes cluster
 

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -365,19 +365,9 @@ Create a namespace that can host one or more domains:
 
 ```bash
 $ kubectl create namespace sample-domain1-ns
-```
 
-##### Upgrade the operator
-
-Upgrade the operator to manage the WebLogic domains in namespace `sample-domain1-ns`.
-
-```bash
-$ cd /root/weblogic-kubernetes-operator
-$ helm upgrade weblogic-operator  kubernetes/charts/weblogic-operator \
-  --namespace sample-weblogic-operator-ns \
-  --reuse-values \
-  --set "domainNamespaces={sample-domain1-ns}" \
-  --wait
+## label the domain namespace so that the operator can autodetect and create WebLogic Server pods.
+$ kubectl label namespace sample-domain1-ns weblogic-operator=enabled
 ```
 
 ##### Secrets

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -7,7 +7,7 @@ description: "Sample for using the operator to set up a WLS cluster on the Tanzu
 
 
 This sample demonstrates how to use the Oracle [WebLogic Server Kubernetes Operator](/weblogic-kubernetes-operator/) (hereafter “the operator”) to set up a WebLogic Server (WLS) cluster on the Tanzu Kubernetes Grid (TKG).
-After performing the sample steps, your WLS domain runs on a TKG Kubernetes cluster instance and you can manage your WLS domain by using the WebLogic Server Administration Console.
+After performing the sample steps, your WLS domain with domain source type of Model In Image runs on an TKG Kubernetes cluster instance. Once the domain has been provisioned you can monitor it using the WebLogic Administration console.
 
 TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kubernetes clusters. To learn more, see the [Tanzu Kubernetes Grid (TKG)](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) overview page.
 
@@ -35,7 +35,7 @@ This sample assumes the following prerequisite environment setup.
 ##### Create the Tanzu Kubernetes cluster
 
 Create the Kubernetes cluster using the TKG CLI. See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) to set up your Kubernetes cluster.
-After your Kubernetes cluster is up and running, run the following command to make sure `kubectl` can access the Kubernetes cluster.
+After your Kubernetes cluster is up and running, run the following commands to make sure `kubectl` can access the Kubernetes cluster.
 
 ```bash
 $ kubectl get nodes -o wide
@@ -48,7 +48,7 @@ k8s-cluster-101-md-0-577b7dc766-p2gkz   Ready      <none>   2d20h   v1.18.6+vmwa
 
 ##### Oracle Container Registry
 
-You will need an Oracle account. The following steps will direct you to accept the license agreement for WebLogic Server.  Make note of your Oracle Account password and email.  This sample pertains to 12.2.1.4, but other versions may work as well.
+You will need an Oracle Container Registry account. The following steps will direct you to accept Oracle Standard Terms and Restrictions to pull the WebLogic Server images.  Make note of your Oracle Account password and email.  This sample pertains to 12.2.1.4, but other versions may work as well.
 
 Obtain the WebLogic Server image from the [Oracle Container Registry](https://container-registry.oracle.com/).
 

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -14,10 +14,10 @@ TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kube
 #### Contents
 
  - [Prerequisites](#prerequisites)
-   - [Create the Tanzu kubernetes cluster](#create-the-tanzu-cluster)
-   - [Oracle container registry](#oracle-container-registry)
+   - [Create the Tanzu Kubernetes cluster](#create-the-tanzu-kubernetes-cluster)
+   - [Oracle Container Registry](#oracle-container-registry)
  - [Install WebLogic Server Kubernetes Operator](#install-weblogic-server-kubernetes-operator)
- - [Create docker image](#create-docker-image)
+ - [Create Docker image](#create-docker-image)
  - [Create WebLogic domain](#create-weblogic-domain)
  - [Invoke the web application](#invoke-the-web-application)
 
@@ -60,13 +60,13 @@ Obtain the WebLogic Server image from the [Oracle Container Registry](https://co
 
 #### Install WebLogic Server Kubernetes Operator
 
-The Oracle WebLogic Server Kubernetes Operator is an adapter to integrate WebLogic Server and Kubernetes, allowing Kubernetes to serve as a container infrastructure hosting WLS instances. 
+The Oracle WebLogic Server Kubernetes Operator is an adapter to integrate WebLogic Server and Kubernetes, allowing Kubernetes to serve as a container infrastructure hosting WLS instances.
 The operator runs as a Kubernetes Pod and stands ready to perform actions related to running WLS on Kubernetes.
 
 Clone the Oracle WebLogic Server Kubernetes Operator repository to your machine. We will use several scripts in this repository to create a WebLogic domain. This sample was tested with v3.1.0.
 Kubernetes Operators, use [Helm](https://helm.sh/) to manage Kubernetes applications. The operator’s Helm chart is located in the `kubernetes/charts/weblogic-operator` directory. Install the operator by running the following commands.
 
-Clone repository
+Clone the repository.
 
 ```bash
 $ git clone https://github.com/oracle/weblogic-kubernetes-operator.git
@@ -93,7 +93,7 @@ subjects:
 EOF
 ```
 
-Create namespace and service account for the operator
+Create a namespace and service account for the operator.
 
 ```bash
 $ kubectl create namespace sample-weblogic-operator-ns
@@ -104,7 +104,7 @@ $ kubectl create serviceaccount -n sample-weblogic-operator-ns sample-weblogic-o
 serviceaccount/sample-weblogic-operator-sa created
 ```
 
-Install the operator
+Install the operator.
 
 ```bash
 $ helm install weblogic-operator kubernetes/charts/weblogic-operator \
@@ -120,7 +120,7 @@ REVISION: 1
 TEST SUITE: None
 ```
 
-Verify the operator with the following command; the status will be running.
+Verify the operator with the following commands; the status will be running.
 
 ```bash
 $ helm list -A
@@ -136,7 +136,6 @@ weblogic-operator-775b668c8f-nwwnn   1/1     Running   0          32s
 
 #### Create Docker image
 
-##### Image creation
 
   - [Image creation prerequisites](#image-creation-prerequisites)
   - [Image creation - Introduction](#image-creation---introduction)
@@ -147,7 +146,7 @@ weblogic-operator-775b668c8f-nwwnn   1/1     Running   0          32s
 
 ##### Image creation prerequisites
 1. The `JAVA_HOME` environment variable must be set and must reference a valid JDK 8 or 11 installation.
-2. Copy the sample to a new directory; for example, use directory `/tmp/mii-sample`.
+2. Copy the sample to a new directory; for example, use the directory `/tmp/mii-sample`.
 
 ```bash
 $ mkdir /tmp/mii-sample
@@ -155,7 +154,7 @@ $ cp -r /root/weblogic-kubernetes-operator/kubernetes/samples/scripts/create-web
 ```
 
 
-Note: We will refer to this working copy of the sample as `/tmp/mii-sample`; however, you can use a different location.
+**Note**: We will refer to this working copy of the sample as `/tmp/mii-sample`; however, you can use a different location.
 
 Download the latest WebLogic Deploying Tooling (WDT) and WebLogic Image Tool (WIT) installer ZIP files to your `/tmp/mii-sample/model-images` directory. Both WDT and WIT are required to create your Model in Image Docker images.
 
@@ -189,17 +188,16 @@ These steps will install WIT to the `/tmp/mii-sample/model-images/imagetool` dir
 
 ##### Image creation - Introduction
 
-The goal of the initial use case ‘image creation’ is to demonstrate using the WebLogic Image Tool to create an image named `model-in-image:WLS-v1` from files that you will stage to `/tmp/mii-sample/model-images/model-in-image:WLS-v1/`. 
-The staged files will contain a web application in a WDT archive, and WDT model configuration for a WebLogic Administration Server called admin-server and a WebLogic cluster called cluster-1.
+The goal of image creation is to demonstrate using the WebLogic Image Tool to create an image named `model-in-image:WLS-v1` from files that you will stage to `/tmp/mii-sample/model-images/model-in-image:WLS-v1/`.
+The staged files will contain a web application in a WDT archive, and WDT model configuration for a WebLogic Administration Server called `admin-server` and a WebLogic cluster called `cluster-1`.
 
-Overall, a Model in Image image must contain a WebLogic Server installation and a WebLogic Deploy Tooling installation in its `/u01/wdt/weblogic-deploy` directory. 
-In addition, if you have WDT model archive files, then the image must also contain these files in its `/u01/wdt/models` directory. 
-Finally, an image optionally may also contain your WDT model YAML file and properties files in the same `/u01/wdt/models` directory. 
-If you do not specify a WDT model YAML file in your `/u01/wdt/models` directory, then the model YAML file must be supplied dynamically using a Kubernetes ConfigMap that is referenced by your Domain `spec.model.configMap` field. 
+Overall, a Model in Image image must contain a WebLogic Server installation and a WebLogic Deploy Tooling installation in its `/u01/wdt/weblogic-deploy` directory.
+In addition, if you have WDT model archive files, then the image must also contain these files in its `/u01/wdt/models` directory.
+Finally, an image optionally may also contain your WDT model YAML file and properties files in the same `/u01/wdt/models` directory.
+If you do not specify a WDT model YAML file in your `/u01/wdt/models` directory, then the model YAML file must be supplied dynamically using a Kubernetes ConfigMap that is referenced by your Domain `spec.model.configMap` field.
 We provide an example of using a model ConfigMap later in this sample.
 
-Here are the steps for creating the image `model-in-image:WLS-v1`:
-
+The following sections contain the steps for creating the image `model-in-image:WLS-v1`.
 
 ##### Understanding your first archive
 
@@ -210,7 +208,7 @@ The archive top directory, named `wlsdeploy`, contains a directory named `applic
   - WDT archives can contain multiple applications, libraries, and other components.
   - WDT archives have a [well defined directory structure](https://github.com/oracle/weblogic-deploy-tooling/blob/master/site/archive.md), which always has `wlsdeploy` as the top directory.
 
-The application displays important details about the WebLogic Server instance that it’s running on: namely its domain name, cluster name, and server name, as well as the names of any data sources that are targeted to the server. 
+The application displays important details about the WebLogic Server instance that it’s running on: namely its domain name, cluster name, and server name, as well as the names of any data sources that are targeted to the server.
 
 
 ##### Staging a ZIP file of the archive
@@ -232,7 +230,7 @@ $ zip -r /tmp/mii-sample/model-images/model-in-image__WLS-v1/archive.zip wlsdepl
 
 ##### Staging model files
 
-In this step, you explore the staged WDT model YAML file and properties in the `/tmp/mii-sample/model-in-image__WLS-v1` directory. The model in this directory references the web application in your archive, 
+In this step, you explore the staged WDT model YAML file and properties in the `/tmp/mii-sample/model-in-image__WLS-v1` directory. The model in this directory references the web application in your archive,
 configures a WebLogic Server Administration Server, and configures a WebLogic cluster. It consists of only two files, `model.10.properties`, a file with a single property, and, `model.10.yaml`, a YAML file with your WebLogic configuration `model.10.yaml`.
 
 ```
@@ -297,7 +295,7 @@ A Model in Image image can contain multiple properties files, archive ZIP files,
 
 ##### Creating the image with WIT
 
-At this point, you have staged all of the files needed for image `model-in-image:WLS-v1`; they include:
+At this point, you have staged all of the files needed for the image `model-in-image:WLS-v1`; they include:
 
   - `/tmp/mii-sample/model-images/weblogic-deploy.zip`
   - `/tmp/mii-sample/model-images/model-in-image__WLS-v1/model.10.yaml`
@@ -346,8 +344,6 @@ Also, if you run the `docker images` command, then you will see a Docker image n
 
 #### Create WebLogic domain
 
-##### Deploy resources - Introduction
-
 In this section, you will deploy the new image to namespace `sample-domain1-ns`, including the following steps:
 
 - Create a namespace for WebLogic domain
@@ -369,7 +365,7 @@ $ kubectl create namespace sample-domain1-ns
 ```
 
 ##### Upgrade the operator
-Upgrade the operator to manage the WebLogic domains in namespace `sample-domain1-ns`
+Upgrade the operator to manage the WebLogic domains in namespace `sample-domain1-ns`.
 
 ```bash
 $ cd /root/weblogic-kubernetes-operator
@@ -382,7 +378,7 @@ $ helm upgrade weblogic-operator  kubernetes/charts/weblogic-operator \
 
 ##### Secrets
 
-First, create the secrets needed by WLS type model domain. In this case, you have two secrets.
+First, create the secrets needed by the WLS type model domain. In this case, you have two secrets.
 
 Run the following `kubectl` commands to deploy the required secrets:
 
@@ -581,13 +577,13 @@ service/sample-domain1-managed-server2     ClusterIP   None           <none>    
 
 #### Invoke the web application
 
-##### Create load balancer
+##### Create a load balancer
 
 Create a load balancer to access the WebLogic Server Administration Console and applications deployed in the cluster.
-Tanzu supports MetalLB load balancer and NGINX ingress for routing.
+Tanzu supports the MetalLB load balancer and NGINX ingress for routing.
 
 
-##### Install the MetalLB load balancer by running following commands.
+##### Install the MetalLB load balancer by running following commands
 
 ```bash
 ## create namespace metallb-system
@@ -596,7 +592,7 @@ $ kubectl create ns metallb-system
 ## deploy MetalLB load balancer
 $ kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.9.2/manifests/metallb.yaml -n metallb-system
 
-## create secret 
+## create secret
 $ kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
 $ cat metallb-configmap.yaml
@@ -644,7 +640,7 @@ $ helm install ingress-nginx ingress-nginx/ingress-nginx
 ```
 
 
-##### Create ingress routing for accessing application deployed in cluster
+##### Create ingress routing for accessing the application deployed in the cluster
 
 ```bash
 $ cat cluster-ingress.yaml
@@ -705,10 +701,11 @@ sample-nginx-ingress-hostrouting   <none>   domain1.org   192.168.100.50   80   
 ```
 
 ##### Access the Administration Console
-Access the Administration Console using the load balancer IP (192.168.100.50)
+Access the Administration Console using the load balancer IP address (`192.168.100.50`).
+
 `http://192.168.100.50/console`
 
-##### Access the sample application 
+##### Access the sample application
 
 ```bash
 ## Access the sample application using the load balancer IP (192.168.100.50)

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -1,0 +1,759 @@
+---
+title: "Tanzu Kubernetes Service"
+date: 2020-11-16T13:34:31-05:00
+weight: 9
+description: "Sample for using the operator to set up a WLS cluster on the Tanzu Kubernetes Service."
+---
+
+
+This sample demonstrates how to use the Oracle [WebLogic Server Kubernetes Operator](/weblogic-kubernetes-operator/) (hereafter “the operator”) to set up a WebLogic Server (WLS) cluster on the Tanzu Kubernetes Grid (TKG).
+After performing the sample steps,, your WLS domain runs on a TKG Kubernetes cluster instance and you can manage your WLS domain by using the WebLogic Server Administration Console.
+
+TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kubernetes clusters. To learn more, see the [Tanzu Kubernetes Grid (TKG)](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) overview page.
+
+#### Contents
+
+ - [Prerequisites](#prerequisites)
+   - [Create the Tanzu kubernetes cluster](#create-the-tanzu-cluster)
+   - [Oracle container registry](#oracle-container-registry)
+ - [Install WebLogic Server Kubernetes Operator](#install-weblogic-server-kubernetes-operator)
+ - [Create docker image](#create-docker-image)
+ - [Create WebLogic domain](#create-weblogic-domain)
+ - [Invoke the web application](#invoke-the-web-application)
+
+#### Prerequisites
+
+This sample assumes the following prerequisite environment setup.
+
+* WebLogic Server Kubernetes operator: This document was tested with version v3.1.0.
+* Operating System: GNU/Linux.
+* [Git](https://git-scm.com/downloads); use `git --version` to test if `git` works.  This document was tested with version 2.17.1.
+* TKG CLI; use `tkg version` to test if tkg works. This document was tested with version v1.1.3.
+* [kubectl](https://kubernetes-io-vnext-staging.netlify.com/docs/tasks/tools/install-kubectl/); use `kubectl version` to test if `kubectl` works.  This document was tested with version v1.18.6.
+* [helm](https://helm.sh/docs/intro/install/); version 3.1 or later; use `helm version` to check the `helm` version.  This document was tested with version v3.2.1.
+
+##### Create the Tanzu Kubernetes cluster
+
+Create the Kubernetes cluster using the TKG CLI. See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) to set up your Kubernetes cluster.
+After your Kubernetes cluster is up and running, run the following command to make sure `kubectl` can access the Kubernetes cluster.
+
+```bash
+$ kubectl get nodes -o wide
+NAME                                    STATUS     ROLES    AGE     VERSION            INTERNAL-IP       EXTERNAL-IP       OS-IMAGE                 KERNEL-VERSION   CONTAINER-RUNTIME
+k8s-cluster-101-control-plane-8nj7t     NotReady   master   2d20h   v1.18.6+vmware.1   192.168.100.147   192.168.100.147   VMware Photon OS/Linux   4.19.132-1.ph3   containerd://1.3.4
+k8s-cluster-101-md-0-577b7dc766-552hn   Ready      <none>   2d20h   v1.18.6+vmware.1   192.168.100.148   192.168.100.148   VMware Photon OS/Linux   4.19.132-1.ph3   containerd://1.3.4
+k8s-cluster-101-md-0-577b7dc766-m8wrc   Ready      <none>   2d20h   v1.18.6+vmware.1   192.168.100.149   192.168.100.149   VMware Photon OS/Linux   4.19.132-1.ph3   containerd://1.3.4
+k8s-cluster-101-md-0-577b7dc766-p2gkz   Ready      <none>   2d20h   v1.18.6+vmware.1   192.168.100.150   192.168.100.150   VMware Photon OS/Linux   4.19.132-1.ph3   containerd://1.3.4
+```
+
+##### Oracle Container Registry
+
+You will need an Oracle account. The following steps will direct you to accept the license agreement for WebLogic Server.  Make note of your Oracle Account password and email.  This sample pertains to 12.2.1.4, but other versions may work as well.
+
+Obtain the WebLogic Server image from the [Oracle Container Registry](https://container-registry.oracle.com/).
+
+  - First time users, [follow these directions](/weblogic-kubernetes-operator/userguide/managing-domains/domain-in-image/base-images/#obtaining-standard-images-from-the-oracle-container-registry).   
+  - Find and then pull the WebLogic 12.2.1.4 install image:
+     ```bash
+     $ docker pull container-registry.oracle.com/middleware/weblogic:12.2.1.4
+     ```
+
+#### Install WebLogic Server Kubernetes Operator
+
+The Oracle WebLogic Server Kubernetes Operator is an adapter to integrate WebLogic Server and Kubernetes, allowing Kubernetes to serve as a container infrastructure hosting WLS instances. 
+The operator runs as a Kubernetes Pod and stands ready to perform actions related to running WLS on Kubernetes.
+
+Clone the Oracle WebLogic Server Kubernetes Operator repository to your machine. We will use several scripts in this repository to create a WebLogic domain. This sample was tested with v3.1.0.
+Kubernetes Operators, use [Helm](https://helm.sh/) to manage Kubernetes applications. The operator’s Helm chart is located in the `kubernetes/charts/weblogic-operator` directory. Install the operator by running the following commands.
+
+Clone repository
+
+```bash
+$ git clone https://github.com/oracle/weblogic-kubernetes-operator.git
+$ cd weblogic-kubernetes-operator
+$ git checkout v3.1.0
+```
+
+Grant the Helm service account the cluster-admin role.
+
+```bash
+$ cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: helm-user-cluster-admin-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system
+EOF
+```
+
+Create namespace and service account for the operator
+
+```bash
+$ kubectl create namespace sample-weblogic-operator-ns
+namespace/sample-weblogic-operator-ns created
+
+
+$ kubectl create serviceaccount -n sample-weblogic-operator-ns sample-weblogic-operator-sa
+serviceaccount/sample-weblogic-operator-sa created
+```
+
+Install the operator
+
+```bash
+$ helm install weblogic-operator kubernetes/charts/weblogic-operator \
+  --namespace sample-weblogic-operator-ns \
+  --set serviceAccount=sample-weblogic-operator-sa \
+  --set "enableClusterRoleBinding=true" --wait
+
+NAME: weblogic-operator
+LAST DEPLOYED: Tue Nov 17 09:33:58 2020
+NAMESPACE: sample-weblogic-operator-ns
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+Verify the operator with the following command; the status will be running.
+
+```bash
+$ helm list -A
+NAME                        NAMESPACE                     REVISION   UPDATED                                 STATUS       CHART                   APP VERSION
+sample-weblogic-operator    sample-weblogic-operator-ns   1          2020-11-17 09:33:58.584239273 -0700 PDT deployed     weblogic-operator-3.1
+
+
+$ kubectl get pods -n sample-weblogic-operator-ns
+NAME                                 READY   STATUS    RESTARTS   AGE
+weblogic-operator-775b668c8f-nwwnn   1/1     Running   0          32s
+```
+
+
+#### Create Docker image
+
+##### Image creation
+
+  - [Image creation prerequisites](#image-creation-prerequisites)
+  - [Image creation - Introduction](#image-creation---introduction)
+  - [Understanding your first archive](#understanding-your-first-archive)
+  - [Staging a ZIP file of the archive](#staging-a-zip-file-of-the-archive)
+  - [Staging model files](#staging-model-files)
+  - [Creating the image with WIT](#creating-the-image-with-wit)
+
+##### Image creation prerequisites
+1. The `JAVA_HOME` environment variable must be set and must reference a valid JDK 8 or 11 installation.
+2. Copy the sample to a new directory; for example, use directory `/tmp/mii-sample`.
+
+```bash
+$ mkdir /tmp/mii-sample
+$ cp -r /root/weblogic-kubernetes-operator/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/* /tmp/mii-sample
+```
+
+
+Note: We will refer to this working copy of the sample as `/tmp/mii-sample`; however, you can use a different location.
+
+Download the latest WebLogic Deploying Tooling (WDT) and WebLogic Image Tool (WIT) installer ZIP files to your `/tmp/mii-sample/model-images` directory. Both WDT and WIT are required to create your Model in Image Docker images.
+
+For example, visit the GitHub [WebLogic Deploy Tooling Releases](https://github.com/oracle/weblogic-deploy-tooling/releases) and [WebLogic Image Tool Releases](https://github.com/oracle/weblogic-image-tool/releases) web pages to determine the latest release version for each, and then, assuming the version numbers are `1.9.7` and `1.9.5` respectively, call:
+
+```bash
+$ cd /tmp/mii-sample/model-images
+
+$ curl -m 120 -fL https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.7/weblogic-deploy.zip \
+  -o /tmp/mii-sample/model-images/weblogic-deploy.zip
+
+$ curl -m 120 -fL https://github.com/oracle/weblogic-image-tool/releases/download/release-1.9.5/imagetool.zip \
+  -o /tmp/mii-sample/model-images/imagetool.zip
+```
+
+
+To set up the WebLogic Image Tool, run the following commands:
+```bash
+$ cd /tmp/mii-sample/model-images
+
+$ unzip imagetool.zip
+
+$ ./imagetool/bin/imagetool.sh cache addInstaller \
+  --type wdt \
+  --version latest \
+  --path /tmp/mii-sample/model-images/weblogic-deploy.zip
+```
+
+These steps will install WIT to the `/tmp/mii-sample/model-images/imagetool` directory, plus put a `wdt_latest` entry in the tool’s cache which points to the WDT ZIP file installer. You will use WIT later in the sample for creating model images.
+
+
+##### Image creation - Introduction
+
+The goal of the initial use case ‘image creation’ is to demonstrate using the WebLogic Image Tool to create an image named `model-in-image:WLS-v1` from files that you will stage to `/tmp/mii-sample/model-images/model-in-image:WLS-v1/`. 
+The staged files will contain a web application in a WDT archive, and WDT model configuration for a WebLogic Administration Server called admin-server and a WebLogic cluster called cluster-1.
+
+Overall, a Model in Image image must contain a WebLogic Server installation and a WebLogic Deploy Tooling installation in its `/u01/wdt/weblogic-deploy` directory. 
+In addition, if you have WDT model archive files, then the image must also contain these files in its `/u01/wdt/models` directory. 
+Finally, an image optionally may also contain your WDT model YAML file and properties files in the same `/u01/wdt/models` directory. 
+If you do not specify a WDT model YAML file in your `/u01/wdt/models` directory, then the model YAML file must be supplied dynamically using a Kubernetes ConfigMap that is referenced by your Domain `spec.model.configMap` field. 
+We provide an example of using a model ConfigMap later in this sample.
+
+Here are the steps for creating the image `model-in-image:WLS-v1`:
+
+
+##### Understanding your first archive
+
+The sample includes a predefined archive directory in `/tmp/mii-sample/archives/archive-v1` that you will use to create an archive ZIP file for the image.
+
+The archive top directory, named `wlsdeploy`, contains a directory named `applications`, which includes an ‘exploded’ sample JSP web application in the directory, `myapp-v1`. Three useful aspects to remember about WDT archives are:
+  - A model image can contain multiple WDT archives.
+  - WDT archives can contain multiple applications, libraries, and other components.
+  - WDT archives have a [well defined directory structure](https://github.com/oracle/weblogic-deploy-tooling/blob/master/site/archive.md), which always has `wlsdeploy` as the top directory.
+
+The application displays important details about the WebLogic Server instance that it’s running on: namely its domain name, cluster name, and server name, as well as the names of any data sources that are targeted to the server. 
+
+
+##### Staging a ZIP file of the archive
+
+When you create the image, you will use the files in the staging directory, `/tmp/mii-sample/model-in-image__WLS-v1`. In preparation, you need it to contain a ZIP file of the WDT application archive.
+
+Run the following commands to create your application archive ZIP file and put it in the expected directory:
+
+```bash
+# Delete existing archive.zip in case we have an old leftover version
+$ rm -f /tmp/mii-sample/model-images/model-in-image__WLS-v1/archive.zip
+
+# Move to the directory which contains the source files for our archive
+$ cd /tmp/mii-sample/archives/archive-v1
+
+# Zip the archive to the location will later use when we run the WebLogic Image Tool
+$ zip -r /tmp/mii-sample/model-images/model-in-image__WLS-v1/archive.zip wlsdeploy
+```
+
+##### Staging model files
+
+In this step, you explore the staged WDT model YAML file and properties in the `/tmp/mii-sample/model-in-image__WLS-v1` directory. The model in this directory references the web application in your archive, 
+configures a WebLogic Server Administration Server, and configures a WebLogic cluster. It consists of only two files, `model.10.properties`, a file with a single property, and, `model.10.yaml`, a YAML file with your WebLogic configuration `model.10.yaml`.
+
+```
+CLUSTER_SIZE=5
+```
+
+Here is the WLS `model.10.yaml`:
+
+```
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+    ServerStartMode: 'prod'
+
+topology:
+    Name: '@@ENV:CUSTOM_DOMAIN_NAME@@'
+    AdminServerName: 'admin-server'
+    Cluster:
+        'cluster-1':
+            DynamicServers:
+                ServerTemplate:  'cluster-1-template'
+                ServerNamePrefix: 'managed-server'
+                DynamicClusterSize: '@@PROP:CLUSTER_SIZE@@'
+                MaxDynamicClusterSize: '@@PROP:CLUSTER_SIZE@@'
+                MinDynamicClusterSize: '0'
+                CalculatedListenPorts: false
+    Server:
+        'admin-server':
+            ListenPort: 7001
+    ServerTemplate:
+        'cluster-1-template':
+            Cluster: 'cluster-1'
+            ListenPort: 8001
+
+appDeployments:
+    Application:
+        myapp:
+            SourcePath: 'wlsdeploy/applications/myapp-v1'
+            ModuleType: ear
+            Target: 'cluster-1'
+```
+
+
+
+The model files:
+
+- Define a WebLogic domain with:
+    - Cluster `cluster-1`
+    - Administration Server `admin-server`
+    - A `cluster-1` targeted EAR application that’s located in the WDT archive ZIP file at `wlsdeploy/applications/myapp-v1`
+
+- Leverage macros to inject external values:
+    - The property file `CLUSTER_SIZE` property is referenced in the model YAML file `DynamicClusterSize` and `MaxDynamicClusterSize` fields using a PROP macro.
+    - The model file domain name is injected using a custom environment variable named `CUSTOM_DOMAIN_NAME` using an ENV macro.
+        - You set this environment variable later in this sample using an env field in its Domain.
+        - _This conveniently provides a simple way to deploy multiple differently named domains using the same model image_.
+    - The model file administrator user name and password are set using a `weblogic-credentials` secret macro reference to the WebLogic credential secret.
+        - This secret is in turn referenced using the `webLogicCredentialsSecret` field in the Domain.
+        - The `weblogic-credentials` is a reserved name that always dereferences to the owning Domain actual WebLogic credentials secret name.
+
+A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete discussion of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) files in the Model in Image user documentation.
+
+##### Creating the image with WIT
+
+At this point, you have staged all of the files needed for image `model-in-image:WLS-v1`; they include:
+
+  - `/tmp/mii-sample/model-images/weblogic-deploy.zip`
+  - `/tmp/mii-sample/model-images/model-in-image__WLS-v1/model.10.yaml`
+  - `/tmp/mii-sample/model-images/model-in-image__WLS-v1/model.10.properties`
+  - `/tmp/mii-sample/model-images/model-in-image__WLS-v1/archive.zip`
+
+If you don’t see the `weblogic-deploy.zip` file, then you missed a step in the prerequisites.
+
+Now, you use the Image Tool to create an image named `model-in-image:WLS-v1` that’s layered on a base WebLogic image. You’ve already set up this tool during the prerequisite steps.
+
+Run the following commands to create the model image and verify that it worked:
+
+```bash
+$ cd /tmp/mii-sample/model-images
+$ ./imagetool/bin/imagetool.sh update \
+  --tag model-in-image:WLS-v1 \
+  --fromImage container-registry.oracle.com/middleware/weblogic:12.2.1.4 \
+  --wdtModel      ./model-in-image__WLS-v1/model.10.yaml \
+  --wdtVariables  ./model-in-image__WLS-v1/model.10.properties \
+  --wdtArchive    ./model-in-image__WLS-v1/archive.zip \
+  --wdtModelOnly \
+  --wdtDomainType WLS \
+  --chown oracle:root
+```
+
+If you don’t see the `imagetool` directory, then you missed a step in the prerequisites.
+
+This command runs the WebLogic Image Tool in its Model in Image mode, and does the following:
+
+  - Builds the final Docker image as a layer on the `container-registry.oracle.com/middleware/weblogic:12.2.1.4` base image.
+  - Copies the WDT ZIP file that’s referenced in the WIT cache into the image.
+      - Note that you cached WDT in WIT using the keyword `latest` when you set up the cache during the sample prerequisites steps.
+      - This lets WIT implicitly assume it’s the desired WDT version and removes the need to pass a `-wdtVersion` flag.
+  - Copies the specified WDT model, properties, and application archives to image location `/u01/wdt/models`.
+
+When the command succeeds, it should end with output like the following:
+
+```
+[INFO   ] Build successful. Build time=36s. Image tag=model-in-image:WLS-v1
+```
+
+Also, if you run the `docker images` command, then you will see a Docker image named `model-in-image:WLS-v1`.
+
+> Note: If you have Kubernetes cluster worker nodes that are remote to your local machine, then you need to put the image in a location that these nodes can access. See [Ensuring your Kubernetes cluster can access images](#ensuring-your-kubernetes-cluster-can-access-images).
+
+
+#### Create WebLogic domain
+
+##### Deploy resources - Introduction
+
+In this section, you will deploy the new image to namespace `sample-domain1-ns`, including the following steps:
+
+- Create a namespace for WebLogic domain
+- Upgrade the operator to manage the WebLogic domain namespace    
+- Create a Secret containing your WebLogic administrator user name and password.
+- Create a Secret containing your Model in Image runtime encryption password:
+    - All Model in Image domains must supply a runtime encryption Secret with a `password` value.
+    - It is used to encrypt configuration that is passed around internally by the operator.
+    - The value must be kept private but can be arbitrary; you can optionally supply a different secret value every time you restart the domain.
+- Deploy a Domain YAML file that references the new image.
+- Wait for the domain’s Pods to start and reach their ready state.
+
+##### Namespace
+
+Create a namespace that can host one or more domains:
+
+```bash
+$ kubectl create namespace sample-domain1-ns
+```
+
+##### Upgrade the operator
+Upgrade the operator to manage the WebLogic domains in namespace `sample-domain1-ns`
+
+```bash
+$ cd /root/weblogic-kubernetes-operator
+$ helm upgrade weblogic-operator  kubernetes/charts/weblogic-operator \
+  --namespace sample-weblogic-operator-ns \
+  --reuse-values \
+  --set "domainNamespaces={sample-domain1-ns}" \
+  --wait
+```
+
+##### Secrets
+
+First, create the secrets needed by WLS type model domain. In this case, you have two secrets.
+
+Run the following `kubectl` commands to deploy the required secrets:
+
+```bash
+$ kubectl -n sample-domain1-ns create secret generic \
+  sample-domain1-weblogic-credentials \
+   --from-literal=username=weblogic --from-literal=password=welcome1
+$ kubectl -n sample-domain1-ns label  secret \
+  sample-domain1-weblogic-credentials \
+  weblogic.domainUID=sample-domain1
+
+$ kubectl -n sample-domain1-ns create secret generic \
+  sample-domain1-runtime-encryption-secret \
+   --from-literal=password=my_runtime_password
+$ kubectl -n sample-domain1-ns label  secret \
+  sample-domain1-runtime-encryption-secret \
+  weblogic.domainUID=sample-domain1
+```
+
+  Some important details about these secrets:
+
+  - The WebLogic credentials secret:
+    - It is required and must contain `username` and `password` fields.
+    - It must be referenced by the `spec.webLogicCredentialsSecret` field in your Domain.
+    - It also must be referenced by macros in the `domainInfo.AdminUserName` and `domainInfo.AdminPassWord` fields in your model YAML file.
+
+  - The Model WDT runtime secret:
+    - This is a special secret required by Model in Image.
+    - It must contain a `password` field.
+    - It must be referenced using the `spec.model.runtimeEncryptionSecret` field in its Domain.
+    - It must remain the same for as long as the domain is deployed to Kubernetes but can be changed between deployments.
+    - It is used to encrypt data as it's internally passed using log files from the domain's introspector job and on to its WebLogic Server pods.
+
+  - Deleting and recreating the secrets:
+    - You delete a secret before creating it, otherwise the create command will fail if the secret already exists.
+    - This allows you to change the secret when using the `kubectl create secret` command.
+
+  - You name and label secrets using their associated domain UID for two reasons:
+    - To make it obvious which secrets belong to which domains.
+    - To make it easier to clean up a domain. Typical cleanup scripts use the `weblogic.domainUID` label as a convenience for finding all resources associated with a domain.
+
+##### Domain resource
+
+Now, you create a Domain YAML file. A Domain is the key resource that tells the operator how to deploy a WebLogic domain.
+
+Copy the following to a file called `/tmp/mii-sample/mii-initial.yaml` or similar, or use the file `/tmp/mii-sample/domain-resources/WLS/mii-initial-d1-WLS-v1.yaml` that is included in the sample source.
+
+
+  {{%expand "Click here to view the WLS Domain YAML file." %}}
+  ```
+    #
+    # This is an example of how to define a Domain resource.
+    #
+    apiVersion: "weblogic.oracle/v8"
+    kind: Domain
+    metadata:
+      name: sample-domain1
+      namespace: sample-domain1-ns
+      labels:
+        weblogic.domainUID: sample-domain1
+
+    spec:
+      # Set to 'FromModel' to indicate 'Model in Image'.
+      domainHomeSourceType: FromModel
+
+      # The WebLogic Domain Home, this must be a location within
+      # the image for 'Model in Image' domains.
+      domainHome: /u01/domains/sample-domain1
+
+      # The WebLogic Server Docker image that the Operator uses to start the domain
+      image: "model-in-image:WLS-v1"
+
+      # Defaults to "Always" if image tag (version) is ':latest'
+      imagePullPolicy: "IfNotPresent"
+
+      # Identify which Secret contains the credentials for pulling an image
+      #imagePullSecrets:
+      #- name: regsecret
+
+      # Identify which Secret contains the WebLogic Admin credentials,
+      # the secret must contain 'username' and 'password' fields.
+      webLogicCredentialsSecret:
+        name: sample-domain1-weblogic-credentials
+
+      # Whether to include the WebLogic Server stdout in the pod's stdout, default is true
+      includeServerOutInPodLog: true
+
+      # Whether to enable overriding your log file location, see also 'logHome'
+      #logHomeEnabled: false
+
+      # The location for domain log, server logs, server out, introspector out, and Node Manager log files
+      # see also 'logHomeEnabled', 'volumes', and 'volumeMounts'.
+      #logHome: /shared/logs/sample-domain1
+
+      # Set which WebLogic Servers the Operator will start
+      # - "NEVER" will not start any server in the domain
+      # - "ADMIN_ONLY" will start up only the administration server (no managed servers will be started)
+      # - "IF_NEEDED" will start all non-clustered servers, including the administration server, and clustered servers up to their replica count.
+      serverStartPolicy: "IF_NEEDED"
+
+      # Settings for all server pods in the domain including the introspector job pod
+      serverPod:
+        # Optional new or overridden environment variables for the domain's pods
+        # - This sample uses CUSTOM_DOMAIN_NAME in its image model file
+        #   to set the Weblogic domain name
+        env:
+        - name: CUSTOM_DOMAIN_NAME
+          value: "domain1"
+        - name: JAVA_OPTIONS
+          value: "-Dweblogic.StdoutDebugEnabled=false"
+        - name: USER_MEM_ARGS
+          value: "-XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom "
+
+        # Optional volumes and mounts for the domain's pods. See also 'logHome'.
+        #volumes:
+        #- name: weblogic-domain-storage-volume
+        #  persistentVolumeClaim:
+        #    claimName: sample-domain1-weblogic-sample-pvc
+        #volumeMounts:
+        #- mountPath: /shared
+        #  name: weblogic-domain-storage-volume
+
+      # The desired behavior for starting the domain's administration server.
+      adminServer:
+        # The serverStartState legal values are "RUNNING" or "ADMIN"
+        # "RUNNING" means the listed server will be started up to "RUNNING" mode
+        # "ADMIN" means the listed server will be start up to "ADMIN" mode
+        serverStartState: "RUNNING"
+        # Setup a Kubernetes node port for the administration server default channel
+        #adminService:
+        #  channels:
+        #  - channelName: default
+        #    nodePort: 30701
+
+      # The number of managed servers to start for unlisted clusters
+      replicas: 1
+
+      # The desired behavior for starting a specific cluster's member servers
+      clusters:
+      - clusterName: cluster-1
+        serverStartState: "RUNNING"
+        replicas: 2
+
+      # Change the `restartVersion` to force the introspector job to rerun
+      # and apply any new model configuration, to also force a subsequent
+      # roll of your domain's WebLogic Server pods.
+      restartVersion: '1'
+
+      configuration:
+
+        # Settings for domainHomeSourceType 'FromModel'
+        model:
+          # Valid model domain types are 'WLS', 'JRF', and 'RestrictedJRF', default is 'WLS'
+          domainType: "WLS"
+
+          # Optional configmap for additional models and variable files
+          #configMap: sample-domain1-wdt-config-map
+
+          # All 'FromModel' domains require a runtimeEncryptionSecret with a 'password' field
+          runtimeEncryptionSecret: sample-domain1-runtime-encryption-secret
+
+        # Secrets that are referenced by model yaml macros
+        # (the model yaml in the optional configMap or in the image)
+        #secrets:
+        #- sample-domain1-datasource-secret
+  ```
+  {{% /expand %}}
+
+
+  > **Note**: Before you deploy the domain custom resource, determine if you have Kubernetes cluster worker nodes that are remote to your local machine. If so, you need to put the Domain's image in a location that these nodes can access and you may also need to modify your Domain YAML file to reference the new location. See [Ensuring your Kubernetes cluster can access images]({{< relref "/samples/simple/domains/model-in-image/_index.md#ensuring-your-kubernetes-cluster-can-access-images" >}}).
+
+Run the following command to create the domain custom resource:
+
+```bash
+$ kubectl apply -f /tmp/mii-sample/domain-resources/WLS/mii-initial-d1-WLS-v1.yaml
+```
+> **Note**: If you are choosing not to use the predefined Domain YAML file and instead created your own Domain YAML file earlier, then substitute your custom file name in the above command. Previously, we suggested naming it `/tmp/mii-sample/mii-initial.yaml`.
+
+Verify the WebLogic Server pods are all running:
+
+```
+$ kubectl get all -n sample-domain1-ns
+NAME                                 READY   STATUS    RESTARTS   AGE
+pod/sample-domain1-admin-server      1/1     Running   0          41m
+pod/sample-domain1-managed-server1   1/1     Running   0          40m
+pod/sample-domain1-managed-server2   1/1     Running   0          40m
+
+NAME                                       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+service/sample-domain1-admin-server        ClusterIP   None           <none>        7001/TCP   41m
+service/sample-domain1-cluster-cluster-1   ClusterIP   100.66.99.27   <none>        8001/TCP   40m
+service/sample-domain1-managed-server1     ClusterIP   None           <none>        8001/TCP   40m
+service/sample-domain1-managed-server2     ClusterIP   None           <none>        8001/TCP   40m
+
+
+```
+
+#### Invoke the web application
+
+##### Create load balancer
+
+Create a load balancer to access the WebLogic Server Administration Console and applications deployed in the cluster.
+Tanzu supports MetalLB load balancer and NGINX ingress for routing.
+
+
+##### Install the MetalLB load balancer by running following commands.
+
+```bash
+## create namespace metallb-system
+$ kubectl create ns metallb-system
+
+## deploy MetalLB load balancer
+$ kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.9.2/manifests/metallb.yaml -n metallb-system
+
+## create secret 
+$ kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+
+$ cat metallb-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.100.50-192.168.100.65
+
+$ kubectl apply -f metallb-configmap.yaml
+configmap/config created
+
+$ kubectl get all -n metallb-system
+NAME                              READY   STATUS    RESTARTS   AGE
+pod/controller-684f5d9b49-jkzfk   1/1     Running   0          2m14s
+pod/speaker-b457r                 1/1     Running   0          2m14s
+pod/speaker-bzmmj                 1/1     Running   0          2m14s
+pod/speaker-gphh5                 1/1     Running   0          2m14s
+pod/speaker-lktgc                 1/1     Running   0          2m14s
+
+NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE
+daemonset.apps/speaker   4         4         4       4            4           beta.kubernetes.io/os=linux   2m14s
+
+NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/controller   1/1     1            1           2m14s
+
+NAME                                    DESIRED   CURRENT   READY   AGE
+replicaset.apps/controller-684f5d9b49   1         1         1       2m14s
+```
+
+
+##### Install NGINX
+
+```bash
+$ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+$ helm repo update
+$ helm install ingress-nginx ingress-nginx/ingress-nginx
+```
+
+
+##### Create ingress routing for accessing application deployed in cluster
+
+```bash
+$ cat cluster-ingress.yaml
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: sample-nginx-ingress-hostrouting
+  namespace: sample-domain1-ns
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: 'domain1.org'
+    http:
+      paths:
+      - path:
+        backend:
+          serviceName: sample-domain1-cluster-cluster-1
+          servicePort: 8001
+
+$ kubectl apply -f cluster-ingress.yaml
+```
+
+##### Create ingress for Administration Console access
+
+```bash
+$ cat admin-ingress.yaml
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: sample-nginx-ingress-adminconsole
+  namespace: sample-domain1-ns
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host:
+    http:
+      paths:
+      - path:
+        backend:
+          serviceName: sample-domain1-admin-server
+          servicePort: 7001
+
+$ kubectl apply -f admin-ingress.yaml
+
+```
+
+##### Verify ingresses are running
+
+```bash
+$ kubectl get ingresses -n sample-domain1-ns
+NAME                               CLASS    HOSTS         ADDRESS          PORTS   AGE
+sample-nginx-ingress-adminconsole   <none>  *                              80      7m18s
+sample-nginx-ingress-hostrouting   <none>   domain1.org   192.168.100.50   80      7m18s
+```
+
+##### Access the Administration Console
+Access the Administration Console using the load balancer IP (192.168.100.50)
+`http://192.168.100.50/console`
+
+##### Access the sample application 
+
+```bash
+## Access the sample application using the load balancer IP (192.168.100.50)
+$ curl --show-error -H 'Host: domain1.org' http://192.168.100.50/myapp_war/index.jsp
+
+
+<html><body><pre>
+*****************************************************************
+
+Hello World! This is version 'v1' of the mii-sample JSP web-app.
+
+Welcome to WebLogic Server 'managed-server1'!
+
+ domain UID  = 'sample-domain1'
+ domain name = 'domain1'
+
+Found 1 local cluster runtime:
+  Cluster 'cluster-1'
+
+Found 0 local data sources:
+
+*****************************************************************
+</pre></body></html>
+
+root@cli-vm:~/weblogic-kubernetes-operator# curl --show-error -H 'Host: domain1.org' http://192.168.100.50/myapp_war/index.jsp
+
+
+
+
+
+<html><body><pre>
+*****************************************************************
+
+Hello World! This is version 'v1' of the mii-sample JSP web-app.
+
+Welcome to WebLogic Server 'managed-server2'!
+
+ domain UID  = 'sample-domain1'
+ domain name = 'domain1'
+
+Found 1 local cluster runtime:
+  Cluster 'cluster-1'
+
+Found 0 local data sources:
+
+*****************************************************************
+</pre></body></html>
+```

--- a/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/docs-source/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -7,7 +7,7 @@ description: "Sample for using the operator to set up a WLS cluster on the Tanzu
 
 
 This sample demonstrates how to use the Oracle [WebLogic Server Kubernetes Operator](/weblogic-kubernetes-operator/) (hereafter “the operator”) to set up a WebLogic Server (WLS) cluster on the Tanzu Kubernetes Grid (TKG).
-After performing the sample steps, your WLS domain with domain source type of Model In Image runs on an TKG Kubernetes cluster instance. Once the domain has been provisioned you can monitor it using the WebLogic Administration console.
+After performing the sample steps, your WLS domain with a Model in Image domain source type runs on a TKG Kubernetes cluster instance. After the domain has been provisioned, you can monitor it using the WebLogic Server Administration console.
 
 TKG is a managed Kubernetes Service that lets you quickly deploy and manage Kubernetes clusters. To learn more, see the [Tanzu Kubernetes Grid (TKG)](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.2/vmware-tanzu-kubernetes-grid-12/GUID-index.html) overview page.
 
@@ -48,7 +48,7 @@ k8s-cluster-101-md-0-577b7dc766-p2gkz   Ready      <none>   2d20h   v1.18.6+vmwa
 
 ##### Oracle Container Registry
 
-You will need an Oracle Container Registry account. The following steps will direct you to accept Oracle Standard Terms and Restrictions to pull the WebLogic Server images.  Make note of your Oracle Account password and email.  This sample pertains to 12.2.1.4, but other versions may work as well.
+You will need an Oracle Container Registry account. The following steps will direct you to accept the Oracle Standard Terms and Restrictions to pull the WebLogic Server images.  Make note of your Oracle Account password and email.  This sample pertains to 12.2.1.4, but other versions may work as well.
 
 Obtain the WebLogic Server image from the [Oracle Container Registry](https://container-registry.oracle.com/).
 


### PR DESCRIPTION
Creating a sample for running operator on Tanzu Kubernetes grid.
The sample uses model-in-image domain and metallb loadbalancer for accessing applications deployed in cluster.
Also has example to configure nginx for accessing admin console.