### PR TITLE
add Tanzu support

### DIFF
--- a/docs-source/content/release-notes.md
+++ b/docs-source/content/release-notes.md
@@ -8,7 +8,7 @@ draft: false
 
 | Date | Version | Introduces backward incompatibilities? | Change |
 | --- | --- | --- | --- |
-| November 13, 2020 | v3.1.0 | no | Enhanced options for specifying managed namespaces. Helm 3.1.3+ now required. |
+| November 13, 2020 | v3.1.0 | no | Enhanced options for specifying managed namespaces. Helm 3.1.3+ now required. Added support for Tanzu Kubernetes Service. |
 | November 9, 2020 | v3.0.3 | no | This release contains a fix for pods that are stuck in the Terminating state after an unexpected shut down of a worker node. |
 | September 15, 2020 | v3.0.2 | no | This release contains several fixes, including improvements to log rotation and a fix that avoids unnecessarily updating the domain status. |
 | August 13, 2020 | v3.0.1 | no | Fixed an issue preventing the REST interface from working after a Helm upgrade. Helm 3.1.3+ now required. |

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -48,7 +48,7 @@ Container Services for use with Kubernetes* on OCI Compute, and on "Authorized C
 
 ### Microsoft Azure Kubernetes Service
 
-[Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/) is a hosted Kubernetes environment.  The WebLogic Kubernetes
+[Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/) is a hosted Kubernetes environment.  The WebLogic Server Kubernetes
 Operator, Oracle WebLogic Sever 12c, and Oracle Fusion Middleware Infrastructure 12c are fully supported and certified on Azure Kubernetes Service (as per the documents
 referenced above).
 
@@ -61,6 +61,20 @@ AKS support and limitations:
 * Oracle databases running in Oracle Cloud Infrastructure are supported for Fusion Middleware
   Infrastructure MDS data stores only when accessed through an OCI FastConnect.
 * Windows Server containers are not currently supported, only Linux containers.
+
+### VMware Tanzu Kubernetes Service
+
+Tanzu Kubernetes Grid (TKG) is a managed Kubernetes Service that lets you quickly deploy and manage Kubernetes clusters. The WebLogic Server Kubernetes
+Operator and Oracle WebLogic Sever are fully supported and certified on VMware Tanzu Kubernetes Grid Multicloud 1.1.3 (with vSphere 6.7U3).
+
+TKG support and limitations:
+
+* Both Domain in Image and Model in Image domain home source types are supported. Domain in PV is not supported.
+* VSphere CSI driver supports only volumes with Read-Write-Once policy. This does not allow writing stores on PV.  
+   * For applications requiring HA, use JMS and JTA stores in the database.
+* The ingress used for certification is NGINX, with MetalLB load balancer.
+* Public Internet access is allowed only on ports 80, 443.
+
 
 ### Oracle Linux Cloud Native Environment (OLCNE)
 

--- a/docs-source/content/userguide/introduction/introduction.md
+++ b/docs-source/content/userguide/introduction/introduction.md
@@ -73,7 +73,6 @@ TKG support and limitations:
 * VSphere CSI driver supports only volumes with Read-Write-Once policy. This does not allow writing stores on PV.  
    * For applications requiring HA, use JMS and JTA stores in the database.
 * The ingress used for certification is NGINX, with MetalLB load balancer.
-* Public Internet access is allowed only on ports 80, 443.
 
 
 ### Oracle Linux Cloud Native Environment (OLCNE)


### PR DESCRIPTION
As per OWLS-85984: WKO - Document Certification of Operator on TANZU K8s, added Tanzu support to the Release Notes and supported environments docs.