### PR TITLE
Fix for mac os and validation error messages when no parameters are specified (OWLS-86060)

### DIFF
--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -630,7 +630,6 @@ function validateJqAvailable {
 }
 
 function validateYqAvailable {
-  osName=`uname`
   if [[ "$OSTYPE" == "darwin"* ]] && ! [ -x "$(command -v yq)" ]; then
     validationError "yq is not installed"
   fi

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -587,7 +587,7 @@ function getTopology {
   local __result=$3 
 
   osName=`uname`
-  if [ "${osName}" == 'Darwin' ]; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
     configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
       -n ${domainNamespace} -o yaml --ignore-not-found)
   else 
@@ -599,7 +599,7 @@ function getTopology {
       This script requires that the introspector job for the specified domain ran \
       successfully and generated this config map. Exiting."
     exit 1
-  elif [ "${osName}" == 'Darwin' ]; then
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
     jsonTopology=$(echo "${configMap}" | yq r - data.[topology.yaml] | yq r - -j)
   else
     topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')
@@ -632,7 +632,7 @@ function validateJqAvailable {
 
 function validateYqAvailable {
   osName=`uname`
-  if [ "${osName}" == 'Darwin' ] && ! [ -x "$(command -v yq)" ]; then
+  if [[ "$OSTYPE" == "darwin"* ]] && ! [ -x "$(command -v yq)" ]; then
     validationError "yq is not installed"
   fi
 }

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -586,7 +586,6 @@ function getTopology {
   local domainNamespace=$2
   local __result=$3 
 
-  osName=`uname`
   if [[ "$OSTYPE" == "darwin"* ]]; then
     configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
       -n ${domainNamespace} -o yaml --ignore-not-found)

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -77,6 +77,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -83,17 +83,18 @@ function initialize {
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."
   fi
 
-  isValidCluster=""
-  validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
-
-  if [ "${isValidCluster}" != 'true' ]; then
-    validationError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}."
-  fi
-
   failIfValidationErrors
+
 }
 
 initialize
+
+isValidCluster=""
+validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
+if [ "${isValidCluster}" != 'true' ]; then
+  printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
+  exit 1
+fi
 
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)

--- a/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
@@ -75,7 +75,14 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+
+if [ -z "${domainJson}" ]; then
+  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. \
+    This script requires that the introspector job for the specified domain ran \
+    successfully and generated the domain resource. Exiting."
+  exit 1
+fi
 
 getDomainPolicy "${domainJson}" serverStartPolicy
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
@@ -67,6 +67,8 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
+
   failIfValidationErrors
 }
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -120,6 +120,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   # Validate that server name parameter is specified.
   if [ -z "${serverName}" ]; then

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -81,17 +81,17 @@ function initialize {
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."
   fi
 
-  isValidCluster=""
-  validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
-
-  if [ "${isValidCluster}" != 'true' ]; then
-    validationError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. "
-  fi
-
   failIfValidationErrors
 }
 
 initialize
+
+isValidCluster=""
+validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
+if [ "${isValidCluster}" != 'true' ]; then
+  printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
+  exit 1
+fi
 
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -75,6 +75,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."

--- a/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
@@ -73,7 +73,14 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+
+if [ -z "${domainJson}" ]; then
+  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. \
+    This script requires that the introspector job for the specified domain ran \
+    successfully and generated the domain resource. Exiting."
+  exit 1
+fi
 
 getDomainPolicy "${domainJson}" serverStartPolicy
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
@@ -66,6 +66,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
   failIfValidationErrors
 }
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -116,6 +116,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   # Validate that server name parameter is specified.
   if [ -z "${serverName}" ]; then


### PR DESCRIPTION
1. Fixed the python yaml module issue on Mac OS by using yq instead of python
2. Fix validation error messages for start/stop cluster and domain scripts when no parameters are specified as part of OWLS-86060.