### PR TITLE
Fix for mac os and validation error messages when no parameters are specified (OWLS-86060)

### DIFF
--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -257,10 +257,7 @@ function getSortedListOfServers {
   local sortedServers=()
   local otherServers=()
 
-  getConfigMap "${domainUid}" "${domainNamespace}" configMap
-  topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')
-  jsonTopology=$(python -c \
-    'import sys, yaml, json; print json.dumps(yaml.safe_load('"${topology}"'), indent=4)')
+  getTopology "${domainUid}" "${domainNamespace}" jsonTopology
   clusterTopology=$(echo ${jsonTopology} | jq -r '.domain | .configuredClusters[] | select (.name == '\"${clusterName}\"')')
   dynaCluster=$(echo ${clusterTopology} | jq .dynamicServersConfig)
   if [ "${dynaCluster}" == "null" ]; then
@@ -509,10 +506,7 @@ function validateServerAndFindCluster {
 
   eval $__isValidServer=false
   eval $__clusterName=UNKNOWN
-  getConfigMap "${domainUid}" "${domainNamespace}" configMap
-  topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')
-  jsonTopology=$(python -c \
-    'import sys, yaml, json; print json.dumps(yaml.safe_load('"${topology}"'), indent=4)')
+  getTopology "${domainUid}" "${domainNamespace}" jsonTopology
   adminServer=$(echo $jsonTopology | jq -r .domain.adminServerName)
   if [ "${serverName}" == "${adminServer}" ]; then
     printError "Server '${serverName}' is administration server. The '${script}' script doesn't support starting or stopping administration server."
@@ -578,12 +572,7 @@ function validateClusterName {
   local clusterName=$3
   local __isValidCluster=$4
 
-  getConfigMap "${domainUid}" "${domainNamespace}" configMap
-  configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
-    -n ${domainNamespace} -o json)
-  topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')
-  jsonTopology=$(python -c \
-    'import sys, yaml, json; print json.dumps(yaml.safe_load('"${topology}"'), indent=4)')
+  getTopology "${domainUid}" "${domainNamespace}" jsonTopology
   clusters=($(echo $jsonTopology | jq -cr .domain.configuredClusters[].name))
   if  checkStringInArray "${clusterName}" "${clusters[@]}" ; then
     eval $__isValidCluster=true
@@ -592,20 +581,31 @@ function validateClusterName {
   fi
 }
 
-function getConfigMap {
+function getTopology {
   local domainUid=$1
   local domainNamespace=$2
   local __result=$3 
 
-  configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
-    -n ${domainNamespace} -o json --ignore-not-found)
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
+      -n ${domainNamespace} -o yaml --ignore-not-found)
+  else 
+    configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
+      -n ${domainNamespace} -o json --ignore-not-found)
+  fi
   if [ -z "${configMap}" ]; then
     printError "Domain config map '${domainUid}-weblogic-domain-introspect-cm' not found. \
       This script requires that the introspector job for the specified domain ran \
       successfully and generated this config map. Exiting."
     exit 1
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    jsonTopology=$(echo "${configMap}" | yq r - data.[topology.yaml] | yq r - -j)
+  else
+    topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')
+    jsonTopology=$(python -c \
+    'import sys, yaml, json; print json.dumps(yaml.safe_load('"${topology}"'), indent=4)')
   fi
-  eval $__result="'${configMap}'"
+  eval $__result="'${jsonTopology}'"
 }
 
 
@@ -626,6 +626,12 @@ checkStringInArray() {
 function validateJqAvailable {
   if ! [ -x "$(command -v jq)" ]; then
     validationError "jq is not installed"
+  fi
+}
+
+function validateYqAvailable {
+  if [[ "$OSTYPE" == "darwin"* ]] && ! [ -x "$(command -v yq)" ]; then
+    validationError "yq is not installed"
   fi
 }
 

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -649,14 +649,6 @@ function validateKubernetesCliAvailable {
   fi
 }
 
-#
-# Function to exit and print an error message
-# $1 - text of message
-function fail {
-  printError $*
-  exit 1
-}
-
 # Function to print an error message
 function printError {
   echo [`timestamp`][ERROR] $*
@@ -720,6 +712,7 @@ function validationError {
 #
 function failIfValidationErrors {
   if [ "$validateErrors" = true ]; then
-    fail 'The errors listed above must be resolved before the script can continue'
+    printError 'The errors listed above must be resolved before the script can continue. Please see usage information below.'
+    usage 1
   fi
 }

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -92,7 +92,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -89,15 +89,19 @@ function initialize {
 
 initialize
 
+# Get the domain in json format
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+if [ -z "${domainJson}" ]; then
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  exit 1
+fi
+
 isValidCluster=""
 validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
 if [ "${isValidCluster}" != 'true' ]; then
   printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
   exit 1
 fi
-
-# Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
 
 getDomainPolicy "${domainJson}" domainStartPolicy
 # Fail if effective start policy of domain is NEVER or ADMIN_ONLY

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -77,22 +77,24 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."
   fi
 
-  isValidCluster=""
-  validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
-
-  if [ "${isValidCluster}" != 'true' ]; then
-    validationError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}."
-  fi
-
   failIfValidationErrors
+
 }
 
 initialize
+
+isValidCluster=""
+validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
+if [ "${isValidCluster}" != 'true' ]; then
+  printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
+  exit 1
+fi
 
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -92,7 +92,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
@@ -78,9 +78,7 @@ initialize
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 
 if [ -z "${domainJson}" ]; then
-  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. \
-    This script requires that the introspector job for the specified domain ran \
-    successfully and generated the domain resource. Exiting."
+  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
@@ -67,13 +67,22 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
+
   failIfValidationErrors
 }
 
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+
+if [ -z "${domainJson}" ]; then
+  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. \
+    This script requires that the introspector job for the specified domain ran \
+    successfully and generated the domain resource. Exiting."
+  exit 1
+fi
 
 getDomainPolicy "${domainJson}" serverStartPolicy
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -120,6 +120,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   # Validate that server name parameter is specified.
   if [ -z "${serverName}" ]; then

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -135,7 +135,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -133,9 +133,9 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
-if [ $? -ne 0 ]; then
-  printError "Unable to get domain resource. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+if [ -z "${domainJson}" ]; then
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -135,7 +135,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -75,22 +75,23 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."
-  fi
-
-  isValidCluster=""
-  validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
-
-  if [ "${isValidCluster}" != 'true' ]; then
-    validationError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. "
   fi
 
   failIfValidationErrors
 }
 
 initialize
+
+isValidCluster=""
+validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
+if [ "${isValidCluster}" != 'true' ]; then
+  printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
+  exit 1
+fi
 
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -86,15 +86,19 @@ function initialize {
 
 initialize
 
+# Get the domain in json format
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+if [ -z "${domainJson}" ]; then
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  exit 1
+fi
+
 isValidCluster=""
 validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
 if [ "${isValidCluster}" != 'true' ]; then
   printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
   exit 1
 fi
-
-# Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
 
 # Get server start policy for this server
 getClusterPolicy "${domainJson}" "${clusterName}" startPolicy

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -89,7 +89,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -89,7 +89,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
@@ -76,9 +76,7 @@ initialize
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 
 if [ -z "${domainJson}" ]; then
-  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. \
-    This script requires that the introspector job for the specified domain ran \
-    successfully and generated the domain resource. Exiting."
+  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
@@ -66,13 +66,21 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
   failIfValidationErrors
 }
 
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+
+if [ -z "${domainJson}" ]; then
+  printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. \
+    This script requires that the introspector job for the specified domain ran \
+    successfully and generated the domain resource. Exiting."
+  exit 1
+fi
 
 getDomainPolicy "${domainJson}" serverStartPolicy
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -128,16 +128,19 @@ function initialize {
 
 initialize
 
+# Get the domain in json format
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+if [ -z "${domainJson}" ]; then
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  exit 1
+fi
+
 # Validate that specified server is either part of a cluster or is an independent managed server
 validateServerAndFindCluster "${domainUid}" "${domainNamespace}" "${serverName}" isValidServer clusterName
 if [ "${isValidServer}" != 'true' ]; then
   printError "Server ${serverName} is not part of any cluster and it's not an independent managed server. Please make sure that server name specified is correct."
   exit 1
 fi
-
-
-# Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json)
 
 getEffectivePolicy "${domainJson}" "${serverName}" "${clusterName}" effectivePolicy
 if [ -n "${clusterName}" ]; then

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -131,7 +131,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' provided with '-d' and '-n' arguments are correct."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -131,7 +131,7 @@ initialize
 # Get the domain in json format
 domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
-  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1
 fi
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -116,6 +116,7 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
+  validateYqAvailable
 
   # Validate that server name parameter is specified.
   if [ -z "${serverName}" ]; then


### PR DESCRIPTION
1. Fixed the python yaml module issue on Mac OS by using yq instead of python
2. Fix validation error messages for start/stop cluster and domain scripts when no parameters are specified as part of OWLS-86060.