### PR TITLE
Fix for owls-85429 in operator 3.0.3 release

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -898,7 +898,8 @@ public abstract class PodStepContext extends BasePodStepContext {
 
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<Object> callResponses) {
-      return doNext(replacePod(getNext()), packet);
+      PodAwaiterStepFactory pw = packet.getSpi(PodAwaiterStepFactory.class);
+      return doNext(pw.waitForDelete(pod, replacePod(getNext())), packet);
     }
   }
 
@@ -920,6 +921,7 @@ public abstract class PodStepContext extends BasePodStepContext {
       PodAwaiterStepFactory pw = packet.getSpi(PodAwaiterStepFactory.class);
       return doNext(pw.waitForReady(newPod, getNext()), packet);
     }
+
   }
 
   private class PatchPodResponseStep extends BaseResponseStep {


### PR DESCRIPTION
Fix for owls-85429. This change fixes 409 error response in ReplacePodResponseStep during pod replacement caused due to in-progress delete operation. The fix waits for pod delete operation to complete before starting pod create operation. 