### PR TITLE
Updated the ItServerStartPolicy Tests to use new domain LifeCycle script instead of using patch commands

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -3,12 +3,17 @@
 
 package oracle.weblogic.kubernetes;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiException;
@@ -27,6 +32,8 @@ import oracle.weblogic.domain.DomainSpec;
 import oracle.weblogic.domain.ManagedServer;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
+import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -35,6 +42,7 @@ import org.awaitility.core.ConditionFactory;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -48,6 +56,8 @@ import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
@@ -64,8 +74,11 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyO
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
+import static org.apache.commons.io.FileUtils.copyDirectory;
+import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -134,18 +147,33 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @IntegrationTest
 class ItServerStartPolicy {
 
+  public static final String SERVER_LIFECYCLE = "Server";
+  public static final String CLUSTER_LIFECYCLE = "Cluster";
+  public static final String DOMAIN = "DOMAIN";
+  public static final String STOP_SERVER_SCRIPT = "stopServer.sh";
+  public static final String START_SERVER_SCRIPT = "startServer.sh";
+  public static final String STOP_CLUSTER_SCRIPT = "stopCluster.sh";
+  public static final String START_CLUSTER_SCRIPT = "startCluster.sh";
+  public static final String STOP_DOMAIN_SCRIPT = "stopDomain.sh";
+  public static final String START_DOMAIN_SCRIPT = "startDomain.sh";
+
   private static String opNamespace = null;
   private static String domainNamespace = null;
   private static ConditionFactory withStandardRetryPolicy = null;
 
   private static int replicaCount = 1;
-  private static final String domainUid = "mii-start-policy";
+  private static String domainUid = "mii-start-policy";
   private StringBuffer checkCluster = null;
   private V1Patch patch = null;
 
   private final String adminServerPodName = domainUid + "-admin-server";
   private final String managedServerPrefix = domainUid + "-managed-server";
   private static LoggingFacade logger = null;
+
+  private final Path samplePath = Paths.get(ITTESTS_DIR, "../kubernetes/samples");
+  private final Path tempSamplePath = Paths.get(WORK_DIR, "sample-testing");
+  private final Path domainLifecycleSamplePath = Paths.get(samplePath + "/scripts/domain-lifecycle");
+
 
   /**
    * Install Operator.
@@ -252,7 +280,8 @@ class ItServerStartPolicy {
    * Make sure that Only the Administration server is stopped. 
    * Restart the Administration server by patching the resource definition with 
    *  spec/adminServer/serverStartPolicy set to IF_NEEDED.
-   * Make sure that the Administration server is in RUNNING state. 
+   * Make sure that the Administration server is in RUNNING state.
+   * Verify that the sample script, stopServer.sh can not shutdown admin server
    */
   @Test
   @DisplayName("Restart the Administration server with serverStartPolicy")
@@ -266,7 +295,7 @@ class ItServerStartPolicy {
 
     patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "NEVER");
     logger.info("Domain is patched to shutdown administration server");
-   
+
     checkPodDeleted(adminServerPodName, domainUid, domainNamespace);
     logger.info("Administration server shutdown success");
 
@@ -291,15 +320,23 @@ class ItServerStartPolicy {
     checkPodReadyAndServiceExists(adminServerPodName, 
             domainUid, domainNamespace);
     logger.info("AdminServer restart success");
+
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // verify that the sample script can not shutdown admin server
+    String result =  assertDoesNotThrow(() ->
+          executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, "admin-server", "", false),
+          String.format("Failed to run %s", STOP_SERVER_SCRIPT));
+    assertTrue(result.contains("script doesn't support starting or stopping administration server"),
+        "The script shouldn't stop the admin server");
   }
 
   /**
-   * Stop a configured cluster by patching the resource definition with 
-   *  spec/clusters/1/serverStartPolicy set to NEVER.
+   * Stop a configured cluster using the sample script stopCluster.sh
    * Make sure that only server(s) in the configured cluster are stopped. 
    * Make sure that server(s) in the dynamic cluster are in RUNNING state. 
-   * Restart the cluster by patching the resource definition with 
-   *  spec/clusters/1/serverStartPolicy set to IF_NEEDED.
+   * Restart the cluster using the sample script startCluster.sh
    * Make sure that servers in the configured cluster are in RUNNING state. 
    */
   @Test
@@ -315,8 +352,12 @@ class ItServerStartPolicy {
               domainUid, domainNamespace);
     logger.info("(BeforePatch) configured cluster managed server is RUNNING");
 
-    patchServerStartPolicy("/spec/clusters/1/serverStartPolicy", "NEVER");
-    logger.info("Domain is patched to shutdown configured cluster");
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify all clustered server pods are shutdown after stopCluster script execution
+    logger.info("Stop configured cluster using the script");
+    executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-2");
 
     checkPodDeleted(configServerPodName, domainUid, domainNamespace);
     logger.info("Config cluster shutdown success");
@@ -330,8 +371,9 @@ class ItServerStartPolicy {
     assertFalse(assertDoesNotThrow(() -> isDynRestarted.call().booleanValue()),
          "Dynamic managed server pod must not be restated");
 
-    patchServerStartPolicy("/spec/clusters/1/serverStartPolicy", "IF_NEEDED");
-    logger.info("Domain is patched to start configured cluster");
+    // Verify all clustered server pods are started after startCluster script execution
+    logger.info("Start configured cluster using the script");
+    executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-2");
 
     checkPodReadyAndServiceExists(configServerPodName, 
               domainUid, domainNamespace);
@@ -339,13 +381,11 @@ class ItServerStartPolicy {
   }
 
   /**
-   * Stop a dynamic cluster by patching the resource definition with 
-   *  spec/clusters/1/serverStartPolicy set to NEVER.
+   * Stop a dynamic cluster using the sample script stopCluster.sh.
    * Make sure that only servers in the dynamic cluster are stopped. 
    * Make sure that only servers in the configured cluster are in the 
    * RUNNING state. 
-   * Restart the dynamic cluster by patching the resource definition with 
-   *  spec/clusters/1/serverStartPolicy set to IF_NEEDED.
+   * Restart the dynamic cluster using the sample script startCluster.sh
    * Make sure that servers in the dynamic cluster are in RUNNING state again. 
    */
   @Test
@@ -361,8 +401,12 @@ class ItServerStartPolicy {
               domainUid, domainNamespace);
     logger.info("(BeforePatch) dynamic cluster managed server is RUNNING");
 
-    patchServerStartPolicy("/spec/clusters/0/serverStartPolicy", "NEVER");
-    logger.info("Domain is patched to stop dynamic cluster");
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify all clustered server pods are shut down after stopCluster script execution
+    logger.info("Stop dynamic cluster using the script");
+    executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-1");
 
     checkPodDeleted(dynamicServerPodName, domainUid, domainNamespace);
     logger.info("Dynamic cluster shutdown success");
@@ -374,8 +418,9 @@ class ItServerStartPolicy {
     assertFalse(assertDoesNotThrow(() -> isCfgRestarted.call().booleanValue()),
          "Configured managed server pod must not be restated");
 
-    patchServerStartPolicy("/spec/clusters/0/serverStartPolicy", "IF_NEEDED");
-    logger.info("Domain is patched to start dynamic cluster");
+    // Verify all clustered server pods are started after startCluster script execution
+    logger.info("Start dynamic cluster using the script");
+    executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-1");
 
     checkPodReadyAndServiceExists(dynamicServerPodName, 
               domainUid, domainNamespace);
@@ -383,14 +428,12 @@ class ItServerStartPolicy {
   }
 
   /**
-   * Stop the entire domain by patching the resource definition with 
-   *  spec/serverStartPolicy set to NEVER.
+   * Stop the entire domain using the sample script stopDomain.sh
    * Make sure that all servers in the domain are stopped. 
    * Restart the domain by patching the resource definition with 
    *  spec/serverStartPolicy set to ADMIN_ONLY.
    * Make sure that ONLY Admin Server is in RUNNING state. 
-   * Restart the domain by patching the resource definition with 
-   *  spec/serverStartPolicy set to IF_NEEDED.
+   * Restart the domain using the sample script startDomain.sh
    * Make sure that all servers in the domain are in RUNNING state. 
    */
   @Test
@@ -400,8 +443,12 @@ class ItServerStartPolicy {
     String configServerPodName = domainUid + "-config-cluster-server1";
     String standaloneServerPodName = domainUid + "-standalone-managed";
 
-    patchServerStartPolicy("/spec/serverStartPolicy", "NEVER");
-    logger.info("Domain is patched to stop entire WebLogic domain");
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify all WebLogic server instance pods are shut down after stopDomain script execution
+    logger.info("Stop entire WebLogic domain using the script");
+    executeLifecycleScript(STOP_DOMAIN_SCRIPT, DOMAIN, null);
    
     // make sure all the server pods are removed after patch
     checkPodDeleted(adminServerPodName, domainUid, domainNamespace);
@@ -428,10 +475,9 @@ class ItServerStartPolicy {
 
     logger.info("!!! Domain restart (ADMIN_ONLY) success !!!");
 
-    // Patch the Domain with serverStartPolicy set to IF_NEEDED
-    // Here all the Servers should come up
-    patchServerStartPolicy("/spec/serverStartPolicy", "IF_NEEDED");
-    logger.info("Domain is patched to start all servers in the domain");
+    // Verify all WebLogic server instance pods are started after startDomain script execution
+    logger.info("Start entire WebLogic domain using the script");
+    executeLifecycleScript(START_DOMAIN_SCRIPT, DOMAIN, null);
 
     // check dynamic managed server pods are ready
     for (int i = 1; i <= replicaCount; i++) {
@@ -454,29 +500,39 @@ class ItServerStartPolicy {
    * by patching the resource definition with 
    *  spec/managedServers/1/serverStartPolicy set to ALWAYS.
    * Make sure that managed server config-cluster-server2 is up and running
+   * Verify that if server start policy is ALWAYS and the server is selected
+   * to start based on the replica count, it means that server is already started or is
+   * in the process of starting. In this case, script exits without making any changes
    * Stop the managed server by patching the resource definition 
    *   with spec/managedServers/1/serverStartPolicy set to IF_NEEDED.
    * Make sure the specified managed server is stopped as per replica count.
    */
-
   @Test
   @DisplayName("Start/stop config cluster managed server by updating serverStartPolicy to ALWAYS/IF_NEEDED")
   public void testConfigClusterStartServerUsingAlways() {
-    String serverPodName = domainUid + "-config-cluster-server2";
+    String serverName = "config-cluster-server2";
+    String serverPodName = domainUid + "-" + serverName;
 
     // Make sure that managed server is not running 
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
 
-    patchServerStartPolicy(
-         "/spec/managedServers/1/serverStartPolicy", "ALWAYS");
+    patchServerStartPolicy("/spec/managedServers/1/serverStartPolicy", "ALWAYS");
     logger.info("Domain is patched to start configured cluster managed server");
 
     checkPodReadyAndServiceExists(serverPodName, 
           domainUid, domainNamespace);
     logger.info("Configured cluster managed server is RUNNING");
 
-    patchServerStartPolicy(
-         "/spec/managedServers/1/serverStartPolicy", "IF_NEEDED");
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify that if server start policy is ALWAYS and the server is selected
+    // to start based on the replica count, it means that server is already started or is
+    // in the process of starting. In this case, script exits without making any changes.
+    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
+    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
+
+    patchServerStartPolicy("/spec/managedServers/1/serverStartPolicy", "IF_NEEDED");
     logger.info("Domain is patched to stop configured cluster managed server");
 
     logger.info("Wait for managed server ${0} to be shutdown", serverPodName);
@@ -492,15 +548,18 @@ class ItServerStartPolicy {
    * by patching the resource definition with 
    *  spec/managedServers/2/serverStartPolicy set to ALWAYS.
    * Make sure that managed server managed-server2 is up and running
+   * Verify that if server start policy is ALWAYS and the server is selected
+   * to start based on the replica count, it means that server is already started or is
+   * in the process of starting. In this case, script exits without making any changes.
    * Stop the managed server by patching the resource definition 
    *   with spec/managedServers/2/serverStartPolicy set to IF_NEEDED.
    * Make sure the specified managed server is stopped as per replica count.
    */
-
   @Test
   @DisplayName("Start/stop dynamic cluster managed server by updating serverStartPolicy to ALWAYS/IF_NEEDED")
   public void testDynamicClusterStartServerUsingAlways() {
-    String serverPodName = domainUid + "-managed-server2";
+    String serverName = "managed-server2";
+    String serverPodName = domainUid + "-" + serverName;
 
     // Make sure that managed server is not running 
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
@@ -511,6 +570,15 @@ class ItServerStartPolicy {
     checkPodReadyAndServiceExists(serverPodName, 
           domainUid, domainNamespace);
     logger.info("Second managed server in dynamic cluster is RUNNING");
+
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify that if server start policy is ALWAYS and the server is selected
+    // to start based on the replica count, it means that server is already started or is
+    // in the process of starting. In this case, script exits without making any changes.
+    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
+    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
 
     patchServerStartPolicy("/spec/managedServers/2/serverStartPolicy", 
                            "IF_NEEDED");
@@ -525,15 +593,13 @@ class ItServerStartPolicy {
    * Add the first managed server (config-cluster-server1) in a configured 
    * cluster with serverStartPolicy IF_NEEDED. 
    * Initially, the server will come up since the replica count is set to 1.
-   * (a) Update the serverStartPolicy for config-cluster-server1 to NEVER
-   *      by patching the resource definition with 
-   *        spec/managedServers/3/serverStartPolicy set to NEVER.
+   * (a) Shutdown config-cluster-server1 using the sample script stopServer.sh
+   *     with keep_replica_constant option set to true
    *     Make sure that managed server config-cluster-server1 is shutdown.
    *     Make sure that managed server config-cluster-server2 comes up
    *       to maintain the replica count of 1.
-   * (b) Update the serverStartPolicy for config-cluster-server1 to IF_NEEDED
-   *       by patching the resource definition with 
-   *       spec/managedServers/3/serverStartPolicy set to IF_NEEDED.
+   * (b) Restart config-cluster-server1 using the sample script startServer.sh
+   *     with keep_replica_constant option set to true
    *     Make sure that managed server config-cluster-server2 is shutdown.
    *     Make sure that managed server config-cluster-server1 comes up
    *       to maintain the replica count of 1.
@@ -541,16 +607,19 @@ class ItServerStartPolicy {
   @Test
   @DisplayName("Stop a running config cluster managed server and verify the replica count is maintained")
   public void testConfigClusterReplicaCountIsMaintained() {
-    String serverPodName = domainUid + "-config-cluster-server1";
+    String serverName = "config-cluster-server1";
+    String serverPodName = domainUid + "-" + serverName;
     String serverPodName2 = domainUid + "-config-cluster-server2";
+    String keepReplicaCountConstantParameter = "-k";
 
     // Make sure that managed server(2) is not running 
     checkPodDeleted(serverPodName2, domainUid, domainNamespace);
 
-    // Patch(Shutdown) the config-cluster-server1 
-    patchServerStartPolicy(
-         "/spec/managedServers/3/serverStartPolicy", "NEVER");
-    logger.info("Domain is patched to shutdown cluster managed server");
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // shutdown config-cluster-server1 with keep_replica_constant option
+    executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, keepReplicaCountConstantParameter);
 
     // Make sure config-cluster-server1 is deleted 
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
@@ -558,9 +627,8 @@ class ItServerStartPolicy {
     checkPodReadyAndServiceExists(serverPodName2, domainUid, domainNamespace);
     logger.info("Configured cluster managed Server(2) is RUNNING");
 
-    // Patch(start) the config-cluster-server1 
-    patchServerStartPolicy(
-         "/spec/managedServers/3/serverStartPolicy", "IF_NEEDED");
+    // start config-cluster-server1 with keep_replica_constant option
+    executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, keepReplicaCountConstantParameter);
 
     // Make sure config-cluster-server2 is deleted 
     checkPodDeleted(serverPodName2, domainUid, domainNamespace);
@@ -573,15 +641,13 @@ class ItServerStartPolicy {
    * Add the first managed server (managed-server1) in a dynamic 
    * cluster with serverStartPolicy IF_NEEDED. 
    * Initially, the server will come up since the replica count is set to 1.
-   * (a) Update the serverStartPolicy for managed-server1 to NEVER
-   *      by patching the resource definition with 
-   *        spec/managedServers/4/serverStartPolicy set to NEVER.
+   * (a) Shutdown config-cluster-server1 using the sample script stopServer.sh
+   *     with keep_replica_constant option set to true
    *     Make sure that managed server managed-server1 is shutdown.
    *     Make sure that managed server managed-server2 comes up
    *       to maintain the replica count of 1.
-   * (b) Update the serverStartPolicy for managed-server1 to IF_NEEDED
-   *       by patching the resource definition with 
-   *       spec/managedServers/4/serverStartPolicy set to IF_NEEDED.
+   * (b) Restart config-cluster-server1 using the sample script startServer.sh
+   *     with keep_replica_constant option set to true
    *     Make sure that managed server managed-server2 is shutdown.
    *     Make sure that managed server managed-server1 comes up
    *       to maintain the replica count of 1.
@@ -591,24 +657,21 @@ class ItServerStartPolicy {
   public void testDynamicClusterReplicaCountIsMaintained() {
     String serverPodName = domainUid + "-managed-server1";
     String serverPodName2 = domainUid + "-managed-server2";
+    String keepReplicaCountConstantParameter = "-k";
 
     // Make sure that managed server(2) is not running 
     checkPodDeleted(serverPodName2, domainUid, domainNamespace);
 
-    // Patch(Shutdown) the managed-server1 
-    patchServerStartPolicy(
-         "/spec/managedServers/4/serverStartPolicy", "NEVER");
-    logger.info("Domain is patched to shutdown dynamic managed server");
+    // shutdown managed-server1 with keep_replica_constant option
+    executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, "managed-server1", keepReplicaCountConstantParameter);
 
     // Make sure maanged-server1 is deleted 
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
     checkPodReadyAndServiceExists(serverPodName2, domainUid, domainNamespace);
     logger.info("Dynamic cluster managed server(2) is RUNNING");
 
-    // Patch(start) the managed-server1 
-    patchServerStartPolicy(
-         "/spec/managedServers/4/serverStartPolicy", "IF_NEEDED");
-    logger.info("Domain is patched to start dynamic managed server");
+    // start managed-server1 with keep_replica_constant option
+    executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, "managed-server1", keepReplicaCountConstantParameter);
 
     // Make sure managed-server2 is deleted 
     checkPodDeleted(serverPodName2, domainUid, domainNamespace);
@@ -624,36 +687,45 @@ class ItServerStartPolicy {
    * Make sure that ONLY the specified managed server is stopped. 
    * Restart the independent managed server by patching the resource definition 
    * with spec/managedServers/0/serverStartPolicy set to ALWAYS.
-   * Make sure that the specified managed server is in RUNNING state.
+   * Make sure that the specified managed server is in RUNNING state
+   * Verify that if server start policy is ALWAYS and the server is selected
+   * to start based on the replica count, it means that server is already started or is
+   * in the process of starting. In this case, script exits without making any changes.
    */
-
   // The usecase fails NEVER->ALWAYS
   // https://bug.oraclecorp.com/pls/bug/webbug_print.show?c_rptno=31833260
   @Test
   @DisplayName("Restart the standalone managed server with serverStartPolicy")
   public void testStandaloneManagedRestartAlways() {
-
-    String configServerPodName = domainUid + "-standalone-managed";
+    String serverName = "standalone-managed";
+    String serverPodName = domainUid + "-" + serverName;
 
     // Make sure that configured managed server is ready 
-    checkPodReadyAndServiceExists(configServerPodName, 
+    checkPodReadyAndServiceExists(serverPodName,
             domainUid, domainNamespace);
     logger.info("Configured managed server is RUNNING");
 
-    patchServerStartPolicy(
-         "/spec/managedServers/0/serverStartPolicy", "NEVER");
+    patchServerStartPolicy("/spec/managedServers/0/serverStartPolicy", "NEVER");
     logger.info("Domain is patched to shutdown standalone managed server");
 
-    checkPodDeleted(configServerPodName, domainUid, domainNamespace);
+    checkPodDeleted(serverPodName, domainUid, domainNamespace);
     logger.info("Configured managed server shutdown success");
 
-    patchServerStartPolicy(
-         "/spec/managedServers/0/serverStartPolicy", "ALWAYS");
+    patchServerStartPolicy("/spec/managedServers/0/serverStartPolicy", "ALWAYS");
     logger.info("Domain is patched to start standalone managed server");
 
-    checkPodReadyAndServiceExists(configServerPodName, 
+    checkPodReadyAndServiceExists(serverPodName,
             domainUid, domainNamespace);
     logger.info("Configured managed server restart success");
+
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify that if server start policy is ALWAYS and the server is selected
+    // to start based on the replica count, it means that server is already started or is
+    // in the process of starting. In this case, script exits without making any changes.
+    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
+    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
   }
 
   /**
@@ -663,36 +735,175 @@ class ItServerStartPolicy {
    * Make sure that ONLY the specified managed server is stopped. 
    * Restart the independent managed server by patching the resource definition 
    * with spec/managedServers/0/serverStartPolicy set to IF_NEEDED.
-   * Make sure that the specified managed server is in RUNNING state.
+   * Make sure that the specified managed server is in RUNNING state
+   * Verify that if server start policy is IF_NEEDED and the server is selected
+   * to start based on the replica count, it means that server is already started or is
+   * in the process of starting. In this case, script exits without making any changes.
    */
-
   // The usecase fails NEVER->IF_NEEDED
   // https://bug.oraclecorp.com/pls/bug/webbug_print.show?c_rptno=31833260
   @Test
   @DisplayName("Restart the standalone managed server with serverStartPolicy")
   public void testStandaloneManagedRestartIfNeeded() {
-
-    String configServerPodName = domainUid + "-standalone-managed";
+    String serverName = "standalone-managed";
+    String serverPodName = domainUid + "-" + serverName;
 
     // Make sure that configured managed server is ready 
-    checkPodReadyAndServiceExists(configServerPodName,
+    checkPodReadyAndServiceExists(serverPodName,
         domainUid, domainNamespace);
     logger.info("Standalone managed server is RUNNING");
 
-    patchServerStartPolicy(
-        "/spec/managedServers/0/serverStartPolicy", "NEVER");
+    patchServerStartPolicy("/spec/managedServers/0/serverStartPolicy", "NEVER");
     logger.info("Domain is patched to shutdown standalone managed server");
 
-    checkPodDeleted(configServerPodName, domainUid, domainNamespace);
+    checkPodDeleted(serverPodName, domainUid, domainNamespace);
     logger.info("Standalone managed server shutdown success");
 
-    patchServerStartPolicy(
-        "/spec/managedServers/0/serverStartPolicy", "IF_NEEDED");
+    patchServerStartPolicy("/spec/managedServers/0/serverStartPolicy", "IF_NEEDED");
     logger.info("Domain is patched to start standalone managed server");
 
-    checkPodReadyAndServiceExists(configServerPodName,
+    checkPodReadyAndServiceExists(serverPodName,
         domainUid, domainNamespace);
     logger.info("Standalone managed server restart success");
+
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // Verify that if server start policy is IF_NEEDED and the server is selected
+    // to start based on the replica count, it means that server is already started or is
+    // in the process of starting. In this case, script exits without making any changes.
+    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
+    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
+  }
+
+  /**
+   * Negative test to verify:
+   * (a) the sample script can not stop or start a non-exist server
+   * (b) the sample script can not stop or start a non-exist cluster
+   * (c) the sample script can not stop or start a non-exist domain.
+   */
+  @Test
+  @DisplayName("Restart the configured cluster with serverStartPolicy")
+  public void testRestartWrongComponentNeg() {
+    //copy the samples directory to a temporary location
+    setupSample();
+    String wrongServerName = "ms1";
+    String regex = ".*" + wrongServerName + ".*\\s*is not part";
+
+    // verify that the script can not stop a non-exist server
+    String result =  assertDoesNotThrow(() ->
+        executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, wrongServerName, "", false),
+        String.format("Failed to run %s", STOP_CLUSTER_SCRIPT));
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a server that doesn't exist");
+
+    // verify that the script can not start a non-exist server
+    result =  assertDoesNotThrow(() ->
+        executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, wrongServerName, "", false),
+      String.format("Failed to run %s", START_SERVER_SCRIPT));
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't start a server that doesn't exist");
+
+    // verify that the script can not stop a non-exist cluster
+    String wrongClusterName = "cluster-3";
+    regex = ".*" + wrongClusterName + ".*\\s*not part of domain";
+    result =  assertDoesNotThrow(() ->
+        executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, wrongClusterName, "", false),
+        String.format("Failed to run %s", STOP_CLUSTER_SCRIPT));
+    assertTrue(result.contains("cluster cluster-3 is not part of domain"),
+        "The script shouldn't stop a cluster that doesn't exist");
+
+    // verify that the script can not start a non-exist cluster
+    result =  assertDoesNotThrow(() ->
+        executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, wrongClusterName, "", false),
+        String.format("Failed to run %s", STOP_CLUSTER_SCRIPT));
+    assertTrue(result.contains("cluster cluster-3 is not part of domain"),
+        "The script shouldn't start a cluster that doesn't exist");
+
+    // verify that the script can not stop a non-exist domain
+    String domainName = "mii-start-policy" + "-123";
+    regex = ".*" + domainName + ".*\\s*not found";
+    result = assertDoesNotThrow(() ->
+        executeLifecycleScript(STOP_DOMAIN_SCRIPT, DOMAIN, null, "", false, domainName),
+        String.format("Failed to run %s", STOP_DOMAIN_SCRIPT));
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a domain that doesn't exist");
+
+    // verify that the script can not start a non-exist domain
+    result = assertDoesNotThrow(() ->
+        executeLifecycleScript(START_DOMAIN_SCRIPT, DOMAIN, null, "", false, domainName),
+        String.format("Failed to run %s", START_DOMAIN_SCRIPT));
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't start a domain that doesn't exist");
+  }
+
+  /**
+   * Negative test to verify that the sample script can not start a server that exceeds the max cluster size
+   * e.g. the max cluster size is 2, the sample script can't start server 3
+   */
+  @Test
+  @DisplayName("Restart the configured cluster with serverStartPolicy")
+  public void testStartMSBeyondLimitNeg() {
+    String serverName = "config-cluster-server3";
+    String regex = ".*" + serverName + ".*\\s*is not part";
+
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    // verify that the script can not start a server that exceeds the max cluster size
+    String result =  assertDoesNotThrow(() ->
+        executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, "", false),
+        String.format("Failed to run %s", START_SERVER_SCRIPT));
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a server that is beyong the limit");
+  }
+
+  /**
+   * Negative test to verify that after the admin server is stopped, the sample script can start or stop a server.
+   */
+  @Disabled
+  @Test
+  @DisplayName("Shutdown Admin server and start/stop a manged server")
+  public void testServerRestartMSWithoutAdminNeg() {
+    String serverName = "config-cluster-server1";
+
+    //copy the samples directory to a temporary location
+    setupSample();
+
+    try {
+      // shutdown the admin server
+      patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "NEVER");
+      logger.info("Domain is patched to shutdown administration server");
+
+      // verify that the script can stop a server in absent of admin server
+      assertDoesNotThrow(() ->
+          executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, "", true),
+          String.format("Failed to run %s", STOP_SERVER_SCRIPT));
+      checkPodDeleted(serverName, domainUid, domainNamespace);
+      logger.info("Shutdown " + serverName + " without admin server success");
+
+      // verify that the script can start a server in absent of admin server
+      assertDoesNotThrow(() ->
+          executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, "", true),
+          String.format("Failed to run %s", START_SERVER_SCRIPT));
+      checkPodReadyAndServiceExists(serverName, domainUid, domainNamespace);
+      logger.info("Start " + serverName + " without admin server success");
+
+      // verify that in absent of admin server, when server is part of a cluster and
+      // keep_replica_constant option is false (the default)
+      // and the effective start policy of the server is IF_NEEDED and increasing replica count
+      // will naturally start the server, the script increases the replica count
+      String serverName2 = "config-cluster-server2";
+      assertDoesNotThrow(() ->
+          executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName2, "", true),
+          String.format("Failed to run %s", START_SERVER_SCRIPT));
+      checkPodReadyAndServiceExists(serverName, domainUid, domainNamespace);
+      logger.info("Start " + serverName2 + " without admin server success");
+    } finally {
+      // restart admin server
+      patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "IF_NEEDED");
+      logger.info("Domain is patched to start administration server");
+
+      logger.info("Check admin service/pod {0} is created in namespace {1}",
+          adminServerPodName, domainNamespace);
+      checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+      logger.info("AdminServer restart success");
+    }
   }
 
   private static void createDomainSecret(String secretName, String username, String password, String domNamespace)
@@ -858,4 +1069,70 @@ class ItServerStartPolicy {
     assertTrue(crdPatched, "patchDomainCustomResource failed");
   }
 
+  // copy samples directory to a temporary location
+  private void setupSample() {
+    assertDoesNotThrow(() -> {
+      // copy ITTESTS_DIR + "../kubernates/samples" to WORK_DIR + "/sample-testing"
+      logger.info("Deleting and recreating {0}", tempSamplePath);
+      Files.createDirectories(tempSamplePath);
+      deleteDirectory(tempSamplePath.toFile());
+      Files.createDirectories(tempSamplePath);
+
+      logger.info("Copying {0} to {1}", samplePath, tempSamplePath);
+      copyDirectory(samplePath.toFile(), tempSamplePath.toFile());
+    });
+  }
+
+  // Function to execute domain lifecyle scripts
+  private String executeLifecycleScript(String script, String scriptType, String entityName) {
+    return executeLifecycleScript(script, scriptType, entityName, "");
+  }
+
+  // Function to execute domain lifecyle scripts
+  private String executeLifecycleScript(String script, String scriptType, String entityName, String extraParams) {
+    return executeLifecycleScript(script, scriptType, entityName, extraParams, true);
+  }
+
+  // Function to execute domain lifecyle scripts
+  private String executeLifecycleScript(String script,
+                                        String scriptType,
+                                        String entityName,
+                                        String extraParams,
+                                        boolean checkResult,
+                                        String... args) {
+    String domainName = (args.length == 0) ? domainUid : args[0];
+    CommandParams params;
+    //boolean result;
+    //String commonParameters = " -d " + domainUid + " -n " + domainNamespace;
+    String commonParameters = " -d " + domainName + " -n " + domainNamespace;
+    params = new CommandParams().defaults();
+    if (scriptType.equals(SERVER_LIFECYCLE)) {
+      params.command("sh "
+          + Paths.get(domainLifecycleSamplePath.toString(), "/" + script).toString()
+          + commonParameters + " -s " + entityName + " " + extraParams);
+    } else if (scriptType.equals(CLUSTER_LIFECYCLE)) {
+      params.command("sh "
+          + Paths.get(domainLifecycleSamplePath.toString(), "/" + script).toString()
+          + commonParameters + " -c " + entityName);
+    } else {
+      params.command("sh "
+          + Paths.get(domainLifecycleSamplePath.toString(), "/" + script).toString()
+          + commonParameters);
+    }
+
+    ExecResult execResult = Command.withParams(params).executeAndReturnResult();
+    if (checkResult) {
+      assertEquals(0, execResult.exitValue(),
+          String.format("Failed to execute script  %s ", script));
+    }
+
+    return execResult.toString();
+  }
+
+  private boolean verifyExecuteResult(String result, String regex) {
+    Pattern pattern = Pattern.compile(regex);
+    Matcher matcher = pattern.matcher(result);
+
+    return matcher.find();
+  }
 }


### PR DESCRIPTION
Update the test methods in ItServerStartPolicy class to use new domain LifeCycle script instead of using patch commands. See the coverage in ItSamples.java. The  ItSamples class does not cover independent managed server and configured cluster and AdminServer shutdown.

 Add some Negative Tests:
(a) can not shutdown admin server
(b) server/domain/cluster does not exists as passed thru command line
in a command line pass -c foo. ( where there is no such cluster foo in domain resource )
(c) start a manged server beyond limit
max Dynamic Cluster size is 3, you start a managed managed-server4
(d) shutdown Admin server and start/stop a manged server

padded Jenkins job:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3191 (parallel)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3193 (parallel)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3192 (sequential)

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3214 (parallel)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3219 (parallel)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3218 (sequential)