### PR TITLE
OWLS-77957 - Populate server and domain related env variables to init containers

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1EnvVarSource;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Toleration;
@@ -104,6 +105,18 @@ public abstract class BasePodStepContext extends StepContextBase {
     vars.add(new V1EnvVar().name(name).value(value));
   }
 
+  private void addEnvVar(List<V1EnvVar> vars, String name, String value, V1EnvVarSource valueFrom) {
+    if ((value != null) && (!value.isEmpty())) {
+      addEnvVar(vars, name, value);
+    } else {
+      addEnvVarWithValueFrom(vars, name, valueFrom);
+    }
+  }
+
+  private void addEnvVarWithValueFrom(List<V1EnvVar> vars, String name, V1EnvVarSource valueFrom) {
+    vars.add(new V1EnvVar().name(name).valueFrom(valueFrom));
+  }
+
   protected void addEnvVarIfTrue(boolean condition, List<V1EnvVar> vars, String name) {
     if (condition) {
       addEnvVar(vars, name, "true");
@@ -119,9 +132,9 @@ public abstract class BasePodStepContext extends StepContextBase {
     return false;
   }
 
-  protected void addIfMissing(List<V1EnvVar> vars, String name, String value) {
+  protected void addIfMissing(List<V1EnvVar> vars, String name, String value, V1EnvVarSource valueFrom) {
     if (!hasEnvVar(vars, name)) {
-      addEnvVar(vars, name, value);
+      addEnvVar(vars, name, value, valueFrom);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -119,6 +119,12 @@ public abstract class BasePodStepContext extends StepContextBase {
     return false;
   }
 
+  protected void addIfMissing(List<V1EnvVar> vars, String name, String value) {
+    if (!hasEnvVar(vars, name)) {
+      addEnvVar(vars, name, value);
+    }
+  }
+
   protected void addDefaultEnvVarIfMissing(List<V1EnvVar> vars, String name, String value) {
     if (!hasEnvVar(vars, name)) {
       addEnvVar(vars, name, value);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -590,12 +590,18 @@ public abstract class PodStepContext extends BasePodStepContext {
     V1PodSpec podSpec = createPodSpec(tuningParameters)
         .readinessGates(getReadinessGates())
         .initContainers(getServerSpec().getInitContainers().stream()
-                .map(c -> c.env(getEnvironmentVariables(tuningParameters))).collect(Collectors.toList()));
+                .map(c -> c.env(createEnv(c, tuningParameters))).collect(Collectors.toList()));
 
     for (V1Volume additionalVolume : getVolumes(getDomainUid())) {
       podSpec.addVolumesItem(additionalVolume);
     }
     return podSpec;
+  }
+
+  private List<V1EnvVar> createEnv(V1Container c, TuningParameters tuningParameters) {
+    List<V1EnvVar> envVars = Optional.ofNullable(c.getEnv()).orElse(new ArrayList<>());
+    envVars.addAll(getEnvironmentVariables(tuningParameters));
+    return envVars;
   }
 
   // ---------------------- model methods ------------------------------

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonPatchBuilder;
 
@@ -588,7 +589,8 @@ public abstract class PodStepContext extends BasePodStepContext {
   protected V1PodSpec createSpec(TuningParameters tuningParameters) {
     V1PodSpec podSpec = createPodSpec(tuningParameters)
         .readinessGates(getReadinessGates())
-        .initContainers(getServerSpec().getInitContainers());
+        .initContainers(getServerSpec().getInitContainers().stream()
+                .map(c -> c.env(getEnvironmentVariables(tuningParameters))).collect(Collectors.toList()));
 
     for (V1Volume additionalVolume : getVolumes(getDomainUid())) {
       podSpec.addVolumesItem(additionalVolume);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -599,10 +599,11 @@ public abstract class PodStepContext extends BasePodStepContext {
   }
 
   private List<V1EnvVar> createEnv(V1Container c, TuningParameters tuningParameters) {
-    List<V1EnvVar> envVars = new ArrayList<>();
-    Optional.ofNullable(c.getEnv()).ifPresent(envVars::addAll);
-    envVars.addAll(getEnvironmentVariables(tuningParameters));
-    return envVars;
+    List<V1EnvVar> initContainerEnvVars = new ArrayList<>();
+    Optional.ofNullable(c.getEnv()).ifPresent(initContainerEnvVars::addAll);
+    getEnvironmentVariables(tuningParameters).forEach(envVar ->
+            addDefaultEnvVarIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue()));
+    return initContainerEnvVars;
   }
 
   // ---------------------- model methods ------------------------------

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -599,7 +599,8 @@ public abstract class PodStepContext extends BasePodStepContext {
   }
 
   private List<V1EnvVar> createEnv(V1Container c, TuningParameters tuningParameters) {
-    List<V1EnvVar> envVars = Optional.ofNullable(c.getEnv()).orElse(new ArrayList<>());
+    List<V1EnvVar> envVars = new ArrayList<>();
+    Optional.ofNullable(c.getEnv()).ifPresent(envVars::addAll);
     envVars.addAll(getEnvironmentVariables(tuningParameters));
     return envVars;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -602,7 +602,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     List<V1EnvVar> initContainerEnvVars = new ArrayList<>();
     Optional.ofNullable(c.getEnv()).ifPresent(initContainerEnvVars::addAll);
     getEnvironmentVariables(tuningParameters).forEach(envVar ->
-            addIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue()));
+            addIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue(), envVar.getValueFrom()));
     return initContainerEnvVars;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -602,7 +602,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     List<V1EnvVar> initContainerEnvVars = new ArrayList<>();
     Optional.ofNullable(c.getEnv()).ifPresent(initContainerEnvVars::addAll);
     getEnvironmentVariables(tuningParameters).forEach(envVar ->
-            addDefaultEnvVarIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue()));
+            addIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue()));
     return initContainerEnvVars;
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -30,6 +30,8 @@ import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.helpers.DomainStatusMatcher.hasStatus;
 import static oracle.kubernetes.operator.helpers.Matchers.hasContainer;
 import static oracle.kubernetes.operator.helpers.Matchers.hasEnvVar;
+import static oracle.kubernetes.operator.helpers.Matchers.hasInitContainer;
+import static oracle.kubernetes.operator.helpers.Matchers.hasInitContainerWithEnvVar;
 import static oracle.kubernetes.operator.helpers.Matchers.hasPvClaimVolume;
 import static oracle.kubernetes.operator.helpers.Matchers.hasVolume;
 import static oracle.kubernetes.operator.helpers.Matchers.hasVolumeMount;
@@ -509,14 +511,33 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   public void whenDomainHasInitContainers_createAdminPodWithThem() {
     getConfigurator()
         .withInitContainer(
-            createContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+            createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle")));
+  }
+
+  @Test
+  public void whenDomainWithEnvVarHasInitContainers_verifyAdminPodInitContainersHaveEnvVar() {
+    getConfigurator().withEnvironmentVariable("item1", "value1")
+            .withInitContainer(
+                    createInitContainer("container1", "busybox", ADMIN_SERVER, "sh",
+                            "-c", "echo admin server && sleep 120"))
+            .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER,
+                    "ls /oracle"));
+
+    assertThat(
+            getCreatedPodSpecInitContainers(),
+            allOf(
+                    hasInitContainerWithEnvVar("container1", "busybox", ADMIN_SERVER,
+                            new V1EnvVar().name("item1").value("value1"),
+                            "sh", "-c", "echo admin server && sleep 120"),
+                    hasInitContainerWithEnvVar("container2", "oraclelinux", ADMIN_SERVER,
+                            new V1EnvVar().name("item1").value("value1"),  "ls /oracle")));
   }
 
   @Test
@@ -524,30 +545,50 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getConfigurator()
         .configureAdminServer()
         .withInitContainer(
-            createContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+            createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle")));
+  }
+
+  @Test
+  public void whenServerWithEnvVarHasInitContainers_verifyAdminPodInitContainersHaveEnvVar() {
+    getConfigurator().withEnvironmentVariable("item1", "value1")
+            .configureAdminServer()
+            .withInitContainer(
+                    createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c",
+                            "echo admin server && sleep 120"))
+            .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER,
+                    "ls /oracle"));
+
+    assertThat(
+            getCreatedPodSpecInitContainers(),
+            allOf(
+                    hasInitContainerWithEnvVar("container1", "busybox", ADMIN_SERVER,
+                            new V1EnvVar().name("item1").value("value1"),
+                            "sh", "-c", "echo admin server && sleep 120"),
+                    hasInitContainerWithEnvVar("container2", "oraclelinux", ADMIN_SERVER,
+                            new V1EnvVar().name("item1").value("value1"), "ls /oracle")));
   }
 
   @Test
   public void whenServerHasDuplicateInitContainers_createAdminPodWithCombination() {
     getConfigurator()
         .withInitContainer(
-            createContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /top"))
+            createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /top"))
         .configureAdminServer()
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle")));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -511,8 +511,8 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   public void whenDomainHasInitContainers_createAdminPodWithThem() {
     getConfigurator()
         .withInitContainer(
-            createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle"));
+            createContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
@@ -525,9 +525,9 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   public void whenDomainWithEnvVarHasInitContainers_verifyAdminPodInitContainersHaveEnvVar() {
     getConfigurator().withEnvironmentVariable("item1", "value1")
             .withInitContainer(
-                    createInitContainer("container1", "busybox", ADMIN_SERVER, "sh",
+                    createContainer("container1", "busybox", "sh",
                             "-c", "echo admin server && sleep 120"))
-            .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER,
+            .withInitContainer(createContainer("container2", "oraclelinux",
                     "ls /oracle"));
 
     assertThat(
@@ -545,8 +545,8 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getConfigurator()
         .configureAdminServer()
         .withInitContainer(
-            createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle"));
+            createContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
@@ -560,9 +560,9 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getConfigurator().withEnvironmentVariable("item1", "value1")
             .configureAdminServer()
             .withInitContainer(
-                    createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c",
-                            "echo admin server && sleep 120"))
-            .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER,
+                   createContainer("container1", "busybox", "sh", "-c",
+                           "echo admin server && sleep 120"))
+            .withInitContainer(createContainer("container2", "oraclelinux",
                     "ls /oracle"));
 
     assertThat(
@@ -579,10 +579,10 @@ public class AdminPodHelperTest extends PodHelperTestBase {
   public void whenServerHasDuplicateInitContainers_createAdminPodWithCombination() {
     getConfigurator()
         .withInitContainer(
-            createInitContainer("container1", "busybox", ADMIN_SERVER, "sh", "-c", "echo admin server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /top"))
+            createContainer("container1", "busybox", "sh", "-c", "echo admin server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /top"))
         .configureAdminServer()
-        .withInitContainer(createInitContainer("container2", "oraclelinux", ADMIN_SERVER, "ls /oracle"));
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -541,9 +541,9 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   public void whenDomainHasInitContainers_createPodWithThem() {
     getConfigurator()
         .withInitContainer(
-            createInitContainer(
-                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
+            createContainer(
+                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
@@ -557,9 +557,9 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
     getConfigurator()
         .configureServer(SERVER_NAME)
         .withInitContainer(
-            createInitContainer(
-                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
+            createContainer(
+                "container1", "busybox",  "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
@@ -576,10 +576,10 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
     getConfigurator()
             .configureServer(SERVER_NAME)
             .withInitContainer(
-                    createInitContainer("container1", "busybox", SERVER_NAME,
+                    createContainer("container1", "busybox",
                             "sh", "-c",
                             "echo managed server && sleep 120"))
-            .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME,
+            .withInitContainer(createContainer("container2", "oraclelinux",
                     "ls /oracle"));
 
     assertThat(
@@ -595,11 +595,11 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   public void whenServerHasDuplicateInitContainers_createPodWithCombination() {
     getConfigurator()
         .withInitContainer(
-            createInitContainer(
-                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /top"))
+            createContainer(
+                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /top"))
         .configureServer(SERVER_NAME)
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
@@ -613,9 +613,9 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
     getConfigurator()
         .configureCluster(CLUSTER_NAME)
         .withInitContainer(
-            createInitContainer(
-                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
+            createContainer(
+                "container1", "busybox",  "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
     testSupport.addToPacket(ProcessingConstants.CLUSTER_NAME, CLUSTER_NAME);
 
     assertThat(
@@ -629,16 +629,16 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   public void whenServerAndClusterHasDuplicateInitContainers_createPodWithCombination() {
     getConfigurator()
         .withInitContainer(
-            createInitContainer(
-                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /top"))
+            createContainer(
+                "container1", "busybox","sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /top"))
         .configureServer(SERVER_NAME)
-        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
+        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
     getConfigurator()
         .configureCluster(CLUSTER_NAME)
         .withInitContainer(
-            createInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo cluster && sleep 120"))
-        .withInitContainer(createInitContainer("container3", "oraclelinux", SERVER_NAME, "ls /cluster"));
+            createContainer("container1", "busybox", "sh", "-c", "echo cluster && sleep 120"))
+        .withInitContainer(createContainer("container3", "oraclelinux", "ls /cluster"));
     testSupport.addToPacket(ProcessingConstants.CLUSTER_NAME, CLUSTER_NAME);
 
     assertThat(

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -37,6 +37,8 @@ import static oracle.kubernetes.operator.WebLogicConstants.ADMIN_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.helpers.Matchers.hasContainer;
 import static oracle.kubernetes.operator.helpers.Matchers.hasEnvVar;
+import static oracle.kubernetes.operator.helpers.Matchers.hasInitContainer;
+import static oracle.kubernetes.operator.helpers.Matchers.hasInitContainerWithEnvVar;
 import static oracle.kubernetes.operator.helpers.Matchers.hasPvClaimVolume;
 import static oracle.kubernetes.operator.helpers.Matchers.hasResourceQuantity;
 import static oracle.kubernetes.operator.helpers.Matchers.hasVolume;
@@ -539,15 +541,15 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   public void whenDomainHasInitContainers_createPodWithThem() {
     getConfigurator()
         .withInitContainer(
-            createContainer(
-                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+            createInitContainer(
+                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo managed server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle")));
   }
 
   @Test
@@ -555,32 +557,55 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
     getConfigurator()
         .configureServer(SERVER_NAME)
         .withInitContainer(
-            createContainer(
-                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+            createInitContainer(
+                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo managed server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle")));
+  }
+
+  @Test
+  public void whenServerWithEnvVarHasInitContainers_verifyInitContainersHaveEnvVar() {
+    V1EnvVar envVar = toEnvVar(ITEM1, END_VALUE_1);
+    testSupport.addToPacket(ProcessingConstants.ENVVARS, Collections.singletonList(envVar));
+
+    getConfigurator()
+            .configureServer(SERVER_NAME)
+            .withInitContainer(
+                    createInitContainer("container1", "busybox", SERVER_NAME,
+                            "sh", "-c",
+                            "echo managed server && sleep 120"))
+            .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME,
+                    "ls /oracle"));
+
+    assertThat(
+            getCreatedPodSpecInitContainers(),
+            allOf(
+                    hasInitContainerWithEnvVar("container1", "busybox", SERVER_NAME, envVar,
+                            "sh", "-c", "echo managed server && sleep 120"),
+                    hasInitContainerWithEnvVar("container2", "oraclelinux", SERVER_NAME, envVar,
+                            "ls /oracle")));
   }
 
   @Test
   public void whenServerHasDuplicateInitContainers_createPodWithCombination() {
     getConfigurator()
         .withInitContainer(
-            createContainer(
-                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /top"))
+            createInitContainer(
+                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /top"))
         .configureServer(SERVER_NAME)
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo managed server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle")));
   }
 
   @Test
@@ -588,40 +613,40 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
     getConfigurator()
         .configureCluster(CLUSTER_NAME)
         .withInitContainer(
-            createContainer(
-                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+            createInitContainer(
+                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
     testSupport.addToPacket(ProcessingConstants.CLUSTER_NAME, CLUSTER_NAME);
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo managed server && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle")));
+            hasInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle")));
   }
 
   @Test
   public void whenServerAndClusterHasDuplicateInitContainers_createPodWithCombination() {
     getConfigurator()
         .withInitContainer(
-            createContainer(
-                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"))
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /top"))
+            createInitContainer(
+                "container1", "busybox", SERVER_NAME, "sh", "-c", "echo managed server && sleep 120"))
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /top"))
         .configureServer(SERVER_NAME)
-        .withInitContainer(createContainer("container2", "oraclelinux", "ls /oracle"));
+        .withInitContainer(createInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"));
     getConfigurator()
         .configureCluster(CLUSTER_NAME)
         .withInitContainer(
-            createContainer("container1", "busybox", "sh", "-c", "echo cluster && sleep 120"))
-        .withInitContainer(createContainer("container3", "oraclelinux", "ls /cluster"));
+            createInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo cluster && sleep 120"))
+        .withInitContainer(createInitContainer("container3", "oraclelinux", SERVER_NAME, "ls /cluster"));
     testSupport.addToPacket(ProcessingConstants.CLUSTER_NAME, CLUSTER_NAME);
 
     assertThat(
         getCreatedPodSpecInitContainers(),
         allOf(
-            hasContainer("container1", "busybox", "sh", "-c", "echo cluster && sleep 120"),
-            hasContainer("container2", "oraclelinux", "ls /oracle"),
-            hasContainer("container3", "oraclelinux", "ls /cluster")));
+            hasInitContainer("container1", "busybox", SERVER_NAME, "sh", "-c", "echo cluster && sleep 120"),
+            hasInitContainer("container2", "oraclelinux", SERVER_NAME, "ls /oracle"),
+            hasInitContainer("container3", "oraclelinux", SERVER_NAME, "ls /cluster")));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
@@ -3,7 +3,9 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -30,6 +32,16 @@ public class Matchers {
   public static Matcher<Iterable<? super V1Container>> hasContainer(
       String name, String image, String... command) {
     return hasItem(createContainer(name, image, command));
+  }
+
+  public static Matcher<Iterable<? super V1Container>> hasInitContainer(
+          String name, String image, String serverName, String... command) {
+    return hasItem(createInitContainer(name, image, serverName, command));
+  }
+
+  public static Matcher<Iterable<? super V1Container>> hasInitContainerWithEnvVar(
+          String name, String image, String serverName, V1EnvVar envVar, String... command) {
+    return hasItem(createInitContainerWithEnvVar(name, image, serverName, envVar, command));
   }
 
   public static Matcher<Iterable<? super V1EnvVar>> hasEnvVar(String name, String value) {
@@ -64,6 +76,19 @@ public class Matchers {
 
   private static V1Container createContainer(String name, String image, String... command) {
     return new V1Container().name(name).image(image).command(Arrays.asList(command));
+  }
+
+  private static V1Container createInitContainer(String name, String image, String serverName, String... command) {
+    return new V1Container().name(name).image(image).command(Arrays.asList(command))
+            .env(PodHelperTestBase.getPredefinedEnvVariables(serverName));
+  }
+
+  private static V1Container createInitContainerWithEnvVar(String name, String image, String serverName,
+                                                       V1EnvVar envVar, String... command) {
+    List<V1EnvVar> envVars = new ArrayList<>(Arrays.asList(envVar));
+    envVars.addAll(PodHelperTestBase.getPredefinedEnvVariables(serverName));
+    return new V1Container().name(name).image(image).command(Arrays.asList(command))
+            .env(envVars);
   }
 
   @SuppressWarnings("unused")

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
@@ -84,11 +84,31 @@ public class Matchers {
   }
 
   private static V1Container createInitContainerWithEnvVar(String name, String image, String serverName,
-                                                       V1EnvVar envVar, String... command) {
+                                                           V1EnvVar envVar, String... command) {
     List<V1EnvVar> envVars = new ArrayList<>(Arrays.asList(envVar));
-    envVars.addAll(PodHelperTestBase.getPredefinedEnvVariables(serverName));
+    PodHelperTestBase.getPredefinedEnvVariables(serverName).forEach(predefEnvVar ->
+            addIfMissing(envVars, predefEnvVar.getName(), predefEnvVar.getValue()));
     return new V1Container().name(name).image(image).command(Arrays.asList(command))
             .env(envVars);
+  }
+
+  protected static void addEnvVar(List<V1EnvVar> vars, String name, String value) {
+    vars.add(new V1EnvVar().name(name).value(value));
+  }
+
+  protected static boolean listHasEnvVar(List<V1EnvVar> vars, String name) {
+    for (V1EnvVar var : vars) {
+      if (name.equals(var.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected static void addIfMissing(List<V1EnvVar> vars, String name, String value) {
+    if (!listHasEnvVar(vars, name)) {
+      addEnvVar(vars, name, value);
+    }
   }
 
   @SuppressWarnings("unused")

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -181,6 +181,36 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     return new V1Container().name(name).image(image).command(Arrays.asList(command));
   }
 
+  static V1Container createInitContainer(String name, String image, String serverName, String... command) {
+    return new V1Container().name(name).image(image).command(Arrays.asList(command))
+            .env(getPredefinedEnvVariables(serverName));
+  }
+
+  static List<V1EnvVar> getPredefinedEnvVariables(String serverName) {
+    List<V1EnvVar> envVars  = new ArrayList<>();
+    envVars.add(createEnvVar("DOMAIN_NAME", DOMAIN_NAME));
+    envVars.add(createEnvVar("DOMAIN_HOME", "/u01/oracle/user_projects/domains"));
+    envVars.add(createEnvVar("ADMIN_NAME", ADMIN_SERVER));
+    envVars.add(createEnvVar("ADMIN_PORT", Integer.toString(ADMIN_PORT)));
+    envVars.add(createEnvVar("SERVER_NAME", serverName));
+    envVars.add(createEnvVar("DOMAIN_UID", UID));
+    envVars.add(createEnvVar("NODEMGR_HOME", NODEMGR_HOME));
+    envVars.add(createEnvVar("LOG_HOME", null));
+    envVars.add(createEnvVar("SERVER_OUT_IN_POD_LOG", Boolean.toString(INCLUDE_SERVER_OUT_IN_POD_LOG)));
+    envVars.add(createEnvVar("SERVICE_NAME", LegalNames.toServerServiceName(UID, serverName)));
+    envVars.add(createEnvVar("AS_SERVICE_NAME", LegalNames.toServerServiceName(UID, ADMIN_SERVER)));
+    envVars.add(createEnvVar(
+            "USER_MEM_ARGS",
+            "-Djava.security.egd=file:/dev/./urandom"));
+    envVars.add(createEnvVar("ADMIN_USERNAME", null));
+    envVars.add(createEnvVar("ADMIN_PASSWORD", null));
+    return envVars;
+  }
+
+  private static V1EnvVar createEnvVar(String name, String value) {
+    return new V1EnvVar().name(name).value(value);
+  }
+
   private String getServerName() {
     return serverName;
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -181,11 +181,6 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     return new V1Container().name(name).image(image).command(Arrays.asList(command));
   }
 
-  static V1Container createInitContainer(String name, String image, String serverName, String... command) {
-    return new V1Container().name(name).image(image).command(Arrays.asList(command))
-            .env(getPredefinedEnvVariables(serverName));
-  }
-
   static List<V1EnvVar> getPredefinedEnvVariables(String serverName) {
     List<V1EnvVar> envVars  = new ArrayList<>();
     envVars.add(createEnvVar("DOMAIN_NAME", DOMAIN_NAME));


### PR DESCRIPTION
Populate the same set of environment variables that are populated in WebLogic server container to init containters. Added unit test for new behavior. 
Integration test url - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3194/