### PR TITLE
Operator Upgrade from v3.0.4 to develop

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
@@ -502,7 +502,7 @@ public class ItOperatorUpgrade {
     Path archivePath = Paths.get(ITTESTS_DIR, "../src/integration-tests/apps/testwebapp.war");
     logger.info("Deploying application {0} to domain {1} cluster target cluster-1 in namespace {2}",
         archivePath, domainUid, namespace);
-    logger.info("Deploying webapp {0} to admin server", archivePath);
+    logger.info("Deploying webapp {0} to admin server and cluster", archivePath);
     deployUsingWlst(adminServerPodName, 
           "7001", ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, 
           "cluster-1,admin-server", archivePath, namespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
@@ -103,19 +103,6 @@ public class ItOperatorUpgrade {
   }
 
   /**
-   * Operator upgrade from 2.5.0 to latest.
-   * Install 2.5.0 release Operator from GitHub chart repository and create a domain.
-   * Delete Operator and install latest Operator and verify CRD version is updated
-   * and the domain can be managed by scaling the cluster using operator REST api.
-   */
-  @Test
-  @DisplayName("Upgrade Operator from 2.5.0 to latest")
-  public void testOperatorUpgradeFrom2_5_0(@Namespaces(3) List<String> namespaces) {
-    this.namespaces = namespaces;
-    upgradeOperator("2.5.0", OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, false);
-  }
-
-  /**
    * Operator upgrade from 2.6.0 to latest.
    * Install 2.6.0 Operator from GitHub chart repository and create a domain.
    * Delete Operator and install latest Operator and verify CRD version is updated

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorUpgrade.java
@@ -18,8 +18,6 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CleanupUtil;
-import oracle.weblogic.kubernetes.utils.DeployUtil;
-import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,7 +32,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX;
-import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_GITHUB_CHART_REPO_URL;
@@ -60,12 +57,11 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServic
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.scaleAndVerifyCluster;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.upgradeAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.DeployUtil.deployUsingWlst;
 import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -178,7 +174,6 @@ public class ItOperatorUpgrade {
     upgradeOperator("3.0.2", OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
-
   /**
    * Operator upgrade from 3.0.3 to latest.
    * Install 3.0.3 Operator from GitHub chart repository and create a domain.
@@ -192,6 +187,21 @@ public class ItOperatorUpgrade {
   public void testOperatorUpgradeFrom3_0_3(@Namespaces(3) List<String> namespaces) {
     this.namespaces = namespaces;
     upgradeOperator("3.0.3", OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+  }
+
+  /**
+   * Operator upgrade from 3.0.4 to latest.
+   * Install 3.0.4 Operator from GitHub chart repository and create a domain.
+   * Deploy an application to the cluster in domain and verify the application can be
+   * accessed while the operator is upgraded and after the upgrade.
+   * Upgrade operator with latest Operator image and verify CRD version and image are updated
+   * and the domain can be managed by scaling the cluster using operator REST api.
+   */
+  @Test
+  @DisplayName("Upgrade Operator from 3.0.4 to latest")
+  public void testOperatorUpgradeFrom3_0_4(@Namespaces(3) List<String> namespaces) {
+    this.namespaces = namespaces;
+    upgradeOperator("3.0.4", OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   /**
@@ -282,9 +292,8 @@ public class ItOperatorUpgrade {
                     opNamespace1,
                     appAvailability,
                     managedServerPodNamePrefix,
-                    replicaCount,
-                    "8001",
-                    "testwebapp/index.jsp");
+                    adminServerPodName,
+                    replicaCount);
               });
       accountingThread.start();
 
@@ -325,11 +334,11 @@ public class ItOperatorUpgrade {
           } catch (InterruptedException ie) {
             // do nothing
           }
-          // check the application availability data that we have collected, and see if
+          // check the app availability data that we have collected, and see if
           // the application has been available all the time during the upgrade
-          logger.info("Verify that the application was available when the operator was being upgraded");
+          logger.info("Verify that application was available during upgrade");
           assertTrue(appAlwaysAvailable(appAvailability),
-              "Application was not always available when the operator was getting upgraded");
+              "Application was not always available during operator upgrade");
         }
       }
     } else {
@@ -490,23 +499,13 @@ public class ItOperatorUpgrade {
   }
 
   private void deployAndAccessApplication(String namespace, String externalServiceNameSuffix) {
-    logger.info("Getting node port for admin server default channel");
-    int serviceNodePort = assertDoesNotThrow(() ->
-            getServiceNodePort(namespace, getExternalServicePodName(adminServerPodName,
-                externalServiceNameSuffix), "default"),
-        "Getting admin server node port failed");
-    assertNotEquals(-1, serviceNodePort, "admin server default node port is not valid");
-
     Path archivePath = Paths.get(ITTESTS_DIR, "../src/integration-tests/apps/testwebapp.war");
     logger.info("Deploying application {0} to domain {1} cluster target cluster-1 in namespace {2}",
         archivePath, domainUid, namespace);
-    ExecResult result = DeployUtil.deployUsingRest(K8S_NODEPORT_HOST,
-        String.valueOf(serviceNodePort),
-        ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT,
-        "cluster-1", archivePath, null, "testwebapp");
-    assertNotNull(result, "Application deployment failed");
-    logger.info("Application deployment returned {0}", result.toString());
-    assertEquals("202", result.stdout(), "Deployment didn't return HTTP status code 202");
+    logger.info("Deploying webapp {0} to admin server", archivePath);
+    deployUsingWlst(adminServerPodName, 
+          "7001", ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, 
+          "cluster-1,admin-server", archivePath, namespace);
 
     // check if the application is accessible inside of a server pod using quick retry policy
     logger.info("Check and wait for the application to become ready");
@@ -514,41 +513,60 @@ public class ItOperatorUpgrade {
       checkAppIsRunning(withQuickRetryPolicy, namespace, managedServerPodNamePrefix + i,
           "8001", "testwebapp/index.jsp", managedServerPodNamePrefix + i);
     }
+    checkAppIsRunning(withQuickRetryPolicy, namespace, adminServerPodName,
+          "7001", "testwebapp/index.jsp", adminServerPodName);
   }
 
   /**
-   * Check application availability while the operator upgrade is happening and once the ugprade is complete
-   * by accessing the application inside the managed server pods.
+   * Check application availability in the admin and managed server(s) during 
+   * operator upgrade and once the ugprade is complete by accessing the 
+   * application inside the server pods.
    */
   private static void collectAppAvailability(
       String domainNamespace,
       String operatorNamespace,
       List<Integer> appAvailability,
       String managedServerPrefix,
-      int replicaCount,
-      String internalPort,
-      String appPath
+      String adminPodName,
+      int replicaCount
   ) {
-    // Access the pod periodically to check application's availability while upgrade is happening
-    // and after upgrade is complete.
+    // Access the pod periodically to check application's availability during 
+    // upgrade and after upgrade is complete.
     // appAccessedAfterUpgrade is used to access the app once after upgrade is complete
     boolean appAccessedAfterUpgrade = false;
+    String appPath = "testwebapp/index.jsp";
+
     while (!appAccessedAfterUpgrade) {
       boolean isUpgradeComplete = checkHelmReleaseRevision(OPERATOR_RELEASE_NAME, operatorNamespace, "2");
       // upgrade is not complete or app is not accessed after upgrade
       if (!isUpgradeComplete || !appAccessedAfterUpgrade) {
+        // Check application accessibility on admin server 
+        if (appAccessibleInPod(
+              domainNamespace,
+              adminPodName,
+              "7001",
+              appPath,
+              adminPodName)) {
+          appAvailability.add(1);
+          logger.info("application accessible in admin pod " + adminPodName);
+        } else {
+          appAvailability.add(0);
+          logger.info("application not accessible in admin pod " + adminPodName);
+        }
+        
+        // Check application accessibility on managed servers
         for (int i = 1; i <= replicaCount; i++) {
           if (appAccessibleInPod(
               domainNamespace,
               managedServerPrefix + i,
-              internalPort,
+              "8001",
               appPath,
               managedServerPrefix + i)) {
             appAvailability.add(1);
-            logger.fine("application is accessible in pod " + managedServerPrefix + i);
+            logger.info("application is accessible in pod " + managedServerPrefix + i);
           } else {
             appAvailability.add(0);
-            logger.fine("application is not accessible in pod " + managedServerPrefix + i);
+            logger.info("application is not accessible in pod " + managedServerPrefix + i);
           }
         }
       }


### PR DESCRIPTION
Added a new test method to update operator from Version 3.0.4 to develop.
   Extended the continuous application availability verification to use admin server in addition to managed server(s)
   This will make sure none of the WebLogic sever got re-started during Operator version upgrade 

Upgrade Run
https://build.weblogick8s.org:8443/job/wko-tmp/114