### PR TITLE
Modified Integration Test infra to add istio v1.7.3

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -260,7 +260,7 @@ public interface TestConstants {
   public static final String DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME = "weblogic-operator-external-rest-identity";
 
   // istio constants
-  public static final String ISTIO_VERSION = "1.5.4";
+  public static final String ISTIO_VERSION = "1.7.3";
 
   //MySQL database constants
   public static final String MYSQL_VERSION = "5.6";

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -27,7 +27,8 @@ istiodir=${workdir}/istio-${version}
 echo "Installing Istio version [${version}] in location [${istiodir}]"
 
 kubectl delete namespace istio-system --ignore-not-found
-#kubectl create namespace istio-system
+# istio installation will create the namespace 'istio-system' 
+# kubectl create namespace istio-system
 
 ( cd $workdir;  
   curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${version} TARGET_ARCH=x86_64 sh -

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -5,9 +5,12 @@
 # Description:
 #
 #  This script install a given version of istio using Helm v3.x
-#  Default istio version is 1.5.4 
+#  Default istio version is 1.7.3 
 #  https://istio.io/docs/setup/install/istioctl/
 #  https://istio.io/latest/docs/setup/install/standalone-operator/
+#  https://github.com/istio/istio/releases
+#  https://github.com/istio/istio/tags
+
 
 # Usage:
 #
@@ -23,25 +26,23 @@ workdir=$2
 istiodir=${workdir}/istio-${version}
 echo "Installing Istio version [${version}] in location [${istiodir}]"
 
-helm repo add istio.io https://storage.googleapis.com/istio-release/releases/${version}/charts/
-
 kubectl delete namespace istio-system --ignore-not-found
-kubectl create namespace istio-system
+#kubectl create namespace istio-system
 
 ( cd $workdir;  
-  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${version} sh 
+  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${version} TARGET_ARCH=x86_64 sh -
 )
 
-( cd ${istiodir}/install/kubernetes/helm
-  helm template istio-init istio-init --namespace istio-system | kubectl apply -f -
-  kubectl -n istio-system wait --for=condition=complete job --all
-  helm template istio --namespace istio-system | kubectl apply -f -
+( cd ${istiodir}
+  bin/istioctl x precheck 
+  bin/istioctl install --set profile=demo -y
+  bin/istioctl verify-install
+  bin/istioctl version
 )
 }
 
-
 # MAIN
-version=${1:-1.5.4}
+version=${1:-1.7.3}
 workdir=${2:-`pwd`}
 
 if [ ! -d ${workdir} ]; then 

--- a/integration-tests/src/test/resources/bash-scripts/uninstall-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/uninstall-istio.sh
@@ -5,7 +5,7 @@
 # Description:
 #
 #  This script uninstall a given version of istio using Helm v3.x
-#  Default istio version is 1.5.4 
+#  Default istio version is 1.7.3 
 #  https://istio.io/docs/setup/install/istioctl/
 #  https://istio.io/latest/docs/setup/install/standalone-operator/
 
@@ -21,20 +21,16 @@ version=$1
 workdir=$2
 
 istiodir=${workdir}/istio-${version}
-
 echo "Uninstalling Istio version [${version}] from location [${istiodir}]"
-
 ( cd ${istiodir}
-  helm template istio-init install/kubernetes/helm/istio-init --namespace istio-system | kubectl delete -f -
-  kubectl -n istio-system wait --for=condition=complete job --all
-  helm template istio install/kubernetes/helm/istio --namespace istio-system | kubectl delete -f -
+  bin/istioctl x uninstall --purge -y
 )
 kubectl delete namespace istio-system --ignore-not-found
 rm -rf ${istiodir}
 }
 
 # MAIN
-version=${1:-1.5.4}
+version=${1:-1.7.3}
 workdir=${2:-`pwd`}
 
 istiodir=${workdir}/istio-${version}


### PR DESCRIPTION
Modified Integration Test infra to support istio  v1.7.3

Note :  It requires minimum K8s version 1.16

Jenkin Parallel Run 
   https://build.weblogick8s.org:8443/job/wko-tmp/118/  ( all ISTIO tests passed ) 