### PR TITLE
OWLS-86407 - Fixed the logic to start clustered managed server pods when admin server pod not running

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import static java.lang.System.lineSeparator;
 import static oracle.kubernetes.operator.helpers.PodHelper.hasClusterNameOrNull;
+import static oracle.kubernetes.operator.helpers.PodHelper.isNotAdminServer;
 
 /**
  * Operator's mapping between custom resource Domain and runtime details about that domain,
@@ -95,23 +96,34 @@ public class DomainPresenceInfo {
   }
 
   /**
-   * Counts the number of unclustered servers and servers in the specified cluster that are scheduled.
+   * Counts the number of unclustered managed servers and managed servers in the specified cluster that are scheduled.
    * @param clusterName cluster name of the pod server
    * @return Number of scheduled servers
    */
-  public long getNumScheduledServers(String clusterName) {
-    return getServersInNoOtherCluster(clusterName)
+  public long getNumScheduledManagedServers(String clusterName, String adminServerName) {
+    return getManagedServersInNoOtherCluster(clusterName, adminServerName)
           .filter(PodHelper::isScheduled)
           .count();
   }
 
   /**
-   * Counts the number of unclustered servers and servers in the specified cluster that are ready.
+   * Counts the number of unclustered servers (including admin) and servers in the specified cluster that are ready.
    * @param clusterName cluster name of the pod server
    * @return Number of ready servers
    */
   public long getNumReadyServers(String clusterName) {
     return getServersInNoOtherCluster(clusterName)
+            .filter(PodHelper::hasReadyServer)
+            .count();
+  }
+
+  /**
+   * Counts the number of unclustered managed servers and managed servers in the specified cluster that are ready.
+   * @param clusterName cluster name of the pod server
+   * @return Number of ready servers
+   */
+  public long getNumReadyManagedServers(String clusterName, String adminServerName) {
+    return getManagedServersInNoOtherCluster(clusterName, adminServerName)
           .filter(PodHelper::hasReadyServer)
           .count();
   }
@@ -119,9 +131,19 @@ public class DomainPresenceInfo {
   @Nonnull
   private Stream<V1Pod> getServersInNoOtherCluster(String clusterName) {
     return getServers().values().stream()
+            .map(ServerKubernetesObjects::getPod)
+            .map(AtomicReference::get)
+            .filter(this::isNotDeletingPod)
+            .filter(p -> hasClusterNameOrNull(p, clusterName));
+  }
+
+  @Nonnull
+  private Stream<V1Pod> getManagedServersInNoOtherCluster(String clusterName, String adminServerName) {
+    return getServers().values().stream()
           .map(ServerKubernetesObjects::getPod)
           .map(AtomicReference::get)
           .filter(this::isNotDeletingPod)
+          .filter(p -> isNotAdminServer(p, adminServerName))
           .filter(p -> hasClusterNameOrNull(p, clusterName));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -96,9 +96,21 @@ public class DomainPresenceInfo {
   }
 
   /**
-   * Counts the number of unclustered managed servers and managed servers in the specified cluster that are scheduled.
+   * Counts the number of unclustered servers and servers in the specified cluster that are scheduled.
    * @param clusterName cluster name of the pod server
    * @return Number of scheduled servers
+   */
+  public long getNumScheduledServers(String clusterName) {
+    return getServersInNoOtherCluster(clusterName)
+            .filter(PodHelper::isScheduled)
+            .count();
+  }
+
+  /**
+   * Counts the number of unclustered managed servers and managed servers in the specified cluster that are scheduled.
+   * @param clusterName cluster name of the pod server
+   * @param adminServerName Name of the admin server
+   * @return Number of scheduled managed servers
    */
   public long getNumScheduledManagedServers(String clusterName, String adminServerName) {
     return getManagedServersInNoOtherCluster(clusterName, adminServerName)

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -39,6 +39,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVERS_TO_ROLL;
 
 public class PodHelper {
@@ -112,6 +113,22 @@ public class PodHelper {
 
   private static String getClusterName(@Nonnull Map<String,String> labels) {
     return labels.get(CLUSTERNAME_LABEL);
+  }
+
+  static boolean isNotAdminServer(@Nullable V1Pod pod, String adminServerName) {
+    return getServerName(pod) != adminServerName;
+  }
+
+  private static String getServerName(@Nullable V1Pod pod) {
+    return Optional.ofNullable(pod)
+            .map(V1Pod::getMetadata)
+            .map(V1ObjectMeta::getLabels)
+            .map(PodHelper::getServerName)
+            .orElse(null);
+  }
+
+  private static String getServerName(@Nonnull Map<String,String> labels) {
+    return labels.get(SERVERNAME_LABEL);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -116,7 +116,7 @@ public class PodHelper {
   }
 
   static boolean isNotAdminServer(@Nullable V1Pod pod, String adminServerName) {
-    return getServerName(pod) != adminServerName;
+    return Optional.ofNullable(getServerName(pod)).map(s -> !s.equals(adminServerName)).orElse(true);
   }
 
   private static String getServerName(@Nullable V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -187,10 +187,10 @@ public class ManagedServerUpIteratorStep extends Step {
     }
 
     private boolean canStartConcurrently(long numReady) {
-      return (ignoreConcurrencyLimits() || numPodsNotReady(numReady) < this.maxConcurrency);
+      return (ignoreConcurrencyLimits() || numNotReady(numReady) < this.maxConcurrency);
     }
 
-    private long numPodsNotReady(long numReady) {
+    private long numNotReady(long numReady) {
       return getNumServersStarted() - numReady;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -24,10 +24,13 @@ import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
+
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 
 /**
  * A step which will bring up the specified managed servers in parallel.
@@ -168,7 +171,7 @@ public class ManagedServerUpIteratorStep extends Step {
 
       if (startDetailsQueue.isEmpty()) {
         return doNext(new ManagedServerUpAfterStep(getNext()), packet);
-      } else if (hasServerAvailableToStart(packet.getSpi(DomainPresenceInfo.class))) {
+      } else if (hasServerAvailableToStart(packet)) {
         numStarted.getAndIncrement();
         return doForkJoin(this, packet, Collections.singletonList(startDetailsQueue.poll()));
       } else {
@@ -176,13 +179,15 @@ public class ManagedServerUpIteratorStep extends Step {
       }
     }
 
-    private boolean hasServerAvailableToStart(DomainPresenceInfo info) {
-      return ((numStarted.get() < info.getNumScheduledServers(clusterName))
-              && (canStartConcurrently(info.getNumReadyServers(clusterName))));
+    private boolean hasServerAvailableToStart(Packet packet) {
+      DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
+      String adminServerName = ((WlsDomainConfig) packet.get(DOMAIN_TOPOLOGY)).getAdminServerName();
+      return ((numStarted.get() <= info.getNumScheduledManagedServers(clusterName, adminServerName)
+              && (canStartConcurrently(info.getNumReadyManagedServers(clusterName, adminServerName)))));
     }
 
     private boolean canStartConcurrently(long numReady) {
-      return ((this.maxConcurrency > 0) && (numStarted.get() < (this.maxConcurrency + numReady - 1)))
+      return ((this.maxConcurrency > 0) && (numStarted.get() < (this.maxConcurrency + numReady)))
           || (this.maxConcurrency == 0);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -182,13 +182,21 @@ public class ManagedServerUpIteratorStep extends Step {
     private boolean hasServerAvailableToStart(Packet packet) {
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
       String adminServerName = ((WlsDomainConfig) packet.get(DOMAIN_TOPOLOGY)).getAdminServerName();
-      return ((numStarted.get() <= info.getNumScheduledManagedServers(clusterName, adminServerName)
+      return ((numStartedManagedServers() <= info.getNumScheduledManagedServers(clusterName, adminServerName)
               && (canStartConcurrently(info.getNumReadyManagedServers(clusterName, adminServerName)))));
     }
 
     private boolean canStartConcurrently(long numReady) {
-      return ((this.maxConcurrency > 0) && (numStarted.get() < (this.maxConcurrency + numReady)))
-          || (this.maxConcurrency == 0);
+      return ((this.maxConcurrency > 0) && (numStartedManagedServers() < (this.maxConcurrency + numReady)))
+          || ignoreConcurrencyLimits();
+    }
+
+    private int numStartedManagedServers() {
+      return numStarted.get();
+    }
+
+    private boolean ignoreConcurrencyLimits() {
+      return this.maxConcurrency == 0;
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -182,16 +182,16 @@ public class ManagedServerUpIteratorStep extends Step {
     private boolean hasServerAvailableToStart(Packet packet) {
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
       String adminServerName = ((WlsDomainConfig) packet.get(DOMAIN_TOPOLOGY)).getAdminServerName();
-      return ((numStartedManagedServers() <= info.getNumScheduledManagedServers(clusterName, adminServerName)
+      return ((getNumServersStarted() <= info.getNumScheduledManagedServers(clusterName, adminServerName)
               && (canStartConcurrently(info.getNumReadyManagedServers(clusterName, adminServerName)))));
     }
 
     private boolean canStartConcurrently(long numReady) {
-      return ((this.maxConcurrency > 0) && (numStartedManagedServers() < (this.maxConcurrency + numReady)))
-          || ignoreConcurrencyLimits();
+      return (ignoreConcurrencyLimits() ||
+              (this.maxConcurrency > 0) && (getNumServersStarted() < (this.maxConcurrency + numReady)));
     }
 
-    private int numStartedManagedServers() {
+    private int getNumServersStarted() {
       return numStarted.get();
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -187,7 +187,11 @@ public class ManagedServerUpIteratorStep extends Step {
     }
 
     private boolean canStartConcurrently(long numReady) {
-      return (ignoreConcurrencyLimits() || (getNumServersStarted() < (this.maxConcurrency + numReady)));
+      return (ignoreConcurrencyLimits() || numPodsNotReady(numReady) < this.maxConcurrency);
+    }
+
+    private long numPodsNotReady(long numReady) {
+      return getNumServersStarted() - numReady;
     }
 
     private int getNumServersStarted() {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -187,8 +187,7 @@ public class ManagedServerUpIteratorStep extends Step {
     }
 
     private boolean canStartConcurrently(long numReady) {
-      return (ignoreConcurrencyLimits() ||
-              (this.maxConcurrency > 0) && (getNumServersStarted() < (this.maxConcurrency + numReady)));
+      return (ignoreConcurrencyLimits() || (getNumServersStarted() < (this.maxConcurrency + numReady)));
     }
 
     private int getNumServersStarted() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoTest.java
@@ -128,9 +128,9 @@ public class DomainPresenceInfoTest {
     addServer("MS5", null);
     addScheduledServer("MS6", null);
 
-    assertThat(info.getNumScheduledServers("cluster1"), equalTo(2L));
-    assertThat(info.getNumScheduledServers("cluster2"), equalTo(2L));
-    assertThat(info.getNumScheduledServers(null), equalTo(1L));
+    assertThat(info.getNumScheduledManagedServers("cluster1", "admin-server"), equalTo(2L));
+    assertThat(info.getNumScheduledManagedServers("cluster2", "admin-server"), equalTo(2L));
+    assertThat(info.getNumScheduledManagedServers(null, "admin-server"), equalTo(1L));
   }
 
   private void addScheduledServer(String serverName, String clusterName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainPresenceInfoTest.java
@@ -128,9 +128,9 @@ public class DomainPresenceInfoTest {
     addServer("MS5", null);
     addScheduledServer("MS6", null);
 
-    assertThat(info.getNumScheduledManagedServers("cluster1", "admin-server"), equalTo(2L));
-    assertThat(info.getNumScheduledManagedServers("cluster2", "admin-server"), equalTo(2L));
-    assertThat(info.getNumScheduledManagedServers(null, "admin-server"), equalTo(1L));
+    assertThat(info.getNumScheduledServers("cluster1"), equalTo(2L));
+    assertThat(info.getNumScheduledServers("cluster2"), equalTo(2L));
+    assertThat(info.getNumScheduledServers(null), equalTo(1L));
   }
 
   private void addScheduledServer(String serverName, String clusterName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStepTest.java
@@ -94,7 +94,7 @@ public class ManagedServerUpIteratorStepTest {
   private final Step nextStep = new TerminalStep();
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final List<Memento> mementos = new ArrayList<>();
-  private DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfoWithServers(ADMIN);
+  private DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfoWithAdminServer();
   private final WlsDomainConfig domainConfig = createDomainConfig();
   private final Collection<ServerStartupInfo> startupInfos = new ArrayList<>();
 
@@ -108,9 +108,9 @@ public class ManagedServerUpIteratorStepTest {
             .withCluster(clusterConfig);
   }
 
-  private DomainPresenceInfo createDomainPresenceInfoWithServers(String... serverNames) {
+  private DomainPresenceInfo createDomainPresenceInfoWithAdminServer() {
     DomainPresenceInfo dpi = new DomainPresenceInfo(domain);
-    Arrays.asList(serverNames).forEach(serverName -> addServer(dpi, serverName));
+    addServer(dpi, ADMIN);
     return dpi;
   }
 
@@ -249,16 +249,20 @@ public class ManagedServerUpIteratorStepTest {
   }
 
   @Test
-  public void whenAdminServerNotRunning_managedServerPodIsCreated() {
-    domainPresenceInfo = createDomainPresenceInfoWithServers();
+  public void whileAdminServerStopped_canStartManagedServer() {
+    createDomainPresenceInfoWithNoAdminServer();
     addWlsCluster(CLUSTER1, MS1);
-    testSupport
-            .addToPacket(ProcessingConstants.DOMAIN_TOPOLOGY, domainConfig)
-            .addDomainPresenceInfo(domainPresenceInfo);
 
     invokeStepWithServerStartupInfos();
 
     assertThat(getStartedManagedServers(), hasSize(1));
+  }
+
+  private void createDomainPresenceInfoWithNoAdminServer() {
+    domainPresenceInfo = new DomainPresenceInfo(domain);
+    testSupport
+            .addToPacket(ProcessingConstants.DOMAIN_TOPOLOGY, domainConfig)
+            .addDomainPresenceInfo(domainPresenceInfo);
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStepTest.java
@@ -94,7 +94,7 @@ public class ManagedServerUpIteratorStepTest {
   private final Step nextStep = new TerminalStep();
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final List<Memento> mementos = new ArrayList<>();
-  private final DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfoWithServers();
+  private DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfoWithServers(ADMIN);
   private final WlsDomainConfig domainConfig = createDomainConfig();
   private final Collection<ServerStartupInfo> startupInfos = new ArrayList<>();
 
@@ -110,7 +110,6 @@ public class ManagedServerUpIteratorStepTest {
 
   private DomainPresenceInfo createDomainPresenceInfoWithServers(String... serverNames) {
     DomainPresenceInfo dpi = new DomainPresenceInfo(domain);
-    addServer(dpi, ADMIN);
     Arrays.asList(serverNames).forEach(serverName -> addServer(dpi, serverName));
     return dpi;
   }
@@ -245,6 +244,19 @@ public class ManagedServerUpIteratorStepTest {
 
     invokeStepWithServerStartupInfos();
     testSupport.setTime(SCHEDULING_DETECTION_DELAY, TimeUnit.MILLISECONDS);
+
+    assertThat(getStartedManagedServers(), hasSize(1));
+  }
+
+  @Test
+  public void whenAdminServerNotRunning_managedServerPodIsCreated() {
+    domainPresenceInfo = createDomainPresenceInfoWithServers();
+    addWlsCluster(CLUSTER1, MS1);
+    testSupport
+            .addToPacket(ProcessingConstants.DOMAIN_TOPOLOGY, domainConfig)
+            .addDomainPresenceInfo(domainPresenceInfo);
+
+    invokeStepWithServerStartupInfos();
 
     assertThat(getStartedManagedServers(), hasSize(1));
   }


### PR DESCRIPTION
Fixed the logic to start clustered managed server pods when admin server pod is not running. The previous logic was assuming that admin server pod is scheduled and ready when starting managed server pods.   Added a unit test for the new behavior. 

Integration test results at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3305