### PR TITLE
Plugin updates to be compatible with latest JDK

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -1655,7 +1655,7 @@ public class CommonTestUtils {
    * @param domainName Name of domain to which cluster belongs
    * @param namespace cluster's namespace
    * @param replicaCount replica count value to match
-   * @return
+   * @return true, if the cluster's replica count matches the input parameter value.
    */
   public static boolean checkClusterReplicaCountMatches(String clusterName, String domainName,
                                                         String namespace, Integer replicaCount) throws ApiException {

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -30,7 +30,7 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.6</version>
+        <version>${git-commit-id-plugin-version}</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -370,7 +370,7 @@ public abstract class PodStepContext extends BasePodStepContext {
         patchBuilder, "/metadata/annotations/", getAnnotations(currentPod), getPodAnnotations());
 
     return new CallBuilder()
-            .patchPodAsync(getPodName(), getNamespace(), getDomainUid(),
+        .patchPodAsync(getPodName(), getNamespace(), getDomainUid(),
             new V1Patch(patchBuilder.build().toString()), patchResponse(next));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ActionResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ActionResponseStep.java
@@ -25,8 +25,8 @@ public abstract class ActionResponseStep<T> extends DefaultResponseStep<T> {
   @Override
   public NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
     return callResponse.getResult() == null
-            ? doNext(packet)
-            : doNext(createSuccessStep(callResponse.getResult(),
+        ? doNext(packet)
+        : doNext(createSuccessStep(callResponse.getResult(),
             new ContinueOrNextStep(callResponse, getNext())), packet);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -672,8 +672,8 @@
     <maven-dependency-plugin-version>3.1.2</maven-dependency-plugin-version>
     <exec-maven-plugin-version>3.0.0</exec-maven-plugin-version>
     <spotbugs-maven-plugin-version>4.1.4</spotbugs-maven-plugin-version>
-    <spotbugs-version>4.1.4</spotbugs-version>
-    <checkstyle-version>8.36.2</checkstyle-version>
+    <spotbugs-version>4.2.0</spotbugs-version>
+    <checkstyle-version>8.38</checkstyle-version>
     <pmd-java-version>6.21.0</pmd-java-version>
     <directory-maven-version>0.1</directory-maven-version>
     <maven-jxr-plugin-version>3.0.0</maven-jxr-plugin-version>
@@ -710,7 +710,8 @@
     <src-generated-swagger>${root-generated-swagger}/main/java</src-generated-swagger>
     <domain-swagger-file>${project.basedir}/swagger/domain.json</domain-swagger-file>
     <skip.unit.tests>false</skip.unit.tests>
-    <jacoco.version>0.8.5</jacoco.version>
+    <jacoco.version>0.8.6</jacoco.version>
+    <git-commit-id-plugin-version>4.0.0</git-commit-id-plugin-version>
     <aggregate.report.dir>buildtime-reports/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
     <checkstyle.config.location>${root.basedir}/build-tools/checkstyle/customized_google_checks.xml</checkstyle.config.location>
   </properties>


### PR DESCRIPTION
Very minor updates to plugins to be compatible with JDK 15.0.1. When I updated the checkstyle plugin, this then required a few minor changes to Java files because of issues that were previously not detected.