### PR TITLE
OWLS-86409: Additional Managed Server LifeCycle Tests and update usecases without Admin Server  

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -250,7 +250,7 @@
             <id>wls-image-cert</id>
             <properties>
                 <skipITs>false</skipITs>
-                <includes-failsafe>**/ItParameterizedDomain.java,**/ItServerStartPolicy.java,**/ItMiiUpdateDomainConfig.java,**/ItIntrospectVersion.java,**/ItMiiSample.java,**/ItJrfDomainInPV.java,**/ItStickySession.java,**/ItSessionMigration.java</includes-failsafe>
+                <includes-failsafe>**/ItParameterizedDomain.java,**/ItServerStartPolicy.java,**/ItMiiUpdateDomainConfig.java,**/ItIntrospectVersion.java,**/ItMiiSample.java,**/ItStickySession.java,**/ItSessionMigration.java</includes-failsafe>
             </properties>
         </profile>
         <profile>

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -869,7 +869,7 @@ class ItServerStartPolicy {
    * is not saved once the server is shutdown unless we use domain-on-pv model
    * So in MII case, startServer.sh script update the replica count but the 
    * server startup is defered till we re-start the adminserver. Here the 
-   * operator tries to starti the managed server but it will keep on failing 
+   * operator tries to start the managed server but it will keep on failing 
    * until AdminServer is available.   
    */
   @Order(15)
@@ -947,7 +947,7 @@ class ItServerStartPolicy {
    * is not saved once the server is shutdown unless we use domain-on-pv model
    * So in MII case, startServer.sh script update the replica count but the 
    * server startup is defered till we re-start the adminserver. Here the 
-   * operator tries to starti the managed server but it will keep on failing 
+   * operator tries to start the managed server but it will keep on failing 
    * until AdminServer is available.   
    */
   @Order(16)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -42,9 +42,9 @@ import org.awaitility.core.ConditionFactory;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -65,6 +65,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomRe
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isPodRestarted;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodInitializing;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createOcirRepoSecret;
@@ -85,81 +86,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
- * Create a WebLogic domain with one dynamic cluster (with two managed servers)
- * one configured cluster (with two managed servers) and a standalone manged 
- * server. The replica count is set to 1 and serverStartPolicy is set to 
- * IF_NEEDED at managed server level. 
- * This test class verifies the following scenarios.
- *
- * <p>testAdminServerRestart
- *  Restart the Administration Server by changing serverStartPolicy 
- *   IF_NEEDED->NEVER->IF_NEEDED
- *  Verify that the sample script can not start admin server
- *
- * <p>testDomainRestart
- *  Restart the entire domain by using the sample script stopDomain.sh and startDomain.sh
- *
- * <p>testConfigClusterRestart
- *  Restart all servers in configured cluster by
- *    using the sample script stopCluster.sh and startCluster.sh
- *
- * <p>testDynamicClusterRestart
- *  Restart all servers in dynamic cluster by
- *    using the sample script stopCluster.sh and startCluster.sh
- *
- * <p>testConfigClusterStartServerUsingAlways
- *  Restart a server in configured cluster (beyond replica count) 
- *   IF_NEEDED->ALWAYS->IF_NEEDED
- *  Verify that if server start policy is ALWAYS and the server is selected
- *   to start based on the replica count, the sample script exits without making any changes
- *
- * <p>testDynamicClusterStartServerUsingAlways
- *  Restart a server in dynamic cluster (beyond replica count) 
- *   IF_NEEDED->ALWAYS->IF_NEEDED
- *  Verify that if server start policy is ALWAYS and the server is selected
- *   to start based on the replica count, the sample script exits without making any changes
- *
- * <p>testConfigClusterReplicaCountIsMaintained
- *  Shutdown a running managed server (say ms1) in a config
- *    cluster using the sample script stopServer.sh
- *  Make sure next managed server (say ms2) is scheduled to run to maintain the 
- *    replica count while the running managed server ms1 goes down.
- *  Start server ms1 in a config cluster using the sample script startServer.sh
- *  Make sure server ms2 goes down and server ms1 is re-scheduled to maintain 
- *    the replica count
- *
- * <p>testDynamicClusterReplicaCountIsMaintained
- *  Shutdown a running managed server (say ms1) in a dynamic
- *    cluster using the sample script stopServer.sh
- *  Make sure next managed server (say ms2) is scheduled to run to maintain the 
- *    replica count while the running managed server ms1 goes down.
- *  Start server ms1 in a dynamic cluster using the sample script startServer.sh.
- *  Make sure server ms2 goes down and server ms1 is re-scheduled to maintain 
- *    the replica count
- *
- * <p>testStandaloneManagedRestartIfNeeded
- *  Restart standalone server by changing serverStartPolicy 
- *   IF_NEEDED->NEVER->IF_NEEDED
- *  Verify that if server start policy is IF_NEEDED and the server is selected
- *   to start based on the replica count, the sample script exits without making any changes
- *
- * <p>testStandaloneManagedRestartAlways
- *  Restart standalone server by changing serverStartPolicy 
- *   IF_NEEDED->NEVER->ALWAYS
- *  Verify that if server start policy is ALWAYS and the server is selected
- *   to start based on the replica count, the sample script exits without making any changes
- *
- * <p>testStartDynamicClusterServerRandomlyPicked
- *   Start a dynamic cluster managed server picked randomly within the max cluster size
- *
- * <p>testRestartNonExistingComponent
- *   Verify that the sample script can not stop or start non-existing domain, cluster or server
- *
- * <p>testStartManagedServerBeyondMaxClusterLimit
- *   Verify that the sample script can not start a server that exceeds the max cluster size
- *
- * <p>testServerRestartManagedServerWithoutAdmin
- *   In the absence of Administration Server, sample script can start/stop a managed server
+ * Create a (MII) WebLogic domain with a dynamic cluster with two managed 
+ * servers, a configured cluster with two managed servers and a standalone 
+ * manged server. The replica count is set to 1 and serverStartPolicy is set 
+ * to IF_NEEDED at managed server level. 
  */
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -189,11 +119,9 @@ class ItServerStartPolicy {
   private final String adminServerPodName = domainUid + "-admin-server";
   private final String managedServerPrefix = domainUid + "-managed-server";
   private static LoggingFacade logger = null;
-
   private static final Path samplePath = Paths.get(ITTESTS_DIR, "../kubernetes/samples");
   private static final Path tempSamplePath = Paths.get(WORK_DIR, "sample-testing");
   private static final Path domainLifecycleSamplePath = Paths.get(samplePath + "/scripts/domain-lifecycle");
-
 
   /**
    * Install Operator.
@@ -306,6 +234,7 @@ class ItServerStartPolicy {
    * Make sure that the Administration server is in RUNNING state.
    * Verify that the sample script can not start or shutdown admin server
    */
+  @Order(1)
   @Test
   @DisplayName("Restart the Administration server with serverStartPolicy")
   public void testAdminServerRestart() {
@@ -359,12 +288,15 @@ class ItServerStartPolicy {
   }
 
   /**
-   * Stop a configured cluster using the sample script stopCluster.sh
-   * Make sure that only server(s) in the configured cluster are stopped. 
-   * Make sure that server(s) in the dynamic cluster are in RUNNING state. 
+   * Stop the configured cluster using the sample script stopCluster.sh
+   * Verify that server(s) in the configured cluster are stopped. 
+   * Verify that server(s) in the dynamic cluster are in RUNNING state. 
    * Restart the cluster using the sample script startCluster.sh
    * Make sure that servers in the configured cluster are in RUNNING state. 
+   * The usecase also verify the scripts startCluster.sh/stopCluster.sh make 
+   * no changes in a running/stopped cluster respectively.
    */
+  @Order(2)
   @Test
   @DisplayName("Restart the configured cluster with serverStartPolicy")
   public void testConfigClusterRestart() {
@@ -376,9 +308,11 @@ class ItServerStartPolicy {
 
     checkPodReadyAndServiceExists(configServerPodName, 
               domainUid, domainNamespace);
-    logger.info("(BeforePatch) configured cluster managed server is RUNNING");
+    // startCluster.sh does not take any action on a running cluster
+    String result = executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-2");
+    assertTrue(result.contains("No changes needed"), "startCluster.sh shouldn't make changes");
 
-    // Verify all clustered server pods are shutdown after stopCluster script execution
+    // Verify dynamic server are shutdown after stopCluster script execution
     logger.info("Stop configured cluster using the script");
     executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-2");
 
@@ -394,23 +328,27 @@ class ItServerStartPolicy {
     assertFalse(assertDoesNotThrow(() -> isDynRestarted.call().booleanValue()),
          "Dynamic managed server pod must not be restated");
 
-    // Verify all clustered server pods are started after startCluster script execution
+    // stopCluster.sh does not take any action on a stopped cluster
+    result = executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-2");
+    assertTrue(result.contains("No changes needed"), "stopCluster.sh shouldn't make changes");
+    // Verify dynamic server are started after startCluster script execution
     logger.info("Start configured cluster using the script");
     executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-2");
-
     checkPodReadyAndServiceExists(configServerPodName, 
               domainUid, domainNamespace);
     logger.info("Configured cluster restart success");
   }
 
   /**
-   * Stop a dynamic cluster using the sample script stopCluster.sh.
-   * Make sure that only servers in the dynamic cluster are stopped. 
-   * Make sure that only servers in the configured cluster are in the 
-   * RUNNING state. 
+   * Stop the dynamic cluster using the sample script stopCluster.sh.
+   * Verify that server(s) in the dynamic cluster are stopped. 
+   * Verify that server(s) in the configured cluster are in the RUNNING state. 
    * Restart the dynamic cluster using the sample script startCluster.sh
    * Make sure that servers in the dynamic cluster are in RUNNING state again. 
+   * The usecase also verify the scripts startCluster.sh/stopCluster.sh make 
+   * no changes in a running/stopped cluster respectively.
    */
+  @Order(3)
   @Test
   @DisplayName("Restart the dynamic cluster with serverStartPolicy")
   public void testDynamicClusterRestart() {
@@ -419,15 +357,21 @@ class ItServerStartPolicy {
     String configServerPodName = domainUid + "-config-cluster-server1";
 
     DateTime cfgTs = getPodCreationTime(domainNamespace, configServerPodName);
-
     checkPodReadyAndServiceExists(dynamicServerPodName, domainUid, domainNamespace);
+    // startCluster.sh does not take any action on a running cluster
+    String result = executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-1");
+    assertTrue(result.contains("No changes needed"), "startCluster.sh shouldn't make changes");
 
-    // Verify all clustered server pods are shut down after stopCluster script execution
+    // Verify dynamic server are shut down after stopCluster script execution
     logger.info("Stop dynamic cluster using the script");
     executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-1");
 
     checkPodDeleted(dynamicServerPodName, domainUid, domainNamespace);
     logger.info("Dynamic cluster shutdown success");
+
+    // stopCluster.sh does not take any action on a stopped cluster
+    result = executeLifecycleScript(STOP_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-1");
+    assertTrue(result.contains("No changes needed"), "stopCluster.sh shouldn't make changes");
 
     // check managed server from other cluster are not affected
     Callable<Boolean> isCfgRestarted = 
@@ -436,10 +380,9 @@ class ItServerStartPolicy {
     assertFalse(assertDoesNotThrow(() -> isCfgRestarted.call().booleanValue()),
          "Configured managed server pod must not be restated");
 
-    // Verify all clustered server pods are started after startCluster script execution
+    // Verify clustered server are started after startCluster script execution
     logger.info("Start dynamic cluster using the script");
     executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, "cluster-1");
-
     checkPodReadyAndServiceExists(dynamicServerPodName, 
               domainUid, domainNamespace);
     logger.info("Dynamic cluster restart success");
@@ -453,7 +396,10 @@ class ItServerStartPolicy {
    * Make sure that ONLY Admin Server is in RUNNING state. 
    * Restart the domain using the sample script startDomain.sh
    * Make sure that all servers in the domain are in RUNNING state. 
+   * The usecase also verify the scripts startDomain.sh/stopDomain.sh make 
+   * no changes in a running/stopped domain respectively.
    */
+  @Order(4)
   @Test
   @DisplayName("Restart the Domain with serverStartPolicy")
   public void testDomainRestart() {
@@ -461,7 +407,11 @@ class ItServerStartPolicy {
     String configServerPodName = domainUid + "-config-cluster-server1";
     String standaloneServerPodName = domainUid + "-standalone-managed";
 
-    // Verify all WebLogic server instance pods are shut down after stopDomain script execution
+    // startDomain.sh does not take any action on a running domain
+    String result = executeLifecycleScript(START_DOMAIN_SCRIPT, DOMAIN, null);
+    assertTrue(result.contains("No changes needed"), "startDomain.sh shouldn't make changes");
+
+    // Verify server instance(s) are shut down after stopDomain script execution
     logger.info("Stop entire WebLogic domain using the script");
     executeLifecycleScript(STOP_DOMAIN_SCRIPT, DOMAIN, null);
    
@@ -472,6 +422,10 @@ class ItServerStartPolicy {
     }
     checkPodDeleted(configServerPodName, domainUid, domainNamespace);
     checkPodDeleted(standaloneServerPodName, domainUid, domainNamespace);
+
+    // stopDomain.sh does not take any action on a stopped domain
+    result = executeLifecycleScript(STOP_DOMAIN_SCRIPT, DOMAIN, null);
+    assertTrue(result.contains("No changes needed"), "stopDomain.sh shouldn't make changes");
 
     // Patch the Domain with serverStartPolicy set to ADMIN_ONLY
     // Here only Admin server pod should come up
@@ -487,7 +441,7 @@ class ItServerStartPolicy {
     checkPodDeleted(configServerPodName, domainUid, domainNamespace);
     checkPodDeleted(standaloneServerPodName, domainUid, domainNamespace);
 
-    // Verify all WebLogic server instance pods are started after startDomain script execution
+    // Verify server instances are started after startDomain script execution
     logger.info("Start entire WebLogic domain using the script");
     executeLifecycleScript(START_DOMAIN_SCRIPT, DOMAIN, null);
 
@@ -496,7 +450,6 @@ class ItServerStartPolicy {
       checkPodReadyAndServiceExists(managedServerPrefix + i, 
            domainUid, domainNamespace);
     }
-
     checkPodReadyAndServiceExists(configServerPodName, 
           domainUid, domainNamespace);
     checkPodReadyAndServiceExists(standaloneServerPodName, 
@@ -505,67 +458,58 @@ class ItServerStartPolicy {
   }
 
   /**
-   * The domain custom resource has a second configured manged server with serverStartPolicy IF_NEEDED
-   * Initially, the server will not come up since the replica count is set to 1
-   * Update the serverStartPolicy for config-cluster-server2 to ALWAYS
-   * by patching the resource definition with 
+   * Verify ALWAYS serverStartPolicy (config cluster) overrides replica count.
+   * The configured cluster has a second managed server(config-cluster-server2)
+   * with serverStartPolicy set to IF_NEEDED. Initially, the server will not 
+   * come up since the replica count for the cluster is set to 1. 
+   * Update the serverStartPolicy for the server config-cluster-server2 to i
+   * ALWAYS by patching the resource definition with 
    *  spec/managedServers/1/serverStartPolicy set to ALWAYS
    * Make sure that managed server config-cluster-server2 is up and running
-   * Verify that if server start policy is ALWAYS and the server is selected
-   * to start based on the replica count, it means that server is already started or is
-   * in the process of starting. In this case, script exits without making any changes
    * Stop the managed server by patching the resource definition 
    *   with spec/managedServers/1/serverStartPolicy set to IF_NEEDED.
    * Make sure the specified managed server is stopped as per replica count.
    */
+  @Order(5)
   @Test
   @DisplayName("Start/stop config cluster managed server by updating serverStartPolicy to ALWAYS/IF_NEEDED")
-  public void testConfigClusterStartServerUsingAlways() {
+  public void testConfigClusterStartServerAlways() {
     String serverName = "config-cluster-server2";
     String serverPodName = domainUid + "-" + serverName;
 
     // Make sure that managed server is not running 
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
-
     patchServerStartPolicy("/spec/managedServers/1/serverStartPolicy", "ALWAYS");
-    logger.info("Domain is patched to start configured cluster managed server");
-
+    logger.info("Configured managed server is patched to set the serverStartPolicy to ALWAYS");
     checkPodReadyAndServiceExists(serverPodName, 
           domainUid, domainNamespace);
     logger.info("Configured cluster managed server is RUNNING");
 
-    // Verify that if server start policy is ALWAYS and the server is selected
-    // to start based on the replica count, it means that server is already started or is
-    // in the process of starting. In this case, script exits without making any changes.
-    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
-    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
-
+    // Stop the server by changing the serverStartPolicy to IF_NEEDED
     patchServerStartPolicy("/spec/managedServers/1/serverStartPolicy", "IF_NEEDED");
-    logger.info("Domain is patched to stop configured cluster managed server");
-
+    logger.info("Domain resource patched to shutdown the second managed server in configured cluster");
     logger.info("Wait for managed server ${0} to be shutdown", serverPodName);
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
     logger.info("Config cluster managed server shutdown success");
   }
 
   /**
-   * Add managed server configuration (managed-server2) to CRD in a dynamic 
-   * cluster with ServerStartPolicy IF_NEEDED. 
-   * So initially, the server will not come up since replica count is set to 1.
+   * Verify ALWAYS serverStartPolicy (dynamic cluster) overrides replica count.
+   * The dynamic cluster has a second managed server(managed-server2)
+   * with serverStartPolicy set to IF_NEEDED. Initially, the server will not 
+   * come up since the replica count for the cluster is set to 1. 
    * Update the ServerStartPolicy for managed-server2 to ALWAYS
    * by patching the resource definition with 
    *  spec/managedServers/2/serverStartPolicy set to ALWAYS.
    * Make sure that managed server managed-server2 is up and running
-   * Verify that if server start policy is ALWAYS and the server is selected
-   * to start based on the replica count, it means that server is already started or is
-   * in the process of starting. In this case, script exits without making any changes.
    * Stop the managed server by patching the resource definition 
    *   with spec/managedServers/2/serverStartPolicy set to IF_NEEDED.
    * Make sure the specified managed server is stopped as per replica count.
    */
+  @Order(6)
   @Test
   @DisplayName("Start/stop dynamic cluster managed server by updating serverStartPolicy to ALWAYS/IF_NEEDED")
-  public void testDynamicClusterStartServerUsingAlways() {
+  public void testDynamicClusterStartServerAlways() {
     String serverName = "managed-server2";
     String serverPodName = domainUid + "-" + serverName;
 
@@ -573,20 +517,14 @@ class ItServerStartPolicy {
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
     
     patchServerStartPolicy("/spec/managedServers/2/serverStartPolicy","ALWAYS");
-    logger.info("Domain resource patched to start the second managed server in dynamic cluster");
+    logger.info("Dynamic managed server is patched to set the serverStartPolicy to ALWAYS");
     checkPodReadyAndServiceExists(serverPodName, 
           domainUid, domainNamespace);
     logger.info("Second managed server in dynamic cluster is RUNNING");
 
-    // Verify that if server start policy is ALWAYS and the server is selected
-    // to start based on the replica count, it means that server is already started or is
-    // in the process of starting. In this case, script exits without making any changes.
-    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
-    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
-
+    // Stop the server by changing the serverStartPolicy to IF_NEEDED
     patchServerStartPolicy("/spec/managedServers/2/serverStartPolicy","IF_NEEDED");
     logger.info("Domain resource patched to shutdown the second managed server in dynamic cluster");
-
     logger.info("Wait for managed server ${0} to be shutdown", serverPodName);
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
     logger.info("Dynamic cluster second managed server shutdown success");
@@ -607,8 +545,9 @@ class ItServerStartPolicy {
    *     Make sure that managed server config-cluster-server1 comes up
    *       to maintain the replica count of 1.
    */
+  @Order(7)
   @Test
-  @DisplayName("Stop a running config cluster managed server and verify the replica count is maintained")
+  @DisplayName("Stop/Start a running config cluster managed server and verify the replica count is maintained")
   public void testConfigClusterReplicaCountIsMaintained() {
     String serverName = "config-cluster-server1";
     String serverPodName = domainUid + "-" + serverName;
@@ -652,8 +591,9 @@ class ItServerStartPolicy {
    *     Make sure that managed server managed-server1 comes up
    *       to maintain the replica count of 1.
    */
+  @Order(8)
   @Test
-  @DisplayName("Stop a running dynamic cluster managed server and verify the replica count ")
+  @DisplayName("Stop/Start a running dynamic cluster managed server and verify the replica count ")
   public void testDynamicClusterReplicaCountIsMaintained() {
     String serverPodName = domainUid + "-managed-server1";
     String serverPodName2 = domainUid + "-managed-server2";
@@ -681,19 +621,18 @@ class ItServerStartPolicy {
   }
 
   /**
-   * Start independent managed server by setting serverStartPolicy to IF_NEEDED.
-   * Stop an independent managed server by patching the resource definition with 
+   * Start an independent managed server with serverStartPolicy to IF_NEEDED.
+   * The serverStartPolicy transition is IF_NEEDED-->NEVER-->ALWAYS
+   * Stop an independent managed server by patching the domain resource with 
    *  spec/managedServers/0/serverStartPolicy set to NEVER.
    * Make sure that ONLY the specified managed server is stopped. 
    * Restart the independent managed server by patching the resource definition 
    * with spec/managedServers/0/serverStartPolicy set to ALWAYS.
    * Make sure that the specified managed server is in RUNNING state
-   * Verify that if server start policy is ALWAYS and the server is selected
-   * to start based on the replica count, it means that server is already started or is
-   * in the process of starting. In this case, script exits without making any changes.
    */
+  @Order(9)
   @Test
-  @DisplayName("Restart the standalone managed server with serverStartPolicy")
+  @DisplayName("Restart the standalone managed server with serverStartPolicy ALWAYS")
   public void testStandaloneManagedRestartAlways() {
     String serverName = "standalone-managed";
     String serverPodName = domainUid + "-" + serverName;
@@ -714,29 +653,22 @@ class ItServerStartPolicy {
 
     checkPodReadyAndServiceExists(serverPodName,
             domainUid, domainNamespace);
-    logger.info("Configured managed server restart success");
-
-    // Verify that if server start policy is ALWAYS and the server is selected
-    // to start based on the replica count, it means that server is already started or is
-    // in the process of starting. In this case, script exits without making any changes.
-    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
-    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
+    logger.info("Standalone managed server restart (ALWAYS) success");
   }
 
   /**
-   * Start independent managed server by setting serverStartPolicy to IF_NEEDED.
-   * Stop an independent managed server by patching the resource definition with 
+   * Start an independent managed server with serverStartPolicy to IF_NEEDED.
+   * The serverStartPolicy transition is IF_NEEDED-->NEVER-->IF_NEEDED
+   * Stop an independent managed server by patching the domain resource with 
    *  spec/managedServers/0/serverStartPolicy set to NEVER.
    * Make sure that ONLY the specified managed server is stopped. 
    * Restart the independent managed server by patching the resource definition 
    * with spec/managedServers/0/serverStartPolicy set to IF_NEEDED.
    * Make sure that the specified managed server is in RUNNING state
-   * Verify that if server start policy is IF_NEEDED and the server is selected
-   * to start based on the replica count, it means that server is already started or is
-   * in the process of starting. In this case, script exits without making any changes.
    */
+  @Order(10)
   @Test
-  @DisplayName("Restart the standalone managed server with serverStartPolicy")
+  @DisplayName("Restart the standalone managed server with serverStartPolicy IF_NEEDED")
   public void testStandaloneManagedRestartIfNeeded() {
     String serverName = "standalone-managed";
     String serverPodName = domainUid + "-" + serverName;
@@ -751,25 +683,68 @@ class ItServerStartPolicy {
 
     checkPodDeleted(serverPodName, domainUid, domainNamespace);
     logger.info("Standalone managed server shutdown success");
-
     patchServerStartPolicy("/spec/managedServers/0/serverStartPolicy", "IF_NEEDED");
     logger.info("Domain is patched to start standalone managed server");
-
     checkPodReadyAndServiceExists(serverPodName,
         domainUid, domainNamespace);
-    logger.info("Standalone managed server restart success");
-
-    // Verify that if server start policy is IF_NEEDED and the server is selected
-    // to start based on the replica count, it means that server is already started or is
-    // in the process of starting. In this case, script exits without making any changes.
-    String result = executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName);
-    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
+    logger.info("Standalone managed server restart (IF_NEEDED) success");
   }
 
   /**
-   * Start a dynamic cluster managed server within the max cluster size
-   * and the managed server name is not next in line to be started by the Operator but one a customer picks .
+   * Stop the independent managed server using the sample script stopServer.sh
+   * Start the independent managed server using the sample script startServer.sh
+   * The usecase also verify the scripts startServer.sh/stopServer.sh make 
+   * no changes in a running/stopped server respectively.
    */
+  @Order(11)
+  @Test
+  @DisplayName("Restart the standalone managed server with sample script")
+  public void testStandaloneManagedRestart() {
+    String serverName = "standalone-managed";
+    String serverPodName = domainUid + "-" + serverName;
+    String keepReplicaCountConstantParameter = "-k";
+
+    // Make sure that configured managed server is ready 
+    checkPodReadyAndServiceExists(serverPodName,
+            domainUid, domainNamespace);
+    logger.info("Configured managed server is RUNNING");
+    // startServer.sh does not take any action on a running server
+    String result = executeLifecycleScript(START_SERVER_SCRIPT, 
+          SERVER_LIFECYCLE, "standalone-managed", 
+          keepReplicaCountConstantParameter);
+    assertTrue(result.contains("No changes needed"), "startServer.sh shouldn't make changes");
+
+    // shutdown standalone-managed using the script stopServer.sh
+    executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, 
+         "standalone-managed", keepReplicaCountConstantParameter);
+    logger.info("Script executed to shutdown standalone managed server");
+
+    checkPodDeleted(serverPodName, domainUid, domainNamespace);
+    logger.info("Standalone managed server shutdown success");
+
+    // stopServer.sh does not take any action on a stopped server
+    result = executeLifecycleScript(STOP_SERVER_SCRIPT, 
+          SERVER_LIFECYCLE, "standalone-managed", 
+          keepReplicaCountConstantParameter);
+    assertTrue(result.contains("No changes needed"), "stopServer.sh shouldn't make changes");
+
+    executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, 
+            "standalone-managed", keepReplicaCountConstantParameter);
+    logger.info("Script executed to start standalone managed server");
+
+    checkPodReadyAndServiceExists(serverPodName,
+            domainUid, domainNamespace);
+    logger.info("Standalone managed server restart success");
+  }
+
+  /**
+   * Make sure the startServer script can start any server (not in order)
+   * in a dynamic cluster within the max cluster size limit. 
+   * Say the max cluster size is 3 and managed-server1 is running.
+   * startServer script can start managed-server3 explicitly by skipping 
+   * managed-server2. 
+   */
+  @Order(12)
   @Test
   @DisplayName("Pick a dynamic cluster managed server randomly within the max cluster size and verify it starts")
   public void testStartDynamicClusterServerRandomlyPicked() {
@@ -790,15 +765,16 @@ class ItServerStartPolicy {
 
     // Verify that a randomly picked dynamic cluster managed server within the max cluster size starts successfully
     checkPodReadyAndServiceExists(serverPodName3, domainUid, domainNamespace);
-    logger.info("Replica Count Increased and a new Dynamic cluster managed server {0} is RUNNING", serverPodName3);
+    logger.info("Randomly picked dynamic cluster managed server {0} is RUNNING", serverPodName3);
   }
 
   /**
-   * Negative test to verify:
+   * Negative tests to verify:
    * (a) the sample script can not stop or start a non-existing server
    * (b) the sample script can not stop or start a non-existing cluster
    * (c) the sample script can not stop or start a non-existing domain.
    */
+  @Order(13)
   @Test
   @DisplayName("Verify that the sample script can not stop or start non-existing components")
   public void testRestartNonExistingComponent() {
@@ -849,11 +825,15 @@ class ItServerStartPolicy {
   }
 
   /**
-   * Negative test to verify that the sample script can not start a server that exceeds the max cluster size
-   * Currently, the domain resource has a configured cluster with two managed servers
-   * and a dynamic cluster with MaxClusterSize set to 5. The sample script shouldn't start server 3
-   * in configured cluster and server 6 in dynamic cluster.
+   * Negative test to verify that the sample script can not start a server that
+   * exceeds the max cluster size
+   * Currently, the domain resource has a configured cluster with two managed 
+   * servers and a dynamic cluster with MaxClusterSize set to 5. 
+   * The sample script shouldn't start i
+   * configured managed server config-cluster-server3 in configured cluster 
+   * and managed-server-6 in dynamic cluster.
    */
+  @Order(14)
   @Test
   @DisplayName("Verify that the sample script can not start a server that exceeds the max cluster size")
   public void testStartManagedServerBeyondMaxClusterLimit() {
@@ -865,65 +845,172 @@ class ItServerStartPolicy {
     String result =  assertDoesNotThrow(() ->
         executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, configServerName, "", false),
         String.format("Failed to run %s", START_SERVER_SCRIPT));
-    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a server that is beyong the limit");
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a server that is beyond the limit");
 
     // verify that the script can not start a server in dynamic cluster that exceeds the max cluster size
     regex = ".*outside the range of allowed servers";
     result =  assertDoesNotThrow(() ->
         executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, dynServerName, "", false),
         String.format("Failed to run %s", START_SERVER_SCRIPT));
-    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a server that is beyong the limit");
+    assertTrue(verifyExecuteResult(result, regex),"The script shouldn't stop a server that is beyond the limit");
   }
 
   /**
-   * Verify that after the admin server is stopped, the sample script can start or stop a managed server.
+   * Refer JIRA https://jira.oraclecorp.com/jira/browse/OWLS-86251
+   * Refer JIRA https://jira.oraclecorp.com/jira/browse/OWLS-86407
+   * Once the admin server is stopped, operator can not start a new managed 
+   * server from scrtach if it has never been started eralier with Admin Server
+   * Once the admin server is stopped, the managed server can only be started 
+   * in MSI (managed server independence) mode. To start a manged server in 
+   * MSI mode, the pre-requisite is the that the manged server MUST be started 
+   * once before admin server is shutdown, so that the embedded LDAP server is 
+   * replicated from admin server to the managed server. 
+   * In this case of MII and DomainInImage model, the server state/configuration
+   * is not saved once the server is shutdown unless we use domain-on-pv model
+   * So in MII case, startServer.sh script update the replica count but the 
+   * server startup is defered till we re-start the adminserver. Here the 
+   * operator tries to starti the managed server but it will keep on failing 
+   * until AdminServer is available.   
    */
-  @Disabled("Due to the bug OWLS-86251")
+  @Order(15)
   @Test
-  @DisplayName("In the absence of Administration Server, sample script can start/stop a managed server")
-  public void testServerRestartManagedServerWithoutAdmin() {
-    String serverName = "config-cluster-server1";
+  @DisplayName("Manage dynamic cluster server in absence of Administration Server")
+  public void testDynamicServerLifeCycleWithoutAdmin() {
+    String serverName = "managed-server1";
+    // domainUid + "-" + serverName;
+    String serverPodName = managedServerPrefix + "1";
+    // Here managed server can be stopped without admin server 
+    // but can not be started to RUNNING state.
 
     try {
+      // Make sure that managed-server-1 is RUNNING
+      checkPodReadyAndServiceExists(serverPodName, domainUid, domainNamespace);
+      logger.info("Server Pod [" + serverName + "] is in RUNNING state");
+
       // shutdown the admin server
       patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "NEVER");
       logger.info("Domain is patched to shutdown administration server");
+      checkPodDeleted(adminServerPodName, domainUid, domainNamespace);
+      logger.info("Administration server shutdown success");
 
-      // verify that the script can stop a server in absent of admin server
+      // verify the script can stop the server by reducing replica count
       assertDoesNotThrow(() ->
-          executeLifecycleScript(STOP_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, "", true),
+          executeLifecycleScript(STOP_SERVER_SCRIPT, 
+                                 SERVER_LIFECYCLE, serverName, "", true),
           String.format("Failed to run %s", STOP_SERVER_SCRIPT));
-      checkPodDeleted(serverName, domainUid, domainNamespace);
-      logger.info("Shutdown " + serverName + " without admin server success");
+      checkPodDeleted(serverPodName, domainUid, domainNamespace);
+      logger.info("Shutdown [" + serverName + "] without admin server success");
 
-      // verify that the script can start a server in absent of admin server
+      // Here the script increase the replica count by 1, but operator cannot 
+      // start server in MSI mode as the server state (configuration) is 
+      // lost while stopping the server in mii model.
+      
       assertDoesNotThrow(() ->
           executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, "", true),
           String.format("Failed to run %s", START_SERVER_SCRIPT));
-      checkPodReadyAndServiceExists(serverName, domainUid, domainNamespace);
-      logger.info("Start " + serverName + " without admin server success");
+      logger.info("Replica count increased without admin server");
 
-      // verify that in absent of admin server, when server is part of a cluster and
-      // keep_replica_constant option is false (the default)
-      // and the effective start policy of the server is IF_NEEDED and increasing replica count
-      // will naturally start the server, the script increases the replica count
-      String serverName2 = "managed-server2";
-      assertDoesNotThrow(() ->
-          executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName2, "", true),
-          String.format("Failed to run %s", START_SERVER_SCRIPT));
-      checkPodReadyAndServiceExists(serverName, domainUid, domainNamespace);
-      logger.info("Start " + serverName2 + " without admin server success");
+      // Check if pod in init state
+      // Here the server pd is created but does not goes into 1/1 state
+      checkPodInitializing(serverPodName, domainUid, domainNamespace);
+      logger.info("Server[" + serverName + "] pod is initialized");
+
+      // (re)Start Start the admin
+      patchServerStartPolicy(
+             "/spec/adminServer/serverStartPolicy", "IF_NEEDED");
+      checkPodReadyAndServiceExists(
+             adminServerPodName, domainUid, domainNamespace);
+      logger.info("AdminServer restart success");
+
+      checkPodReadyAndServiceExists(serverPodName, domainUid, domainNamespace);
+      logger.info("(re)Started [" + serverName + "] on admin server restart");
     } finally {
       // restart admin server
       patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "IF_NEEDED");
-      logger.info("Domain is patched to start administration server");
-
       logger.info("Check admin service/pod {0} is created in namespace {1}",
           adminServerPodName, domainNamespace);
       checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
-      logger.info("AdminServer restart success");
     }
   }
+
+  /**
+   * Refer JIRA https://jira.oraclecorp.com/jira/browse/OWLS-86251
+   * Refer JIRA https://jira.oraclecorp.com/jira/browse/OWLS-86407
+   * Once the admin server is stopped, operator can not start a new managed 
+   * server from scrtach if it has never been started eralier with Admin Server
+   * Once the admin server is stopped, the managed server can only be started 
+   * in MSI (managed server independence) mode. To start a manged server in 
+   * MSI mode, the pre-requisite is the that the manged server MUST be started 
+   * once before admin server is shutdown, so that the embedded LDAP server is 
+   * replicated from admin server to the managed server. 
+   * In this case of MII and DomainInImage model, the server state/configuration
+   * is not saved once the server is shutdown unless we use domain-on-pv model
+   * So in MII case, startServer.sh script update the replica count but the 
+   * server startup is defered till we re-start the adminserver. Here the 
+   * operator tries to starti the managed server but it will keep on failing 
+   * until AdminServer is available.   
+   */
+  @Order(16)
+  @Test
+  @DisplayName("Manage configured cluster server in absence of Administration Server")
+  public void testConfiguredServerLifeCycleWithoutAdmin() {
+    String serverName = "config-cluster-server1";
+    String serverPodName = domainUid + "-" + serverName;
+
+    // Here managed server can be stopped without admin server 
+    // but can not be started to RUNNING state.
+
+    try {
+      // Make sure that config-cluster-server1 is RUNNING
+      checkPodReadyAndServiceExists(serverPodName, domainUid, domainNamespace);
+      logger.info("Server Pod [" + serverName + "] is in RUNNING state");
+
+      // shutdown the admin server
+      patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "NEVER");
+      logger.info("Domain is patched to shutdown administration server");
+      checkPodDeleted(adminServerPodName, domainUid, domainNamespace);
+      logger.info("Administration server shutdown success");
+
+      // verify the script can stop the server by reducing replica count
+      assertDoesNotThrow(() ->
+          executeLifecycleScript(STOP_SERVER_SCRIPT, 
+                                 SERVER_LIFECYCLE, serverName, "", true),
+          String.format("Failed to run %s", STOP_SERVER_SCRIPT));
+      checkPodDeleted(serverPodName, domainUid, domainNamespace);
+      logger.info("Shutdown [" + serverName + "] without admin server success");
+
+      // Here the script increase the replica count by 1, but operator cannot 
+      // start server in MSI mode as the server state (configuration) is 
+      // lost while stopping the server in mii model.
+      
+      assertDoesNotThrow(() ->
+          executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, serverName, "", true),
+          String.format("Failed to run %s", START_SERVER_SCRIPT));
+      logger.info("Replica count increased without admin server");
+
+      // Check if pod in init state
+      // Here the server pd is created but does not goes into 1/1 state
+      checkPodInitializing(serverPodName, domainUid, domainNamespace);
+      logger.info("Server[" + serverName + "] pod is initialized");
+
+      // (re)Start Start the admin
+      patchServerStartPolicy(
+             "/spec/adminServer/serverStartPolicy", "IF_NEEDED");
+      checkPodReadyAndServiceExists(
+             adminServerPodName, domainUid, domainNamespace);
+      logger.info("AdminServer restart success");
+
+      checkPodReadyAndServiceExists(serverPodName, domainUid, domainNamespace);
+      logger.info("(re)Started [" + serverName + "] on admin server restart");
+    } finally {
+      // restart admin server
+      patchServerStartPolicy("/spec/adminServer/serverStartPolicy", "IF_NEEDED");
+      logger.info("Check admin service/pod {0} is created in namespace {1}",
+          adminServerPodName, domainNamespace);
+      checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+    }
+  }
+
 
   private static void createDomainSecret(String secretName, String username, String password, String domNamespace)
           throws ApiException {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -462,7 +462,7 @@ class ItServerStartPolicy {
    * The configured cluster has a second managed server(config-cluster-server2)
    * with serverStartPolicy set to IF_NEEDED. Initially, the server will not 
    * come up since the replica count for the cluster is set to 1. 
-   * Update the serverStartPolicy for the server config-cluster-server2 to i
+   * Update the serverStartPolicy for the server config-cluster-server2 to 
    * ALWAYS by patching the resource definition with 
    *  spec/managedServers/1/serverStartPolicy set to ALWAYS
    * Make sure that managed server config-cluster-server2 is up and running


### PR DESCRIPTION
Added the following new test cases
   ItServerStartPolicy.testStandaloneManagedRestart 
   ItServerStartPolicy.testConfiguredServerLifeCycleWithoutAdmin  ( msi mode ) 
   ItServerStartPolicy.testDynamicServerLifeCycleWithoutAdmin       (msi mode)

Added extra verification for starting/stopping a domain/cluster/servers with already started/stopped domain/cluster/servers

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3322/