### PR TITLE
negative test for changing domain name using MII dynamic update 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -1205,6 +1205,19 @@ public class TestActions {
   }
 
   /**
+   * Returns the status phase of the pod.
+   *
+   * @param namespace in which to check for the pod status
+   * @param labelSelectors in the format "weblogic.domainUID in (%s)"
+   * @param podName name of the pod to check
+   * @return the status phase of the pod
+   * @throws ApiException if Kubernetes client API call fails
+   */
+  public static String getPodStatusPhase(String namespace, String labelSelectors, String podName) throws ApiException {
+    return Pod.getPodStatusPhase(namespace, labelSelectors, podName);
+  }
+
+  /**
    * Get a pod's log.
    *
    * @param podName name of the pod

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Pod.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Pod.java
@@ -120,6 +120,19 @@ public class Pod {
   }
 
   /**
+   * Returns the status phase of the pod.
+   *
+   * @param namespace in which to check for the pod status
+   * @param labelSelectors in the format "weblogic.domainUID in (%s)"
+   * @param podName name of the pod to check
+   * @return the status phase of the pod
+   * @throws ApiException if Kubernetes client API call fails
+   */
+  public static String getPodStatusPhase(String namespace, String labelSelectors, String podName) throws ApiException {
+    return Kubernetes.getPodStatusPhase(namespace, labelSelectors, podName);
+  }
+
+  /**
    * Patch domain to shutdown a WebLogic  server by changing the value of
    * its serverStartPolicy property to NEVER.
    *

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -537,7 +537,12 @@ public class Kubernetes {
    */
   public static String getPodStatusPhase(String namespace, String labelSelectors, String podName) throws ApiException {
     V1Pod pod = getPod(namespace, labelSelectors, podName);
-    return pod.getStatus().getPhase();
+    if (pod != null && pod.getStatus() != null) {
+      return pod.getStatus().getPhase();
+    } else {
+      getLogger().info("Pod does not exist or pod status is null");
+      return "";
+    }
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -527,6 +527,20 @@ public class Kubernetes {
   }
 
   /**
+   * Returns the status phase of the pod.
+   *
+   * @param namespace in which to check for the pod status
+   * @param labelSelectors in the format "weblogic.domainUID in (%s)"
+   * @param podName name of the pod to check
+   * @return the status phase of the pod
+   * @throws ApiException if Kubernetes client API call fails
+   */
+  public static String getPodStatusPhase(String namespace, String labelSelectors, String podName) throws ApiException {
+    V1Pod pod = getPod(namespace, labelSelectors, podName);
+    return pod.getStatus().getPhase();
+  }
+
+  /**
    * Get the creationTimestamp for a given pod with following parameters.
    *
    * @param namespace in which to check for the pod existence


### PR DESCRIPTION
This is a negative test for MII dynamic update - changing domain name at runtime (unsupported).

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3337/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3340/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3343/