### PR TITLE
Remove istio enablement for Operator namespace

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
@@ -167,7 +167,7 @@ public class ItIstioCrossDomainTransaction {
 
     assertDoesNotThrow(() -> addLabelsToNamespace(domain1Namespace,labelMap));
     assertDoesNotThrow(() -> addLabelsToNamespace(domain2Namespace,labelMap));
-    assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
+    // assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
 
     // install and verify operator
     installAndVerifyOperator(opNamespace, domain1Namespace, domain2Namespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInImage.java
@@ -107,7 +107,7 @@ class ItIstioDomainInImage {
     labelMap.put("istio-injection", "enabled");
 
     assertDoesNotThrow(() -> addLabelsToNamespace(domainNamespace,labelMap));
-    assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
+    // assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
 
     // install and verify operator
     installAndVerifyOperator(opNamespace, domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
@@ -135,7 +135,7 @@ public class ItIstioDomainInPV  {
     labelMap.put("istio-injection", "enabled");
 
     assertDoesNotThrow(() -> addLabelsToNamespace(domainNamespace,labelMap));
-    assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
+    // assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
 
     // install operator and verify its running in ready state
     installAndVerifyOperator(opNamespace, domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
@@ -104,7 +104,7 @@ class ItIstioMiiDomain {
     Map<String, String> labelMap = new HashMap();
     labelMap.put("istio-injection", "enabled");
     assertDoesNotThrow(() -> addLabelsToNamespace(domainNamespace,labelMap));
-    assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
+    // assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
 
     // install and verify operator
     installAndVerifyOperator(opNamespace, domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioTwoDomainsInImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioTwoDomainsInImage.java
@@ -115,7 +115,7 @@ class ItIstioTwoDomainsInImage {
 
     assertDoesNotThrow(() -> addLabelsToNamespace(domainNamespace1,labelMap));
     assertDoesNotThrow(() -> addLabelsToNamespace(domainNamespace2,labelMap));
-    assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
+    // assertDoesNotThrow(() -> addLabelsToNamespace(opNamespace,labelMap));
 
     logger.info("Namespaces [{0}, {1}, {2}] labeled with istio-injection",
          opNamespace, domainNamespace1, domainNamespace2);


### PR DESCRIPTION
Recently after Upgrade to istio 1.7.3, we are observing intermittent failures in istio usecases when  the Operator container fails to comes up.  We have a tracking JIRA for this issue.   https://jira.oraclecorp.com/jira/browse/OWLS-86461

Since the current istio usecase does not using mTLS, there is no need enable istio for Operator Namespace. This may be considered as workaround till we resolve the issue OWLS-86461 or upgrade the istio version.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3353/  
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3354/ 
