### PR TITLE
Address locale and potential count issues with combining aplit values

### DIFF
--- a/operator-build-maven-plugin/src/main/java/oracle/kubernetes/mojo/shunit2/ShUnit2Mojo.java
+++ b/operator-build-maven-plugin/src/main/java/oracle/kubernetes/mojo/shunit2/ShUnit2Mojo.java
@@ -99,7 +99,7 @@ public class ShUnit2Mojo extends AbstractMojo {
 
   @Override
   public void execute() throws MojoFailureException, MojoExecutionException {
-    if (isEnvironmentNotSupported()) {
+    if (isEnvironmentNotSupported() || isSkipTestsRequested()) {
       return;
     }
     
@@ -110,6 +110,10 @@ public class ShUnit2Mojo extends AbstractMojo {
     if ((totalNumFailures() + totalNumErrors()) != 0) {
       throw new MojoFailureException(String.format("%d failures, %d errors", totalNumFailures(), totalNumErrors()));
     }
+  }
+
+  private boolean isSkipTestsRequested() {
+    return "true".equalsIgnoreCase(System.getProperty("skip.unit.tests"));
   }
 
   private boolean isEnvironmentNotSupported() throws MojoExecutionException {

--- a/operator-build-maven-plugin/src/test/java/oracle/kubernetes/mojo/shunit2/ShUnit2MojoTest.java
+++ b/operator-build-maven-plugin/src/test/java/oracle/kubernetes/mojo/shunit2/ShUnit2MojoTest.java
@@ -51,6 +51,7 @@ public class ShUnit2MojoTest extends MojoTestBase {
 
   private static final String TEST_SCRIPT = "shunit2";
   private static final String OS_NAME_PROPERTY = "os.name";
+  private static final String SKIP_UNIT_TESTS_PROPERTY = "skip.unit.tests";
   private static final String[] INSTALLED_OSX_BASH_VERSION = {
       "GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)",
       "Copyright (C) 2007 Free Software Foundation, Inc."
@@ -89,6 +90,7 @@ public class ShUnit2MojoTest extends MojoTestBase {
     mementos.add(StaticStubSupport.install(ShUnit2Mojo.class, "fileSystem", fileSystem));
     mementos.add(StaticStubSupport.install(ShUnit2Mojo.class, "builderFunction", builderFunction));
     mementos.add(SystemPropertySupport.install(OS_NAME_PROPERTY, "Linux"));
+    mementos.add(SystemPropertySupport.install(SKIP_UNIT_TESTS_PROPERTY, ""));
 
     setMojoParameter("outputDirectory", TEST_CLASSES_DIRECTORY);
     setMojoParameter("sourceDirectory", SOURCE_DIRECTORY);
@@ -170,6 +172,15 @@ public class ShUnit2MojoTest extends MojoTestBase {
     fileSystem.defineFileContents(TEST_CLASSES_DIRECTORY, "");
 
     executeMojo();
+  }
+
+  @Test
+  public void ifSkipUnitTestSet_skipTesting() throws MojoFailureException, MojoExecutionException {
+    System.setProperty(SKIP_UNIT_TESTS_PROPERTY, "true");
+
+    executeMojo();
+
+    assertThat(getInfoLines(), empty());
   }
 
   @Test

--- a/operator/src/main/java/oracle/kubernetes/operator/IntrospectorConfigMapConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/IntrospectorConfigMapConstants.java
@@ -61,6 +61,13 @@ public interface IntrospectorConfigMapConstants {
    */
   @Nonnull
   static String getIntrospectorVolumePath(int index) {
-    return "/weblogic-operator/introspector" + suffix(index);
+    return "/weblogic-operator/introspector" + mountSuffix(index);
   }
+
+  /**  A (possibly empty) suffix for introspector volume paths. */
+  static String mountSuffix(int index) {
+    return index == 0 ? "" : "_" + String.format("%03d", index);
+  }
+
+
 }

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -533,7 +533,7 @@ function restorePrimordialDomain() {
 # $1 the name of the encoded file in the config map
 function restoreEncodedTar() {
   cd / || return 1
-  cat ${OPERATOR_ROOT}/introspector*/${1} > /tmp/domain.secure
+  LC_COLLATE=C LC_ALL=C cat ${OPERATOR_ROOT}/introspector*/${1} > /tmp/domain.secure
   base64 -d "/tmp/domain.secure" > /tmp/domain.tar.gz || return 1
 
   tar -xzf /tmp/domain.tar.gz || return 1

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -423,8 +423,8 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
         getCreatedPodSpecContainer().getVolumeMounts(),
         allOf(
               hasItem(writableVolumeMount(INTROSPECTOR_VOLUME, "/weblogic-operator/introspector")),
-              hasItem(writableVolumeMount(INTROSPECTOR_VOLUME + "_1", "/weblogic-operator/introspector_1")),
-              hasItem(writableVolumeMount(INTROSPECTOR_VOLUME + "_2", "/weblogic-operator/introspector_2"))
+              hasItem(writableVolumeMount(INTROSPECTOR_VOLUME + "_1", "/weblogic-operator/introspector_001")),
+              hasItem(writableVolumeMount(INTROSPECTOR_VOLUME + "_2", "/weblogic-operator/introspector_002"))
               ));
   }
 


### PR DESCRIPTION
This addresses two issues:

1. In some environments, copying values split across multiple volumes was joining the pieces in the wrong order. Setting the LOCALE as part of the copy addresses that.

2. There was a concern that if we ever needed to split a file across more than ten volumes, the numbering would not result in a proper copy. That is addressed by using 0-padding with three digits. It seems very unlikely that we'd ever need more than 1000 config maps. 