### PR TITLE
Shell unit test fix

### DIFF
--- a/operator-build-maven-plugin/src/main/java/oracle/kubernetes/mojo/shunit2/ShUnit2Mojo.java
+++ b/operator-build-maven-plugin/src/main/java/oracle/kubernetes/mojo/shunit2/ShUnit2Mojo.java
@@ -99,7 +99,7 @@ public class ShUnit2Mojo extends AbstractMojo {
 
   @Override
   public void execute() throws MojoFailureException, MojoExecutionException {
-    if (isEnvironmentNotSupported()) {
+    if (isEnvironmentNotSupported() || isSkipTestsRequested()) {
       return;
     }
     
@@ -110,6 +110,10 @@ public class ShUnit2Mojo extends AbstractMojo {
     if ((totalNumFailures() + totalNumErrors()) != 0) {
       throw new MojoFailureException(String.format("%d failures, %d errors", totalNumFailures(), totalNumErrors()));
     }
+  }
+
+  private boolean isSkipTestsRequested() {
+    return "true".equalsIgnoreCase(System.getProperty("skip.unit.tests"));
   }
 
   private boolean isEnvironmentNotSupported() throws MojoExecutionException {

--- a/operator-build-maven-plugin/src/test/java/oracle/kubernetes/mojo/shunit2/ShUnit2MojoTest.java
+++ b/operator-build-maven-plugin/src/test/java/oracle/kubernetes/mojo/shunit2/ShUnit2MojoTest.java
@@ -51,6 +51,7 @@ public class ShUnit2MojoTest extends MojoTestBase {
 
   private static final String TEST_SCRIPT = "shunit2";
   private static final String OS_NAME_PROPERTY = "os.name";
+  private static final String SKIP_UNIT_TESTS_PROPERTY = "skip.unit.tests";
   private static final String[] INSTALLED_OSX_BASH_VERSION = {
       "GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)",
       "Copyright (C) 2007 Free Software Foundation, Inc."
@@ -89,6 +90,7 @@ public class ShUnit2MojoTest extends MojoTestBase {
     mementos.add(StaticStubSupport.install(ShUnit2Mojo.class, "fileSystem", fileSystem));
     mementos.add(StaticStubSupport.install(ShUnit2Mojo.class, "builderFunction", builderFunction));
     mementos.add(SystemPropertySupport.install(OS_NAME_PROPERTY, "Linux"));
+    mementos.add(SystemPropertySupport.install(SKIP_UNIT_TESTS_PROPERTY, ""));
 
     setMojoParameter("outputDirectory", TEST_CLASSES_DIRECTORY);
     setMojoParameter("sourceDirectory", SOURCE_DIRECTORY);
@@ -170,6 +172,15 @@ public class ShUnit2MojoTest extends MojoTestBase {
     fileSystem.defineFileContents(TEST_CLASSES_DIRECTORY, "");
 
     executeMojo();
+  }
+
+  @Test
+  public void ifSkipUnitTestSet_skipTesting() throws MojoFailureException, MojoExecutionException {
+    System.setProperty(SKIP_UNIT_TESTS_PROPERTY, "true");
+
+    executeMojo();
+
+    assertThat(getInfoLines(), empty());
   }
 
   @Test

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -533,7 +533,7 @@ function restorePrimordialDomain() {
 # $1 the name of the encoded file in the config map
 function restoreEncodedTar() {
   cd / || return 1
-  cat ${OPERATOR_ROOT}/introspector*/${1} > /tmp/domain.secure
+  cat $(ls ${OPERATOR_ROOT}/introspector*/${1} | sort -V) > /tmp/domain.secure || return 1
   base64 -d "/tmp/domain.secure" > /tmp/domain.tar.gz || return 1
 
   tar -xzf /tmp/domain.tar.gz || return 1


### PR DESCRIPTION
This addresses two issues:

1. In some environments, copying values split across multiple volumes was joining the pieces in the wrong order. Setting the LOCALE as part of the copy addresses that.

2. The shunit2 plugin now honors the `skip.unit.tests` property