### PR TITLE
Parameterize the istio version based on environment varaiable

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -259,9 +259,9 @@ public interface TestConstants {
       PROJECT_ROOT + "/../kubernetes/samples/scripts/rest/generate-external-rest-identity.sh";
   public static final String DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME = "weblogic-operator-external-rest-identity";
 
-  // Default ISTIO version is 1.7.6
+  // Default ISTIO version is 1.7.3
   public static final String ISTIO_VERSION = 
-        Optional.ofNullable(System.getenv("ISTIO_VERSION")).orElse("1.7.6");
+        Optional.ofNullable(System.getenv("ISTIO_VERSION")).orElse("1.7.3");
 
   //MySQL database constants
   public static final String MYSQL_VERSION = "5.6";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -259,8 +259,9 @@ public interface TestConstants {
       PROJECT_ROOT + "/../kubernetes/samples/scripts/rest/generate-external-rest-identity.sh";
   public static final String DEFAULT_EXTERNAL_REST_IDENTITY_SECRET_NAME = "weblogic-operator-external-rest-identity";
 
-  // istio constants
-  public static final String ISTIO_VERSION = "1.7.3";
+  // Default ISTIO version is 1.7.6
+  public static final String ISTIO_VERSION = 
+        Optional.ofNullable(System.getenv("ISTIO_VERSION")).orElse("1.7.6");
 
   //MySQL database constants
   public static final String MYSQL_VERSION = "5.6";


### PR DESCRIPTION
Due to recent intermittent Jenkin failures in Istio Usecases, modify the integration test infra to install a given version of ISTIO based on a environment variable ISTIO_VERSION.  The default is v 1.7.3  that matches with Verrazzano usage.

  public static final String ISTIO_VERSION =
        Optional.ofNullable(System.getenv("ISTIO_VERSION")).orElse("1.7.3");

This PR gives a flexibility to run the integration test against a custom version of ISTIO which is being updated frequently.

https://build.weblogick8s.org:8443/job/wko-tmp/138/  ( v1.7.3 ) 
https://build.weblogick8s.org:8443/job/wko-tmp/139/  ( v1.7.6 )

None of the results are clean. We have similar failure in both runs.  
We have the JIRA  OWLS-86461 open to track the intermittent issue