### PR TITLE
OWLS-86552 - Multiple pod restarts during rolling update fix. 

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -94,10 +94,11 @@ public class ManagedServerUpIteratorStep extends Step {
     }
 
     if (!work.isEmpty()) {
-      return doForkJoin(DomainStatusUpdater.createStatusUpdateStep(getNext()), packet, work);
+      return doForkJoin(DomainStatusUpdater.createStatusUpdateStep(
+              new ManagedServerUpAfterStep(getNext())), packet, work);
     }
 
-    return doNext(DomainStatusUpdater.createStatusUpdateStep(getNext()), packet);
+    return doNext(DomainStatusUpdater.createStatusUpdateStep(new ManagedServerUpAfterStep(getNext())), packet);
   }
 
 
@@ -167,7 +168,7 @@ public class ManagedServerUpIteratorStep extends Step {
     public NextAction apply(Packet packet) {
 
       if (startDetailsQueue.isEmpty()) {
-        return doNext(new ManagedServerUpAfterStep(getNext()), packet);
+        return doNext(getNext(), packet);
       } else if (hasServerAvailableToStart(packet.getSpi(DomainPresenceInfo.class))) {
         numStarted.getAndIncrement();
         return doForkJoin(this, packet, Collections.singletonList(startDetailsQueue.poll()));


### PR DESCRIPTION
Fix for multiple pod restarts during rolling update. In a domain with multiple clusters, previously it was launching multiple roll commands (one for each cluster) during rolling update. With this change, the roll command gets launched only once after all managed servers are started. This change executes the ManagedServerUpAfter step after the servers in all the clusters get started instead of executing it after servers start in each cluster . 