### PR TITLE
OWLS-86816 - Fix to generate domain processing event only when there domain updates

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -87,9 +87,9 @@ public class ManagedServersUpStep extends Step {
   }
 
   private static boolean isServiceOnlyServers(List<ServerShutdownInfo> serversToStop) {
-    List<ServerShutdownInfo> list = serversToStop.stream()
+    List<ServerShutdownInfo> nonServiceOnlyServers = serversToStop.stream()
             .filter(ssi -> !ssi.isServiceOnly()).collect(Collectors.toList());
-    return list.isEmpty();
+    return nonServiceOnlyServers.isEmpty();
   }
 
   private static List<ServerShutdownInfo> getServersToStop(

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -218,7 +218,6 @@ public class ManagedServersUpStep extends Step {
         addServerToStart(serverConfig, clusterName, server);
       } else if (shouldPrecreateServerService(server)) {
         preCreateServers.add(serverName);
-
         addShutdownInfo(new ServerShutdownInfo(serverConfig, clusterName, server, true));
       } else {
         addShutdownInfo(new ServerShutdownInfo(serverConfig, clusterName, server, false));


### PR DESCRIPTION
OWLS-86816 - Operator generates domain processing events every time domain presence is rechecked even when there are no domain updates. This happens in cases where cluster's replica count is lower than the max cluster size. In such cases, `serversToStop` list in the `ManagedServersUpStep` contains servers that should not be started. Later in processing, the `ServerDown` step checks if the server pod is null and invokes `DeletePod` step only when the server pod is not null. 

This fix removes the servers that are already stopped (servers with null pod) from `serversToStop` list and it also checks whether server only needs it's service pre-created. In such cases, the domain processing events are not generated.