### PR TITLE
OWLS-86630 - scalingAction.sh needs adjustment in finding latest API version

### DIFF
--- a/src/scripts/scaling/scalingAction.sh
+++ b/src/scripts/scaling/scalingAction.sh
@@ -118,9 +118,8 @@ function get_domain_api_version() {
 # Find domain version
   local domain_api_version
   if [ -x "$(command -v jq)" ]; then
-    local extractVersionCmd="(.groups[] | select (.name == \"weblogic\.oracle\") | .preferredVersion.version)"
-    trace "jq using $extractVersionCmd"
-    domain_api_version=$(echo "${APIS}" | jq "${extractVersionCmd}")
+    local extractVersionCmd="(.groups[] | select (.name == \"weblogic.oracle\") | .preferredVersion.version)"
+    domain_api_version=$(echo "${APIS}" | jq -r "${extractVersionCmd}")
   else
 cat > cmds-$$.py << INPUT
 import sys, json

--- a/src/scripts/scaling/scalingAction.sh
+++ b/src/scripts/scaling/scalingAction.sh
@@ -102,29 +102,33 @@ port=$(echo "${STATUS}" | python cmds-$$.py)
 # Retrieve the api version of the deployed Custom Resource Domain
 function get_domain_api_version() {
   # Retrieve Custom Resource Definition for WebLogic domain
-  local CRD=$(curl \
+  local APIS=$(curl \
     -v \
     --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
     -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
     -X GET \
-    $kubernetes_master/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/domains.weblogic.oracle)
+    $kubernetes_master/apis)
   if [ $? -ne 0 ]
     then
-      trace "Failed to retrieve Custom Resource Definition for WebLogic domain"
-      trace "CRD: $CRD"
+      trace "Failed to retrieve list of APIs from Kubernetes cluster"
+      trace "APIS: $APIS"
       exit 1
   fi
 
 # Find domain version
   local domain_api_version
   if [ -x "$(command -v jq)" ]; then
-    domain_api_version=$(echo "${CRD}" | jq -r '.spec.version')
+    local extractVersionCmd="(.groups[] | select (.name == \"weblogic\.oracle\") | .preferredVersion.version)"
+    trace "jq using $extractVersionCmd"
+    domain_api_version=$(echo "${APIS}" | jq "${extractVersionCmd}")
   else
 cat > cmds-$$.py << INPUT
 import sys, json
-print(json.load(sys.stdin)["spec"]["version"])
+for i in json.load(sys.stdin)["groups"]:
+  if i["name"] == "weblogic.oracle":
+    print(i["preferredVersion"]["version"])
 INPUT
-domain_api_version=`echo ${CRD} | python cmds-$$.py`
+domain_api_version=`echo ${APIS} | python cmds-$$.py`
   fi
   echo "$domain_api_version"
 }
@@ -249,7 +253,7 @@ import sys, json
 for i in json.load(sys.stdin)["items"]:
   j = i["status"]["clusters"]
   for index, cs in enumerate(j):
-    if j[index]["clusterName"] == "$clusterName"
+    if j[index]["clusterName"] == "$clusterName":
       print j[index]["minimumReplicas"]
 INPUT
   minReplicas=`echo ${DOMAIN} | python cmds-$$.py`
@@ -438,15 +442,15 @@ in_cluster_startup=$(is_defined_in_clusters "$DOMAIN")
 current_replica_count=$(get_replica_count "$in_cluster_startup" "$DOMAIN")
 trace "current number of managed servers is $current_replica_count"
 
-# Cleanup cmds-$$.py
-[ -e cmds-$$.py ] && rm cmds-$$.py
-
 # Calculate new managed server count
 new_ms=$(calculate_new_ms_count "$scaling_action" "$current_replica_count" "$scaling_size")
 
 # Verify the requested new managed server count is not less than
 # configured minimum replica count for the cluster
 verify_minimum_ms_count_for_cluster "$new_ms" "$DOMAIN" "$wls_cluster_name"
+
+# Cleanup cmds-$$.py
+[ -e cmds-$$.py ] && rm cmds-$$.py
 
 # Create the scaling request body
 request_body=$(get_request_body "$new_ms")


### PR DESCRIPTION
Update get_domain_api_version in scalingAction.sh to use kubernetes /apis instead of /apis/apiextensions.k8s.io/v1beta1/customresourcedefinites to find the API version for the operator.

Also fixes a missing colon in python script generated for get_min_replicas, and removing it afterwards.

Example of /apis result returned from kubernetes:

```
{
  "kind": "APIGroupList",
  "apiVersion": "v1",
  "groups": [
    {
     ...
    },
    ...
    {
      "name": "weblogic.oracle",
      "versions": [
        {
          "groupVersion": "weblogic.oracle/v8",
          "version": "v8"
        },
        {
          "groupVersion": "weblogic.oracle/v7",
          "version": "v7"
        }
      ],
      "preferredVersion": {
        "groupVersion": "weblogic.oracle/v8",
        "version": "v8"
      }
    }
  ]
}
```

get_domain_api_version would return v8 from `preferredVersion.version` of the group with name weblogic.oracle. 

Jenkins result: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3532/testReport/