### PR TITLE
Owls-86939 - Generate domain processing completed event when scaling up a cluster

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -55,7 +55,7 @@ public class DomainPresenceInfo {
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
 
   private final List<String> validationWarnings = Collections.synchronizedList(new ArrayList<>());
-  private EventItem eventType;
+  private EventItem lastEventItem;
 
   /**
    * Create presence for a domain.
@@ -474,12 +474,12 @@ public class DomainPresenceInfo {
     resetFailureCount();
   }
 
-  public EventItem getEventType() {
-    return eventType;
+  EventItem getLastEventItem() {
+    return lastEventItem;
   }
 
-  public void setEventType(EventItem eventType) {
-    this.eventType = eventType;
+  void setLastEventItem(EventItem lastEventItem) {
+    this.lastEventItem = lastEventItem;
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -54,6 +54,7 @@ public class DomainPresenceInfo {
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
 
   private final List<String> validationWarnings = Collections.synchronizedList(new ArrayList<>());
+  private Enum eventType;
 
   /**
    * Create presence for a domain.
@@ -470,6 +471,14 @@ public class DomainPresenceInfo {
   /** Sets the last completion time to now. */
   public void complete() {
     resetFailureCount();
+  }
+
+  public Enum getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(Enum eventType) {
+    this.eventType = eventType;
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import static java.lang.System.lineSeparator;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem;
 import static oracle.kubernetes.operator.helpers.PodHelper.hasClusterNameOrNull;
 import static oracle.kubernetes.operator.helpers.PodHelper.isNotAdminServer;
 
@@ -54,7 +55,7 @@ public class DomainPresenceInfo {
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
 
   private final List<String> validationWarnings = Collections.synchronizedList(new ArrayList<>());
-  private Enum eventType;
+  private EventItem eventType;
 
   /**
    * Create presence for a domain.
@@ -473,11 +474,11 @@ public class DomainPresenceInfo {
     resetFailureCount();
   }
 
-  public Enum getEventType() {
+  public EventItem getEventType() {
     return eventType;
   }
 
-  public void setEventType(Enum eventType) {
+  public void setEventType(EventItem eventType) {
     this.eventType = eventType;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -100,7 +100,7 @@ public class EventHelper {
 
       LOGGER.fine(MessageKeys.CREATING_EVENT, eventData.eventItem);
 
-      Optional.ofNullable(info).ifPresent(dpi -> dpi.setEventType(eventData.eventItem));
+      Optional.ofNullable(info).ifPresent(dpi -> dpi.setLastEventItem(eventData.eventItem));
 
       V1Event event = createEvent(packet, eventData);
       return doNext(new CallBuilder()
@@ -113,11 +113,11 @@ public class EventHelper {
 
     private boolean isDuplicatedStartedEvent(DomainPresenceInfo info) {
       return eventData.eventItem == EventItem.DOMAIN_PROCESSING_STARTING
-          && Optional.ofNullable(info).map(dpi -> dpi.getEventType() == DOMAIN_PROCESSING_STARTING).orElse(false);
+          && Optional.ofNullable(info).map(dpi -> dpi.getLastEventItem() == DOMAIN_PROCESSING_STARTING).orElse(false);
     }
 
     private boolean hasProcessingNotStarted(DomainPresenceInfo info) {
-      return Optional.ofNullable(info).map(dpi -> dpi.getEventType() != DOMAIN_PROCESSING_STARTING).orElse(false);
+      return Optional.ofNullable(info).map(dpi -> dpi.getLastEventItem() != DOMAIN_PROCESSING_STARTING).orElse(false);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -112,8 +112,8 @@ public class EventHelper {
     }
 
     private boolean isDuplicatedStartedEvent(DomainPresenceInfo info) {
-      return Optional.ofNullable(info).map(dpi -> dpi.getEventType() == DOMAIN_PROCESSING_STARTING).orElse(false)
-              && eventData.eventItem == EventItem.DOMAIN_PROCESSING_STARTING;
+      return eventData.eventItem == EventItem.DOMAIN_PROCESSING_STARTING
+          && Optional.ofNullable(info).map(dpi -> dpi.getEventType() == DOMAIN_PROCESSING_STARTING).orElse(false);
     }
 
     private boolean hasProcessingNotStarted(DomainPresenceInfo info) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -12,7 +12,6 @@ import io.kubernetes.client.openapi.models.V1ObjectReference;
 import oracle.kubernetes.operator.EventConstants;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
-import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
@@ -91,17 +90,16 @@ public class EventHelper {
     @Override
     public NextAction apply(Packet packet) {
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
-      if (hasProcessingNotStarted(packet, info) && (eventData.eventItem == DOMAIN_PROCESSING_COMPLETED)) {
+      if (hasProcessingNotStarted(info) && (eventData.eventItem == DOMAIN_PROCESSING_COMPLETED)) {
         return doNext(packet);
       }
 
-      if (isDuplicatedStartedEvent(packet)) {
+      if (isDuplicatedStartedEvent(info)) {
         return doNext(packet);
       }
 
       LOGGER.fine(MessageKeys.CREATING_EVENT, eventData.eventItem);
 
-      packet.put(ProcessingConstants.EVENT_TYPE, eventData.eventItem);
       Optional.ofNullable(info).ifPresent(dpi -> dpi.setEventType(eventData.eventItem));
 
       V1Event event = createEvent(packet, eventData);
@@ -113,19 +111,14 @@ public class EventHelper {
           packet);
     }
 
-    private boolean isDuplicatedStartedEvent(Packet packet) {
-      return eventData.eventItem == EventItem.DOMAIN_PROCESSING_STARTING
-          && packet.get(ProcessingConstants.EVENT_TYPE) == EventItem.DOMAIN_PROCESSING_STARTING;
+    private boolean isDuplicatedStartedEvent(DomainPresenceInfo info) {
+      return Optional.ofNullable(info).map(dpi -> dpi.getEventType() == DOMAIN_PROCESSING_STARTING).orElse(false)
+              && eventData.eventItem == EventItem.DOMAIN_PROCESSING_STARTING;
     }
 
-    private boolean hasProcessingNotStarted(Packet packet, DomainPresenceInfo info) {
-      boolean startedEventNotFound = packet.get(ProcessingConstants.EVENT_TYPE) != DOMAIN_PROCESSING_STARTING;
-      if ((startedEventNotFound) && (info != null)) {
-        startedEventNotFound = info.getEventType() != DOMAIN_PROCESSING_STARTING;
-      }
-      return startedEventNotFound;
+    private boolean hasProcessingNotStarted(DomainPresenceInfo info) {
+      return Optional.ofNullable(info).map(dpi -> dpi.getEventType() != DOMAIN_PROCESSING_STARTING).orElse(false);
     }
-
   }
 
   private static V1Event createEvent(

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -447,10 +447,11 @@ public class DomainProcessorTest {
 
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
 
+    // Scale up the cluster and execute the make right flow again with explicit recheck
     domainConfigurator.configureCluster(CLUSTER).withReplicas(3);
     newDomain.getMetadata().setCreationTimestamp(new DateTime());
     long timestamp = System.currentTimeMillis();
-    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain.withMetadata(newDomain.getMetadata())))
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_COMPLETED_EVENT",
             containsEvent(getEventsAfterTimestamp(timestamp), DOMAIN_PROCESSING_COMPLETED_EVENT), is(true));

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -59,6 +59,7 @@ import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
+import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -435,6 +436,30 @@ public class DomainProcessorTest {
     return Optional.ofNullable(events).get()
             .stream()
             .filter(e -> reason.equals(e.getReason())).findFirst().orElse(null) == null;
+  }
+
+  @Test
+  public void whenScalingUpDomain_domainProcessingCompletedEventsGenerated()
+          throws JsonProcessingException {
+    establishPreviousIntrospection(null, Arrays.asList(1, 2));
+
+    domainConfigurator.configureCluster(CLUSTER).withReplicas(2);
+
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
+
+    domainConfigurator.configureCluster(CLUSTER).withReplicas(3);
+    newDomain.getMetadata().setCreationTimestamp(new DateTime());
+    long timestamp = System.currentTimeMillis();
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain.withMetadata(newDomain.getMetadata())))
+            .withExplicitRecheck().execute();
+    assertThat("Event DOMAIN_PROCESSING_COMPLETED_EVENT",
+            containsEvent(getEventsAfterTimestamp(timestamp), DOMAIN_PROCESSING_COMPLETED_EVENT), is(true));
+  }
+
+  private static boolean containsEvent(List<V1Event> events, String reason) {
+    return Optional.ofNullable(events).get()
+            .stream()
+            .filter(e -> reason.equals(e.getReason())).findFirst().orElse(null) != null;
   }
 
   @Test


### PR DESCRIPTION
OWLS-86939 - The domain processing completed event is not generated during a scale up operation. This is because event type in the packet is not `domain processing starting` . The domain processing started event is generated during managed server pod creation which happens in a child fiber and packet in the child fiber is different from packet in the parent fiber. In ManagedServerIteratorUpStep, the packet is cloned and passed to each child fiber with additional info such as SERVER_NAME, SCAN etc.. Hence the `domain processing started` event type in not set in the parent packet. 

This proposed fix stores the event type/item in DomainPresenceInfo instead of storing it in the packet. I have added a unit test which reproduces the issue. Integration test results are at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3571/