### PR TITLE
OWLS-87041 - Fix to start namespaces when namespaces are listed in multiple chunks

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
@@ -136,7 +136,7 @@ class DomainRecheck {
 
   private class NamespaceListResponseStep extends DefaultResponseStep<V1NamespaceList> {
 
-    private List<String> namespacesToStart = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> namespacesToStart = Collections.synchronizedList(new ArrayList<>());
 
     private NamespaceListResponseStep() {
       super(new Namespaces.NamespaceListAfterStep(domainNamespaces));
@@ -164,11 +164,11 @@ class DomainRecheck {
       return doContinueListOrNext(callResponse, packet, createNextSteps(domainNamespaces));
     }
 
-    private Step createNextSteps(Set<String> namespacesToStartNow) {
+    private Step createNextSteps(Set<String> currentBatchOfNamespacesToStart) {
       List<Step> nextSteps = new ArrayList<>();
-      if (!namespacesToStartNow.isEmpty()) {
-        namespacesToStart.addAll(namespacesToStartNow);
-      }
+
+      // Add current batch of namespaces to start to the bigger list
+      namespacesToStart.addAll(currentBatchOfNamespacesToStart);
       if (!namespacesToStart.isEmpty()) {
         nextSteps.add(createStartNamespacesStep(namespacesToStart));
         if (Namespaces.getConfiguredDomainNamespaces() == null) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
@@ -136,6 +136,8 @@ class DomainRecheck {
 
   private class NamespaceListResponseStep extends DefaultResponseStep<V1NamespaceList> {
 
+    private List<String> namespacesToStart = Collections.synchronizedList(new ArrayList<>());
+
     private NamespaceListResponseStep() {
       super(new Namespaces.NamespaceListAfterStep(domainNamespaces));
     }
@@ -165,10 +167,13 @@ class DomainRecheck {
     private Step createNextSteps(Set<String> namespacesToStartNow) {
       List<Step> nextSteps = new ArrayList<>();
       if (!namespacesToStartNow.isEmpty()) {
-        nextSteps.add(createStartNamespacesStep(namespacesToStartNow));
+        namespacesToStart.addAll(namespacesToStartNow);
+      }
+      if (!namespacesToStart.isEmpty()) {
+        nextSteps.add(createStartNamespacesStep(namespacesToStart));
         if (Namespaces.getConfiguredDomainNamespaces() == null) {
           nextSteps.add(
-                RunInParallel.perNamespace(namespacesToStartNow, DomainRecheck.this::createNamespaceReview));
+                RunInParallel.perNamespace(namespacesToStart, DomainRecheck.this::createNamespaceReview));
         }
       }
       nextSteps.add(getNext());

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
@@ -166,8 +166,6 @@ class DomainRecheck {
 
     private Step createNextSteps(Set<String> currentBatchOfNamespacesToStart) {
       List<Step> nextSteps = new ArrayList<>();
-
-      // Add current batch of namespaces to start to the bigger list
       namespacesToStart.addAll(currentBatchOfNamespacesToStart);
       if (!namespacesToStart.isEmpty()) {
         nextSteps.add(createStartNamespacesStep(namespacesToStart));

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -440,8 +440,8 @@ public class MainTest extends ThreadFactoryTestBase {
 
     testSupport.runSteps(createDomainRecheck().readExistingNamespaces());
 
-    assertThat(getStartingNamespaces("NS1", "NS"+MULTICHUNK_LAST_NAMESPACE_NUM),
-            contains("NS1", "NS"+MULTICHUNK_LAST_NAMESPACE_NUM));
+    assertThat(getStartingNamespaces("NS1", "NS" + MULTICHUNK_LAST_NAMESPACE_NUM),
+            contains("NS1", "NS" + MULTICHUNK_LAST_NAMESPACE_NUM));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -335,6 +335,10 @@ public class MainTest extends ThreadFactoryTestBase {
     return Arrays.stream(NAMESPACES).filter(domainNamespaces::isStarting).collect(Collectors.toList());
   }
 
+  private List<String> getStartingNamespaces(String...namespaces) {
+    return Arrays.stream(namespaces).filter(domainNamespaces::isStarting).collect(Collectors.toList());
+  }
+
   @NotNull
   DomainRecheck createDomainRecheck() {
     return new DomainRecheck(delegate);
@@ -423,6 +427,21 @@ public class MainTest extends ThreadFactoryTestBase {
 
   private void defineSelectionStrategy(SelectionStrategy selectionStrategy) {
     TuningParameters.getInstance().put(Namespaces.SELECTION_STRATEGY_KEY, selectionStrategy.toString());
+  }
+
+  @Test
+  public void whenNamespacesListedInMultipleChunks_allNamespacesStarted() {
+    loggerControl.withLogLevel(Level.WARNING).collectLogMessages(logRecords, MessageKeys.NAMESPACE_IS_MISSING);
+
+    defineSelectionStrategy(SelectionStrategy.List);
+    String namespaceString = "NS1,NS" + MULTICHUNK_LAST_NAMESPACE_NUM;
+    HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
+    createNamespaces(MULTICHUNK_LAST_NAMESPACE_NUM);
+
+    testSupport.runSteps(createDomainRecheck().readExistingNamespaces());
+
+    assertThat(getStartingNamespaces("NS1", "NS"+MULTICHUNK_LAST_NAMESPACE_NUM),
+            contains("NS1", "NS"+MULTICHUNK_LAST_NAMESPACE_NUM));
   }
 
   @Test
@@ -596,7 +615,7 @@ public class MainTest extends ThreadFactoryTestBase {
   @Test
   public void withNamespaceList_onReadExistingNamespaces_whenConfiguredDomainNamespaceMissing_noEventCreated() {
     defineSelectionStrategy(SelectionStrategy.List);
-    String namespaceString = "NS1,NS" + LAST_NAMESPACE_NUM;
+    String namespaceString = "NS" + LAST_NAMESPACE_NUM + ",NS" + DEFAULT_CALL_LIMIT;
     HelmAccessStub.defineVariable(HelmAccess.OPERATOR_DOMAIN_NAMESPACES, namespaceString);
     createNamespaces(LAST_NAMESPACE_NUM - 1);
 


### PR DESCRIPTION
OWLS-87041 - OKD (Openshift) creates a large number of namespaces and domain is not started when namespaces are listed in multiple chunks. This is caused because the last chunk of namespaces (partial list) overwrites any previous chunks and only namespaces contained in the last chunk are started if they also happen to be part of the operator's target namespaces. 

This change collects the namespaces returned in all chunks in a bigger list so that all namespaces are started. Integration test link - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3595/ . There's a single test failure which is unrelated to this change.