### PR TITLE
Fixed monitoring exporter web app build failure

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporter.java
@@ -1256,7 +1256,7 @@ class ItMonitoringExporter {
 
   private static void buildMonitoringExporterApp(String configFile, String appDir) {
 
-    String command = String.format("cd %s && mvn install -Dmaven.test.skip=true -Dconfiguration=%s/exporter/%s",
+    String command = String.format("cd %s && mvn clean install -Dmaven.test.skip=true -Dconfiguration=%s/exporter/%s",
         monitoringExporterSrcDir,
         RESOURCE_DIR,
         configFile);


### PR DESCRIPTION
 If integration test runs against other then master branch from monitoring exporter GitHub project, instead of using prebuilt war file it builds web application. Due creation two different web apps for monitoring exporter, second build fails due existed build artifacts. Fixed by adding mvn clean. 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3729/ 