### PR TITLE
Update all references to use ghcr.io for container images

### DIFF
--- a/buildDockerImage.sh
+++ b/buildDockerImage.sh
@@ -33,7 +33,7 @@ while getopts "t:" optname; do
   esac
 done
 
-IMAGE_NAME=${name:-oracle/weblogic-kubernetes-operator:3.1.1}
+IMAGE_NAME=${name:-ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1}
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 
 # Proxy settings

--- a/docs-source/content/faq/namespace-management.md
+++ b/docs-source/content/faq/namespace-management.md
@@ -43,7 +43,7 @@ elkIntegrationEnabled: false
 externalDebugHttpPort: 30999
 externalRestEnabled: false
 externalRestHttpsPort: 31001
-image: oracle/weblogic-kubernetes-operator:3.1.1
+image: ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1
 imagePullPolicy: IfNotPresent
 internalDebugHttpPort: 30999
 istioEnabled: false

--- a/docs-source/content/quickstart/get-images.md
+++ b/docs-source/content/quickstart/get-images.md
@@ -19,7 +19,7 @@ and accept the license agreement for the [WebLogic Server image](https://hub.doc
 1. Pull the operator image:
 
     ```bash
-    $ docker pull oracle/weblogic-kubernetes-operator:3.1.1
+    $ docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1
     ```
 
 1. Pull the Traefik ingress controller image:

--- a/docs-source/content/quickstart/install.md
+++ b/docs-source/content/quickstart/install.md
@@ -51,7 +51,7 @@ $ helm install traefik-operator traefik/traefik \
     ```bash
     $ helm install sample-weblogic-operator kubernetes/charts/weblogic-operator \
       --namespace sample-weblogic-operator-ns \
-      --set image=oracle/weblogic-kubernetes-operator:3.1.1 \
+      --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1 \
       --set serviceAccount=sample-weblogic-operator-sa \
       --set "enableClusterRoleBinding=true" \
       --set "domainNamespaceSelectionStrategy=LabelSelector" \

--- a/docs-source/content/userguide/introduction/architecture.md
+++ b/docs-source/content/userguide/introduction/architecture.md
@@ -18,7 +18,7 @@ The operator is packaged in a [Docker image](https://hub.docker.com/r/oracle/web
 
 ```
 $ docker login
-$ docker pull oracle/weblogic-kubernetes-operator:3.1.1
+$ docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1
 ```
 
 For more details on acquiring the operator image and prerequisites for installing the operator, consult the [Quick Start guide]({{< relref "/quickstart/_index.md" >}}).

--- a/docs-source/content/userguide/managing-domains/domain-lifecycle/restarting.md
+++ b/docs-source/content/userguide/managing-domains/domain-lifecycle/restarting.md
@@ -188,7 +188,7 @@ d. Update the `image` field of the Domain YAML file, specifying the new image na
      ```
      domain:
        spec:
-         image: oracle/weblogic-updated:3.1.1
+         image: ghcr.io/oracle/weblogic-updated:3.1.1
      ```
 e. The operator will now initiate a rolling restart, which will apply the updated image, for all the servers in the domain.
 

--- a/docs-source/content/userguide/managing-operators/installation/_index.md
+++ b/docs-source/content/userguide/managing-operators/installation/_index.md
@@ -117,7 +117,7 @@ the `helm upgrade` command requires that you supply a new Helm chart and image. 
 ```
 $ helm upgrade \
   --reuse-values \
-  --set image=oracle/weblogic-kubernetes-operator:3.1.1 \
+  --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1 \
   --namespace weblogic-operator-namespace \
   --wait \
   weblogic-operator \

--- a/docs-source/content/userguide/managing-operators/using-the-operator/using-helm.md
+++ b/docs-source/content/userguide/managing-operators/using-the-operator/using-helm.md
@@ -100,11 +100,11 @@ javaLoggingLevel:  "FINE"
 ##### `image`
 Specifies the Docker image containing the operator code.
 
-Defaults to `oracle/weblogic-kubernetes-operator:3.1.1`.
+Defaults to `ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1`.
 
 Example:
 ```
-image:  "oracle/weblogic-kubernetes-operator:some-tag"
+image:  "ghcr.io/oracle/weblogic-kubernetes-operator:some-tag"
 ```
 
 ##### `imagePullPolicy`

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -63,7 +63,7 @@ domainNamespaces:
 enableClusterRoleBinding: false
 
 # image specifies the Docker image containing the operator.
-image: "oracle/weblogic-kubernetes-operator:3.1.1"
+image: "ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1"
 
 # imagePullPolicy specifies the image pull policy for the operator's Docker image.
 imagePullPolicy: IfNotPresent

--- a/kubernetes/hands-on-lab/tutorials/install.operator.ocishell.md
+++ b/kubernetes/hands-on-lab/tutorials/install.operator.ocishell.md
@@ -78,7 +78,7 @@ Execute the following `helm install`:
 helm install sample-weblogic-operator \
   kubernetes/charts/weblogic-operator \
   --namespace sample-weblogic-operator-ns \
-  --set "image=oracle/weblogic-kubernetes-operator:3.1.1" \
+  --set "image=ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1" \
   --set "serviceAccount=sample-weblogic-operator-sa" \
   --set "enableClusterRoleBinding=true" \
   --set "domainNamespaceSelectionStrategy=LabelSelector" \


### PR DESCRIPTION
Docker has removed the "oracle" repo. Therefore, you can no longer `docker pull oracle/weblogic-kubernetes-operator:3.1.1`. Thankfully, we have already pushed this image to ghcr.io and the Oracle Container Registry. This change updates the documentation and samples to pull as follows: `docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.1.1`.