### PR TITLE
OWLS87181 add doc note and log message for 403 error on creating NamespaceWatchingStopped event

### DIFF
--- a/docs-source/content/userguide/managing-domains/domain-events.md
+++ b/docs-source/content/userguide/managing-domains/domain-events.md
@@ -20,7 +20,7 @@ This document describes Kubernetes events that the operator generates about reso
 
 #### Operator-generated event types
 
-The operator generates these event types, which indicate the following:
+The operator generates these event types in a domain namespace, which indicate the following:
 
  *  `DomainCreated`: A new domain is created.
  *  `DomainChanged`: A change has been made to an existing domain.
@@ -29,14 +29,14 @@ The operator generates these event types, which indicate the following:
  *  `DomainProcessingFailed`: The operator has encountered a problem while it was processing the domain resource. The failure either could be a configuration error or a Kubernetes API error.
  *  `DomainProcessingRetrying`: The operator is going to retry the processing of a domain after it encountered an failure.
  *  `DomainProcessingCompleted`:  The operator successfully completed the processing of a domain resource.
- *  `DomainProcessingAborted`:  The operator stopped processing a domain when the operator encountered a fatal error or a failure that persisted after the specified maximum number of retries.
+ *  `DomainProcessingAborted`:  The operator stopped processing a domain when the operator encountered a fatal error, or a failure that persisted after the specified maximum number of retries.
  *  `DomainValidationError`:  A validation error or warning is found in a domain resource. Please refer to the event message for details.
  *  `NamespaceWatchingStarted`: The operator has started watching for domains in a namespace.
- *  `NamespaceWatchingStopped`: The operator has stopped watching for domains in a namespace.
+ *  `NamespaceWatchingStopped`: The operator has stopped watching for domains in a namespace. Note that the creation of this event in a domain namespace is the operator's best effort only; the event will not be generated if the required Kubernetes privilege is removed when a namespace is no longer managed by the operator.
 
 #### Operator-generated event details
 
-Each operator-generated event contains the following fields:
+Each operator-generated event in a domain namespace contains the following fields:
  *  `metadata`
     *  `namespace`:  Same as the domain resource namespace.
     *  `labels`:   `weblogic.createdByOperator=true` and, for a domain event, `weblogic.domainUID=<domainUID>`.

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/UnrecoverableErrorBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/UnrecoverableErrorBuilder.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator.calls;
 
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1Event;
 import oracle.kubernetes.operator.calls.unprocessable.UnrecoverableErrorBuilderImpl;
 
 public class UnrecoverableErrorBuilder {
@@ -28,12 +29,20 @@ public class UnrecoverableErrorBuilder {
     return callResponse.isFailure() && isNotFound(callResponse.getE());
   }
 
+  public static boolean isUnauthorizedFailure(CallResponse<V1Event> callResponse) {
+    return callResponse.isFailure() && isUnauthorized(callResponse.getE());
+  }
+
   private static boolean isUnrecoverable(ApiException e) {
     return UnrecoverableErrorBuilderImpl.isUnrecoverable(e);
   }
 
   private static boolean isNotFound(ApiException e) {
     return UnrecoverableErrorBuilderImpl.isNotFound(e);
+  }
+
+  private static boolean isUnauthorized(ApiException e) {
+    return UnrecoverableErrorBuilderImpl.isUnauthorized(e);
   }
 
   /**
@@ -54,4 +63,5 @@ public class UnrecoverableErrorBuilder {
     ApiException apiException = callResponse.getE();
     return new FailureStatusSourceException(fromFailedCall(callResponse), apiException);
   }
+
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/unprocessable/UnrecoverableErrorBuilderImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/unprocessable/UnrecoverableErrorBuilderImpl.java
@@ -69,6 +69,10 @@ public class UnrecoverableErrorBuilderImpl implements FailureStatusSource {
     return code == 404 || code == 410;
   }
 
+  public static boolean isUnauthorized(ApiException e) {
+    return e.getCode() == 403;
+  }
+
   /**
    * Create unrecoverable error builder.
    */

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -132,6 +132,7 @@ public class MessageKeys {
   public static final String POD_FORCE_DELETED = "WLSKO-0179";
   public static final String CREATING_EVENT = "WLSKO-0180";
   public static final String REPLACING_EVENT = "WLSKO-0181";
+  public static final String CREATING_EVENT_UNAUTHORIZED = "WLSKO-0182";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -128,8 +128,9 @@ WLSKO-0176=Job {1} in namespace {0} failed, job details are {2}
 WLSKO-0177=Pod {0} in namespace {1} failed, the pod status is {2}
 WLSKO-0178=Operator cannot proceed, as the Custom Resource Definition for ''domains.weblogic.oracle'' is not installed.
 WLSKO-0179=Pod {0} in namespace {1} detected as stuck, and force-deleted
-WLSKO-0180=Creating event: {0}
-WLSKO-0181=Replacing event: {0}
+WLSKO-0180=Creating event {0}
+WLSKO-0181=Replacing event {0}
+WLSKO-0182=Cannot create event {0} in namespace {1} due to an authorization error
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -4,10 +4,13 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -71,6 +74,8 @@ import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_PR
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.NAMESPACE_WATCHING_STARTED;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.NAMESPACE_WATCHING_STOPPED;
 import static oracle.kubernetes.operator.helpers.EventHelper.createEventStep;
+import static oracle.kubernetes.operator.logging.MessageKeys.CREATING_EVENT_UNAUTHORIZED;
+import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -91,6 +96,8 @@ public class EventHelperTest {
   private final MakeRightDomainOperation makeRightOperation
       = processor.createMakeRightOperation(info);
   private final String jobPodName = LegalNames.toJobIntrospectorName(UID);
+  private final TestUtils.ConsoleHandlerMemento loggerControl = TestUtils.silenceOperatorLogger();
+  private final Collection<LogRecord> logRecords = new ArrayList<>();
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -546,8 +553,7 @@ public class EventHelperTest {
 
   @Test
   public void whenCreateEventStepCalledWithNSWatchStoppedEvent_eventCreatedWithExpectedLabels() {
-    testSupport.runSteps(createEventStep(
-        new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
 
     Map<String, String> expectedLabels = new HashMap<>();
     expectedLabels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
@@ -558,8 +564,7 @@ public class EventHelperTest {
 
   @Test
   public void whenNSWatchStoppedEventCreated_eventCreatedWithExpectedInvolvedObject() {
-    testSupport.runSteps(createEventStep(
-        new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
 
     assertThat("Found NAMESPACE_WATCHING_STOPPED event with expected involvedObject",
         containsEventWithInvolvedObject(getEvents(testSupport),
@@ -569,8 +574,7 @@ public class EventHelperTest {
 
   @Test
   public void whenNSWatchStoppedEventCreated_fail404OnReplace_eventCreatedWithExpectedCount() {
-    testSupport.runSteps(createEventStep(
-        new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
     dispatchAddedEventWatches();
 
     V1Event event = EventTestUtils.getEventWithReason(getEvents(testSupport), NAMESPACE_WATCHING_STOPPED_EVENT);
@@ -586,8 +590,7 @@ public class EventHelperTest {
 
   @Test
   public void whenNSWatchStoppedEventCreatedTwice_fail403OnReplace_eventCreatedOnce() {
-    Step eventStep = createEventStep(
-        new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS));
+    Step eventStep = createEventStep(new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS));
 
     testSupport.runSteps(eventStep);
     dispatchAddedEventWatches();
@@ -600,6 +603,16 @@ public class EventHelperTest {
     assertThat("Found 1 NAMESPACE_WATCHING_STOPPED events",
         getNumberOfEvents(getEvents(testSupport),
             NAMESPACE_WATCHING_STOPPED_EVENT), equalTo(1));
+  }
+
+  @Test
+  public void whenNSWatchStoppedEventCreated_fail403OnCreate_foundExpectedLogMessage() {
+    loggerControl.withLogLevel(Level.INFO).collectLogMessages(logRecords, CREATING_EVENT_UNAUTHORIZED);
+    testSupport.failOnCreate(KubernetesTestSupport.EVENT, null, NS, 403);
+
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STOPPED).namespace(NS).resourceName(NS)));
+
+    assertThat(logRecords, containsInfo(CREATING_EVENT_UNAUTHORIZED, NAMESPACE_WATCHING_STOPPED_EVENT, NS));
   }
 
   private void dispatchAddedEventWatches() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -526,8 +526,8 @@ public class KubernetesTestSupport extends FiberTestSupport {
     boolean matches(String resourceType, RequestParams requestParams, Operation operation) {
       return this.resourceType.equals(resourceType)
           && (this.operation == null || this.operation == operation)
-          && Objects.equals(name, operation.getName(requestParams))
-          && Objects.equals(namespace, requestParams.namespace);
+          && (name == null || Objects.equals(name, operation.getName(requestParams)))
+          && (namespace == null || Objects.equals(namespace, requestParams.namespace));
     }
 
     HttpErrorException getException() {


### PR DESCRIPTION
Add a note in the documentation for the possible authorization error on creating NamespaceWatchingStopped event.
Add a log message when the operator hits a 403 error on creating NamespaceWatchingStopped event.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3760/