### PR TITLE
OWLS-86750 - remove dependency on org.apache.commons.io from application_deployment.py

### DIFF
--- a/integration-tests/src/test/resources/python-scripts/application_deployment.py
+++ b/integration-tests/src/test/resources/python-scripts/application_deployment.py
@@ -6,8 +6,10 @@ import os
 import traceback
 
 from java.util import Base64
-from org.apache.commons.io import FileUtils
+from java.nio.file import Files
+from java.nio.file import Path
 from java.io import File
+from java.io import FileOutputStream
 
 script_name = 'application_deployment.py'
 print 'script_name: ' + script_name
@@ -35,9 +37,10 @@ def usage():
 def decode_archive():
   try:
     print 'decoding archive...'
-    encoded_archive_bytes = FileUtils.readFileToByteArray(File(node_archive_path))
+    encoded_archive_bytes = Files.readAllBytes(File(node_archive_path).toPath())
     decoded_archive_bytes = Base64.getMimeDecoder().decode(encoded_archive_bytes)
-    FileUtils.writeByteArrayToFile(File(archive_name), decoded_archive_bytes)
+    fos = FileOutputStream(File(archive_name))
+    fos.write(decoded_archive_bytes)
     print 'successfully decoded archive'
   except:
     print 'Decoding application archive failed'


### PR DESCRIPTION
Updated application_deployment.py test script to remove its usage of methods from Apache Commons IO package, which is causing InvalidJarIndexException when using linux-8-slim images. 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3840/

Testing ItIntrospectVersion with change and with test modified to use deployUsingWlst instead of deployUsingRest:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3837/testReport/oracle.weblogic.kubernetes/ItIntrospectVersion/ 