### PR TITLE
Fix test for useNonPriviledgedPorts

### DIFF
--- a/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
 {{- if or (not (.Values.persistentVolumeClaimName)) (.Values.virtualHostName) }}
         env:
 {{- end }}
-{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+{{- if .Values.useNonPriviledgedPorts }}
           - name: NonPriviledgedPorts
             value: "true"
 {{- end }}
@@ -82,7 +82,7 @@ spec:
 {{- end }}
         readinessProbe:
           tcpSocket:
-{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+{{- if .Values.useNonPriviledgedPorts }}
             port: 8080
 {{- else }}
             port: 80
@@ -94,7 +94,7 @@ spec:
           timeoutSeconds: 2
         livenessProbe:
           tcpSocket:
-{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+{{- if .Values.useNonPriviledgedPorts }}
             port: 8080
 {{- else }}
             port: 80

--- a/kubernetes/samples/charts/apache-webtier/templates/service.yaml
+++ b/kubernetes/samples/charts/apache-webtier/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app: {{ template "apache.fullname" . }}
   ports:
-{{- if ( .Values.useNonPriviledgedPorts ) and eq .Values.useNonPriviledgedPorts "true"}}
+{{- if .Values.useNonPriviledgedPorts }}
     - port: 8080
 {{- else}}
     - port: 80

--- a/kubernetes/samples/charts/apache-webtier/values.yaml
+++ b/kubernetes/samples/charts/apache-webtier/values.yaml
@@ -53,7 +53,7 @@ customCert:
 customKey:
 
 # Unique ID identifying a domain.
-# This ID must not contain an underscope ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.
+# This ID must not contain an underscore ("_"), and must be lowercase and unique across all domains in a Kubernetes cluster.
 domainUID: "domain1"
 
 # Cluster name
@@ -74,5 +74,6 @@ managedServerPort: 8001
 # where 'myhost' is the IP of the machine that runs the Apache web tier, and 
 #       'myport' is the port that the Apache web tier is publicly exposed to.
 location: "/weblogic"
+
 # Use non privileged port 8080 to listen. If set to false, default privileged port 80 will be used.
 useNonPriviledgedPorts: false


### PR DESCRIPTION
The apache-webtier chart was using an unnecessarily complex test for a Boolean value. This test stopped working at Helm version 3.5.0, because that version interpreted the statement as a function call. Replacing the test with a simpler expression resolved the issue.