### PR TITLE
OWLS71169 - Added methods to add existing PDB info to DomainPresenceInfo during domain recheck.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -14,7 +14,10 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceList;
+import io.kubernetes.client.openapi.models.V1beta1PodDisruptionBudget;
+import io.kubernetes.client.openapi.models.V1beta1PodDisruptionBudgetList;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.PodDisruptionBudgetHelper;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.work.Packet;
@@ -46,6 +49,11 @@ class DomainResourcesValidation {
       @Override
       Consumer<V1ServiceList> getServiceListProcessing() {
         return l -> addServiceList(l);
+      }
+
+      @Override
+      Consumer<V1beta1PodDisruptionBudgetList> getPodDisruptionBudgetListProcessing() {
+        return l -> addPodDisruptionBudgetList(l);
       }
 
       @Override
@@ -86,6 +94,17 @@ class DomainResourcesValidation {
     String domainUid = ServiceHelper.getServiceDomainUid(service);
     if (domainUid != null) {
       ServiceHelper.addToPresence(getDomainPresenceInfo(domainUid), service);
+    }
+  }
+
+  private void addPodDisruptionBudgetList(V1beta1PodDisruptionBudgetList list) {
+    list.getItems().forEach(this::addPodDisruptionBudget);
+  }
+
+  private void addPodDisruptionBudget(V1beta1PodDisruptionBudget pdb) {
+    String domainUid = PodDisruptionBudgetHelper.getDomainUid(pdb);
+    if (domainUid != null) {
+      PodDisruptionBudgetHelper.addToPresence(getDomainPresenceInfo(domainUid), pdb);
     }
   }
 


### PR DESCRIPTION
Added methods to add existing PDB info to DomainPresenceInfo during domain recheck. This is to avoid the conflict messages generated during PDB creation.