### PR TITLE
Skip WebLogic console test in slim images

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -649,8 +649,9 @@ public class ItIntrospectVersion {
    * a. Creates new WebLogic credentials using WLST.
    * b. Creates new Kubernetes secret for WebLogic credentials.
    * c. Patch the Domain Resource with new credentials, restartVerion and introspectVersion.
-   * d. Verifies the servers in the domain restarted and accessing the admin server console with new password works.
-   * e. Verifies the the admin server console access with old credentials fail.
+   * d. Verifies the servers in the domain are restarted .
+   * e. Make a REST api call to access management console using new password.
+   * f. Make a REST api call to access management console using old password.
    */
   @Order(3)
   @Test

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.opentest4j.AssertionFailedError;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -91,7 +90,6 @@ import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallNginx;
 import static oracle.weblogic.kubernetes.actions.impl.Domain.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.impl.Pod.getPod;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChanged;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
 import static oracle.weblogic.kubernetes.utils.CommonPatchTestUtils.patchDomainResource;
@@ -115,6 +113,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getPodsWithTimeSt
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyNginx;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.setPodAntiAffinity;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.verifyCredentials;
 import static oracle.weblogic.kubernetes.utils.DeployUtil.deployUsingRest;
 import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
 import static oracle.weblogic.kubernetes.utils.TestUtils.verifyServerCommunication;
@@ -126,7 +125,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -224,7 +222,7 @@ public class ItIntrospectVersion {
     final String adminServerName = "admin-server";
     final String adminServerPodName = domainUid + "-" + adminServerName;
 
-    final String managedServerNameBase = "ms-";
+    final String managedServerNameBase = "managed-server";
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
     final int managedServerPort = 8001;
 
@@ -533,11 +531,19 @@ public class ItIntrospectVersion {
     final String adminServerName = "admin-server";
     final String adminServerPodName = domainUid + "-" + adminServerName;
 
-    final String managedServerNameBase = "ms-";
+    final String managedServerNameBase = "managed-server";
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
 
     final int replicaCount = 3;
     final int newAdminPort = 7005;
+
+    checkServiceExists(adminServerPodName, introDomainNamespace);
+    checkPodReady(adminServerPodName, domainUid, introDomainNamespace);
+    // verify managed server services created
+    for (int i = 1; i <= replicaCount; i++) {
+      checkServiceExists(managedServerPodNamePrefix + i, introDomainNamespace);
+      checkPodReady(managedServerPodNamePrefix + i, domainUid, introDomainNamespace);
+    }
 
     // get the pod creation time stamps
     LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
@@ -654,7 +660,7 @@ public class ItIntrospectVersion {
     final String adminServerName = "admin-server";
     final String adminServerPodName = domainUid + "-" + adminServerName;
 
-    final String managedServerNameBase = "ms-";
+    final String managedServerNameBase = "managed-server";
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
 
     int replicaCount = 3;
@@ -763,17 +769,16 @@ public class ItIntrospectVersion {
         introDomainNamespace, getExternalServicePodName(adminServerPodName), "default"),
         "Getting admin server node port failed");
     assertNotEquals(-1, serviceNodePort, "Couldn't get valid node port for default channel");
-
-    logger.info("Validating WebLogic admin server access by login to console");
-    boolean loginSuccessful = assertDoesNotThrow(()
-        -> adminNodePortAccessible(serviceNodePort, ADMIN_USERNAME_PATCH, ADMIN_PASSWORD_PATCH),
-        "Access to admin server node port failed");
-    assertTrue(loginSuccessful, "Console login validation failed");
-
-    logger.info("Validating WebLogic admin server access by login to console using old credentials");
-    assertThrows(AssertionFailedError.class, ()
-        -> adminNodePortAccessible(serviceNodePort, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT),
-        "Accessing using old user/password succeeded, supposed to fail");
+ 
+    // Make a REST API call to access management console
+    // So that the test will also work with WebLogic slim image
+    final boolean VALID = true;
+    final boolean INVALID = false;
+    logger.info("Check that after patching current credentials are not valid and new credentials are");
+    verifyCredentials(adminServerPodName, introDomainNamespace, 
+         ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, INVALID);
+    verifyCredentials(adminServerPodName, introDomainNamespace, 
+         ADMIN_USERNAME_PATCH, ADMIN_PASSWORD_PATCH, VALID);
 
     List<String> managedServerNames = new ArrayList<String>();
     for (int i = 1; i <= replicaCount; i++) {
@@ -971,7 +976,7 @@ public class ItIntrospectVersion {
   @DisplayName("Scale up cluster-1 in domain1Namespace and verify label weblogic.introspectVersion set")
   public void testDedicatedModeSameNamespaceScale() {
     final String adminServerName = "admin-server";
-    final String managedServerNameBase = "ms-";
+    final String managedServerNameBase = "managed-server";
     final String adminServerPodName = domainUid + "-" + adminServerName;
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
 
@@ -1080,7 +1085,7 @@ public class ItIntrospectVersion {
 
   private void verifyIntrospectVersionLabelInPod(int replicaCount) {
     final String adminServerName = "admin-server";
-    final String managedServerNameBase = "ms-";
+    final String managedServerNameBase = "managed-server";
     final String adminServerPodName = domainUid + "-" + adminServerName;
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInImage.java
@@ -41,6 +41,7 @@ import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.addLabelsToNamespace;
@@ -209,11 +210,17 @@ class ItIstioDomainInImage {
     int istioIngressPort = getIstioHttpIngressPort();
     logger.info("Istio Ingress Port is {0}", istioIngressPort);
 
-    String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
-    boolean checkConsole = 
-         checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
-    assertTrue(checkConsole, "Failed to access WebLogic console");
-    logger.info("WebLogic console is accessible");
+    // We can not verify Rest Management console thru Adminstration NodePort 
+    // in istio, as we can not enable Adminstration NodePort
+    if (!WEBLOGIC_SLIM) {
+      String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
+      boolean checkConsole = 
+          checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
+      assertTrue(checkConsole, "Failed to access WebLogic console");
+      logger.info("WebLogic console is accessible");
+    } else {
+      logger.info("Skipping WebLogic console in WebLogic slim image");
+    }
 
     Path archivePath = Paths.get(ITTESTS_DIR, "../operator/integration-tests/apps/testwebapp.war");
     ExecResult result = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
@@ -57,6 +57,7 @@ import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.addLabelsToNamespace;
@@ -307,12 +308,18 @@ public class ItIstioDomainInPV  {
     int istioIngressPort = getIstioHttpIngressPort();
     logger.info("Istio http ingress Port is {0}", istioIngressPort);
 
-    String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
-    boolean checkConsole =
-         checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
-    assertTrue(checkConsole, "Failed to access WebLogic console");
-    logger.info("WebLogic console is accessible");
-
+    // We can not verify Rest Management console thru Adminstration NodePort 
+    // in istio, as we can not enable Adminstration NodePort
+    if (!WEBLOGIC_SLIM) {
+      String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
+      boolean checkConsole = 
+          checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
+      assertTrue(checkConsole, "Failed to access WebLogic console");
+      logger.info("WebLogic console is accessible");
+    } else {
+      logger.info("Skipping WebLogic console in WebLogic slim image");
+    }
+  
     Path archivePath = Paths.get(ITTESTS_DIR, "../operator/integration-tests/apps/testwebapp.war");
     ExecResult result = null;
     result = deployToClusterUsingRest(K8S_NODEPORT_HOST, 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
@@ -41,6 +41,7 @@ import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.addLabelsToNamespace;
@@ -215,13 +216,18 @@ class ItIstioMiiDomain {
     int istioIngressPort = getIstioHttpIngressPort();
     logger.info("Istio Ingress Port is {0}", istioIngressPort);
 
-    String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
-    boolean checkConsole = 
-         checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
-    assertTrue(checkConsole, "Failed to access WebLogic console");
-    logger.info("WebLogic console is accessible");
-
-
+    // We can not verify Rest Management console thru Adminstration NodePort 
+    // in istio, as we can not enable Adminstration NodePort
+    if (!WEBLOGIC_SLIM) {
+      String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
+      boolean checkConsole = 
+          checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
+      assertTrue(checkConsole, "Failed to access WebLogic console");
+      logger.info("WebLogic console is accessible");
+    } else {
+      logger.info("Skipping WebLogic console in WebLogic slim image");
+    }
+  
     Path archivePath = Paths.get(ITTESTS_DIR, "../operator/integration-tests/apps/testwebapp.war");
     ExecResult result = null;
     result = deployToClusterUsingRest(K8S_NODEPORT_HOST, 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioTwoDomainsInImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioTwoDomainsInImage.java
@@ -41,6 +41,7 @@ import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.addLabelsToNamespace;
@@ -273,11 +274,18 @@ class ItIstioTwoDomainsInImage {
     int istioIngressPort = getIstioHttpIngressPort();
     logger.info("Istio Ingress Port is {0}", istioIngressPort);
 
-    String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
-    boolean checkConsole = 
-         checkAppUsingHostHeader(consoleUrl, domainNamespace1 + ".org");
-    assertTrue(checkConsole, "Failed to access WebLogic console on domain1");
-    logger.info("WebLogic console on domain1 is accessible");
+    // We can not verify Rest Management console thru Adminstration NodePort 
+    // in istio, as we can not enable Adminstration NodePort
+    if (!WEBLOGIC_SLIM) {
+      String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
+      boolean checkConsole = 
+          checkAppUsingHostHeader(consoleUrl, domainNamespace1 + ".org");
+      assertTrue(checkConsole, "Failed to access WebLogic console on domain1");
+      logger.info("WebLogic console on domain1 is accessible");
+    } else {
+      logger.info("Skipping WebLogic console in WebLogic slim image");
+    }
+  
     Path archivePath = Paths.get(ITTESTS_DIR, "../operator/integration-tests/apps/testwebapp.war");
     ExecResult result = null;
     result = deployToClusterUsingRest(K8S_NODEPORT_HOST, 
@@ -293,9 +301,18 @@ class ItIstioTwoDomainsInImage {
     boolean checkApp = checkAppUsingHostHeader(url, domainNamespace1 + ".org");
     assertTrue(checkApp, "Failed to access WebLogic application on domain1");
 
-    checkConsole = checkAppUsingHostHeader(consoleUrl, domainNamespace2 + ".org");
-    assertTrue(checkConsole, "Failed to access domain2 WebLogic console");
-    logger.info("WebLogic console on domain2 is accessible");
+    // We can not verify Rest Management console thru Adminstration NodePort 
+    // in istio, as we can not enable Adminstration NodePort
+    if (!WEBLOGIC_SLIM) {
+      String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
+      boolean checkConsole = 
+          checkAppUsingHostHeader(consoleUrl, domainNamespace2 + ".org");
+      assertTrue(checkConsole, "Failed to access domain2 WebLogic console");
+      logger.info("WebLogic console on domain2 is accessible");
+    } else {
+      logger.info("Skipping WebLogic console in WebLogic slim image");
+    }
+
     result = deployToClusterUsingRest(K8S_NODEPORT_HOST, 
         String.valueOf(istioIngressPort),
         ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -329,8 +329,8 @@ class ItParameterizedDomain {
    *
    * @param domain oracle.weblogic.domain.Domain object
    */
+  @ParameterizedTest
   @DisplayName("Test admin console login using admin node port")
-  @ParameterizedTest(name = "{index} => domain=''{0}''")
   @MethodSource("domainProvider")
   public void testAdminConsoleLoginUsingAdminNodePort(Domain domain) {
     assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
@@ -355,8 +355,8 @@ class ItParameterizedDomain {
    *
    * @param domain oracle.weblogic.domain.Domain object
    */
-  @DisplayName("Test admin console login using ingress controller")
   @ParameterizedTest
+  @DisplayName("Test admin console login using ingress controller")
   @MethodSource("domainProvider")
   public void testAdminConsoleLoginUsingIngressController(Domain domain) {
     assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -89,6 +89,7 @@ import static oracle.weblogic.kubernetes.TestConstants.WDT_IMAGE_DOMAINHOME_BASE
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.TestConstants.WLS_DOMAIN_TYPE;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ARCHIVE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
@@ -154,6 +155,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Verify scaling up and down the clusters in the domain with different domain types.
@@ -271,6 +273,7 @@ class ItParameterizedDomain {
       createIngressForDomainAndVerify(domainUid, domainNamespace, nodeportshttp, clusterNameMsPortMap, true,
           true, ADMIN_SERVER_PORT);
     }
+    // System.setProperty("WEBLOGIC_IMAGE_TAG", WEBLOGIC_IMAGE_TAG);
   }
 
   /**
@@ -326,15 +329,15 @@ class ItParameterizedDomain {
    *
    * @param domain oracle.weblogic.domain.Domain object
    */
-  @ParameterizedTest
   @DisplayName("Test admin console login using admin node port")
+  @ParameterizedTest(name = "{index} => model=''{0}''")
   @MethodSource("domainProvider")
   public void testAdminConsoleLoginUsingAdminNodePort(Domain domain) {
+    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     assertDomainNotNull(domain);
     String domainUid = domain.getSpec().getDomainUid();
     String domainNamespace = domain.getMetadata().getNamespace();
     String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
-
     logger.info("Getting node port for default channel");
     int serviceNodePort = assertDoesNotThrow(() -> getServiceNodePort(
         domainNamespace, getExternalServicePodName(adminServerPodName), "default"),
@@ -352,12 +355,11 @@ class ItParameterizedDomain {
    *
    * @param domain oracle.weblogic.domain.Domain object
    */
-  @ParameterizedTest
   @DisplayName("Test admin console login using ingress controller")
+  @ParameterizedTest(name = "{index} => model=''{0}''")
   @MethodSource("domainProvider")
   public void testAdminConsoleLoginUsingIngressController(Domain domain) {
-    logger.info("Validating WebLogic admin server access using ingress controller");
-
+    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     assertDomainNotNull(domain);
     String domainUid = domain.getSpec().getDomainUid();
     String domainNamespace = domain.getMetadata().getNamespace();
@@ -383,7 +385,6 @@ class ItParameterizedDomain {
     String domainUid = domain.getSpec().getDomainUid();
     String domainNamespace = domain.getMetadata().getNamespace();
     int numClusters = domain.getSpec().getClusters().size();
-
     String serverName;
     if (numClusters > 1) {
       serverName = domainUid + "-" + clusterName + "-" + MANAGED_SERVER_NAME_BASE + "1";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -330,7 +330,7 @@ class ItParameterizedDomain {
    * @param domain oracle.weblogic.domain.Domain object
    */
   @DisplayName("Test admin console login using admin node port")
-  @ParameterizedTest(name = "{index} => model=''{0}''")
+  @ParameterizedTest(name = "{index} => domain=''{0}''")
   @MethodSource("domainProvider")
   public void testAdminConsoleLoginUsingAdminNodePort(Domain domain) {
     assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
@@ -356,7 +356,7 @@ class ItParameterizedDomain {
    * @param domain oracle.weblogic.domain.Domain object
    */
   @DisplayName("Test admin console login using ingress controller")
-  @ParameterizedTest(name = "{index} => model=''{0}''")
+  @ParameterizedTest
   @MethodSource("domainProvider")
   public void testAdminConsoleLoginUsingIngressController(Domain domain) {
     assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -273,7 +273,6 @@ class ItParameterizedDomain {
       createIngressForDomainAndVerify(domainUid, domainNamespace, nodeportshttp, clusterNameMsPortMap, true,
           true, ADMIN_SERVER_PORT);
     }
-    // System.setProperty("WEBLOGIC_IMAGE_TAG", WEBLOGIC_IMAGE_TAG);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItProductionSecureMode.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItProductionSecureMode.java
@@ -40,6 +40,7 @@ import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
@@ -190,13 +191,19 @@ class ItProductionSecureMode {
     assertTrue(sslNodePort != -1,
           "Could not get the default-admin external service node port");    
     logger.info("Found the administration service nodePort {0}", sslNodePort);
-    String curlCmd = "curl -sk --show-error --noproxy '*' "
-        + " https://" + K8S_NODEPORT_HOST + ":" + sslNodePort
-        + "/console/login/LoginForm.jsp --write-out %{http_code} -o /dev/null";
-    logger.info("Executing default-admin nodeport curl command {0}", curlCmd);
-    assertTrue(callWebAppAndWaitTillReady(curlCmd, 10));
-    logger.info("WebLogic console is accessible thru default-admin service");
 
+    if (!WEBLOGIC_SLIM) {
+      String curlCmd = "curl -sk --show-error --noproxy '*' "
+          + " https://" + K8S_NODEPORT_HOST + ":" + sslNodePort
+          + "/console/login/LoginForm.jsp --write-out %{http_code} " 
+          + " -o /dev/null";
+      logger.info("Executing default-admin nodeport curl command {0}", curlCmd);
+      assertTrue(callWebAppAndWaitTillReady(curlCmd, 10));
+      logger.info("WebLogic console is accessible thru default-admin service");
+    } else {
+      logger.info("Skipping WebLogic console in WebLogic slim image");
+    }
+  
     int nodePort = getServiceNodePort(
            domainNamespace, getExternalServicePodName(adminServerPodName), "default");
     assertTrue(nodePort == -1,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
@@ -102,6 +102,7 @@ import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.VOYAGER_CHART_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createIngress;
@@ -166,7 +167,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Test operator manages multiple domains.
@@ -444,6 +445,7 @@ public class ItTwoDomainsLoadBalancers {
   @Test
   @DisplayName("Verify WebLogic admin console is accessible through NGINX path routing with HTTPS protocol")
   public void testNginxTLSPathRoutingAdminServer() {
+    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     logger.info("Verifying WebLogic admin console is accessible through NGINX path routing with HTTPS protocol");
     for (int i = 0; i < numberOfDomains; i++) {
       verifyAdminServerAccess(true, getNginxLbNodePort("https"), false, "",
@@ -482,6 +484,7 @@ public class ItTwoDomainsLoadBalancers {
   @Test
   @DisplayName("Verify WebLogic admin console is accessible through Voyager path routing with HTTPS protocol")
   public void testVoyagerTLSPathRoutingAdminServer() {
+    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     logger.info("Verifying WebLogic admin console is accessible through Voyager path routing with HTTPS protocol");
     String ingressName = "voyager-tls-pathrouting";
     for (int i = 0; i < numberOfDomains; i++) {
@@ -502,6 +505,7 @@ public class ItTwoDomainsLoadBalancers {
   @Test
   @DisplayName("Verify WebLogic admin console is accessible through Traefik host routing with HTTP protocol")
   public void testTraefikHostRoutingAdminServer() {
+    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     logger.info("Verifying WebLogic admin console is accessible through Traefik host routing with HTTP protocol");
     for (String domainUid : domainUids) {
       verifyAdminServerAccess(false, getTraefikLbNodePort(false), true,
@@ -745,6 +749,7 @@ public class ItTwoDomainsLoadBalancers {
   @Test
   @DisplayName("Verify WebLogic admin console is accessible through Traefik path routing with HTTPS protocol")
   public void testTraefikTLSPathRoutingAdminServer() {
+    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     logger.info("Verifying WebLogic admin console is accessible through Traefik path routing with HTTPS protocol");
 
     verifyAdminServerAccess(true, getTraefikLbNodePort(true), false, "", "");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -275,4 +275,6 @@ public interface TestConstants {
   public String DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX = "-ext";
   public String DEFAULT_INTROSPECTOR_JOB_NAME_SUFFIX = "-introspector";
   public String OLD_DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX = "-external";
+  public static final boolean WEBLOGIC_SLIM =
+      WEBLOGIC_IMAGE_TAG.contains("slim") ? true : false;
 }


### PR DESCRIPTION
Skip the WebLogic Console Tests based on the string "slim" in WebLogic Image

Add the following boolean variable in TestConstants.java
public static final boolean WEBLOGIC_SLIM =  WEBLOGIC_IMAGE_TAG.contains("slim") ? true : false;

In ItTestClass assert it before running console tests 

import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM
import static org.junit.jupiter.api.Assumptions.assumeFalse;
public void testAdminConsoleLoginUsingAdminNodePort(Domain domain) {
    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");

OR 
    if (!WEBLOGIC_SLIM) {
      String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
      boolean checkConsole =
          checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
      assertTrue(checkConsole, "Failed to access WebLogic console");
      logger.info("WebLogic console is accessible");
    } else {
      logger.info("Skipping WebLogic console in WebLogic slim image");
    }