### PR TITLE
use event creation timestamp to sort

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -996,7 +996,7 @@ public class Kubernetes {
           Boolean.FALSE // Boolean | Watch for changes to the described resources.
       );
       events = Optional.ofNullable(list).map(V1EventList::getItems).orElse(Collections.EMPTY_LIST);
-      events.sort(Comparator.comparing(e -> e.getLastTimestamp()));
+      events.sort(Comparator.comparing(e -> e.getMetadata().getCreationTimestamp()));
       Collections.reverse(events);
     } catch (ApiException apex) {
       getLogger().warning(apex.getResponseBody());


### PR DESCRIPTION
Fixing the oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listNamespacedEvents() to sort events based on creation timestamp.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3995/