### PR TITLE
Owls87514 add refresh/retry to event replace operation and populate events maps on operator startup

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -137,7 +137,7 @@ public class DomainProcessorImpl implements DomainProcessor {
     }
   }
 
-  private static void updateEventK8SObjects(V1Event event) {
+  public static void updateEventK8SObjects(V1Event event) {
     getEventK8SObjects(event).update(event);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -10,6 +10,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import io.kubernetes.client.openapi.models.V1Event;
+import io.kubernetes.client.openapi.models.V1EventList;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Service;
@@ -52,6 +54,11 @@ class DomainResourcesValidation {
       }
 
       @Override
+      Consumer<V1EventList> getOperatorEventListProcessing() {
+        return l -> addOperatorEventList(l);
+      }
+
+      @Override
       Consumer<V1beta1PodDisruptionBudgetList> getPodDisruptionBudgetListProcessing() {
         return l -> addPodDisruptionBudgetList(l);
       }
@@ -72,6 +79,14 @@ class DomainResourcesValidation {
 
   private void addPodList(V1PodList list) {
     list.getItems().forEach(this::addPod);
+  }
+
+  private void addEvent(V1Event event) {
+    DomainProcessorImpl.updateEventK8SObjects(event);
+  }
+
+  private void addOperatorEventList(V1EventList list) {
+    list.getItems().forEach(this::addEvent);
   }
 
   private void addPod(V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -357,7 +357,7 @@ public class DomainStatusUpdater {
 
     @Override
     public NextAction onFailure(Packet packet, CallResponse<Domain> callResponse) {
-      if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse)) {
+      if (UnrecoverableErrorBuilder.isAsyncCallUnrecoverableFailure(callResponse)) {
         return super.onFailure(packet, callResponse);
       } else {
         return onFailure(createRetry(context, getNext()), packet, callResponse);

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -321,6 +321,7 @@ public class Main {
     public NextAction onSuccess(Packet packet, CallResponse<V1EventList> callResponse) {
       V1EventList list = callResponse.getResult();
       operatorNamespaceEventWatcher = startWatcher(getOperatorNamespace(), KubernetesUtils.getResourceVersion(list));
+      list.getItems().forEach(DomainProcessorImpl::updateEventK8SObjects);
       return doContinueListOrNext(callResponse, packet);
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -306,7 +306,7 @@ public class Main {
 
   private Step createOperatorNamespaceEventListStep() {
     return new CallBuilder()
-        .withLabelSelectors(ProcessingConstants.DOMAIN_EVENT_LABEL_FILTER)
+        .withLabelSelectors(ProcessingConstants.OPERATOR_EVENT_LABEL_FILTER)
         .listEventAsync(getOperatorNamespace(), new EventListResponseStep(delegate.getDomainProcessor()));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/NamespacedResources.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/NamespacedResources.java
@@ -49,7 +49,7 @@ class NamespacedResources {
     return Step.chain(
           getConfigMapListSteps(),
           getPodEventListSteps(),
-          getDomainEventListSteps(),
+          getOperatorEventListSteps(),
           getJobListSteps(),
           getPodListSteps(),
           getServiceListSteps(),
@@ -147,14 +147,14 @@ class NamespacedResources {
             .listEventAsync(namespace, new ListResponseStep<>(processing));
   }
 
-  private Step getDomainEventListSteps() {
+  private Step getOperatorEventListSteps() {
     return getListProcessing(Processors::getOperatorEventListProcessing)
-        .map(this::createDomainEventListStep).orElse(null);
+        .map(this::createOperatorEventListStep).orElse(null);
   }
 
-  private Step createDomainEventListStep(List<Consumer<V1EventList>> processing) {
+  private Step createOperatorEventListStep(List<Consumer<V1EventList>> processing) {
     return new CallBuilder()
-        .withLabelSelectors(ProcessingConstants.DOMAIN_EVENT_LABEL_FILTER)
+        .withLabelSelectors(ProcessingConstants.OPERATOR_EVENT_LABEL_FILTER)
         .listEventAsync(namespace, new ListResponseStep<>(processing));
   }
 
@@ -238,7 +238,5 @@ class NamespacedResources {
       processors.forEach(p -> p.accept(callResponse.getResult()));
       return doContinueListOrNext(callResponse, packet);
     }
-
   }
-
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/OperatorEventWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/OperatorEventWatcher.java
@@ -16,7 +16,7 @@ import oracle.kubernetes.operator.TuningParameters.WatchTuning;
 import oracle.kubernetes.operator.builders.WatchBuilder;
 import oracle.kubernetes.operator.watcher.WatchListener;
 
-import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_EVENT_LABEL_FILTER;
+import static oracle.kubernetes.operator.ProcessingConstants.OPERATOR_EVENT_LABEL_FILTER;
 
 /**
  * This class handles Domain Event watching. It receives event notifications and sends them into the operator
@@ -60,7 +60,7 @@ public class OperatorEventWatcher extends Watcher<V1Event> {
 
   @Override
   public Watchable<V1Event> initiateWatch(WatchBuilder watchBuilder) throws ApiException {
-    return watchBuilder.withLabelSelector(DOMAIN_EVENT_LABEL_FILTER).createEventWatch(ns);
+    return watchBuilder.withLabelSelector(OPERATOR_EVENT_LABEL_FILTER).createEventWatch(ns);
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -54,5 +54,5 @@ public interface ProcessingConstants {
       + " by adding it to the weblogic-operator-cm configmap.";
 
   String FATAL_INTROSPECTOR_ERROR_MSG = "Stop introspection retry - MII Fatal Error: ";
-  String DOMAIN_EVENT_LABEL_FILTER = LabelConstants.getCreatedByOperatorSelector();
+  String OPERATOR_EVENT_LABEL_FILTER = LabelConstants.getCreatedByOperatorSelector();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/calls/UnrecoverableErrorBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/UnrecoverableErrorBuilder.java
@@ -10,11 +10,11 @@ public class UnrecoverableErrorBuilder {
 
   /**
    * Returns true if the specified call response indicates an unrecoverable response from Kubernetes.
-   * @param callResponse the response from a Kubernetes call
    * @param <T> call response type
+   * @param callResponse the response from a Kubernetes call
    * @return true if an unprocessable entity failure has been reported
    */
-  public static <T> boolean isAsyncCallFailure(CallResponse<T> callResponse) {
+  public static <T> boolean isAsyncCallUnrecoverableFailure(CallResponse<T> callResponse) {
     return callResponse.isFailure() && isUnrecoverable(callResponse.getE());
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -215,6 +215,9 @@ public class CallBuilder {
           wrap(
               createSelfSubjectRulesReviewAsync(
                   usage, (V1SelfSubjectRulesReview) requestParams.body, callback));
+  private final CallFactory<V1Event> readEvent =
+      (requestParams, usage, cont, callback) ->
+          wrap(readEventAsync(usage, requestParams.name, requestParams.namespace, callback));
   private final CallFactory<V1Event> createEvent =
       (requestParams, usage, cont, callback) ->
           wrap(
@@ -1737,6 +1740,28 @@ public class CallBuilder {
   public Step listEventAsync(String namespace, ResponseStep<V1EventList> responseStep) {
     return createRequestAsync(
         responseStep, new RequestParams("listEvent", namespace, null, null, callParams), listEvent);
+  }
+
+  private Call readEventAsync(
+      ApiClient client, String name, String namespace, ApiCallback<V1Event> callback)
+      throws ApiException {
+    return new CoreV1Api(client)
+        .readNamespacedEventAsync(name, namespace, pretty, exact, export, callback);
+  }
+
+  /**
+   * Asynchronous step for reading event.
+   *
+   * @param name Name
+   * @param namespace Namespace
+   * @param responseStep Response step for when call completes
+   * @return Asynchronous step
+   */
+  public Step readEventAsync(
+      String name, String namespace, ResponseStep<V1Event> responseStep) {
+    return createRequestAsync(
+        responseStep, new RequestParams("readEvent", namespace, name, null, callParams),
+        readEvent);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -468,7 +468,7 @@ public abstract class JobStepContext extends BasePodStepContext {
 
     @Override
     public NextAction onFailure(Packet packet, CallResponse<V1Job> callResponse) {
-      if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse)) {
+      if (UnrecoverableErrorBuilder.isAsyncCallUnrecoverableFailure(callResponse)) {
         return updateDomainStatus(packet, callResponse);
       } else {
         return super.onFailure(packet, callResponse);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodDisruptionBudgetHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodDisruptionBudgetHelper.java
@@ -93,7 +93,7 @@ public class PodDisruptionBudgetHelper {
 
       @Override
       public NextAction onFailure(Packet packet, CallResponse<V1beta1PodDisruptionBudget> callResponse) {
-        if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse)) {
+        if (UnrecoverableErrorBuilder.isAsyncCallUnrecoverableFailure(callResponse)) {
           return updateDomainStatus(packet, callResponse);
         } else {
           return onFailure(getConflictStep(), packet, callResponse);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -917,7 +917,7 @@ public abstract class PodStepContext extends BasePodStepContext {
 
     @Override
     public NextAction onFailure(Packet packet, CallResponse<V1Pod> callResponse) {
-      if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse)) {
+      if (UnrecoverableErrorBuilder.isAsyncCallUnrecoverableFailure(callResponse)) {
         return updateDomainStatus(packet, callResponse);
       } else {
         return onFailure(getConflictStep(), packet, callResponse);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -623,7 +623,7 @@ public class ServiceHelper {
 
       @Override
       public NextAction onFailure(Packet packet, CallResponse<V1Service> callResponse) {
-        if (UnrecoverableErrorBuilder.isAsyncCallFailure(callResponse)) {
+        if (UnrecoverableErrorBuilder.isAsyncCallUnrecoverableFailure(callResponse)) {
           return updateDomainStatus(packet, callResponse);
         } else {
           return onFailure(getConflictStep(), packet, callResponse);

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -22,8 +22,10 @@ import java.util.stream.IntStream;
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Event;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1ObjectReference;
 import oracle.kubernetes.operator.Namespaces.SelectionStrategy;
 import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.builders.WatchEvent;
@@ -51,9 +53,12 @@ import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createNiceStub;
 import static com.meterware.simplestub.Stub.createStrictStub;
+import static oracle.kubernetes.operator.EventConstants.DOMAIN_CHANGED_EVENT;
+import static oracle.kubernetes.operator.EventConstants.DOMAIN_CREATED_EVENT;
 import static oracle.kubernetes.operator.EventConstants.NAMESPACE_WATCHING_STARTED_EVENT;
 import static oracle.kubernetes.operator.EventConstants.START_MANAGING_NAMESPACE_EVENT;
 import static oracle.kubernetes.operator.EventConstants.START_MANAGING_NAMESPACE_PATTERN;
+import static oracle.kubernetes.operator.EventConstants.STOP_MANAGING_NAMESPACE_EVENT;
 import static oracle.kubernetes.operator.EventTestUtils.containsEvent;
 import static oracle.kubernetes.operator.EventTestUtils.containsEventWithMessage;
 import static oracle.kubernetes.operator.EventTestUtils.containsEventWithMessageForNamespaces;
@@ -61,6 +66,8 @@ import static oracle.kubernetes.operator.EventTestUtils.getEvents;
 import static oracle.kubernetes.operator.KubernetesConstants.OPERATOR_NAMESPACE_ENV;
 import static oracle.kubernetes.operator.KubernetesConstants.OPERATOR_POD_NAME_ENV;
 import static oracle.kubernetes.operator.KubernetesConstants.SCRIPT_CONFIG_MAP_NAME;
+import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.Main.GIT_BRANCH_KEY;
 import static oracle.kubernetes.operator.Main.GIT_BUILD_TIME_KEY;
 import static oracle.kubernetes.operator.Main.GIT_BUILD_VERSION_KEY;
@@ -81,6 +88,7 @@ import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static oracle.kubernetes.utils.LogMatcher.containsSevere;
 import static oracle.kubernetes.utils.LogMatcher.containsWarning;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -273,6 +281,35 @@ public class MainTest extends ThreadFactoryTestBase {
   }
 
   @Test
+  public void whenOperatorStarted_withoutExistingEvent_nsEventK8SObjectsEmpty() {
+    main.startOperator(null);
+    assertThat(getNSEventMapSize(), equalTo(0));
+  }
+
+  @Test
+  public void whenOperatorStarted_withExistingEvents_nsEventK8SObjectsPopulated() {
+    V1Event event1 = createNSEvent("event1").reason(START_MANAGING_NAMESPACE_EVENT);
+    V1Event event2 = createNSEvent("event2").reason(STOP_MANAGING_NAMESPACE_EVENT);
+
+    testSupport.defineResources(event1, event2);
+    main.startOperator(null);
+    assertThat(getNSEventMapSize(), equalTo(2));
+  }
+
+  private int getNSEventMapSize() {
+    return Optional.ofNullable(nsEventObjects.get(OP_NS)).map(KubernetesEventObjects::size).orElse(0);
+  }
+
+  private V1Event createNSEvent(String name) {
+    return new V1Event()
+        .metadata(new V1ObjectMeta()
+            .name(name)
+            .namespace(OP_NS)
+            .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true"))
+        .involvedObject(new V1ObjectReference().name("Op1").namespace(OP_NS).uid("1234"));
+  }
+
+  @Test
   public void whenOperatorStartedInDedicatedMode_namespaceWatcherIsNotCreated() {
     defineSelectionStrategy(SelectionStrategy.Dedicated);
 
@@ -354,7 +391,6 @@ public class MainTest extends ThreadFactoryTestBase {
 
     assertThat(logRecords, containsSevere(CRD_NOT_INSTALLED));
   }
-
 
   @Test
   public void withNamespaceList_onStartNamespaceStep_startsNamespaces() {
@@ -555,6 +591,44 @@ public class MainTest extends ThreadFactoryTestBase {
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, createStrictStub(DomainProcessor.class)));
 
     assertThat(getScriptMap(NS), notNullValue());
+  }
+
+  @Test
+  public void afterReadingExistingResourcesForNamespace_withoutExistingEvent_domainEventK8SObjectsEmpty() {
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, createStrictStub(DomainProcessor.class)));
+    assertThat(getDomainEventMapSize(), equalTo(0));
+  }
+
+  @Test
+  public void afterReadingExistingResourcesForNamespace_withExistingEvents_domainEventK8SObjectsPopulated() {
+    V1Event event1 = createDomainEvent("event1").reason(DOMAIN_CREATED_EVENT);
+    V1Event event2 = createDomainEvent("event2").reason(DOMAIN_CHANGED_EVENT);
+
+    testSupport.defineResources(event1, event2);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, createStrictStub(DomainProcessor.class)));
+
+    assertThat(getDomainEventMapSize(), equalTo(2));
+  }
+
+  private int getDomainEventMapSize() {
+    return Optional.ofNullable(domainEventObjects.get(NS))
+        .map(m -> this.getEventMapForDomain(m, DOMAIN_UID))
+        .map(KubernetesEventObjects::size)
+        .orElse(0);
+  }
+
+  private KubernetesEventObjects getEventMapForDomain(Map map, String domainUid) {
+    return (KubernetesEventObjects) map.get(domainUid);
+  }
+
+  private V1Event createDomainEvent(String name) {
+    return new V1Event()
+        .metadata(new V1ObjectMeta()
+            .name(name)
+            .namespace(NS)
+            .putLabelsItem(CREATEDBYOPERATOR_LABEL, "true")
+            .putLabelsItem(DOMAINUID_LABEL, DOMAIN_UID))
+        .involvedObject(new V1ObjectReference().name(DOMAIN_UID).namespace(NS).uid("abcd"));
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventRetryStrategyStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventRetryStrategyStub.java
@@ -1,0 +1,18 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import oracle.kubernetes.operator.calls.RetryStrategy;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+
+abstract class EventRetryStrategyStub implements RetryStrategy {
+  @Override
+  public NextAction doPotentialRetry(Step conflictStep, Packet packet, int statusCode) {
+    NextAction na = new NextAction();
+    na.invoke(conflictStep, packet);
+    return na;
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -1130,7 +1130,11 @@ public class KubernetesTestSupport extends FiberTestSupport {
 
     private Object execute() {
       if (failure != null && failure.matches(resourceType, requestParams, operation)) {
-        throw failure.getException();
+        try {
+          throw failure.getException();
+        } finally {
+          failure = null;
+        }
       }
 
       return operation.execute(this, selectRepository(resourceType));


### PR DESCRIPTION
This PR contains two features plus unit tests: 
1) leverage existing refresh-and-retry logic in AsyncRequestStep in replaceEvent operation;
2) populate the cached event objects with existing events on operator restart.

The integration test run in Jenkins https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/3990.