### PR TITLE
OWLS-87753 - Fix to start all managed server pods when watch event notifications not received in jumbo k8s cluster

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
@@ -17,6 +17,15 @@ public interface PodAwaiterStepFactory {
   Step waitForReady(V1Pod pod, Step next);
 
   /**
+   * Waits until the Pod with given name is Ready.
+   *
+   * @param podName Name of the Pod to watch
+   * @param next Next processing step once Pod is ready
+   * @return Asynchronous step
+   */
+  Step waitForReady(String podName, Step next);
+
+  /**
    * Waits until the Pod is deleted.
    *
    * @param pod Pod to watch

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -279,6 +279,17 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
   }
 
   /**
+   * Waits until the Pod with given name is Ready.
+   *
+   * @param podName Name of the Pod to watch
+   * @param next Next processing step once Pod is ready
+   * @return Asynchronous step
+   */
+  public Step waitForReady(String podName, Step next) {
+    return new WaitForPodReadyStep(podName, next);
+  }
+
+  /**
    * Waits until the Pod is deleted.
    *
    * @param pod Pod to watch
@@ -293,6 +304,10 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
     private WaitForPodStatusStep(V1Pod pod, Step next) {
       super(pod, next);
+    }
+
+    private WaitForPodStatusStep(String podName, Step next) {
+      super(podName, null, next);
     }
 
     @Override
@@ -310,6 +325,10 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
     private WaitForPodReadyStep(V1Pod pod, Step next) {
       super(pod, next);
+    }
+
+    private WaitForPodReadyStep(String podName, Step next) {
+      super(podName, next);
     }
 
     // A pod is ready if it is not being deleted and has the ready status.

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -192,7 +192,8 @@ abstract class WaitForReadyStep<T> extends Step {
   }
 
   public String getName() {
-    return initialResource != null ? getMetadata(initialResource).getName() : resourceName;
+    return initialResource != null ? getMetadata(initialResource).getName() :
+            Optional.ofNullable(resourceName).orElse(null);
   }
 
   private DefaultResponseStep<T> resumeIfReady(Callback callback) {

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -178,7 +178,7 @@ abstract class WaitForReadyStep<T> extends Step {
       return createReadAsyncStep(getName(), getNamespace(), getDomainUid(), resumeIfReady(callback));
     } else {
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
-      return createReadAsyncStep(resourceName, Optional.ofNullable(info).map(i -> i.getNamespace()).orElse(null),
+      return createReadAsyncStep(getName(), Optional.ofNullable(info).map(i -> i.getNamespace()).orElse(null),
               Optional.ofNullable(info).map(i -> i.getDomainUid()).orElse(null), resumeIfReady(callback));
     }
   }
@@ -192,7 +192,7 @@ abstract class WaitForReadyStep<T> extends Step {
   }
 
   public String getName() {
-    return getMetadata(initialResource).getName();
+    return initialResource != null ? getMetadata(initialResource).getName() : resourceName;
   }
 
   private DefaultResponseStep<T> resumeIfReady(Callback callback) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -17,9 +18,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import oracle.kubernetes.operator.DomainStatusUpdater;
+import oracle.kubernetes.operator.PodAwaiterStepFactory;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo.ServerStartupInfo;
+import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.logging.LoggingFacade;
@@ -93,6 +96,11 @@ public class ManagedServerUpIteratorStep extends Step {
                               entry.getValue().getServerStartsStepAndPackets(), null), packet.clone()));
     }
 
+    Collection<StepAndPacket> startupWaiters =
+            startupInfos.stream()
+                    .map(ssi -> createManagedServerUpWaiters(packet, ssi)).collect(Collectors.toList());
+    work.addAll(startupWaiters);
+
     if (!work.isEmpty()) {
       return doForkJoin(DomainStatusUpdater.createStatusUpdateStep(
               new ManagedServerUpAfterStep(getNext())), packet, work);
@@ -113,6 +121,17 @@ public class ManagedServerUpIteratorStep extends Step {
   private StepAndPacket createManagedServerUpDetails(Packet packet, ServerStartupInfo ssi) {
     return new StepAndPacket(ServiceHelper.createForServerStep(PodHelper.createManagedPodStep(null)),
             createPacketForServer(packet, ssi));
+  }
+
+  private StepAndPacket createManagedServerUpWaiters(Packet packet, ServerStartupInfo ssi) {
+    String podName = getPodName(packet.getSpi(DomainPresenceInfo.class), ssi.getServerName());
+    return new StepAndPacket(Optional.ofNullable(packet.getSpi(PodAwaiterStepFactory.class))
+            .map(p -> p.waitForReady(podName, null)).orElse(null),
+            createPacketForServer(packet, ssi));
+  }
+
+  String getPodName(DomainPresenceInfo info, String serverName) {
+    return LegalNames.toPodName(info.getDomainUid(), serverName);
   }
 
   private Packet createPacketForServer(Packet packet, ServerStartupInfo ssi) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -76,6 +76,11 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
     }
 
     @Override
+    public Step waitForReady(String podName, Step next) {
+      return next;
+    }
+
+    @Override
     public Step waitForDelete(V1Pod pod, Step next) {
       return next;
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
@@ -181,6 +181,11 @@ public class DomainUpPlanTest {
     }
 
     @Override
+    public Step waitForReady(String podName, Step next) {
+      return null;
+    }
+
+    @Override
     public Step waitForDelete(V1Pod pod, Step next) {
       return null;
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -1467,6 +1467,11 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     }
 
     @Override
+    public Step waitForReady(String podName, Step next) {
+      return next;
+    }
+
+    @Override
     public Step waitForDelete(V1Pod pod, Step next) {
       return next;
     }
@@ -1481,6 +1486,11 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
 
     @Override
     public Step waitForReady(V1Pod pod, Step next) {
+      return new DelayStep(next, delaySeconds);
+    }
+
+    @Override
+    public Step waitForReady(String podName, Step next) {
       return new DelayStep(next, delaySeconds);
     }
 


### PR DESCRIPTION
OWLS-87753- Fix for starting managed servers when watch event notifications are missed.

This change creates waiters for each managed server pod in ManagedServerUpIterator step. These fibers are started in parallel with fibers that schedule and actually start the managed server pods. The waiter fibers invoke WaitForReady step for the corresponding managed server. At the time when WaitFotReady is invoked, managed server pods would not have been created. Hence it passes resourceName to the WaitForReady step instead of the initial resource. The managed server pod state is updated periodically in the DomainPresenceInfo when the callback onSuccess is invoked (every 5 seconds) in waitForReady step. The createReadAndIfReadyCheckStep uses domain-id and namespace from the packet instead of getting it from the initial resource.

The link for integration test results is at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4024/ . There are 5 failures but they seem unrelated to this change.