### PR TITLE
OWLS-87175 - Allow make right flow to continue when live data from the list older than cached data

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -663,7 +663,7 @@ public class DomainProcessorImpl implements DomainProcessor {
             + existingError);
         return false;
       } else if (!liveInfo.isPopulated() && isCachedInfoNewer(liveInfo, cachedInfo)) {
-        LOGGER.fine("Cached domain info from watch event is newer than the live info.");
+        LOGGER.fine("Cached domain info is newer than the live info from the watch event .");
         return false;  // we have already cached this
       } else if (explicitRecheck || isSpecChanged(liveInfo, cachedInfo)) {
         if (exceededFailureRetryCount) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -662,8 +662,6 @@ public class DomainProcessorImpl implements DomainProcessor {
         LOGGER.fine("Stop introspection retry - MII Fatal Error: "
             + existingError);
         return false;
-      } else if (isCachedInfoNewer(liveInfo, cachedInfo)) {
-        return false;  // we have already cached this
       } else if (explicitRecheck || isSpecChanged(liveInfo, cachedInfo)) {
         if (exceededFailureRetryCount) {
           Optional.ofNullable(liveInfo)

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -662,6 +662,9 @@ public class DomainProcessorImpl implements DomainProcessor {
         LOGGER.fine("Stop introspection retry - MII Fatal Error: "
             + existingError);
         return false;
+      } else if (!liveInfo.isPopulated() && isCachedInfoNewer(liveInfo, cachedInfo)) {
+        LOGGER.fine("Cached domain info from watch event is newer than the live info.");
+        return false;  // we have already cached this
       } else if (explicitRecheck || isSpecChanged(liveInfo, cachedInfo)) {
         if (exceededFailureRetryCount) {
           Optional.ofNullable(liveInfo)
@@ -675,7 +678,7 @@ public class DomainProcessorImpl implements DomainProcessor {
               currentIntrospectFailureRetryCount,
               DomainPresence.getDomainPresenceFailureRetryMaxCount());
         }
-
+        LOGGER.fine("Continue the make-right domain presence, explicitRecheck -> " + explicitRecheck);
         return true;
       }
       cachedInfo.setDomain(getDomain());

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
@@ -134,6 +134,7 @@ public class RollingHelper {
       }
 
       if (!clusteredRestarts.isEmpty()) {
+        LOGGER.fine("Restarting server " + packet.get(ProcessingConstants.SERVER_NAME));
         for (Map.Entry<String, Queue<StepAndPacket>> entry : clusteredRestarts.entrySet()) {
           work.add(
               new StepAndPacket(


### PR DESCRIPTION
OWLS-87175 - Allow the make-right flow to continue when live info from the list is older than the cached info for etcd restore case. For etcd restore use-case, cached data can be newer than the live data since etcd snapshot might have been taken at some time in the past. Based on discussion with Ryan, the possibility of cached data being newer than live data is very rare in the normal scenario.  This change along with a fix for  OWLS-87553 (periodic backstop check in the WaitForReady step) seem to resolve the issue in 32401992 in both Fermin's and my local env.

Integration tests results are at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4069/ and manual tests in my env seem to work fine. 