### PR TITLE
Check job condition to determine if job has failed in addition to checking job status

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -132,7 +132,7 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
 
   @Test
   public void whenJobConditionTypeFailedWithTrueStatus_reportFailed() {
-    cachedJob.status(new V1JobStatus().addConditionsItem(new V1JobCondition().type("Failed").status("True")));
+    markJobConditionFailed(cachedJob);
 
     assertThat(JobWatcher.isFailed(cachedJob), is(true));
   }
@@ -203,7 +203,7 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
 
   @Test
   public void whenJobHasNoStatusAndFailedCondition_reportFailed() {
-    markJobFailed(cachedJob);
+    markJobConditionFailed(cachedJob);
     assertThat(JobWatcher.isFailed(cachedJob), is(true));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -202,12 +202,6 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   }
 
   @Test
-  public void whenJobHasNoStatusAndFailedCondition_reportFailed() {
-    markJobConditionFailed(cachedJob);
-    assertThat(JobWatcher.isFailed(cachedJob), is(true));
-  }
-
-  @Test
   public void whenJobHasFailedCount_reportFailed() {
     cachedJob.status(new V1JobStatus().failed(1));
 

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -4,6 +4,8 @@
 package oracle.kubernetes.operator;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -129,6 +131,28 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   }
 
   @Test
+  public void whenJobConditionTypeFailedWithTrueStatus_reportFailed() {
+    cachedJob.status(new V1JobStatus().addConditionsItem(new V1JobCondition().type("Failed").status("True")));
+
+    assertThat(JobWatcher.isFailed(cachedJob), is(true));
+  }
+
+  @Test
+  public void whenJobConditionTypeFailedWithNoStatus_reportNotFailed() {
+    cachedJob.status(new V1JobStatus().addConditionsItem(new V1JobCondition().type("Failed").status("")));
+
+    assertThat(JobWatcher.isFailed(cachedJob), is(false));
+  }
+
+  @Test
+  public void whenJobHasStatusWithNoConditionsAndNotFailed_reportNotFailed() {
+    cachedJob.status(new V1JobStatus().conditions(Collections.emptyList()));
+
+    assertThat(JobWatcher.isFailed(cachedJob), is(false));
+  }
+
+
+  @Test
   public void whenJobRunningAndReadyConditionIsTrue_reportComplete() {
     markJobCompleted(cachedJob);
 
@@ -151,6 +175,10 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
     return setFailedWithReason(job, null);
   }
 
+  private V1Job markJobConditionFailed(V1Job job) {
+    return setFailedConditionWithReason(job, null);
+  }
+
   private V1Job markJobTimedOut(V1Job job) {
     return markJobTimedOut(job, "DeadlineExceeded");
   }
@@ -163,9 +191,20 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
     return job.status(new V1JobStatus().failed(1).addConditionsItem(createCondition("Failed").reason(reason)));
   }
 
+  private V1Job setFailedConditionWithReason(V1Job job, String reason) {
+    return job.status(new V1JobStatus().conditions(
+            new ArrayList<>(Arrays.asList(new V1JobCondition().type("Failed").status("True").reason(reason)))));
+  }
+
   @Test
   public void whenJobHasNoStatus_reportNotFailed() {
     assertThat(JobWatcher.isFailed(cachedJob), is(false));
+  }
+
+  @Test
+  public void whenJobHasNoStatusAndFailedCondition_reportFailed() {
+    markJobFailed(cachedJob);
+    assertThat(JobWatcher.isFailed(cachedJob), is(true));
   }
 
   @Test
@@ -244,6 +283,13 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   @Test
   public void whenWaitForReadyAppliedToFailedJob_performNextStep() {
     startWaitForReady(this::markJobFailed);
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @Test
+  public void whenWaitForReadyAppliedToJobWithFailedCondition_performNextStep() {
+    startWaitForReady(this::markJobConditionFailed);
 
     assertThat(terminalStep.wasRun(), is(true));
   }


### PR DESCRIPTION
This PR evaluates the job condition in addition to job status to determine if the job has failed. In "etcd restore" test, when job remains in the Pending state for more than `ActiveDeadlineSeconds`, the job condition is changed to "failed" but the job status remains null. This causes the fiber to get stuck in the `WaitForJobReady` step. 