### PR TITLE
minor change plus code cleanup and refactoring

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -526,17 +526,14 @@ public class DomainStatusUpdater {
       }
 
       private boolean stillHasPodPendingRestart(DomainStatus status) {
-        boolean found = false;
+        return status.getServers().stream()
+            .map(this::getServerPod)
+            .map(this::getLabels)
+            .anyMatch(m -> m.containsKey(LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL));
+      }
 
-        for (ServerStatus serverStatus : status.getServers()) {
-          V1Pod pod = super.getInfo().getServerPod(serverStatus.getServerName());
-          Map<String, String> labels = getLabels(pod);
-          if (labels.containsKey(LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL)) {
-            found = true;
-            break;
-          }
-        }
-        return found;
+      private V1Pod getServerPod(ServerStatus serverStatus) {
+        return getInfo().getServerPod(serverStatus.getServerName());
       }
 
       private Map<String, String> getLabels(V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -134,7 +135,7 @@ public class DomainStatusUpdater {
    * @return Step
    */
   public static Step createProgressingStartedEventStep(String reason, boolean isPreserveAvailable, Step next) {
-    return Step.chain(EventHelper.createEventStep(new EventData(DOMAIN_PROCESSING_STARTING)),
+    return Step.chain(EventHelper.createEventStep(DOMAIN_PROCESSING_STARTING),
         createProgressingStep(reason, isPreserveAvailable, next));
   }
 
@@ -149,7 +150,7 @@ public class DomainStatusUpdater {
    */
   public static Step createProgressingStartedEventStep(
       DomainPresenceInfo info, String reason, boolean isPreserveAvailable, Step next) {
-    return Step.chain(EventHelper.createEventStep(new EventData(DOMAIN_PROCESSING_STARTING)),
+    return Step.chain(EventHelper.createEventStep(DOMAIN_PROCESSING_STARTING),
         createProgressingStep(info, reason, isPreserveAvailable, next));
   }
 
@@ -361,11 +362,11 @@ public class DomainStatusUpdater {
       if (UnrecoverableErrorBuilder.isAsyncCallUnrecoverableFailure(callResponse)) {
         return super.onFailure(packet, callResponse);
       } else {
-        return onFailure(createRetry(context, getNext()), packet, callResponse);
+        return onFailure(createRetry(context), packet, callResponse);
       }
     }
 
-    public Step createRetry(DomainStatusUpdaterContext context, Step next) {
+    public Step createRetry(DomainStatusUpdaterContext context) {
       return Step.chain(createDomainRefreshStep(context), updaterStep);
     }
 
@@ -417,7 +418,7 @@ public class DomainStatusUpdater {
           .map(DomainPresenceInfo::getDomain)
           .map(Domain::getStatus)
           .map(DomainStatus::getConditions)
-          .orElse(null);
+          .orElse(Collections.emptyList());
 
       for (DomainCondition cond : domainConditions) {
         if ("BackoffLimitExceeded".equals(cond.getReason())) {
@@ -529,15 +530,20 @@ public class DomainStatusUpdater {
 
         for (ServerStatus serverStatus : status.getServers()) {
           V1Pod pod = super.getInfo().getServerPod(serverStatus.getServerName());
-          if (pod != null) {
-            Map<String, String> labels = pod.getMetadata().getLabels();
-            if (labels.keySet().contains(LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL)) {
-              found = true;
-              break;
-            }
+          Map<String, String> labels = getLabels(pod);
+          if (labels.containsKey(LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL)) {
+            found = true;
+            break;
           }
         }
         return found;
+      }
+
+      private Map<String, String> getLabels(V1Pod pod) {
+        return Optional.ofNullable(pod)
+            .map(V1Pod::getMetadata)
+            .map(V1ObjectMeta::getLabels)
+            .orElse(Collections.emptyMap());
       }
 
       private boolean allIntendedServersRunning() {

--- a/operator/src/main/java/oracle/kubernetes/operator/Namespaces.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Namespaces.java
@@ -259,8 +259,8 @@ public class Namespaces {
     static class NamespaceWatchStopEventsStep extends Step {
       final List<StepAndPacket> nsStopEventDetails;
 
-      NamespaceWatchStopEventsStep(List<StepAndPacket> nsStopeventDetails) {
-        this.nsStopEventDetails = nsStopeventDetails;
+      NamespaceWatchStopEventsStep(List<StepAndPacket> nsStopEventDetails) {
+        this.nsStopEventDetails = nsStopEventDetails;
       }
 
       @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -48,9 +48,7 @@ public interface ProcessingConstants {
   String READINESS_PROBE_FAILURE_EVENT_FILTER =
       "reason=Unhealthy,type=Warning,involvedObject.fieldPath=spec.containers{weblogic-server}";
 
-  String EVENT_TYPE = "eventType";
   String FATAL_INTROSPECTOR_ERROR = "FatalIntrospectorError";
-  String DYNAMICUPDATE_INCOMPAT_SPECCHG_ERROR = "DynamicUpdateSpecIncompatibleChange";
 
   String EXCEEDED_INTROSPECTOR_MAX_RETRY_COUNT_ERROR_MSG = "Stop introspection retry - "
       + "exceeded configured domainPresenceFailureRetryMaxCount: "

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -67,8 +67,7 @@ public class EventHelper {
    * @param eventItem event item
    * @return Step for creating an event
    */
-  public static Step createEventStep(
-      EventItem eventItem) {
+  public static Step createEventStep(EventItem eventItem) {
     return createEventStep(new EventData(eventItem));
   }
 
@@ -78,8 +77,7 @@ public class EventHelper {
    * @param eventData event data
    * @return Step for creating an event
    */
-  public static Step createEventStep(
-      EventData eventData) {
+  public static Step createEventStep(EventData eventData) {
     return new CreateEventStep(eventData);
   }
 
@@ -90,8 +88,7 @@ public class EventHelper {
    * @param next next step
    * @return Step for creating an event
    */
-  public static Step createEventStep(
-      EventData eventData, Step next) {
+  public static Step createEventStep(EventData eventData, Step next) {
     return new CreateEventStep(eventData, next);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -64,7 +64,18 @@ public class EventHelper {
   /**
    * Factory for {@link Step} that asynchronously create an event.
    *
-   * @param eventData event item
+   * @param eventItem event item
+   * @return Step for creating an event
+   */
+  public static Step createEventStep(
+      EventItem eventItem) {
+    return createEventStep(new EventData(eventItem));
+  }
+
+  /**
+   * Factory for {@link Step} that asynchronously create an event.
+   *
+   * @param eventData event data
    * @return Step for creating an event
    */
   public static Step createEventStep(
@@ -168,7 +179,7 @@ public class EventHelper {
         if (isForbiddenForNamespaceWatchingStoppedEvent(callResponse)) {
           LOGGER.info(MessageKeys.CREATING_EVENT_FORBIDDEN,
               eventData.eventItem.getReason(), eventData.getNamespace());
-          return onFailureNoRetry(packet, callResponse);
+          return doNext(packet);
         }
         return super.onFailure(packet, callResponse);
       }

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -598,6 +598,7 @@ public class MainTest extends ThreadFactoryTestBase {
     assertThat(domainNamespaces.getDomainEventWatcher(NS), notNullValue());
     assertThat(domainNamespaces.getPodWatcher(NS), notNullValue());
     assertThat(domainNamespaces.getServiceWatcher(NS), notNullValue());
+    assertThat(domainNamespaces.getPodDisruptionBudgetWatcher(NS), notNullValue());
   }
 
   @Test


### PR DESCRIPTION
Changes in this PR:
1) let operator continue, instead of fail, when it hits Unauthorized error on creating NamespaceWatchingStopped event in the domain's namespace. This only happens when a namespace is not managed by the operator any more, and the permissions that are required to create an event in that namespace have been removed; the operator already logs this error.
2) clean up some classes based on warnings that IntelliJ points out.
3) minor refactoring in DomainRecheck as a followup to a review comment to PR#2180. 

Integration test run on Jenkins (completed with 2 known failures): https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4102/.