### PR TITLE
Test changing MaxDynamicClusterSize and MinDynamicClusterSize using dynamic update

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -1044,8 +1044,8 @@ class ItMiiDynamicUpdate {
 
   /**
    * Modify MaxDynamicClusterSize and MinDynamicClusterSize using dynamic update.
-   * Verify the cluster can not be scaled beyond the modified MaxDynamicClusterSize value
-   * and can not be scaled below MinDynamicClusterSize when allowReplicasBelowMinDynClusterSize is set false.
+   * Verify the cluster cannot be scaled beyond the modified MaxDynamicClusterSize value
+   * and cannot be scaled below MinDynamicClusterSize when allowReplicasBelowMinDynClusterSize is set false.
    * Verify JMS message and connection distribution/load balance after scaling the cluster.
    */
   @Test
@@ -1061,15 +1061,13 @@ class ItMiiDynamicUpdate {
     assertTrue(p1Success,
         String.format("Patching replica to 5 failed for domain %s in namespace %s", domainUid, domainNamespace));
 
-    // Make sure the cluster can be scaled to replica count 5
-    // since the MaxDynamicClusterSize is set to 5
+    // Make sure the cluster can be scaled to replica count 5 as MaxDynamicClusterSize is set to 5
     checkPodReadyAndServiceExists(managedServerPrefix + "2", domainUid, domainNamespace);
     checkPodReadyAndServiceExists(managedServerPrefix + "3", domainUid, domainNamespace);
     checkPodReadyAndServiceExists(managedServerPrefix + "4", domainUid, domainNamespace);
     checkPodReadyAndServiceExists(managedServerPrefix + "5", domainUid, domainNamespace);
 
-    // Make sure the cluster can be scaled to replica count 1
-    // since the MinDynamicClusterSize is set to 1
+    // Make sure the cluster can be scaled to replica count 1 as MinDynamicClusterSize is set to 1
     logger.info("[Before Patching] updating the replica count to 1");
     boolean p11Success = assertDoesNotThrow(() ->
             scaleCluster(domainUid, domainNamespace, "cluster-1", 1),
@@ -1149,7 +1147,7 @@ class ItMiiDynamicUpdate {
             "/u01", "JmsTestClient", "t3://" + domainUid + "-cluster-cluster-1:8001", "4", "true"));
 
     // Since the MinDynamicClusterSize is set to 2 in the config map and allowReplicasBelowMinDynClusterSize is set
-    // false, the replica count can not go below 2. So during the following scale down operation
+    // false, the replica count cannot go below 2. So during the following scale down operation
     // only managed-server3 and managed-server4 pod should be removed.
     logger.info("[After Patching] updating the replica count to 1");
     boolean p4Success = assertDoesNotThrow(() ->

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -119,7 +119,7 @@ class ItMiiDynamicUpdate {
   private static String domainNamespace = null;
   private static ConditionFactory withStandardRetryPolicy = null;
   private static ConditionFactory withQuickRetryPolicy;
-  private static int replicaCount = 1;
+  private static int replicaCount = 2;
   private static final String domainUid = "mii-dynamic-update";
   private static String pvName = domainUid + "-pv"; // name of the persistent volume
   private static String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
@@ -130,6 +130,7 @@ class ItMiiDynamicUpdate {
   private final String workManagerName = "newWM";
   private static Path pathToChangeTargetYaml = null;
   private static Path pathToAddClusterYaml = null;
+  private static Path pathToRemoveSystemResourcesYaml = null;
   private static LoggingFacade logger = null;
 
   /**
@@ -1106,66 +1107,97 @@ class ItMiiDynamicUpdate {
     // Patch a running domain with introspectVersion.
     String introspectVersion = patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
-    // Verifying introspector pod is created, runs and deleted
-    verifyIntrospectorRuns(domainUid, domainNamespace);
+    try {
+      // Verifying introspector pod is created, runs and deleted
+      verifyIntrospectorRuns(domainUid, domainNamespace);
 
-    verifyPodIntrospectVersionUpdated(pods.keySet(), introspectVersion, domainNamespace);
+      verifyPodIntrospectVersionUpdated(pods.keySet(), introspectVersion, domainNamespace);
 
-    verifyPodsNotRolled(domainNamespace, pods);
+      verifyPodsNotRolled(domainNamespace, pods);
 
-    // build the standalone JMS Client on Admin pod after rolling restart
-    String destLocation = "/u01/JmsTestClient.java";
-    assertDoesNotThrow(() -> copyFileToPod(domainNamespace,
-        adminServerPodName, "",
-        Paths.get(RESOURCE_DIR, "tunneling", "JmsTestClient.java"),
-        Paths.get(destLocation)));
-    runJavacInsidePod(adminServerPodName, domainNamespace, destLocation);
+      // build the standalone JMS Client on Admin pod after rolling restart
+      String destLocation = "/u01/JmsTestClient.java";
+      assertDoesNotThrow(() -> copyFileToPod(domainNamespace,
+          adminServerPodName, "",
+          Paths.get(RESOURCE_DIR, "tunneling", "JmsTestClient.java"),
+          Paths.get(destLocation)));
+      runJavacInsidePod(adminServerPodName, domainNamespace, destLocation);
 
-    // Scale the cluster using replica count 5, managed-server5 should not come up as new MaxClusterSize is 4
-    logger.info("[After Patching] updating the replica count to 5");
-    boolean p3Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", 5),
-        String.format("Scaling the cluster cluster-1 of domain %s in namespace %s failed", domainUid, domainNamespace));
-    assertTrue(p3Success,
-        String.format("replica patching to 5 failed for domain %s in namespace %s", domainUid, domainNamespace));
-    //  Make sure the 3rd Managed server comes up
-    checkServiceExists(managedServerPrefix + "3", domainNamespace);
-    checkServiceExists(managedServerPrefix + "4", domainNamespace);
-    checkPodDeleted(managedServerPrefix + "5", domainUid, domainNamespace);
+      // Scale the cluster using replica count 5, managed-server5 should not come up as new MaxClusterSize is 4
+      logger.info("[After Patching] updating the replica count to 5");
+      boolean p3Success = assertDoesNotThrow(() ->
+              scaleCluster(domainUid, domainNamespace, "cluster-1", 5),
+          String.format("Scaling the cluster cluster-1 of domain %s in namespace %s failed",
+              domainUid, domainNamespace));
+      assertTrue(p3Success,
+          String.format("replica patching to 5 failed for domain %s in namespace %s", domainUid, domainNamespace));
+      //  Make sure the 3rd Managed server comes up
+      checkServiceExists(managedServerPrefix + "3", domainNamespace);
+      checkServiceExists(managedServerPrefix + "4", domainNamespace);
+      checkPodDeleted(managedServerPrefix + "5", domainUid, domainNamespace);
 
-    // Run standalone JMS Client inside the pod using weblogic.jar in classpath.
-    // The client sends 300 messsage to a Uniform Distributed Queue.
-    // Make sure the messages are distributed across the members evenly
-    // and JMS connection is load balanced across all servers
-    withStandardRetryPolicy
-        .conditionEvaluationListener(
-            condition -> logger.info("Wait for t3 JMS Client to access WLS "
-                    + "(elapsed time {0}ms, remaining time {1}ms)",
-                condition.getElapsedTimeInMS(),
-                condition.getRemainingTimeInMS()))
-        .until(runClientInsidePod(adminServerPodName, domainNamespace,
-            "/u01", "JmsTestClient", "t3://" + domainUid + "-cluster-cluster-1:8001", "4", "true"));
+      // Run standalone JMS Client inside the pod using weblogic.jar in classpath.
+      // The client sends 300 messsage to a Uniform Distributed Queue.
+      // Make sure the messages are distributed across the members evenly
+      // and JMS connection is load balanced across all servers
+      withStandardRetryPolicy
+          .conditionEvaluationListener(
+              condition -> logger.info("Wait for t3 JMS Client to access WLS "
+                      + "(elapsed time {0}ms, remaining time {1}ms)",
+                  condition.getElapsedTimeInMS(),
+                  condition.getRemainingTimeInMS()))
+          .until(runClientInsidePod(adminServerPodName, domainNamespace,
+              "/u01", "JmsTestClient", "t3://" + domainUid + "-cluster-cluster-1:8001", "4", "true"));
 
-    // Since the MinDynamicClusterSize is set to 2 in the config map and allowReplicasBelowMinDynClusterSize is set
-    // false, the replica count cannot go below 2. So during the following scale down operation
-    // only managed-server3 and managed-server4 pod should be removed.
-    logger.info("[After Patching] updating the replica count to 1");
-    boolean p4Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", 1),
-        String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, domainNamespace));
-    assertTrue(p4Success,
-        String.format("Cluster replica patching failed for domain %s in namespace %s", domainUid, domainNamespace));
+      // Since the MinDynamicClusterSize is set to 2 in the config map and allowReplicasBelowMinDynClusterSize is set
+      // false, the replica count cannot go below 2. So during the following scale down operation
+      // only managed-server3 and managed-server4 pod should be removed.
+      logger.info("[After Patching] updating the replica count to 1");
+      boolean p4Success = assertDoesNotThrow(() ->
+              scaleCluster(domainUid, domainNamespace, "cluster-1", 1),
+          String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, domainNamespace));
+      assertTrue(p4Success,
+          String.format("Cluster replica patching failed for domain %s in namespace %s", domainUid, domainNamespace));
 
-    checkPodReadyAndServiceExists(managedServerPrefix + "2", domainUid, domainNamespace);
-    checkPodDoesNotExist(managedServerPrefix + "3", domainUid, domainNamespace);
-    checkPodDoesNotExist(managedServerPrefix + "4", domainUid, domainNamespace);
-    for (int i = 1; i <= replicaCount; i++) {
-      logger.info("Check managed server service {0} available in namespace {1}",
-          managedServerPrefix + i, domainNamespace);
-      checkServiceExists(managedServerPrefix + i, domainNamespace);
+      checkPodReadyAndServiceExists(managedServerPrefix + "2", domainUid, domainNamespace);
+      checkPodDoesNotExist(managedServerPrefix + "3", domainUid, domainNamespace);
+      checkPodDoesNotExist(managedServerPrefix + "4", domainUid, domainNamespace);
+      for (int i = 1; i <= replicaCount; i++) {
+        logger.info("Check managed server service {0} available in namespace {1}",
+            managedServerPrefix + i, domainNamespace);
+        checkServiceExists(managedServerPrefix + i, domainNamespace);
+      }
+    } finally {
+      // remove file store, jms server and jms module
+      // write sparse yaml to file
+      pathToRemoveSystemResourcesYaml = Paths.get(WORK_DIR + "/removesystemresources.yaml");
+      String yamlToRemoveSystemResources = "resources:\n"
+          + "    FileStore:\n"
+          + "        !ClusterFileStore:\n"
+          + "    JMSServer:\n"
+          + "        !ClusterJmsServer:\n"
+          + "    JMSSystemResource:\n"
+          + "        !ClusterJmsModule:\n"
+          + "    JDBCSystemResource:\n"
+          + "        !TestDataSource2:";
+
+      assertDoesNotThrow(() -> Files.write(pathToRemoveSystemResourcesYaml, yamlToRemoveSystemResources.getBytes()));
+
+      replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
+          Arrays.asList(MODEL_DIR + "/model.config.wm.yaml", pathToAddClusterYaml.toString(),
+               pathToRemoveSystemResourcesYaml.toString()), withStandardRetryPolicy);
+
+      // Patch a running domain with introspectVersion.
+      introspectVersion = patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
+
+      // Verifying introspector pod is created, runs and deleted
+      verifyIntrospectorRuns(domainUid, domainNamespace);
+
+      verifyPodIntrospectVersionUpdated(pods.keySet(), introspectVersion, domainNamespace);
+
+      verifyPodsNotRolled(domainNamespace, pods);
     }
   }
-
 
   /**
    * Recreate configmap containing application config target to none.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -256,6 +256,7 @@ public class CommonMiiTestUtils {
    * @param clusterName name of the cluster to add in domain
    * @param configMapName name of the configMap containing Weblogic Deploy Tooling model
    * @param dbSecretName name of the Secret for WebLogic configuration overrides
+   * @param allowReplicasBelowMinDynClusterSize whether to allow scaling below min dynamic cluster size
    * @param onlineUpdateEnabled whether to enable onlineUpdate feature for mii dynamic update
    * @return domain object of the domain resource
    */
@@ -272,6 +273,7 @@ public class CommonMiiTestUtils {
       String clusterName,
       String configMapName,
       String dbSecretName,
+      boolean allowReplicasBelowMinDynClusterSize,
       boolean onlineUpdateEnabled) {
     LoggingFacade logger = getLogger();
 
@@ -288,6 +290,7 @@ public class CommonMiiTestUtils {
         .spec(new DomainSpec()
             .domainUid(domainResourceName)
             .domainHomeSourceType("FromModel")
+            .allowReplicasBelowMinDynClusterSize(allowReplicasBelowMinDynClusterSize)
             .image(imageName)
             .addImagePullSecretsItem(new V1LocalObjectReference()
                 .name(repoSecretName))


### PR DESCRIPTION
  Modify MaxDynamicClusterSize and MinDynamicClusterSize using dynamic update.
  Verify the cluster cannot be scaled beyond the modified MaxDynamicClusterSize value
  and cannot be scaled below MinDynamicClusterSize when allowReplicasBelowMinDynClusterSize is set false.
  Verify JMS message and connection distribution/load balance after scaling the cluster.

Jenkins results -
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4101/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4103/ (In progress)