### PR TITLE
owls-87625 - Remove stranded old named node port service for the domain when deleting and replacing service

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -48,6 +48,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import static oracle.kubernetes.operator.LabelConstants.forDomainUidSelector;
 import static oracle.kubernetes.operator.LabelConstants.getCreatedbyOperatorSelector;
 import static oracle.kubernetes.operator.helpers.KubernetesUtils.getDomainUidLabel;
+import static oracle.kubernetes.operator.helpers.OperatorServiceType.EXTERNAL;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_CREATED;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_EXISTS;
 import static oracle.kubernetes.operator.logging.MessageKeys.ADMIN_SERVICE_REPLACED;
@@ -534,7 +535,7 @@ public class ServiceHelper {
     protected abstract String getServiceCreatedMessageKey();
 
     private Step deleteAndReplaceService(Step next) {
-      if (getSpecType().equals(NODE_PORT_TYPE)) {
+      if (serviceType == EXTERNAL) {
         return deleteAndReplaceNodePortService();
       } else {
         V1DeleteOptions deleteOptions = new V1DeleteOptions();
@@ -824,7 +825,7 @@ public class ServiceHelper {
     private final String adminServerName;
 
     ExternalServiceStepContext(Step conflictStep, Packet packet) {
-      super(conflictStep, packet, OperatorServiceType.EXTERNAL);
+      super(conflictStep, packet, EXTERNAL);
       adminServerName = (String) packet.get(ProcessingConstants.SERVER_NAME);
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -534,10 +534,10 @@ public class ServiceHelper {
     protected abstract String getServiceCreatedMessageKey();
 
     private Step deleteAndReplaceService(Step next) {
-      V1DeleteOptions deleteOptions = new V1DeleteOptions();
       if (getSpecType().equals(NODE_PORT_TYPE)) {
         return deleteAndReplaceNodePortService();
       } else {
+        V1DeleteOptions deleteOptions = new V1DeleteOptions();
         return new CallBuilder()
             .deleteServiceAsync(
                 createServiceName(), getNamespace(), getDomainUid(), deleteOptions, new DeleteServiceResponse(next));
@@ -552,14 +552,9 @@ public class ServiceHelper {
                       new ActionResponseStep<V1ServiceList>() {
                       public Step createSuccessStep(V1ServiceList result, Step next) {
                         Collection<V1Service> c = Optional.ofNullable(result).map(list -> list.getItems().stream()
-                                  .filter(s -> isNodePortService(s))
+                                  .filter(s -> isNodePortType(s))
                                   .collect(Collectors.toList())).orElse(new ArrayList<>());
                         return new DeleteServiceListStep(c, createReplacementService(next));
-                      }
-
-                      private boolean isNodePortService(V1Service svc) {
-                        return Optional.ofNullable(svc).map(s -> s.getSpec())
-                                  .map(s -> s.getType()).map(t -> t.equals(NODE_PORT_TYPE)).orElse(false);
                       }
                     });
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/DeleteServiceListStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/DeleteServiceListStep.java
@@ -19,7 +19,7 @@ import static oracle.kubernetes.operator.helpers.KubernetesUtils.getDomainUidLab
  */
 public class DeleteServiceListStep extends AbstractListStep<V1Service> {
 
-  DeleteServiceListStep(Collection<V1Service> c, Step next) {
+  public DeleteServiceListStep(Collection<V1Service> c, Step next) {
     super(c, next);
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -19,9 +19,11 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServicePort;
+import io.kubernetes.client.openapi.models.V1ServiceSpec;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.calls.FailureStatusSourceException;
@@ -76,6 +78,7 @@ import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
@@ -121,6 +124,8 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
   private static final int NAP_PORT_1 = 7100;
   private static final int NAP_PORT_2 = 37100;
   private static final int NAP_PORT_3 = 37200;
+  public static final String STRANDED = "Stranded";
+  public static final String NODE_PORT = "NodePort";
   private final TerminalStep terminalStep = new TerminalStep();
   @Parameter public String testType;
   @Parameter(1)
@@ -399,11 +404,20 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
 
   private void verifyServiceReplaced(Runnable configurationMutator) {
     recordInitialService();
+    if (testFacade instanceof ExternalServiceTestFacade) {
+      recordStrandedService();
+    }
     configurationMutator.run();
 
     runServiceHelper();
 
     assertThat(logRecords, containsInfo(testFacade.getServiceReplacedLogMessage()));
+    assertThat(getStrandedService(), empty());
+  }
+
+  private List<Object> getStrandedService() {
+    ArrayList<V1Service> svcList = (ArrayList)testSupport.getResources(SERVICE);
+    return svcList.stream().filter(s -> s.getMetadata().getName().equals(STRANDED)).collect(Collectors.toList());
   }
 
   private void configureNewLabel() {
@@ -434,6 +448,16 @@ public class ServiceHelperTest extends ServiceHelperTestBase {
     V1Service originalService = testFacade.createServiceModel(testSupport.getPacket());
     testSupport.defineResources(originalService);
     testFacade.recordService(domainPresenceInfo, originalService);
+  }
+
+  private void recordStrandedService() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(LabelConstants.DOMAINUID_LABEL, UID);
+    labels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
+    V1Service strandedService = new V1Service().metadata(new V1ObjectMeta().name(STRANDED).namespace(NS)
+            .labels(labels)).spec(new V1ServiceSpec().type(NODE_PORT));
+    testSupport.defineResources(strandedService);
+    testFacade.recordService(domainPresenceInfo, strandedService);
   }
 
   @Test


### PR DESCRIPTION
owls-87625 - Operator 3.0.1 version created external NodePort service with "-external" suffix. Operator 3.1.x creates the external NodePort service with shorter name with "-ext" suffix. This is causing an issue when upgrading the Operator from 3.0.1 to 3.1.1 and changing the `restartVersion`.  This is because the port for the external NodePort service created by Operator 3.1.1 is already in use by the NodePort service created by Operator 3.0.1 with the old name (with "-external" suffix).
This change removes stranded old named node port service during the service replace call by listing services of NodePort type created by the Operator for this particular domain. It deletes the node port service returned by the list call and then replaces it with the new name. Integration test results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4105/