### PR TITLE
first pass at fixing integration test to run on OKD

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
@@ -34,6 +34,7 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -42,7 +43,6 @@ import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodIP;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewRestartVersion;
@@ -67,13 +67,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 // which load and verify the cache.
 @DisplayName("Test to create a WebLogic domain with Coherence and verify the use of Coherence cache service")
 @IntegrationTest
+@Tag("okdenv")
 class ItCoherenceTests {
 
   // constants for Coherence
   private static final String PROXY_CLIENT_APP_NAME = "coherence-proxy-client";
   private static final String PROXY_SERVER_APP_NAME = "coherence-proxy-server";
   private static final String APP_LOC_ON_HOST = APP_DIR + "/" + PROXY_CLIENT_APP_NAME;
-  private static final String APP_LOC_IN_POD = "/u01/oracle/apps/" + PROXY_CLIENT_APP_NAME;
+  private static final String APP_LOC_IN_POD = "/u01/apps/" + PROXY_CLIENT_APP_NAME;
   private static final String PROXY_CLIENT_SCRIPT = "buildRunProxyClient.sh";
   private static final String OP_CACHE_LOAD = "load";
   private static final String OP_CACHE_VALIDATE = "validate";
@@ -131,8 +132,8 @@ class ItCoherenceTests {
   void tearDown() {
     // Delete domain custom resource
     logger.info("Delete domain custom resource in namespace {0}", domainNamespace);
-    assertDoesNotThrow(() -> deleteDomainCustomResource(domainUid, domainNamespace),
-        "deleteDomainCustomResource failed with ApiException");
+    //assertDoesNotThrow(() -> deleteDomainCustomResource(domainUid, domainNamespace),
+    //    "deleteDomainCustomResource failed with ApiException");
     logger.info("Deleted Domain Custom Resource " + domainUid + " from " + domainNamespace);
   }
 
@@ -143,7 +144,7 @@ class ItCoherenceTests {
    */
   @Test
   @DisplayName("Create domain with a Coherence cluster using WDT and test rolling restart")
-  public void testCohernceServerRollingRestart() {
+  public void testCoherenceServerRollingRestart() {
     final String successMarker = "CACHE-SUCCESS";
 
     // create a DomainHomeInImage image using WebLogic Image Tool

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItInitContainers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItInitContainers.java
@@ -28,6 +28,7 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
@@ -59,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("Test server's pod init container feature")
 @IntegrationTest
+@Tag("okdenv")
 class ItInitContainers {
 
   private static String opNamespace = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManagedCoherence.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManagedCoherence.java
@@ -36,6 +36,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -44,16 +45,18 @@ import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.VOYAGER_CHART_NAME;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteDomainCustomResource;
+//import static oracle.weblogic.kubernetes.actions.TestActions.deleteDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallVoyager;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createImageAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createOcirRepoSecret;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
@@ -72,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 // Test to associate a Coherence Cluster with multiple WebLogic server clusters.
 @DisplayName("Test to associate a Coherence Cluster with multiple WebLogic server clusters")
 @IntegrationTest
+@Tag("okdenv")
 class ItManagedCoherence {
 
   // constants for Coherence
@@ -135,9 +139,11 @@ class ItManagedCoherence {
     assertNotNull(namespaces.get(2), "Namespace list is null");
     domainNamespace = namespaces.get(2);
 
-    // install and verify Voyager
-    voyagerHelmParams =
-      installAndVerifyVoyager(voyagerNamespace, cloudProvider, enableValidatingWebhook);
+    // install and verify Voyager if not running on OKD
+    if (!OKD) {
+      voyagerHelmParams =
+          installAndVerifyVoyager(voyagerNamespace, cloudProvider, enableValidatingWebhook);
+    }
 
     // install and verify operator
     installAndVerifyOperator(opNamespace, domainNamespace);
@@ -165,8 +171,8 @@ class ItManagedCoherence {
 
     // Delete domain custom resource
     logger.info("Delete domain custom resource in namespace {0}", domainNamespace);
-    assertDoesNotThrow(() -> deleteDomainCustomResource(domainUid, domainNamespace),
-        "deleteDomainCustomResource failed with ApiException");
+    //assertDoesNotThrow(() -> deleteDomainCustomResource(domainUid, domainNamespace),
+    //    "deleteDomainCustomResource failed with ApiException");
     logger.info("Deleted Domain Custom Resource " + domainUid + " from " + domainNamespace);
   }
 
@@ -191,35 +197,50 @@ class ItManagedCoherence {
     // create and verify a two-cluster WebLogic domain with a Coherence cluster
     createAndVerifyDomain(domImage);
 
-    // create Voyager ingress resource
-    Map<String, Integer> clusterNameMsPortMap = new HashMap<>();
-    for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
-      clusterNameMsPortMap.put(CLUSTER_NAME_PREFIX + i, MANAGED_SERVER_PORT);
-    }
 
-    // get hostnames
-    List<String>  hostNames =
-        installVoyagerIngressAndVerify(domainUid, domainNamespace, ingressName, clusterNameMsPortMap);
 
-    // get ingress service Nodeport
-    int ingressServiceNodePort = assertDoesNotThrow(()
-        -> getServiceNodePort(domainNamespace, ingressServiceName, channelName),
-            "Getting admin server node port failed");
-    logger.info("Node port for {0} is: {1} :", ingressServiceName, ingressServiceNodePort);
+    if (OKD) {
+      String cluster1HostName = domainUid + "-cluster-cluster-1";
+      String cluster2HostName = domainUid + "-cluster-cluster-2";
 
-    // get hostname for each cluster
-    for (String hostName : hostNames) {
-      if (hostName.contains("cluster-1")) {
-        cluster1Hostname = hostName;
-      } else if (hostName.contains("cluster-2")) {
-        cluster2Hostname = hostName;
+      final String cluster1IngressHost = createRouteForOKD(cluster1HostName, domainNamespace);
+      final String cluster2IngressHost = createRouteForOKD(cluster2HostName, domainNamespace);
+
+      // test adding data to the cache and retrieving them from the cache
+      boolean testCompletedSuccessfully = assertDoesNotThrow(()
+          -> coherenceCacheTest(cluster1IngressHost), "Test Coherence cache failed");
+      assertTrue(testCompletedSuccessfully, "Test Coherence cache failed");
+    } else {
+      // create Voyager ingress resource
+      Map<String, Integer> clusterNameMsPortMap = new HashMap<>();
+      for (int i = 1; i <= NUMBER_OF_CLUSTERS; i++) {
+        clusterNameMsPortMap.put(CLUSTER_NAME_PREFIX + i, MANAGED_SERVER_PORT);
       }
-    }
 
-    // test adding data to the cache and retrieving them from the cache
-    boolean testCompletedSuccessfully = assertDoesNotThrow(()
-        -> coherenceCacheTest(cluster1Hostname, ingressServiceNodePort), "Test Coherence cache failed");
-    assertTrue(testCompletedSuccessfully, "Test Coherence cache failed");
+      // get hostnames
+      List<String> hostNames =
+          installVoyagerIngressAndVerify(domainUid, domainNamespace, ingressName, clusterNameMsPortMap);
+
+      // get ingress service Nodeport
+      int ingressServiceNodePort = assertDoesNotThrow(()
+              -> getServiceNodePort(domainNamespace, ingressServiceName, channelName),
+          "Getting admin server node port failed");
+      logger.info("Node port for {0} is: {1} :", ingressServiceName, ingressServiceNodePort);
+
+      // get hostname for each cluster
+      for (String hostName : hostNames) {
+        if (hostName.contains("cluster-1")) {
+          cluster1Hostname = hostName;
+        } else if (hostName.contains("cluster-2")) {
+          cluster2Hostname = hostName;
+        }
+      }
+
+      // test adding data to the cache and retrieving them from the cache
+      boolean testCompletedSuccessfully = assertDoesNotThrow(()
+          -> coherenceCacheTest(cluster1Hostname, ingressServiceNodePort), "Test Coherence cache failed");
+      assertTrue(testCompletedSuccessfully, "Test Coherence cache failed");
+    }
   }
 
   private static String createAndVerifyDomainImage() {
@@ -345,21 +366,29 @@ class ItManagedCoherence {
         + "for %s in namespace %s", domainUid, domainNamespace));
   }
 
+  private boolean coherenceCacheTest(String hostName) {
+    return coherenceCacheTest(hostName,0); //OKD does not need a port number
+  }
+
   private boolean coherenceCacheTest(String hostName, int ingressServiceNodePort) {
     logger.info("Starting to test the cache");
 
+    logger.info("BR: hostName = {0} ", hostName);
+    String hostAndPort = (OKD) ? hostName : K8S_NODEPORT_HOST + ":" + ingressServiceNodePort;
+
+    logger.info("BR: hostAndPort = {0} ", hostAndPort);
     // add the data to cache
     String[] firstNameList = {"Frodo", "Samwise", "Bilbo", "peregrin", "Meriadoc", "Gandalf"};
     String[] secondNameList = {"Baggins", "Gamgee", "Baggins", "Took", "Brandybuck", "TheGrey"};
     ExecResult result = null;
     for (int i = 0; i < firstNameList.length; i++) {
-      result = addDataToCache(firstNameList[i], secondNameList[i], hostName, ingressServiceNodePort);
+      result = addDataToCache(firstNameList[i], secondNameList[i], hostName, hostAndPort);
       logger.info("Data added to the cache " + result.stdout());
       assertTrue(result.stdout().contains(firstNameList[i]), "Did not add the expected record");
     }
 
     // check if cache size is 6
-    result = getCacheSize(hostName, ingressServiceNodePort);
+    result = getCacheSize(hostName, hostAndPort);
     logger.info("number of records in cache = " + result.stdout());
     if (!(result.stdout().equals("6"))) {
       logger.info("number of records in cache = " + result.stdout());
@@ -367,11 +396,11 @@ class ItManagedCoherence {
     }
 
     // get the data from cache
-    result = getCacheContents(hostName, ingressServiceNodePort);
+    result = getCacheContents(hostName, hostAndPort);
     logger.info("Cache contains the following entries \n" + result.stdout());
 
     // Now clear the cache
-    result = clearCache(hostName, ingressServiceNodePort);
+    result = clearCache(hostName, hostAndPort);
     logger.info("Cache is cleared and should be empty" + result.stdout());
     if (!(result.stdout().trim().equals("0"))) {
       logger.info("number of records in cache = " + result.stdout());
@@ -384,7 +413,7 @@ class ItManagedCoherence {
   private ExecResult addDataToCache(String firstName,
                                     String secondName,
                                     String hostName,
-                                    int ingressServiceNodePort) {
+                                    String hostAndPort) {
     logger.info("Add initial data to cache");
 
     StringBuffer curlCmd = new StringBuffer("curl --silent --show-error --noproxy '*' ");
@@ -397,9 +426,7 @@ class ItManagedCoherence {
         .append("-X POST -H 'host: ")
         .append(hostName)
         .append("' http://")
-        .append(K8S_NODEPORT_HOST)
-        .append(":")
-        .append(ingressServiceNodePort)
+        .append(hostAndPort)
         .append("/")
         .append(COHERENCE_APP_NAME)
         .append("/")
@@ -414,7 +441,7 @@ class ItManagedCoherence {
     return result;
   }
 
-  private ExecResult getCacheSize(String hostName, int ingressServiceNodePort) {
+  private ExecResult getCacheSize(String hostName, String hostAndPort) {
     logger.info("Get the number of records in cache");
 
     StringBuffer curlCmd = new StringBuffer("curl --silent --show-error --noproxy '*' ");
@@ -423,9 +450,7 @@ class ItManagedCoherence {
         .append("-H 'host: ")
         .append(hostName)
         .append("' http://")
-        .append(K8S_NODEPORT_HOST)
-        .append(":")
-        .append(ingressServiceNodePort)
+        .append(hostAndPort)
         .append("/")
         .append(COHERENCE_APP_NAME)
         .append("/")
@@ -440,7 +465,7 @@ class ItManagedCoherence {
     return result;
   }
 
-  private ExecResult getCacheContents(String hostName, int ingressServiceNodePort) {
+  private ExecResult getCacheContents(String hostName, String hostAndPort) {
     logger.info("Get the records from cache");
 
     StringBuffer curlCmd = new StringBuffer("curl --silent --show-error --noproxy '*' ");
@@ -449,9 +474,7 @@ class ItManagedCoherence {
         .append("-H 'host: ")
         .append(hostName)
         .append("' http://")
-        .append(K8S_NODEPORT_HOST)
-        .append(":")
-        .append(ingressServiceNodePort)
+        .append(hostAndPort)
         .append("/")
         .append(COHERENCE_APP_NAME)
         .append("/")
@@ -466,7 +489,7 @@ class ItManagedCoherence {
     return result;
   }
 
-  private ExecResult clearCache(String hostName, int ingressServiceNodePort) {
+  private ExecResult clearCache(String hostName, String hostAndPort) {
     logger.info("Clean the cache");
 
     StringBuffer curlCmd = new StringBuffer("curl --silent --show-error --noproxy '*' ");
@@ -475,9 +498,7 @@ class ItManagedCoherence {
         .append("-H 'host: ")
         .append(hostName)
         .append("' http://")
-        .append(K8S_NODEPORT_HOST)
-        .append(":")
-        .append(ingressServiceNodePort)
+        .append(hostAndPort)
         .append("/")
         .append(COHERENCE_APP_NAME)
         .append("/")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodTemplates.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodTemplates.java
@@ -27,6 +27,7 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
@@ -56,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("Test to verify domain pod templates.")
 @IntegrationTest
+@Tag("okdenv")
 class ItPodTemplates {
 
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
@@ -28,6 +28,7 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
@@ -56,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("Verify shutdown rules when shutdown properties are defined at different levels")
 @IntegrationTest
+@Tag("okdenv")
 class ItPodsShutdownOption {
 
   private static String domainNamespace = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSessionMigration.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSessionMigration.java
@@ -34,6 +34,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -70,6 +71,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @DisplayName("Test the HTTP session replication features of WebLogic")
 @IntegrationTest
+@Tag("okdenv")
 class ItSessionMigration {
 
   // constants for creating domain image using model in image
@@ -397,7 +399,7 @@ class ItSessionMigration {
 
   private static String buildCurlCommand(String curlUrlPath,
                                          String headerOption) {
-    final String httpHeaderFile = "/u01/oracle/header";
+    final String httpHeaderFile = "/u01/domains/header";
     final String clusterAddress = domainUid + "-cluster-" + clusterName;
     logger.info("Build a curl command with pod name {0}, curl URL path {1} and HTTP header option {2}",
         clusterAddress, curlUrlPath, headerOption);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -22,7 +22,7 @@ public interface TestConstants {
   public static final String WLS_DEFAULT_CHANNEL_NAME = "default";
   public static final String DEFAULT_WLS_IMAGE_TAGS = "12.2.1.3, 12.2.1.4, 14.1.1.0-11";
 
-  // operator constants
+  // operator constants:
   public static final String OPERATOR_RELEASE_NAME = "weblogic-operator";
   public static final String OPERATOR_CHART_DIR =
       "../kubernetes/charts/weblogic-operator";
@@ -275,6 +275,10 @@ public interface TestConstants {
       .orElse("");
   public static final String FSS_DIR = Optional.ofNullable(System.getenv("FSS_DIR"))
       .orElse("");
+
+  //OKD constants
+  public static final boolean OKD = Boolean.parseBoolean(Optional.ofNullable(System.getenv("OKD"))
+          .orElse("false"));
 
   // default name suffixes
   public String DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX = "-ext";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Secret.java
@@ -8,9 +8,18 @@ import java.util.Base64;
 import java.util.List;
 
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
+import io.kubernetes.client.openapi.models.V1ServiceAccount;
+import io.kubernetes.client.openapi.models.V1ServiceAccountList;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
+
+import static oracle.weblogic.kubernetes.TestConstants.OKD;
+import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listServiceAccounts;
+import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.readSecretByReference;
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 
 public class Secret {
 
@@ -44,21 +53,49 @@ public class Secret {
    */
   public static String getSecretOfServiceAccount(String namespace, String serviceAccountName) {
 
+    LoggingFacade logger = getLogger();
     List<V1Secret> v1Secrets = new ArrayList<>();
+    List<V1ServiceAccount> v1ServiceAccounts = new ArrayList<>();
+    List<V1Secret> v1SaSecrets = new ArrayList<>();
+    String token = null;
 
-    V1SecretList secretList = listSecrets(namespace);
-    if (secretList != null) {
-      v1Secrets = secretList.getItems();
-    }
+    if (!OKD) {
+      V1SecretList secretList = listSecrets(namespace);
+      if (secretList != null) {
+        v1Secrets = secretList.getItems();
+      }
 
-    for (V1Secret v1Secret : v1Secrets) {
-      if (v1Secret.getMetadata() != null && v1Secret.getMetadata().getName() != null) {
-        if (v1Secret.getMetadata().getName().startsWith(serviceAccountName)) {
-          return v1Secret.getMetadata().getName();
+      for (V1Secret v1Secret : v1Secrets) {
+        if (v1Secret.getMetadata() != null && v1Secret.getMetadata().getName() != null) {
+          logger.info(" secret name = {0}", v1Secret.getMetadata().getName());
+          if (v1Secret.getMetadata().getName().startsWith(serviceAccountName)) {
+            return v1Secret.getMetadata().getName();
+          }
         }
       }
-    }
+    } else {
+      V1ServiceAccountList serviceAccountList = listServiceAccounts(namespace);
+      if (serviceAccountList != null) {
+        v1ServiceAccounts = serviceAccountList.getItems();
+      }
 
+      try {
+        for (V1ServiceAccount v1ServiceAccount : v1ServiceAccounts) {
+          if (v1ServiceAccount.getMetadata() != null && v1ServiceAccount.getMetadata().getName() != null) {
+            if (v1ServiceAccount.getMetadata().getName().startsWith(serviceAccountName)) {
+              List<V1ObjectReference> saSecretList = v1ServiceAccount.getSecrets();
+              for (V1ObjectReference reference : saSecretList) {
+                // Get the secret.
+                V1Secret secret = readSecretByReference(reference, namespace);
+                return secret.getMetadata().getName();
+              }
+            }
+          }
+        }
+      } catch (ApiException apie) {
+        logger.info(" got ApiException");
+      }
+    }
     return "";
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -54,6 +54,7 @@ import io.kubernetes.client.openapi.models.V1NamespaceBuilder;
 import io.kubernetes.client.openapi.models.V1NamespaceList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
+import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimList;
@@ -1498,6 +1499,27 @@ public class Kubernetes {
       getLogger().warning("Failed to list secrets, status code {0}", list.getHttpStatusCode());
       return null;
     }
+  }
+
+  /**
+   * Read a secret by its object reference.
+   *
+   * @param reference V1ObjectReference An object reference to the Secret you want to read.
+   * @param namespace The Namespace where Secret is defined.
+   * @return V1Secret The requested Secret.
+   * @throws ApiException if there is an API error.
+   */
+  public static V1Secret readSecretByReference(V1ObjectReference reference, String namespace)
+      throws ApiException {
+
+    if (reference.getNamespace() != null) {
+      namespace = reference.getNamespace();
+    }
+
+    V1Secret secret = coreV1Api.readNamespacedSecret(
+            reference.getName(), namespace, "false", Boolean.TRUE, Boolean.TRUE);
+
+    return secret;
   }
 
   // --------------------------- pv/pvc ---------------------------

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -25,6 +25,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.WLS_DEFAULT_CHANNEL_NAME;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.getDomainCustomResource;
@@ -286,28 +287,30 @@ public class Domain {
       String namespace,
       String username,
       String password) {
+
     int adminServiceNodePort
         = getServiceNodePort(namespace, getExternalServicePodName(podName), WLS_DEFAULT_CHANNEL_NAME);
-
     if (username == null) {
       username = ADMIN_USERNAME_DEFAULT;
     }
     if (password == null) {
       password = ADMIN_PASSWORD_DEFAULT;
     }
+    String url = (OKD) ? host : host + ":" + adminServiceNodePort;
 
     // create a RESTful management services command that connects to admin server using given credentials to get
     // information about a managed server
+
     StringBuffer cmdString = new StringBuffer()
         .append("status=$(curl --user " + username + ":" + password)
-        .append(" http://" + host + ":" + adminServiceNodePort)
+        .append(" http://" + url)
         .append("/management/tenant-monitoring/servers/managed-server1")
         .append(" --silent --show-error")
         .append(" --noproxy '*'")
         .append(" -o /dev/null")
         .append(" -w %{http_code});")
         .append(" echo ${status}");
-
+     
     return Command
             .defaultCommandParams()
             .command(cmdString.toString())

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -51,6 +51,7 @@ import static oracle.weblogic.kubernetes.TestConstants.OCIR_USERNAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
 import static oracle.weblogic.kubernetes.TestConstants.OCR_USERNAME;
+import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.REPO_DUMMY_VALUE;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_APP_NAME;
@@ -265,10 +266,13 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
           }
         }
 
+
         // set initialization success to true, not counting the istio installation as not all tests use istio
         isInitializationSuccessful = true;
-        logger.info("Installing istio before any test suites are run");
-        installIstio();
+        if (!OKD) {
+          logger.info("Installing istio before any test suites are run");
+          installIstio();
+        }
       } finally {
         // Initialization is done. Release all waiting other threads. The latch is now disabled so
         // other threads
@@ -310,8 +314,10 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
         && System.getenv("SKIP_CLEANUP").toLowerCase().equals("true")) {
       logger.info("Skipping RESULTS_ROOT clean up after test execution");
     } else {
-      logger.info("Uninstall istio after all test suites are run");
-      uninstallIstio();
+      if (!OKD) {
+        logger.info("Uninstall istio after all test suites are run");
+        uninstallIstio();
+      }
       logger.info("Cleanup WIT/WDT binary form {0}", RESULTS_ROOT);
       try {
         Files.deleteIfExists(Paths.get(RESULTS_ROOT, "wlthint3client.jar"));


### PR DESCRIPTION
Working on getting the integration test to run successfully in OKD environment. If running in OKD env, the tests should use OKD's default ingress controller. Also, added an environment variable "OKD=true" when running in OKD environment and a tag "okdenv" for the tests that are to be run in that env. 