### PR TITLE
OWLS-87849 - scaleCluster.sh script to patch the 'replicas' attribute of the WLS cluster

### DIFF
--- a/kubernetes/samples/scripts/domain-lifecycle/README.md
+++ b/kubernetes/samples/scripts/domain-lifecycle/README.md
@@ -74,3 +74,14 @@ $ stopDomain.sh -d domain1 -n weblogic-domain-1
 [INFO] Patching domain 'domain1' in namespace 'weblogic-domain-1' from serverStartPolicy='IF_NEEDED' to 'NEVER'.
 domain.weblogic.oracle/domain1 patched
 [INFO] Successfully patched domain 'domain1' in namespace 'weblogic-domain-1' with 'NEVER' start policy!
+```
+
+### Scripts to scale a WebLogic cluster
+
+The `scaleCluster.sh` script scales a WebLogic cluster by patching the `spec.clusters[<cluster-name>].replicas` attribute of the domain resource to the specified value. The operator will perform the scaling operation for the WebLogic cluster based on the specified value of the `replicas` attribute. See the script `usage` information by using the `-h` option.
+```
+$ scaleCluster.sh -d domain1 -n weblogic-domain-1 -c cluster-1 -r 3
+[2021-02-26T19:04:14.335 UTC][INFO] Patching replicas for cluster 'cluster-1' to '3'.
+domain.weblogic.oracle/domain1 patched
+[2021-02-26T19:04:14.466 UTC][INFO] Successfully patched replicas for cluster 'cluster-1'!
+```

--- a/kubernetes/samples/scripts/domain-lifecycle/README.md
+++ b/kubernetes/samples/scripts/domain-lifecycle/README.md
@@ -78,7 +78,7 @@ domain.weblogic.oracle/domain1 patched
 
 ### Scripts to scale a WebLogic cluster
 
-The `scaleCluster.sh` script scales a WebLogic cluster by patching the `spec.clusters[<cluster-name>].replicas` attribute of the domain resource to the specified value. The operator will perform the scaling operation for the WebLogic cluster based on the specified value of the `replicas` attribute. See the script `usage` information by using the `-h` option.
+The `scaleCluster.sh` script scales a WebLogic cluster by patching the `spec.clusters[<cluster-name>].replicas` attribute of the domain resource to the specified value. The operator will perform the scaling operation for the WebLogic cluster based on the specified value of the `replicas` attribute after it's value is updated. See the script `usage` information by using the `-h` option.
 ```
 $ scaleCluster.sh -d domain1 -n weblogic-domain-1 -c cluster-1 -r 3
 [2021-02-26T19:04:14.335 UTC][INFO] Patching replicas for cluster 'cluster-1' to '3'.

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -271,7 +271,7 @@ function createPatchJsonToUpdateClusterPolicy {
 #
 # Function to create patch json to update cluster replicas
 # $1 - Domain resource in json format
-# $2 - Name of cluster whose policy will be patched
+# $2 - Name of cluster whose replicas will be patched
 # $3 - replica count
 # $4 - Return value containing patch json string
 #

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -16,7 +16,7 @@ function getClusterPolicy {
   local __clusterPolicy=$3
   local effectivePolicy=""
 
-  clusterPolicyCmd="(.spec.clusters[] \
+  clusterPolicyCmd="(.spec.clusters // empty | .[] \
     | select (.clusterName == \"${clusterName}\")).serverStartPolicy"
   effectivePolicy=$(echo ${domainJson} | jq "${clusterPolicyCmd}")
   if [ "${effectivePolicy}" == "null" ]; then
@@ -249,10 +249,53 @@ function createPatchJsonToUpdateClusterPolicy {
   local policy=$3
   local __result=$4
   
-  replacePolicyCmd="(.spec.clusters[] | select (.clusterName == \"${clusterName}\") \
-    | .serverStartPolicy) |= \"${policy}\""
-  startPolicy=$(echo ${domainJson} | jq "${replacePolicyCmd}" | jq -cr '(.spec.clusters)')
+  clusters=$(echo ${domainJson} | jq -cr '(.spec.clusters)')
+  if [ "${clusters}" == "null" ]; then
+    # cluster doesn't exist, add cluster with server start policy
+    addClusterStartPolicyCmd=".[.| length] |= . + {\"clusterName\":\"${clusterName}\", \
+      \"serverStartPolicy\":\"${policy}\"}"
+    startPolicy=$(echo ${clusters} | jq -c "${addClusterStartPolicyCmd}")
+  else
+    mapCmd="\
+      . |= (map(.clusterName) | index (\"${clusterName}\")) as \$idx | \
+      if \$idx then \
+      .[\$idx][\"serverStartPolicy\"] = \"${policy}\" \
+      else .+  [{clusterName: \"${clusterName}\" , serverStartPolicy: \"${policy}\"}] end"
+    startPolicy=$(echo ${clusters} | jq "${mapCmd}")
+  fi
+
   patchJson="{\"spec\": {\"clusters\": "${startPolicy}"}}"
+  eval $__result="'${patchJson}'"
+}
+
+#
+# Function to create patch json to update cluster replicas
+# $1 - Domain resource in json format
+# $2 - Name of cluster whose policy will be patched
+# $3 - replica count
+# $4 - Return value containing patch json string
+#
+function createPatchJsonToUpdateReplicas {
+  local domainJson=$1
+  local clusterName=$2
+  local replicas=$3
+  local __result=$4
+
+  clusters=$(echo ${domainJson} | jq -cr '(.spec.clusters)')
+  if [ "${clusters}" == "null" ]; then
+    # cluster doesn't exist, add cluster with replicas
+    addClusterReplicasCmd=".[.| length] |= . + {\"clusterName\":\"${clusterName}\", \
+      \"replicas\":${replicas}}"
+    replicasPatch=$(echo ${clusters} | jq -c "${addClusterReplicasCmd}")
+  else
+    mapCmd="\
+      . |= (map(.clusterName) | index (\"${clusterName}\")) as \$idx | \
+      if \$idx then \
+      .[\$idx][\"replicas\"] = ${replicas} \
+      else .+  [{clusterName: \"${clusterName}\" , replicas: ${replicas}}] end"
+    replicasPatch=$(echo ${clusters} | jq "${mapCmd}")
+  fi
+  patchJson="{\"spec\": {\"clusters\": "${replicasPatch}"}}"
   eval $__result="'${patchJson}'"
 }
 
@@ -461,6 +504,32 @@ function isReplicaCountEqualToMinReplicas {
 }
 
 #
+# Function to check if provided replica count is in the allowed range
+# $1 - Domain resource in json format
+# $2 - Name of the cluster
+# $3 - Replica count
+# $4 - Returns "true" or "false" indicating if replica count is in
+#      the allowed range
+# $5 - Returns allowed range for replica count for the given cluster
+#
+function isReplicasInAllowedRange {
+  local domainJson=$1
+  local clusterName=$2
+  local replicas=$3
+  local __result=$4
+  local __range=$5
+
+  eval $__result=true
+  getMinReplicas "${domainJson}" "${clusterName}" minReplicas
+  getMaxReplicas "${domainJson}" "${clusterName}" maxReplicas
+  range="${minReplicas} to ${maxReplicas}"
+  if [ ${replicas} -lt ${minReplicas} ] || [ ${replicas} -gt ${maxReplicas} ]; then
+    eval $__result=false
+    eval $__range="'${range}'"
+  fi
+}
+
+#
 # Function to get minimum replica count for cluster
 # $1 - Domain resource in json format
 # $2 - Name of the cluster
@@ -476,6 +545,24 @@ function getMinReplicas {
     | .minimumReplicas"
   minReplicas=$(echo ${domainJson} | jq "${minReplicaCmd}")
   eval $__result=${minReplicas}
+}
+
+#
+# Function to get maximum replica count for cluster
+# $1 - Domain resource in json format
+# $2 - Name of the cluster
+# $3 - Return value containing maximum replica count
+#
+function getMaxReplicas {
+  local domainJson=$1
+  local clusterName=$2
+  local __result=$3
+
+  eval $__result=0
+  maxReplicaCmd="(.status.clusters[] | select (.clusterName == \"${clusterName}\")) \
+    | .maximumReplicas"
+  maxReplicas=$(echo ${domainJson} | jq "${maxReplicaCmd}")
+  eval $__result=${maxReplicas}
 }
 
 #
@@ -497,13 +584,11 @@ function createReplicaPatch {
   local infoMessage="Current replica count value is same as or greater than maximum number of replica count. \
 Not increasing replica count value."
 
-  maxReplicaCmd="(.status.clusters[] | select (.clusterName == \"${clusterName}\")) \
-    | .maximumReplicas"
   getReplicaCount  "${domainJson}" "${clusterName}" replica
   if [ "${operation}" == "DECREMENT" ]; then
     replica=$((replica-1))
   elif [ "${operation}" == "INCREMENT" ]; then
-    maxReplicas=$(echo ${domainJson} | jq "${maxReplicaCmd}")
+    getMaxReplicas "${domainJson}" "${clusterName}" maxReplicas
     if [ ${replica} -ge ${maxReplicas} ]; then
       printInfo "${infoMessage}"
     else

--- a/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
@@ -1,5 +1,5 @@
 # !/bin/sh
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
@@ -12,7 +12,7 @@ function usage() {
 
   cat << EOF
 
-  This script scales a WebLogic cluster in a domain by patching
+  This script scales a WebLogic cluster in a domain by patching the
   'spec.clusters[<cluster-name>].replicas' attribute of the domain
   resource. This change will cause the operator to perform a scaling
   operation for the WebLogic cluster based on the value of replica count.

--- a/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
@@ -1,0 +1,123 @@
+# !/bin/sh
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+script="${BASH_SOURCE[0]}"
+scriptDir="$( cd "$( dirname "${script}" )" && pwd )"
+source ${scriptDir}/helper.sh
+if [ "${debug}" == "true" ]; then set -x; fi;
+
+function usage() {
+
+  cat << EOF
+
+  This script scales a WebLogic cluster in a domain by patching
+  'spec.clusters[<cluster-name>].replicas' attribute of the domain
+  resource. This change will cause the operator to perform a scaling
+  operation for the WebLogic cluster based on the value of replica count.
+ 
+  Usage:
+ 
+    $(basename $0) -c mycluster -r replicas [-n mynamespace] [-d mydomainuid] [-m kubecli]
+  
+    -c <cluster-name>   : Cluster name parameter is required.
+
+    -r <replicas>       : Replica count, parameter is required.
+
+    -d <domain_uid>     : Domain unique-id. Default is 'sample-domain1'.
+
+    -n <namespace>      : Domain namespace. Default is 'sample-domain1-ns'.
+
+    -m <kubernetes_cli> : Kubernetes command line interface. Default is 'kubectl' if KUBERNETES_CLI env
+                          variable is not set. Otherwise default is the value of KUBERNETES_CLI env variable.
+
+    -v <verbose_mode>   : Enables verbose mode. Default is 'false'.
+
+    -h                  : This help.
+   
+EOF
+exit $1
+}
+
+kubernetesCli=${KUBERNETES_CLI:-kubectl}
+clusterName=""
+domainUid="sample-domain1"
+domainNamespace="sample-domain1-ns"
+verboseMode=false
+patchJson=""
+replicas=""
+
+while getopts "vc:n:m:d:r:h" opt; do
+  case $opt in
+    c) clusterName="${OPTARG}"
+    ;;
+    n) domainNamespace="${OPTARG}"
+    ;;
+    d) domainUid="${OPTARG}"
+    ;;
+    r) replicas="${OPTARG}"
+    ;;
+    m) kubernetesCli="${OPTARG}"
+    ;;
+    v) verboseMode=true;
+    ;;
+    h) usage 0
+    ;;
+    *) usage 1
+    ;;
+  esac
+done
+
+set -eu
+
+#
+# Function to perform validations, read files and initialize workspace
+#
+function initialize {
+
+  validateErrors=false
+
+  validateKubernetesCliAvailable
+  validateJqAvailable
+  validateYqAvailable
+
+  if [ -z "${clusterName}" ]; then
+    validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."
+  fi
+
+  if [ -z "${replicas}" ]; then
+    validationError "Please specify replica count using '-r' parameter e.g. '-r 3'."
+  fi
+
+  failIfValidationErrors
+}
+
+initialize
+
+# Get the domain in json format
+domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+if [ -z "${domainJson}" ]; then
+  printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
+  exit 1
+fi
+
+isValidCluster=""
+validateClusterName "${domainUid}" "${domainNamespace}" "${clusterName}" isValidCluster
+if [ "${isValidCluster}" != 'true' ]; then
+  printError "cluster ${clusterName} is not part of domain ${domainUid} in namespace ${domainNamespace}. Please make sure that cluster name is correct."
+  exit 1
+fi
+
+isReplicasInAllowedRange "${domainJson}" "${clusterName}" "${replicas}" replicasInAllowedRange range
+if [ "${replicasInAllowedRange}" == 'false' ]; then
+  printError "Replicas value is not in the allowed range of ${range}. Exiting."
+  exit 1
+fi
+
+printInfo "Patching replicas for cluster '${clusterName}' to '${replicas}'."
+createPatchJsonToUpdateReplicas "${domainJson}" "${clusterName}" "${replicas}" patchJson
+
+executePatchCommand "${kubernetesCli}" "${domainUid}" "${domainNamespace}" "${patchJson}" "${verboseMode}"
+
+printInfo "Successfully patched replicas for cluster '${clusterName}'!"


### PR DESCRIPTION
OWLS-87849 - The `scaleCluster.sh` script is similar to the cluster stop/start scripts and it patches the replicas attribute for the cluster with the specified value. It performs validations to ensure that clusterName exists in domain topology and that the specified value of replica count is in the allowed range. If the cluster doesn't exist under `.spec.clusters` in the domain resource, it adds the cluster. 
The PR also changes the logic for the cluster stop/start scripts to add the cluster under `.spec.clusters` in the domain resource if it doesn't exist.

Integration test run URL - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4171/