### PR TITLE
Fixes incorrect server validation messages for dynamic server

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -1,9 +1,8 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
+// Copyright (c) 2019, 2021, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -24,10 +23,9 @@ import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
-import oracle.kubernetes.weblogic.domain.model.Cluster;
 import oracle.kubernetes.weblogic.domain.model.Domain;
+import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.KubernetesResourceLookup;
-import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 
 import static java.lang.System.lineSeparator;
 import static oracle.kubernetes.operator.DomainStatusUpdater.BAD_DOMAIN;
@@ -146,33 +144,37 @@ public class DomainValidationSteps {
     }
 
 
-    private void logAndAddWarning(List<String> validationWarnings, String messageKey, Object... params) {
-      LOGGER.warning(messageKey, params);
-      validationWarnings.add(LOGGER.formatMessage(messageKey, params));
+    private void logAndAddValidationWarning(DomainPresenceInfo info, String msgId, Object... params) {
+      LOGGER.warning(msgId, params);
+      info.addValidationWarning(LOGGER.formatMessage(msgId, params));
     }
 
     private void validate(DomainPresenceInfo info, WlsDomainConfig wlsDomainConfig) {
-      List<String> validationWarnings = new ArrayList<>();
+      DomainSpec domainSpec = info.getDomain().getSpec();
 
-      Domain domain = info.getDomain();
-
-      // log warnings for clusters that are specified in domain resource but not configured
-      // in the WebLogic domain
-      for (Cluster cluster : domain.getSpec().getClusters()) {
-        if (!wlsDomainConfig.containsCluster(cluster.getClusterName())) {
-          logAndAddWarning(validationWarnings, MessageKeys.NO_CLUSTER_IN_DOMAIN, cluster.getClusterName());
-        }
-      }
-      // log warnings for managed servers that are specified in domain resource but not configured
-      // in the WebLogic domain
-      for (ManagedServer server : domain.getSpec().getManagedServers()) {
-        if (!wlsDomainConfig.containsServer(server.getServerName())) {
-          logAndAddWarning(validationWarnings, MessageKeys.NO_MANAGED_SERVER_IN_DOMAIN, server.getServerName());
-        }
-      }
       info.clearValidationWarnings();
-      for (String warning: validationWarnings) {
-        info.addValidationWarning(warning);
+
+      // log warnings for each cluster that is specified in domain resource but not configured
+      // in the WebLogic domain
+      domainSpec.getClusters().forEach(
+          c -> warnIfClusterDoesNotExist(wlsDomainConfig, c.getClusterName(), info));
+
+      // log warnings for each managed server that is specified in domain resource but not configured
+      domainSpec.getManagedServers().forEach(
+          s -> warnIfServerDoesNotExist(wlsDomainConfig, s.getServerName(), info));
+    }
+
+    private void warnIfClusterDoesNotExist(WlsDomainConfig domainConfig,
+          String clusterName, DomainPresenceInfo info) {
+      if (!domainConfig.containsCluster(clusterName)) {
+        logAndAddValidationWarning(info, MessageKeys.NO_CLUSTER_IN_DOMAIN, clusterName);
+      }
+    }
+
+    private void warnIfServerDoesNotExist(
+        WlsDomainConfig domainConfig, String serverName, DomainPresenceInfo info) {
+      if (!domainConfig.containsServer(serverName)) {
+        logAndAddValidationWarning(info, MessageKeys.NO_MANAGED_SERVER_IN_DOMAIN, serverName);
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -160,6 +160,7 @@ public class DomainValidationSteps {
           c -> warnIfClusterDoesNotExist(wlsDomainConfig, c.getClusterName(), info));
 
       // log warnings for each managed server that is specified in domain resource but not configured
+      // in the WebLogic domain
       domainSpec.getManagedServers().forEach(
           s -> warnIfServerDoesNotExist(wlsDomainConfig, s.getServerName(), info));
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+// Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.wlsconfig;
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import oracle.kubernetes.utils.OperatorUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -375,6 +376,17 @@ public class WlsClusterConfig {
    */
   public String getUpdateDynamicClusterSizePayload(final int clusterSize) {
     return "{ dynamicClusterSize: " + clusterSize + " }";
+  }
+
+  /**
+   * Whether this cluster contains a server with the given server name,
+   * including servers that are both configured and dynamic servers.
+   *
+   * @param serverName server name to be checked
+   * @return True if the cluster contains a server with the given server name
+   */
+  boolean containsServer(@Nonnull String serverName) {
+    return getServerConfigs().stream().anyMatch(c -> serverName.equals(c.getName()));
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -393,7 +393,7 @@ public class WlsDomainConfig implements WlsDomain {
 
   /**
    * Whether the WebLogic domain contains a server with the given server name,
-   * not including standalone servers, and servers that belong to a
+   * including standalone servers, and servers that belong to a
    * configured or dynamic cluster.
    *
    * @param serverName server name to be checked

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+// Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.wlsconfig;
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.MessageKeys;
@@ -392,18 +393,16 @@ public class WlsDomainConfig implements WlsDomain {
 
   /**
    * Whether the WebLogic domain contains a server with the given server name,
-   * not including servers that are part of a dynamic cluster.
+   * not including standalone servers, and servers that belong to a
+   * configured or dynamic cluster.
    *
    * @param serverName server name to be checked
    * @return True if the WebLogic domain contains a server with the given server name
    */
   public synchronized boolean containsServer(String serverName) {
-    if (serverName != null && servers != null) {
-      for (WlsServerConfig serverConfig : servers) {
-        if (serverConfig.getName().equals(serverName)) {
-          return true;
-        }
-      }
+    if (!Strings.isNullOrEmpty(serverName)) {
+      return getServers().stream().anyMatch(s -> serverName.equals(s.getName()))
+          || getConfiguredClusters().stream().anyMatch(c -> c.containsServer(serverName));
     }
     return false;
   }


### PR DESCRIPTION
Backport portion of PR 2097 that fixes a bug that was found in validation of `serverName` specified in `managedServers`, in that a validation warning message such as the following is added even though the server name exists in a dynamic cluster:

`Managed Server 'managed-server1' specified in the domain resource does not exist in the WebLogic domain home configuration.`