### PR TITLE
fix intermittent test issue in ITMiiDynamicUpdate testMiiChangeListenPort

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -738,8 +738,10 @@ class ItMiiDynamicUpdate {
     // Patch a running domain with introspectVersion.
     patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
-    // Verifying introspector pod is created, runs and deleted
-    verifyIntrospectorRuns(domainUid, domainNamespace);
+    // Verifying introspector pod is deleted
+    logger.info("Verifying introspector pod is deleted");
+    String introspectJobName = getIntrospectJobName(domainUid);
+    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
   }
 
   /**
@@ -779,6 +781,7 @@ class ItMiiDynamicUpdate {
     // clean failed introspector
     // replace WDT config map with config that's added in previous tests,
     // otherwise it will try to delete them, we are not testing deletion here
+
     replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.config.wm.yaml", pathToAddClusterYaml.toString(),
             MODEL_DIR + "/model.jdbc2.yaml"), withStandardRetryPolicy);
@@ -786,8 +789,10 @@ class ItMiiDynamicUpdate {
     // Patch a running domain with introspectVersion.
     patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
-    // Verifying introspector pod is created, runs and deleted
-    verifyIntrospectorRuns(domainUid, domainNamespace);
+    // Verifying introspector pod is deleted
+    logger.info("Verifying introspector pod is deleted");
+    String introspectJobName = getIntrospectJobName(domainUid);
+    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
   }
 
   /**
@@ -830,8 +835,10 @@ class ItMiiDynamicUpdate {
     // Patch a running domain with introspectVersion.
     patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
-    // Verifying introspector pod is created, runs and deleted
-    verifyIntrospectorRuns(domainUid, domainNamespace);
+    // Verifying introspector pod is deleted
+    logger.info("Verifying introspector pod is deleted");
+    String introspectJobName = getIntrospectJobName(domainUid);
+    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
   }
 
   /**
@@ -879,8 +886,10 @@ class ItMiiDynamicUpdate {
     // Patch a running domain with introspectVersion.
     patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
-    // Verifying introspector pod is created, runs and deleted
-    verifyIntrospectorRuns(domainUid, domainNamespace);
+    // Verifying introspector pod is deleted
+    logger.info("Verifying introspector pod is deleted");
+    String introspectJobName = getIntrospectJobName(domainUid);
+    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -740,8 +740,7 @@ class ItMiiDynamicUpdate {
 
     // Verifying introspector pod is deleted
     logger.info("Verifying introspector pod is deleted");
-    String introspectJobName = getIntrospectJobName(domainUid);
-    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
+    checkPodDoesNotExist(getIntrospectJobName(domainUid), domainUid, domainNamespace);
   }
 
   /**
@@ -781,7 +780,6 @@ class ItMiiDynamicUpdate {
     // clean failed introspector
     // replace WDT config map with config that's added in previous tests,
     // otherwise it will try to delete them, we are not testing deletion here
-
     replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.config.wm.yaml", pathToAddClusterYaml.toString(),
             MODEL_DIR + "/model.jdbc2.yaml"), withStandardRetryPolicy);
@@ -791,8 +789,7 @@ class ItMiiDynamicUpdate {
 
     // Verifying introspector pod is deleted
     logger.info("Verifying introspector pod is deleted");
-    String introspectJobName = getIntrospectJobName(domainUid);
-    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
+    checkPodDoesNotExist(getIntrospectJobName(domainUid), domainUid, domainNamespace);
   }
 
   /**
@@ -837,8 +834,7 @@ class ItMiiDynamicUpdate {
 
     // Verifying introspector pod is deleted
     logger.info("Verifying introspector pod is deleted");
-    String introspectJobName = getIntrospectJobName(domainUid);
-    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
+    checkPodDoesNotExist(getIntrospectJobName(domainUid), domainUid, domainNamespace);
   }
 
   /**
@@ -888,8 +884,7 @@ class ItMiiDynamicUpdate {
 
     // Verifying introspector pod is deleted
     logger.info("Verifying introspector pod is deleted");
-    String introspectJobName = getIntrospectJobName(domainUid);
-    checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
+    checkPodDoesNotExist(getIntrospectJobName(domainUid), domainUid, domainNamespace);
   }
 
   /**


### PR DESCRIPTION
In the nightly Jenkins run, sometime we will get the test failure from ITMiiDynamicUpdate#testMiiChangeListenPort, testMiiChangeListenAddress and testMiiChangeSSL. 
The reason of the failure:
Those tests are negative tests and at the end of tests, I updated the config map with correct contents and verify the introspector pod is created, runs and deleted. However if the content change in the config map is too small and the introspector runs very fast, the test will not detect the introspector got created. 
How to fix it:
Just verify the introspector pod was deleted after the config map is updated.

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4207/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4206/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4205/