### PR TITLE
The sip and sips protocols support both TCP and UPD on the same channel

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -427,9 +428,27 @@ public class ServiceHelper {
     abstract void addServicePortIfNeeded(List<V1ServicePort> ports, String portName, String protocol, Integer port);
 
     protected void addServicePortIfNeeded(List<V1ServicePort> ports, V1ServicePort port) {
-      if (!ports.stream().anyMatch(p -> p.getName().equals(port.getName()))) {
+      if (isNoDuplicatedName(ports, port) && isNoDuplicatedProtocolAndPort(ports, port)) {
         ports.add(port);
       }
+    }
+
+    private boolean isNoDuplicatedName(List<V1ServicePort> ports, V1ServicePort port) {
+      return ports.stream().noneMatch(p -> Objects.equals(p.getName(), port.getName()));
+    }
+
+    private boolean isNoDuplicatedProtocolAndPort(List<V1ServicePort> ports, V1ServicePort port) {
+      return ports.stream().noneMatch(p -> isProtocolMatch(p, port) && p.getPort().equals(port.getPort()));
+    }
+
+    private boolean isProtocolMatch(V1ServicePort one, V1ServicePort two) {
+      if (one.getProtocol() == null) {
+        return two.getProtocol() == null || "TCP".equals(two.getProtocol());
+      }
+      if (two.getProtocol() == null) {
+        return "TCP".equals(one.getProtocol());
+      }
+      return one.getProtocol().equals(two.getProtocol());
     }
 
     V1ServicePort createServicePort(String portName, Integer port) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -738,7 +738,8 @@ public class ServiceHelper {
         ports.putIfAbsent(portName, createServicePort(portName, port));
       }
       if (isSipProtocol(protocol)) {
-        addPort(createSipUdpServicePort(portName, port));
+        V1ServicePort udpPort = createSipUdpServicePort(portName, port);
+        ports.putIfAbsent(udpPort.getName(), udpPort);
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsServerConfig.java
@@ -291,7 +291,11 @@ public class WlsServerConfig {
   }
 
   public WlsServerConfig addNetworkAccessPoint(String name, int listenPort) {
-    addNetworkAccessPoint(new NetworkAccessPoint(name, "TCP", listenPort, null));
+    return addNetworkAccessPoint(name, "TCP", listenPort);
+  }
+
+  public WlsServerConfig addNetworkAccessPoint(String name, String protocol, int listenPort) {
+    addNetworkAccessPoint(new NetworkAccessPoint(name, protocol, listenPort, null));
     return this;
   }
 

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -772,8 +772,8 @@ class TopologyGenerator(Generator):
     if istio_enabled == 'true':
       http_protocol = [ 'http' ]
       https_protocol = ['https','admin']
-      tcp_protocol = [ 't3', 'snmp', 'ldap', 'cluster-broadcast', 'iiop']
-      tls_protocol = [ 't3s', 'iiops', 'cluster-broadcast-secure']
+      tcp_protocol = [ 't3', 'snmp', 'ldap', 'cluster-broadcast', 'iiop', 'sip']
+      tls_protocol = [ 't3s', 'iiops', 'cluster-broadcast-secure', 'sips']
       if nap_protocol in http_protocol:
         name = 'http-' + nap.getName().replace(' ', '_')
       elif nap_protocol in https_protocol:

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ClusterServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ClusterServiceHelperTest.java
@@ -23,6 +23,10 @@ public class ClusterServiceHelperTest extends ServiceHelperTest {
   static class ClusterServiceTestFacade extends TestFacade {
     ClusterServiceTestFacade() {
       getExpectedNapPorts().put(LegalNames.toDns1123LegalName(getNap3()), getNapPort3());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName(getNapSipClear()), getNapPortSipClear());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName(getNapSipSecure()), getNapPortSipSecure());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName("udp-" + getNapSipClear()), getNapPortSipClear());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName("udp-" + getNapSipSecure()), getNapPortSipSecure());
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -53,6 +53,7 @@ import static oracle.kubernetes.utils.LogMatcher.containsSevere;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
@@ -1131,5 +1132,31 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
 
   private static V1Pod createManagedServerPodModel(Packet packet) {
     return new PodHelper.ManagedPodStepContext(null, packet).getPodModel();
+  }
+
+  @Test
+  public void whenPodCreated_containerHasTwoPortsForSip() {
+    V1Container v1Container = getCreatedPodSpecContainer();
+
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().endsWith(SIP_CLEAR)).count(), equalTo(2L));
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().equals(SIP_CLEAR)).findFirst().orElseThrow().getProtocol(), equalTo("TCP"));
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().equals("udp-" + SIP_CLEAR))
+        .findFirst().orElseThrow().getProtocol(), equalTo("UDP"));
+  }
+
+  @Test
+  public void whenPodCreated_containerHasTwoPortsForSips() {
+    V1Container v1Container = getCreatedPodSpecContainer();
+
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().endsWith(SIP_SECURE)).count(), equalTo(2L));
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().equals(SIP_SECURE)).findFirst().orElseThrow().getProtocol(), equalTo("TCP"));
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().equals("udp-" + SIP_SECURE))
+        .findFirst().orElseThrow().getProtocol(), equalTo("UDP"));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagerServerServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagerServerServiceHelperTest.java
@@ -14,6 +14,14 @@ public class ManagerServerServiceHelperTest extends ServiceHelperTest {
   }
 
   static class ManagedServerTestFacade extends ServiceHelperTest.ServerTestFacade {
+    ManagedServerTestFacade() {
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName(getNap3()), getNapPort3());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName(getNapSipClear()), getNapPortSipClear());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName(getNapSipSecure()), getNapPortSipSecure());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName("udp-" + getNapSipClear()), getNapPortSipClear());
+      getExpectedNapPorts().put(LegalNames.toDns1123LegalName("udp-" + getNapSipSecure()), getNapPortSipSecure());
+    }
+
     @Override
     public String getServiceCreateLogMessage() {
       return MANAGED_SERVICE_CREATED;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -136,6 +136,8 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   static final String NS = "namespace";
   static final String ADMIN_SERVER = "ADMIN_SERVER";
   static final Integer ADMIN_PORT = 7001;
+  protected static final String SIP_CLEAR = "sip-clear";
+  protected static final String SIP_SECURE = "sip-secure";
   protected static final String DOMAIN_NAME = "domain1";
   protected static final String UID = "uid1";
   protected static final String KUBERNETES_UID = "12345";
@@ -247,7 +249,9 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport(DOMAIN_NAME);
     configSupport.addWlsServer(ADMIN_SERVER, ADMIN_PORT);
     if (!ADMIN_SERVER.equals(serverName)) {
-      configSupport.addWlsServer(serverName, listenPort);
+      configSupport.addWlsServer(serverName, listenPort)
+          .addNetworkAccessPoint(SIP_CLEAR, "sip", 8003)
+          .addNetworkAccessPoint(SIP_SECURE, "sips", 8004);
     }
     configSupport.setAdminServerName(ADMIN_SERVER);
 
@@ -752,9 +756,10 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   public void whenPodCreated_containerUsesListenPort() {
     V1Container v1Container = getCreatedPodSpecContainer();
 
-    assertThat(v1Container.getPorts(), hasSize(1));
-    assertThat(v1Container.getPorts().get(0).getProtocol(), equalTo("TCP"));
-    assertThat(v1Container.getPorts().get(0).getContainerPort(), equalTo(listenPort));
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().equals("default")).findFirst().orElseThrow().getProtocol(), equalTo("TCP"));
+    assertThat(v1Container.getPorts().stream()
+        .filter(p -> p.getName().equals("default")).findFirst().orElseThrow().getContainerPort(), equalTo(listenPort));
   }
 
   abstract String getCreatedMessageKey();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -752,7 +752,7 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
         }
         mismatchDescription.appendText("contains no port with name ").appendValue(expectedName);
       } else {
-        if (matchesSelectedProtocol(matchingPort) && matchSelectedPort(matchingPort)) {
+        if (matchesSelectedProtocol(matchingPort) && matchesSelectedPort(matchingPort)) {
           return true;
         }
         mismatchDescription.appendText("contains port ").appendValue(matchingPort);
@@ -764,7 +764,7 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
       return Objects.equals(expectedProtocol, matchingPort.getProtocol());
     }
 
-    private boolean matchSelectedPort(V1ServicePort matchingPort) {
+    private boolean matchesSelectedPort(V1ServicePort matchingPort) {
       return Objects.equals(expectedValue, matchingPort.getPort());
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -111,6 +111,10 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
   private static final int NAP_PORT_1 = 7100;
   private static final int NAP_PORT_2 = 37100;
   private static final int NAP_PORT_3 = 37200;
+  protected static final String SIP_CLEAR = "sip-clear";
+  protected static final String SIP_SECURE = "sip-secure";
+  private static final int SIP_CLEAR_NAP_PORT = 8003;
+  private static final int SIP_SECURE_NAP_PORT = 8004;
   public static final String STRANDED = "Stranded";
   public static final String NODE_PORT = "NodePort";
   private final TerminalStep terminalStep = new TerminalStep();
@@ -157,6 +161,22 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
     return NAP_PORT_3;
   }
 
+  static String getNapSipClear() {
+    return SIP_CLEAR;
+  }
+
+  static String getNapSipSecure() {
+    return SIP_SECURE;
+  }
+
+  static int getNapPortSipClear() {
+    return SIP_CLEAR_NAP_PORT;
+  }
+
+  static int getNapPortSipSecure() {
+    return SIP_SECURE_NAP_PORT;
+  }
+
   @BeforeEach
   public void setUp() throws Exception {
     configureAdminServer()
@@ -179,10 +199,13 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
         .addWlsServer(ADMIN_SERVER, ADMIN_PORT)
         .addNetworkAccessPoint(NAP_1, NAP_PORT_1)
         .addNetworkAccessPoint(NAP_2, NAP_PORT_2);
+
     configSupport
         .addWlsServer(TEST_SERVER, TEST_PORT)
         .setAdminPort(ADMIN_PORT)
-        .addNetworkAccessPoint(NAP_3, NAP_PORT_3);
+        .addNetworkAccessPoint(NAP_3, NAP_PORT_3)
+        .addNetworkAccessPoint(SIP_CLEAR, "sip", SIP_CLEAR_NAP_PORT)
+        .addNetworkAccessPoint(SIP_SECURE, "sips", SIP_SECURE_NAP_PORT);
     configSupport.addWlsCluster(TEST_CLUSTER, TEST_SERVER);
     configSupport.setAdminServerName(ADMIN_SERVER);
 
@@ -261,8 +284,12 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
     V1Service model = testFacade.createServiceModel(testSupport.getPacket());
 
     for (Map.Entry<String, Integer> entry : testFacade.getExpectedNapPorts().entrySet()) {
-      assertThat(model, containsPort(entry.getKey(), entry.getValue()));
+      assertThat(model, containsPort(entry.getKey(), getExpectedProtocol(entry.getKey()), entry.getValue()));
     }
+  }
+
+  private String getExpectedProtocol(String portName) {
+    return portName.startsWith("udp-") ? "UDP" : "TCP";
   }
 
   @Test
@@ -693,15 +720,26 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
   static class PortMatcher
       extends org.hamcrest.TypeSafeDiagnosingMatcher<io.kubernetes.client.openapi.models.V1Service> {
     private final String expectedName;
+    private final String expectedProtocol;
     private final Integer expectedValue;
 
     private PortMatcher(@Nonnull String expectedName, Integer expectedValue) {
+      this(expectedName, "TCP", expectedValue);
+    }
+
+    private PortMatcher(@Nonnull String expectedName, String expectedProtocol, Integer expectedValue) {
       this.expectedName = expectedName;
+      this.expectedProtocol = expectedProtocol;
       this.expectedValue = expectedValue;
     }
 
     static PortMatcher containsPort(@Nonnull String expectedName, Integer expectedValue) {
       return new PortMatcher(expectedName, expectedValue);
+    }
+
+    static PortMatcher containsPort(@Nonnull String expectedName,
+                                    @Nonnull String expectedProtocol, Integer expectedValue) {
+      return new PortMatcher(expectedName, expectedProtocol, expectedValue);
     }
 
     @Override
@@ -714,7 +752,7 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
         }
         mismatchDescription.appendText("contains no port with name ").appendValue(expectedName);
       } else {
-        if (matchSelectedPort(matchingPort)) {
+        if (matchesSelectedProtocol(matchingPort) && matchSelectedPort(matchingPort)) {
           return true;
         }
         mismatchDescription.appendText("contains port ").appendValue(matchingPort);
@@ -722,9 +760,12 @@ abstract class ServiceHelperTest extends ServiceHelperTestBase {
       return false;
     }
 
+    private boolean matchesSelectedProtocol(V1ServicePort matchingPort) {
+      return Objects.equals(expectedProtocol, matchingPort.getProtocol());
+    }
+
     private boolean matchSelectedPort(V1ServicePort matchingPort) {
-      return "TCP".equals(matchingPort.getProtocol())
-          && Objects.equals(expectedValue, matchingPort.getPort());
+      return Objects.equals(expectedValue, matchingPort.getPort());
     }
 
     private V1ServicePort getPortWithName(V1Service item) {


### PR DESCRIPTION
We received an enhancement request from the mobile communications business unit to better support the sip and sips protocols by updating our container and Service ports to specify both TCP and UDP ports when a network access point supports one of these protocols.

The ports will share a listenAddress, which is legal, but can't share a name, so I've chosen to prefix the UDP port's name with "udp-" since this is also consistent with the Istio port naming convention.

Update:
I figured out why we previously needed the testNodePort filtering behavior... The use of a ports variable created state in the context. If I remove this variable and check for duplication in the generated ports of the model then we can both prevent duplication and allow for the two different SIP service ports that share a listen port.

Outdated:
> Note: I removed calls to a method called "testNodePort" which was written to prevent a container or Service from having ports with the same listenPort value. No unit-tests failed when I removed that code and the behavior this check was preventing was exactly the behavior that I now need.  I also verified with several manual tests with both SIP and non-SIP protocol network access points that there is no duplication of ports otherwise.
