### PR TITLE
Owls 87307 fix and change to store the domain topology in json format (for OWLS-87478) 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -924,7 +924,7 @@ class ItServerStartPolicy {
     assertTrue(verifyExecuteResult(result, regex),"The script shouldn't start a server that is beyond the limit");
 
     // verify that the script can not start a server in dynamic cluster that exceeds the max cluster size
-    regex = ".*outside the range of allowed servers";
+    regex = ".*is outside the allowed range of";
     result =  assertDoesNotThrow(() ->
         executeLifecycleScript(START_SERVER_SCRIPT, SERVER_LIFECYCLE, dynServerName, "", false),
         String.format("Failed to run %s", START_SERVER_SCRIPT));

--- a/kubernetes/samples/scripts/domain-lifecycle/README.md
+++ b/kubernetes/samples/scripts/domain-lifecycle/README.md
@@ -2,7 +2,7 @@
 
 The operator provides sample scripts to start up or shut down a specific Managed Server or cluster in a deployed domain, or the entire deployed domain.
 
-**Note**: Prior to running these scripts, you must have previously created and deployed the domain. These scripts make use of [jq](https://stedolan.github.io/jq/) for processing JSON, you must have `jq 1.5 or higher` installed in order to run these scripts. See the installation options on the [jq downlod](https://stedolan.github.io/jq/download/) page.
+**Note**: Prior to running these scripts, you must have previously created and deployed the domain. These scripts make use of [jq](https://stedolan.github.io/jq/) for processing JSON. You must have `jq 1.5 or higher` installed in order to run these scripts. See the installation options on the [jq downlod](https://stedolan.github.io/jq/download/) page.
 
 These scripts can be helpful when scripting the life cycle of a WebLogic Server domain. For information on how to start, stop, restart, and scale WebLogic Server instances in your domain, see [Domain Life Cycle](https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle).
 

--- a/kubernetes/samples/scripts/domain-lifecycle/README.md
+++ b/kubernetes/samples/scripts/domain-lifecycle/README.md
@@ -2,7 +2,7 @@
 
 The operator provides sample scripts to start up or shut down a specific Managed Server or cluster in a deployed domain, or the entire deployed domain.
 
-**Note**: Prior to running these scripts, you must have previously created and deployed the domain.
+**Note**: Prior to running these scripts, you must have previously created and deployed the domain. These scripts make use of [jq](https://stedolan.github.io/jq/) for processing JSON, you must have `jq 1.5 or higher` installed in order to run these scripts. See the installation options on the [jq downlod](https://stedolan.github.io/jq/download/) page.
 
 These scripts can be helpful when scripting the life cycle of a WebLogic Server domain. For information on how to start, stop, restart, and scale WebLogic Server instances in your domain, see [Domain Life Cycle](https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle).
 

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -657,15 +657,14 @@ function validateServerAndFindCluster {
       if [[ "${serverName}" == "${prefix}"* ]]; then
         maxSize=$(echo ${dynaClusterNamePrefix} | jq -r .max)
         number='^[0-9]+$'
-        if [ $(echo "${serverName}" | grep -c -Eo '[0-9]+$') -gt 0 ]; then
-          serverCount=$(echo "${serverName}" | grep -Eo '[0-9]+$')
-        fi
+        serverCount=$(echo "${serverName:${#prefix}}")
         if ! [[ $serverCount =~ $number ]] ; then
-           printError "Server name is not valid for dynamic cluster."
+           printError "Server name ${serverName} is not valid for dynamic cluster."
            exit 1
         fi
-        if [ "${serverCount}" -gt "${maxSize}" ]; then
-          printError "Server name is outside the range of allowed servers. \
+        if [ "${serverCount}" -lt 1 ] || [ "${serverCount}" -gt "${maxSize}" ]; then
+          printError "Index of server name ${serverName} for dynamic cluster is outside \
+            the allowed range of 1 to ${maxSize}. \
             Please make sure server name is correct."
           exit 1
         fi
@@ -715,6 +714,7 @@ function getTopology {
   local domainUid=$1
   local domainNamespace=$2
   local __result=$3 
+  local __jsonTopology=""
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     configMap=$(${kubernetesCli} get cm ${domainUid}-weblogic-domain-introspect-cm \
@@ -728,14 +728,10 @@ function getTopology {
       This script requires that the introspector job for the specified domain ran \
       successfully and generated this config map. Exiting."
     exit 1
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    jsonTopology=$(echo "${configMap}" | yq r - data.[topology.yaml] | yq r - -j)
   else
-    topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')
-    jsonTopology=$(python -c \
-    'import sys, yaml, json; print json.dumps(yaml.safe_load('"${topology}"'), indent=4)')
+    __jsonTopology=$(echo "${configMap}" | jq -r '.data["topology.json"]')
   fi
-  eval $__result="'${jsonTopology}'"
+  eval $__result="'${__jsonTopology}'"
 }
 
 
@@ -756,19 +752,6 @@ checkStringInArray() {
 function validateJqAvailable {
   if ! [ -x "$(command -v jq)" ]; then
     validationError "jq is not installed"
-  fi
-}
-
-function validateYqAvailable {
-  if [[ "$OSTYPE" == "darwin"* ]] && ! [ -x "$(command -v yq)" ]; then
-    validationError "yq is not installed"
-  fi
-}
-
-# try to execute python to see whether python is available
-function validatePythonAvailable {
-  if ! [ -x "$(command -v python)" ]; then
-    validationError "python is not installed"
   fi
 }
 

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -735,13 +735,17 @@ function getTopology {
   if [ ${__jsonTopology} == null ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       if ! [ -x "$(command -v yq)" ]; then
-        validationError "yq is not installed"
+        validationError "MacOS detected, the domain is hosted on a pre-3.2.0 version of \
+          the Operator, and 'yq' is not installed locally. To fix this, install 'yq', \
+          call the script from Linux instead of MacOS, or upgrade the Operator version."
         exit 1
       fi
       __jsonTopology=$(echo "${configMap}" | yq r - data.[topology.yaml] | yq r - -j)
     else
       if ! [ -x "$(command -v python)" ]; then
-        validationError "python is not installed"
+        validationError "Linux OS detected, the domain is hosted on a pre-3.2.0 version of \
+          the Operator, and 'python' is not installed locally. To fix this, install 'python' \
+          or upgrade the Operator version."
         exit 1
       fi
       __topology=$(echo "${configMap}" | jq '.data["topology.yaml"]')

--- a/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
@@ -80,7 +80,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -77,7 +77,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."

--- a/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
@@ -67,7 +67,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
 
   failIfValidationErrors
 }

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -120,7 +120,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
 
   # Validate that server name parameter is specified.
   if [ -z "${serverName}" ]; then

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -75,7 +75,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
 
   if [ -z "${clusterName}" ]; then
     validationError "Please specify cluster name using '-c' parameter e.g. '-c cluster-1'."

--- a/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
@@ -66,7 +66,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
   failIfValidationErrors
 }
 

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -116,7 +116,6 @@ function initialize {
 
   validateKubernetesCliAvailable
   validateJqAvailable
-  validateYqAvailable
 
   # Validate that server name parameter is specified.
   if [ -z "${serverName}" ]; then

--- a/operator/src/main/java/oracle/kubernetes/operator/IntrospectorConfigMapConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/IntrospectorConfigMapConstants.java
@@ -13,6 +13,9 @@ public interface IntrospectorConfigMapConstants {
   /** The topology generated from the WebLogic domain. */
   String TOPOLOGY_YAML = "topology.yaml";
 
+  /** The topology generated from the WebLogic domain in json format. */
+  String TOPOLOGY_JSON = "topology.json";
+
   /** An MD5 has of the Model-in-Image secrets. */
   String SECRETS_MD_5 = "secrets.md5";
 


### PR DESCRIPTION
Fix for Owls 87307 and change to store the domain topology in JSON format (in addition to YAML format). This change removes the dependency on `yq` and/or `python` when running scripts on Mac OS or with versions of python that don't have YAML module support. This change helps in the documentation of pre-requisites for running domain lifecycle scripts (OWLS-87478).

Integration test run URL - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4235/ 