### PR TITLE
Fix http throwable responses

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -36,7 +37,7 @@ public class AnnotationHelper {
     meta.putAnnotationsItem("prometheus.io/scrape", "true");
   }
 
-  public static V1Pod withSha256Hash(V1Pod pod) {
+  static V1Pod withSha256Hash(V1Pod pod) {
     return DEBUG ? addHashAndDebug(pod) : addHash(pod);
   }
 
@@ -44,14 +45,14 @@ public class AnnotationHelper {
     return withSha256Hash(kubernetesObject, kubernetesObject);
   }
 
-  public static <K extends KubernetesObject> K withSha256Hash(K kubernetesObject, Object objectToHash) {
+  static <K extends KubernetesObject> K withSha256Hash(K kubernetesObject, Object objectToHash) {
     return addHash(kubernetesObject, objectToHash);
   }
 
   private static V1Pod addHashAndDebug(V1Pod pod) {
     String dump = Yaml.dump(pod);
     addHash(pod);
-    pod.getMetadata().putAnnotationsItem(HASHED_STRING, dump);
+    Objects.requireNonNull(pod.getMetadata()).putAnnotationsItem(HASHED_STRING, dump);
     return pod;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -130,7 +130,7 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   abstract Map<String, String> getPodAnnotations();
 
-  String getNamespace() {
+  private String getNamespace() {
     return info.getNamespace();
   }
 
@@ -160,7 +160,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     return info.getDomain();
   }
 
-  String getDomainName() {
+  private String getDomainName() {
     return domainTopology.getName();
   }
 
@@ -176,7 +176,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     return domainTopology.getAdminServerName();
   }
 
-  Integer getAsPort() {
+  private Integer getAsPort() {
     return domainTopology
         .getServerConfig(domainTopology.getAdminServerName())
         .getLocalAdminProtocolChannelPort();
@@ -383,7 +383,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     return createProgressingStep(patchPod(currentPod, updatedPod, next, addRestartRequiredLabel));
   }
 
-  protected Step patchPod(V1Pod currentPod, Step next) {
+  private Step patchPod(V1Pod currentPod, Step next) {
     JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
     KubernetesUtils.addPatches(
         patchBuilder, "/metadata/labels/", getLabels(currentPod), getNonHashedPodLabels());
@@ -395,7 +395,7 @@ public abstract class PodStepContext extends BasePodStepContext {
   }
 
   // Method for online update
-  protected Step patchPod(V1Pod currentPod, V1Pod updatedPod, Step next, boolean addRestartRequiredLabel) {
+  private Step patchPod(V1Pod currentPod, V1Pod updatedPod, Step next, boolean addRestartRequiredLabel) {
     JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
     Map<String, String> updatedLabels = Optional.ofNullable(updatedPod)
         .map(V1Pod::getMetadata)

--- a/operator/src/main/java/oracle/kubernetes/operator/http/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/HttpAsyncRequestStep.java
@@ -8,7 +8,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -107,15 +106,14 @@ public class HttpAsyncRequestStep extends Step {
     }
 
     private void resume(AsyncFiber fiber, HttpResponse<String> response, Throwable throwable) {
-      if (throwable != null) {
-        if (throwable instanceof HttpTimeoutException) {
-          LOGGER.fine(MessageKeys.HTTP_REQUEST_TIMED_OUT, throwable.getMessage());
-        } else if (response == null) {
-          recordThrowableResponse(throwable);
-        }
+      if (throwable instanceof HttpTimeoutException) {
+        LOGGER.fine(MessageKeys.HTTP_REQUEST_TIMED_OUT, throwable.getMessage());
+      } else if (response != null) {
+        recordResponse(response);
+      } else if (throwable != null) {
+        recordThrowableResponse(throwable);
       }
-      
-      Optional.ofNullable(response).ifPresent(this::recordResponse);
+
       fiber.resume(packet);
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/http/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/HttpResponseStep.java
@@ -21,7 +21,15 @@ public abstract class HttpResponseStep extends Step {
 
   @Override
   public NextAction apply(Packet packet) {
-    return Optional.ofNullable(getResponse(packet)).map(r -> doApply(packet, r)).orElse(doNext(packet));
+    return Optional.ofNullable(getResponse(packet))
+        .map(r -> doApply(packet, r))
+        .orElse(Optional.ofNullable(getThrowableResponse(packet))
+            .map(t -> onFailure(packet, null))
+            .orElse(doNext(packet)));
+  }
+
+  private Throwable getThrowableResponse(Packet packet) {
+    return packet.getSpi(Throwable.class);
   }
 
   private NextAction doApply(Packet packet, HttpResponse<String> response) {
@@ -44,6 +52,15 @@ public abstract class HttpResponseStep extends Step {
    */
   static void addToPacket(Packet packet, HttpResponse<String> response) {
     packet.getComponents().put(RESPONSE, Component.createFor(HttpResponse.class, response));
+  }
+
+  /**
+   * Adds the specified throwable to a packet so that this step can access it via {@link Packet#getSpi(Class)} call.
+   * @param packet the packet to which the response should be added
+   * @param throwable the throwable from the server
+   */
+  static void addToPacket(Packet packet, Throwable throwable) {
+    packet.getComponents().put(RESPONSE, Component.createFor(Throwable.class, throwable));
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/http/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/HttpResponseStep.java
@@ -23,9 +23,13 @@ public abstract class HttpResponseStep extends Step {
   public NextAction apply(Packet packet) {
     return Optional.ofNullable(getResponse(packet))
         .map(r -> doApply(packet, r))
-        .orElse(Optional.ofNullable(getThrowableResponse(packet))
-            .map(t -> onFailure(packet, null))
-            .orElse(doNext(packet)));
+        .orElse(handlePossibleThrowableOrContinue(packet));
+  }
+
+  private NextAction handlePossibleThrowableOrContinue(Packet packet) {
+    return Optional.ofNullable(getThrowableResponse(packet))
+        .map(t -> onFailure(packet, null))
+        .orElse(doNext(packet));
   }
 
   private Throwable getThrowableResponse(Packet packet) {

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -139,6 +139,7 @@ public class MessageKeys {
   public static final String BEGIN_MANAGING_NAMESPACE = "WLSKO-0186";
   public static final String END_MANAGING_NAMESPACE = "WLSKO-0187";
   public static final String MII_DOMAIN_DYNAMICALLY_UPDATED = "WLSKO-0188";
+  public static final String HTTP_REQUEST_GOT_THROWABLE = "WLSKO-0189";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStep.java
@@ -49,11 +49,11 @@ public class ManagedServerUpIteratorStep extends Step {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /** The interval in msec that the operator will wait to ensure that started pods have been scheduled on a node. */
-  public static final int SCHEDULING_DETECTION_DELAY = 100;
+  static final int SCHEDULING_DETECTION_DELAY = 100;
 
   private final Collection<ServerStartupInfo> startupInfos;
 
-  public ManagedServerUpIteratorStep(Collection<ServerStartupInfo> startupInfos, Step next) {
+  ManagedServerUpIteratorStep(Collection<ServerStartupInfo> startupInfos, Step next) {
     super(next);
     this.startupInfos = startupInfos;
   }
@@ -133,7 +133,7 @@ public class ManagedServerUpIteratorStep extends Step {
             createPacketForServer(packet, ssi));
   }
 
-  String getPodName(DomainPresenceInfo info, String serverName) {
+  private String getPodName(DomainPresenceInfo info, String serverName) {
     return LegalNames.toPodName(info.getDomainUid(), serverName);
   }
 
@@ -234,7 +234,7 @@ public class ManagedServerUpIteratorStep extends Step {
       this.maxConcurrency = maxConcurrency;
     }
 
-    public int getMaxConcurrency() {
+    int getMaxConcurrency() {
       return this.maxConcurrency;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -53,8 +53,8 @@ import static oracle.kubernetes.utils.OperatorUtils.emptyToNull;
 
 public class ReadHealthStep extends Step {
 
-  public static final String OVERALL_HEALTH_NOT_AVAILABLE = "Not available";
-  public static final String OVERALL_HEALTH_FOR_SERVER_OVERLOADED =
+  static final String OVERALL_HEALTH_NOT_AVAILABLE = "Not available";
+  static final String OVERALL_HEALTH_FOR_SERVER_OVERLOADED =
       OVERALL_HEALTH_NOT_AVAILABLE + " (possibly overloaded)";
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
@@ -305,7 +305,10 @@ public class ReadHealthStep extends Step {
       }
 
       private boolean isServerOverloaded() {
-        return isServerOverloaded(getResponse().statusCode());
+        return Optional.ofNullable(getResponse())
+            .map(HttpResponse::statusCode)
+            .map(this::isServerOverloaded)
+            .orElse(false);
       }
 
       private boolean isServerOverloaded(int statusCode) {

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -118,7 +118,7 @@ WLSKO-0166=for {0}
 WLSKO-0167=with {0}
 WLSKO-0168={0}: {1}
 WLSKO-0169=Job {0} is created at {1}
-WLSKO-0170=HTTP timeout: exception {0}.
+WLSKO-0170=HTTP timeout: {0}.
 WLSKO-0171=Namespace {0} is in operator's domain namespaces list but doesn't exist
 WLSKO-0173=Replace custom resource definition failed: {0}
 WLSKO-0174=Create custom resource definition failed: {0}
@@ -137,6 +137,7 @@ WLSKO-0185=Patching Pod Disruption Budget for WebLogic domain with UID: {0}. Clu
 WLSKO-0186=Start managing namespace {0}
 WLSKO-0187=Stop managing namespace {0}
 WLSKO-0188=Model in Image domain with DomainUID ''{0}'' and server name ''{1}'' online updated successfully. No restart is necessary
+WLSKO-0189=HTTP request method {0} to {1} failed with exception {2}.
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/http/HttpAsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/HttpAsyncRequestStepTest.java
@@ -29,8 +29,10 @@ import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStub;
 import static oracle.kubernetes.operator.logging.MessageKeys.HTTP_METHOD_FAILED;
+import static oracle.kubernetes.operator.logging.MessageKeys.HTTP_REQUEST_GOT_THROWABLE;
 import static oracle.kubernetes.operator.logging.MessageKeys.HTTP_REQUEST_TIMED_OUT;
 import static oracle.kubernetes.utils.LogMatcher.containsFine;
+import static oracle.kubernetes.utils.LogMatcher.containsWarning;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -109,6 +111,12 @@ public class HttpAsyncRequestStepTest {
     FiberTestSupport.doOnExit(nextAction, fiber);
   }
 
+  private void completeWithThrowableBeforeTimeout(NextAction nextAction, Throwable throwable) {
+    responseFuture.completeExceptionally(throwable);
+    FiberTestSupport.doOnExit(nextAction, fiber);
+  }
+
+
   @Test
   public void whenErrorResponseReceived_logMessage() {
     final NextAction nextAction = requestStep.apply(packet);
@@ -118,6 +126,19 @@ public class HttpAsyncRequestStepTest {
     assertThat(logRecords, containsFine(HTTP_METHOD_FAILED));
   }
 
+  @Test
+  public void whenThrowableResponseReceived_logMessage() {
+    Memento m = TestUtils.silenceOperatorLogger()
+        .collectLogMessages(logRecords, HTTP_REQUEST_GOT_THROWABLE)
+        .withLogLevel(Level.WARNING)
+        .ignoringLoggedExceptions(HttpAsyncRequestStep.HttpTimeoutException.class);
+    final NextAction nextAction = requestStep.apply(packet);
+
+    completeWithThrowableBeforeTimeout(nextAction, new Throwable("Test"));
+
+    assertThat(logRecords, containsWarning(HTTP_REQUEST_GOT_THROWABLE));
+    m.revert();
+  }
 
   @Test
   public void whenResponseReceived_populatePacket() {

--- a/operator/src/test/java/oracle/kubernetes/operator/http/HttpAsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/HttpAsyncRequestStepTest.java
@@ -128,16 +128,14 @@ public class HttpAsyncRequestStepTest {
 
   @Test
   public void whenThrowableResponseReceived_logMessage() {
-    Memento m = TestUtils.silenceOperatorLogger()
+    consoleMemento
         .collectLogMessages(logRecords, HTTP_REQUEST_GOT_THROWABLE)
-        .withLogLevel(Level.WARNING)
-        .ignoringLoggedExceptions(HttpAsyncRequestStep.HttpTimeoutException.class);
+        .withLogLevel(Level.WARNING);
     final NextAction nextAction = requestStep.apply(packet);
 
     completeWithThrowableBeforeTimeout(nextAction, new Throwable("Test"));
 
     assertThat(logRecords, containsWarning(HTTP_REQUEST_GOT_THROWABLE));
-    m.revert();
   }
 
   @Test


### PR DESCRIPTION
The PR contains a fix for a problem in http error handling that is discovered during testing domain secure mode enabled without configuring SSL use case, plus some code cleanup based on warnings in IntelliJ. 

Problem: when a HttpAsyncRequestStep's AsyncProcessing is resumed without a response object, it was always considered as a timeout although sometimes resume is called with an Exception that should be made visible to the user. One example of such exceptions is javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target. 

With the fix, operator logs a warning message and fails the corresponding step.

(Note: the changes originally contained a fix for a NPE on unboxing the chosen port number for Prometheus. The code change for this has been removed after merging with the develop branch yesterday; apparently the problematic code has been changed by a PR that is merged yesterday.)

Integration test result in Jenkins before the last merge with develop: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4250/.
Integration test run with the latest: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4255/.
Jenkins job with review changes: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4256/.
