### PR TITLE
Owls 87956 - Generate shorter volume name when override secret name is too long

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -370,20 +370,20 @@ public abstract class JobStepContext extends BasePodStepContext {
 
     if (getConfigOverrides() != null && getConfigOverrides().length() > 0) {
       container.addVolumeMountsItem(
-            readOnlyVolumeMount(getVolumeMountName(getConfigOverrides(), CONFIGMAP_TYPE), OVERRIDES_CM_MOUNT_PATH));
+            readOnlyVolumeMount(getVolumeName(getConfigOverrides(), CONFIGMAP_TYPE), OVERRIDES_CM_MOUNT_PATH));
     }
 
     List<String> configOverrideSecrets = getConfigOverrideSecrets();
     for (String secretName : configOverrideSecrets) {
       container.addVolumeMountsItem(
             readOnlyVolumeMount(
-                  getVolumeMountName(secretName, SECRET_TYPE), OVERRIDE_SECRETS_MOUNT_PATH + '/' + secretName));
+                  getVolumeName(secretName, SECRET_TYPE), OVERRIDE_SECRETS_MOUNT_PATH + '/' + secretName));
     }
 
     if (isSourceWdt()) {
       if (getWdtConfigMap() != null) {
         container.addVolumeMountsItem(
-            readOnlyVolumeMount(getVolumeMountName(getWdtConfigMap(), CONFIGMAP_TYPE), WDTCONFIGMAP_MOUNT_PATH));
+            readOnlyVolumeMount(getVolumeName(getWdtConfigMap(), CONFIGMAP_TYPE), WDTCONFIGMAP_MOUNT_PATH));
       }
       container.addVolumeMountsItem(
           readOnlyVolumeMount(RUNTIME_ENCRYPTION_SECRET_VOLUME,
@@ -395,10 +395,6 @@ public abstract class JobStepContext extends BasePodStepContext {
   }
 
   private String getVolumeName(String resourceName, String type) {
-    return getName(resourceName, type);
-  }
-
-  private String getVolumeMountName(String resourceName, String type) {
     return getName(resourceName, type);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -395,13 +395,16 @@ public abstract class JobStepContext extends BasePodStepContext {
   }
 
   private String getVolumeName(String secretName) {
-    return (secretName.length() > (MAX_ALLOWED_VOLUME_NAME_LENGTH - VOLUME_NAME_SUFFIX.length())
-            ? "long-secret-name-" + volumeIndex.getAndIncrement() : secretName) + VOLUME_NAME_SUFFIX;
+    return getName(secretName, volumeIndex) + VOLUME_NAME_SUFFIX;
   }
 
   private String getVolumeMountName(String secretName) {
-    return (secretName.length() > (MAX_ALLOWED_VOLUME_NAME_LENGTH - VOLUME_NAME_SUFFIX.length())
-            ? "long-secret-name-" + mountIndex.getAndIncrement() : secretName) + VOLUME_NAME_SUFFIX;
+    return getName(secretName, mountIndex) + VOLUME_NAME_SUFFIX;
+  }
+
+  private String getName(String secretName, AtomicInteger index) {
+    return secretName.length() > (MAX_ALLOWED_VOLUME_NAME_LENGTH - VOLUME_NAME_SUFFIX.length())
+            ? "long-secret-name-" + index.getAndIncrement() : secretName;
   }
 
   protected String getContainerName() {

--- a/operator/src/main/java/oracle/kubernetes/operator/utils/ChecksumUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/utils/ChecksumUtils.java
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.utils;
+
+import java.security.MessageDigest;
+import javax.xml.bind.DatatypeConverter;
+
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.logging.MessageKeys;
+
+public class ChecksumUtils {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  /**
+   * Gets the MD5 hash of a string.
+   *
+   * @param data input string
+   * @return MD5 hash value of the data, null in case of an exception.
+   */
+  public static String getMD5Hash(String data) {
+    try {
+      return bytesToHex(MessageDigest.getInstance("MD5").digest(data.getBytes("UTF-8")));
+    } catch (Exception ex) {
+      LOGGER.severe(MessageKeys.EXCEPTION, ex);
+      return null;
+    }
+  }
+
+  private static String bytesToHex(byte[] hash) {
+    return DatatypeConverter.printHexBinary(hash).toLowerCase();
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -87,10 +87,10 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 public class JobHelperTest extends DomainValidationBaseTest {
   private static final String RAW_VALUE_1 = "find uid1 at $(DOMAIN_HOME)";
   private static final String END_VALUE_1 = "find uid1 at /u01/oracle/user_projects/domains";
-  protected static final String VERY_LONG_SECRET_NAME
-          = "very-very-long-secret-name-very-very-long-secret-name-very-very-long-secret-name";
-  protected static final String VERY_LONG_SECRET_NAME_2
-          = "second-very-very-long-secret-name-very-very-long-secret-name-very-very-long-secret-name";
+  protected static final String LONG_SECRET_NAME
+            = "very-long-secret-name-very-long-secret-name-abcdefghijklm";
+  protected static final String SECOND_LONG_SECRET_NAME
+          = "second-very-long-secret-name-very-long-secret-name-very-long-secret-name";
 
   /** 
    * OEVN is the name of an env var that contains a comma-separated list of oper supplied env var names.
@@ -98,8 +98,8 @@ public class JobHelperTest extends DomainValidationBaseTest {
    * time the job ran.
    */
   private static final String OEVN = "OPERATOR_ENVVAR_NAMES";
-  public static final String SECRET_1_VOLUME_NAME = "long-secret-name-1-volume";
-  public static final String SECRET_2_VOLUME_NAME  = "long-secret-name-2-volume";
+  public static final String VOLUME_NAME_FOR_LONG_SECRET_NAME = "long-secret-name-1-volume";
+  public static final String VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME = "long-secret-name-2-volume";
   private Method getDomainSpec;
   private final Domain domain = createTestDomain();
   private final DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo(domain);
@@ -518,52 +518,52 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
   @Test
   public void whenDomainHasConfigOverrideSecretsWithLongName_volumeCreatedWithShorterName() {
-    resourceLookup.defineResource(VERY_LONG_SECRET_NAME, KubernetesResourceType.Secret, NS);
+    resourceLookup.defineResource(LONG_SECRET_NAME, KubernetesResourceType.Secret, NS);
 
     configureDomain()
-            .withConfigOverrideSecrets(VERY_LONG_SECRET_NAME);
+            .withConfigOverrideSecrets(LONG_SECRET_NAME);
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasSecretVolume(SECRET_1_VOLUME_NAME, VERY_LONG_SECRET_NAME, 420));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_1_VOLUME_NAME,
-            "/weblogic-operator/config-overrides-secrets/" + VERY_LONG_SECRET_NAME, true));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
+            "/weblogic-operator/config-overrides-secrets/" + LONG_SECRET_NAME, true));
   }
 
   @Test
   public void whenDomainHasMultipleConfigOverrideSecretsWithLongNames_volumeCreatedWithShorterNames() {
-    resourceLookup.defineResource(VERY_LONG_SECRET_NAME, KubernetesResourceType.Secret, NS);
-    resourceLookup.defineResource(VERY_LONG_SECRET_NAME_2, KubernetesResourceType.Secret, NS);
+    resourceLookup.defineResource(LONG_SECRET_NAME, KubernetesResourceType.Secret, NS);
+    resourceLookup.defineResource(SECOND_LONG_SECRET_NAME, KubernetesResourceType.Secret, NS);
 
     configureDomain()
-            .withConfigOverrideSecrets(VERY_LONG_SECRET_NAME, VERY_LONG_SECRET_NAME_2);
+            .withConfigOverrideSecrets(LONG_SECRET_NAME, SECOND_LONG_SECRET_NAME);
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasSecretVolume(SECRET_1_VOLUME_NAME, VERY_LONG_SECRET_NAME, 420));
-    assertThat(getJobVolumes(), hasSecretVolume(SECRET_2_VOLUME_NAME, VERY_LONG_SECRET_NAME_2, 420));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_1_VOLUME_NAME,
-            "/weblogic-operator/config-overrides-secrets/" + VERY_LONG_SECRET_NAME, true));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_2_VOLUME_NAME,
-            "/weblogic-operator/config-overrides-secrets/" + VERY_LONG_SECRET_NAME_2, true));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME, SECOND_LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
+            "/weblogic-operator/config-overrides-secrets/" + LONG_SECRET_NAME, true));
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME,
+            "/weblogic-operator/config-overrides-secrets/" + SECOND_LONG_SECRET_NAME, true));
   }
 
   @Test
   public void whenDomainHasMultipleConfigOverrideSecretsWithLongAndShortNames_volumeCreatedWithCorrectNames() {
     resourceLookup.defineResource(SECRET_NAME, KubernetesResourceType.Secret, NS);
-    resourceLookup.defineResource(VERY_LONG_SECRET_NAME_2, KubernetesResourceType.Secret, NS);
+    resourceLookup.defineResource(SECOND_LONG_SECRET_NAME, KubernetesResourceType.Secret, NS);
 
     configureDomain()
-            .withConfigOverrideSecrets(SECRET_NAME, VERY_LONG_SECRET_NAME);
+            .withConfigOverrideSecrets(SECRET_NAME, LONG_SECRET_NAME);
 
     runCreateJob();
 
     assertThat(getJobVolumes(), hasSecretVolume(SECRET_NAME + "-volume", SECRET_NAME, 420));
-    assertThat(getJobVolumes(), hasSecretVolume(SECRET_1_VOLUME_NAME, VERY_LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, 420));
     assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_NAME + "-volume",
             "/weblogic-operator/config-overrides-secrets/" + SECRET_NAME, true));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_1_VOLUME_NAME,
-            "/weblogic-operator/config-overrides-secrets/" + VERY_LONG_SECRET_NAME, true));
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
+            "/weblogic-operator/config-overrides-secrets/" + LONG_SECRET_NAME, true));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -100,6 +100,7 @@ public class JobHelperTest extends DomainValidationBaseTest {
   private static final String OEVN = "OPERATOR_ENVVAR_NAMES";
   public static final String VOLUME_NAME_FOR_LONG_SECRET_NAME = "long-secret-name-1-volume";
   public static final String VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME = "long-secret-name-2-volume";
+  public static final int DEFAULT_MODE = 420;
   private Method getDomainSpec;
   private final Domain domain = createTestDomain();
   private final DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo(domain);
@@ -525,7 +526,7 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, DEFAULT_MODE));
     assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
             "/weblogic-operator/config-overrides-secrets/" + LONG_SECRET_NAME, true));
   }
@@ -540,8 +541,9 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, 420));
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME, SECOND_LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, DEFAULT_MODE));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME,
+            SECOND_LONG_SECRET_NAME, DEFAULT_MODE));
     assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
             "/weblogic-operator/config-overrides-secrets/" + LONG_SECRET_NAME, true));
     assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME,
@@ -558,8 +560,8 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasSecretVolume(SECRET_NAME + "-volume", SECRET_NAME, 420));
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, 420));
+    assertThat(getJobVolumes(), hasSecretVolume(SECRET_NAME + "-volume", SECRET_NAME, DEFAULT_MODE));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_SECRET_NAME, DEFAULT_MODE));
     assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_NAME + "-volume",
             "/weblogic-operator/config-overrides-secrets/" + SECRET_NAME, true));
     assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -580,7 +580,7 @@ public class JobHelperTest extends DomainValidationBaseTest {
   @Test
   public void whenDomainHasMultipleConfigOverrideSecretsWithLongAndShortNames_volumeCreatedWithCorrectNames() {
     resourceLookup.defineResource(SECRET_NAME, KubernetesResourceType.Secret, NS);
-    resourceLookup.defineResource(SECOND_LONG_RESOURCE_NAME, KubernetesResourceType.Secret, NS);
+    resourceLookup.defineResource(LONG_RESOURCE_NAME, KubernetesResourceType.Secret, NS);
 
     configureDomain()
             .withConfigOverrideSecrets(SECRET_NAME, LONG_RESOURCE_NAME);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -101,13 +101,16 @@ public class JobHelperTest extends DomainValidationBaseTest {
    * time the job ran.
    */
   private static final String OEVN = "OPERATOR_ENVVAR_NAMES";
-  public static final String VOLUME_SUFFIX1 = "-volume-" + getMD5Hash(LONG_RESOURCE_NAME);
-  public static final String VOLUME_SUFFIX2 = "-volume-" + getMD5Hash(SECOND_LONG_RESOURCE_NAME);
+  public static final String SECRET_VOLUME_SUFFIX1 = "-volume-st-" + getMD5Hash(LONG_RESOURCE_NAME);
+  public static final String SECRET_VOLUME_SUFFIX2 = "-volume-st-" + getMD5Hash(SECOND_LONG_RESOURCE_NAME);
+  public static final String CM_VOLUME_SUFFIX1 = "-volume-cm-" + getMD5Hash(LONG_RESOURCE_NAME);
   public static final int MAX_ALLOWED_VOLUME_NAME_LENGTH = 63;
-  public static final String VOLUME_NAME_FOR_LONG_RESOURCE_NAME =
-          LONG_RESOURCE_NAME.substring(0, MAX_ALLOWED_VOLUME_NAME_LENGTH - VOLUME_SUFFIX1.length()) + VOLUME_SUFFIX1;
-  public static final String VOLUME_NAME_FOR_SECOND_LONG_RESOURCE_NAME = SECOND_LONG_RESOURCE_NAME
-          .substring(0, MAX_ALLOWED_VOLUME_NAME_LENGTH - VOLUME_SUFFIX2.length()) + VOLUME_SUFFIX2;
+  public static final String VOLUME_NAME_FOR_LONG_SECRET_NAME = LONG_RESOURCE_NAME
+          .substring(0, MAX_ALLOWED_VOLUME_NAME_LENGTH - SECRET_VOLUME_SUFFIX1.length()) + SECRET_VOLUME_SUFFIX1;
+  public static final String VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME = SECOND_LONG_RESOURCE_NAME
+          .substring(0, MAX_ALLOWED_VOLUME_NAME_LENGTH - SECRET_VOLUME_SUFFIX2.length()) + SECRET_VOLUME_SUFFIX2;
+  public static final String VOLUME_NAME_FOR_LONG_CONFIG_MAP_NAME = LONG_RESOURCE_NAME
+          .substring(0, MAX_ALLOWED_VOLUME_NAME_LENGTH - SECRET_VOLUME_SUFFIX1.length()) + CM_VOLUME_SUFFIX1;
   public static final int MODE_420 = 420;
   public static final int MODE_365 = 365;
   private Method getDomainSpec;
@@ -536,12 +539,12 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_RESOURCE_NAME, LONG_RESOURCE_NAME, MODE_420));
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_SECOND_LONG_RESOURCE_NAME,
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_RESOURCE_NAME, MODE_420));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME,
             SECOND_LONG_RESOURCE_NAME, MODE_420));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_RESOURCE_NAME,
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
             "/weblogic-operator/config-overrides-secrets/" + LONG_RESOURCE_NAME, true));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_SECOND_LONG_RESOURCE_NAME,
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_SECOND_LONG_SECRET_NAME,
             "/weblogic-operator/config-overrides-secrets/" + SECOND_LONG_RESOURCE_NAME, true));
   }
 
@@ -554,8 +557,8 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasConfigMapVolume(VOLUME_NAME_FOR_LONG_RESOURCE_NAME, LONG_RESOURCE_NAME, MODE_365));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_RESOURCE_NAME,
+    assertThat(getJobVolumes(), hasConfigMapVolume(VOLUME_NAME_FOR_LONG_CONFIG_MAP_NAME, LONG_RESOURCE_NAME, MODE_365));
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_CONFIG_MAP_NAME,
             "/weblogic-operator/config-overrides", true));
   }
 
@@ -569,8 +572,8 @@ public class JobHelperTest extends DomainValidationBaseTest {
 
     runCreateJob();
 
-    assertThat(getJobVolumes(), hasConfigMapVolume(VOLUME_NAME_FOR_LONG_RESOURCE_NAME, LONG_RESOURCE_NAME, MODE_365));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_RESOURCE_NAME,
+    assertThat(getJobVolumes(), hasConfigMapVolume(VOLUME_NAME_FOR_LONG_CONFIG_MAP_NAME, LONG_RESOURCE_NAME, MODE_365));
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_CONFIG_MAP_NAME,
             "/weblogic-operator/wdt-config-map", true));
   }
 
@@ -585,10 +588,10 @@ public class JobHelperTest extends DomainValidationBaseTest {
     runCreateJob();
 
     assertThat(getJobVolumes(), hasSecretVolume(SECRET_NAME + "-volume", SECRET_NAME, MODE_420));
-    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_RESOURCE_NAME, LONG_RESOURCE_NAME, MODE_420));
+    assertThat(getJobVolumes(), hasSecretVolume(VOLUME_NAME_FOR_LONG_SECRET_NAME, LONG_RESOURCE_NAME, MODE_420));
     assertThat(getJobVolumeMounts(), hasVolumeMount(SECRET_NAME + "-volume",
             "/weblogic-operator/config-overrides-secrets/" + SECRET_NAME, true));
-    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_RESOURCE_NAME,
+    assertThat(getJobVolumeMounts(), hasVolumeMount(VOLUME_NAME_FOR_LONG_SECRET_NAME,
             "/weblogic-operator/config-overrides-secrets/" + LONG_RESOURCE_NAME, true));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
 import io.kubernetes.client.openapi.models.V1Probe;
+import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import org.hamcrest.Description;
@@ -68,8 +69,17 @@ public class Matchers {
     return hasItem(new V1VolumeMount().name(name).mountPath(path));
   }
 
+  static Matcher<Iterable<? super V1VolumeMount>> hasVolumeMount(String name, String path, boolean readOnly) {
+    return hasItem(new V1VolumeMount().name(name).mountPath(path).readOnly(readOnly));
+  }
+
   static Matcher<Iterable<? super V1Volume>> hasVolume(String name, String path) {
     return hasItem(new V1Volume().name(name).hostPath(new V1HostPathVolumeSource().path(path)));
+  }
+
+  static Matcher<Iterable<? super V1Volume>> hasSecretVolume(String name, String secretName, Integer defaultMode) {
+    return hasItem(new V1Volume().name(name).secret(new V1SecretVolumeSource()
+            .secretName(secretName).defaultMode(defaultMode)));
   }
 
   static Matcher<Iterable<? super V1Volume>> hasPvClaimVolume(String name, String claimName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
@@ -82,6 +82,11 @@ public class Matchers {
             .secretName(secretName).defaultMode(defaultMode)));
   }
 
+  static Matcher<Iterable<? super V1Volume>> hasConfigMapVolume(String name, String cmName, Integer defaultMode) {
+    return hasItem(new V1Volume().name(name).configMap(new V1ConfigMapVolumeSource().name(cmName)
+            .defaultMode(defaultMode)));
+  }
+
   static Matcher<Iterable<? super V1Volume>> hasPvClaimVolume(String name, String claimName) {
     return hasItem(new V1Volume().name(name).persistentVolumeClaim(
         new V1PersistentVolumeClaimVolumeSource().claimName(claimName)));


### PR DESCRIPTION
OWLS-87956 - K8s volume name has a limit of 63 characters. For override secrets, the operator generates volume name by appending "-volume" to the secret name. If the volume name length exceeds the limit, the volume fails to be mounted.  
This change creates a shorter volume name (based on the ordinal suffix) for the override secrets when the secret name exceeds the limit and uses the old naming scheme when the secret name length is less than the limit. 
Added new unit tests in the JobHelperTest and integration test results are at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4264/