### PR TITLE
add retry count and maximum retry count to retrying event

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainPresence.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainPresence.java
@@ -15,7 +15,12 @@ public class DomainPresence {
         .orElse(DEFAULT_TIMEOUT_SECONDS);
   }
 
-  static int getDomainPresenceFailureRetryMaxCount() {
+  /**
+   * Get the configured max retry count for domain presence failures.
+   *
+   * @return the max retry count
+   */
+  public static int getDomainPresenceFailureRetryMaxCount() {
     return Optional.ofNullable(TuningParameters.getInstance())
         .map(parameters -> parameters.getMainTuning().domainPresenceFailureRetryMaxCount)
         .orElse(DEFAULT_RETRY_MAX_COUNT);

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -740,12 +740,22 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     /**
      * Set the event data that is associated with this operation.
-     * @param eventItem event data
+     * @param eventItem event item
      * @param message event message
      * @return the updated factory
      */
     public MakeRightDomainOperation withEventData(EventItem eventItem, String message) {
       this.eventData = new EventData(eventItem, message);
+      return this;
+    }
+
+    /**
+     * Set the event data that is associated with this operation.
+     * @param eventData event data
+     * @return the updated factory
+     */
+    public MakeRightDomainOperation withEventData(EventData eventData) {
+      this.eventData = eventData;
       return this;
     }
 
@@ -846,7 +856,7 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     private void ensureRetryingEventPresent() {
       if (eventData == null) {
-        eventData = new EventData(DOMAIN_PROCESSING_RETRYING);
+        eventData = new EventData(DOMAIN_PROCESSING_RETRYING).retryCount(getCurrentIntrospectFailureRetryCount());
       }
     }
 
@@ -1061,7 +1071,7 @@ public class DomainProcessorImpl implements DomainProcessor {
                             createMakeRightOperation(existing)
                                 .withDeleting(isDeleting)
                                 .withExplicitRecheck()
-                                .withEventData(EventHelper.EventItem.DOMAIN_PROCESSING_RETRYING, null)
+                                .withEventData(new EventData(DOMAIN_PROCESSING_RETRYING).retryCount(retryCount - 1))
                                 .execute();
                           } else {
                             LOGGER.severe(

--- a/operator/src/main/java/oracle/kubernetes/operator/EventConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/EventConstants.java
@@ -29,9 +29,9 @@ public interface EventConstants {
   String DOMAIN_PROCESSING_FAILED_PATTERN
       = "Failed to complete processing domain resource %s due to: %s, the processing will be retried if needed";
   String DOMAIN_PROCESSING_RETRYING_PATTERN
-      = "Retrying the processing of domain resource %s after one or more failed attempts";
+      = "Retrying processing of domain resource %s, retry %s of a maximum %s";
   String DOMAIN_PROCESSING_ABORTED_PATTERN
-      = "Aborting the processing of domain resource %s permanently due to: %s";
+      = "Aborting processing of domain resource %s permanently due to: %s";
   String DOMAIN_VALIDATION_ERROR_PATTERN
       = "Validation error in domain resource %s: %s";
   String NAMESPACE_WATCHING_STARTED_EVENT = "NamespaceWatchingStarted";

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator;
 import java.util.Optional;
 
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.EventHelper;
 import oracle.kubernetes.operator.helpers.EventHelper.EventItem;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
@@ -27,6 +28,8 @@ public interface MakeRightDomainOperation {
   MakeRightDomainOperation withExplicitRecheck();
 
   MakeRightDomainOperation withEventData(EventItem eventItem, String message);
+
+  MakeRightDomainOperation withEventData(EventHelper.EventData eventdata);
 
   void execute();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -38,6 +38,7 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static oracle.kubernetes.operator.DomainPresence.getDomainPresenceFailureRetryMaxCount;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createFailureRelatedSteps;
@@ -413,7 +414,19 @@ public class EventHelperTest {
     assertThat("Found DOMAIN_PROCESSING_RETRYING event with expected message",
         containsEventWithMessage(getEvents(testSupport),
             EventConstants.DOMAIN_PROCESSING_RETRYING_EVENT,
-            String.format(DOMAIN_PROCESSING_RETRYING_PATTERN, UID)), is(true));
+            String.format(DOMAIN_PROCESSING_RETRYING_PATTERN, UID, 0, getDomainPresenceFailureRetryMaxCount())),
+        is(true));
+  }
+
+  @Test
+  public void whenMakeRightCalled_withRetryingAfterOneRetry_domainProcessingRetryingEventCreatedWithExpectedMessage() {
+    makeRightOperation.withEventData(new EventData(DOMAIN_PROCESSING_RETRYING).retryCount(1)).execute();
+
+    assertThat("Found DOMAIN_PROCESSING_RETRYING event with expected message",
+        containsEventWithMessage(getEvents(testSupport),
+            EventConstants.DOMAIN_PROCESSING_RETRYING_EVENT,
+            String.format(DOMAIN_PROCESSING_RETRYING_PATTERN, UID, 1, getDomainPresenceFailureRetryMaxCount())),
+        is(true));
   }
 
   @Test


### PR DESCRIPTION
Add retry count and maximum retry count to DomainProcessingRetrying event message, and add necessary unit test case in EventHelperTest.java.

Here are examples of generated events with the change and without the change.

48s         Normal    DomainProcessingRetrying   domain/domain1                   Retrying processing of domain resource domain1, retry 2 of a maximum 5

95s         Normal    DomainProcessingRetrying   domain/domain1                   Retrying the processing of domain resource domain1 after one or more failed attempts

Note that operator aggregates "same" events into a single event object with a count that indicates how many such events have been generated. Before this change, all DomainProcessingRetrying events for a particular domain are the "same" because they all have the same event message. With this change, the DomainProcessingRetrying events with different retry counts are considered "different" so we will see more event objects. 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4260/
