### PR TITLE
Documentation and sample correction for setting the resource requests and limits

### DIFF
--- a/docs-source/content/faq/resource-settings.md
+++ b/docs-source/content/faq/resource-settings.md
@@ -34,12 +34,13 @@ You can set Kubernetes memory and CPU requests and limits in a [Domain YAML file
 ```
   spec:
     serverPod:
-      requests:
-        cpu: "250m"
-        memory: "768Mi"
-      limits:
-        cpu: "2"
-        memory: "2Gi"
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "768Mi"
+        limits:
+          cpu: "2"
+          memory: "2Gi"
 ```
 
 Limits and requests for CPU resources are measured in CPU units. One CPU, in Kubernetes, is equivalent to 1 vCPU/Core for cloud providers and 1 hyperthread on bare-metal Intel processors. An `m` suffix in a CPU attribute indicates 'milli-CPU', so `250m` is 25% of a CPU.

--- a/kubernetes/samples/scripts/create-weblogic-domain/manually-create-domain/domain.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/manually-create-domain/domain.yaml
@@ -66,9 +66,10 @@ spec:
       value: "-Dweblogic.StdoutDebugEnabled=false"
     - name: USER_MEM_ARGS
       value: "-Xms256m -Xmx512m -Djava.security.egd=file:/dev/./urandom "
-    requests:
-      cpu: "250m"
-      memory: "768Mi"
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "768Mi"
 
     # If you are storing your domain on a persistent volume (as opposed to inside the image),
     # then uncomment this section and provide the PVC details and mount path here (standard images


### PR DESCRIPTION
Fixed the missing `resources` in the documentation and sample for setting the resource requests and limits in `domain.spec.serverPod` section.