### PR TITLE
Preserve pod SHA256 values

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -497,18 +497,27 @@ public class PodHelper {
     }
 
     @Override
+    V1Pod withNonHashedElements(V1Pod pod) {
+      V1Pod v1Pod = super.withNonHashedElements(pod);
+
+      // Add prometheus annotations. This will overwrite any custom annotations with same name.
+      // Prometheus does not support "prometheus.io/scheme".  The scheme(http/https) can be set
+      // in the Prometheus Chart values yaml under the "extraScrapeConfigs:" section.
+      if (exporterContext.isEnabled()) {
+        final V1ObjectMeta metadata = v1Pod.getMetadata();
+        AnnotationHelper.annotateForPrometheus(metadata, exporterContext.getBasePath(), exporterContext.getPort());
+      }
+
+      return v1Pod;
+    }
+
+    @Override
     protected V1ObjectMeta createMetadata() {
       V1ObjectMeta metadata = super.createMetadata();
       if (getClusterName() != null) {
         metadata.putLabelsItem(CLUSTERNAME_LABEL, getClusterName());
       }
 
-      // Add prometheus annotations. This will overwrite any custom annotations with same name.
-      // Prometheus does not support "prometheus.io/scheme".  The scheme(http/https) can be set
-      // in the Prometheus Chart values yaml under the "extraScrapeConfigs:" section.
-      if (exporterContext.isEnabled()) {
-        AnnotationHelper.annotateForPrometheus(metadata, exporterContext.getBasePath(), exporterContext.getPort());
-      }
       return metadata;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -626,12 +626,7 @@ public abstract class PodStepContext extends BasePodStepContext {
   }
 
   private Integer getMetricsPort() {
-    try {
-      return getListenPort() != null ? getListenPort() : getSslListenPort();
-    } catch (NullPointerException e) {
-      LOGGER.warning("Unable to configure Prometheus: both listen port and SSH port are null");
-      return 0;
-    }
+    return getListenPort() != null ? getListenPort() : getSslListenPort();
   }
 
   private void addHashLabel(V1ObjectMeta metadata, String label, String hash) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -626,7 +626,12 @@ public abstract class PodStepContext extends BasePodStepContext {
   }
 
   private Integer getMetricsPort() {
-    return getListenPort() != null ? getListenPort() : getSslListenPort();
+    try {
+      return getListenPort() != null ? getListenPort() : getSslListenPort();
+    } catch (NullPointerException e) {
+      LOGGER.warning("Unable to configure Prometheus: both listen port and SSH port are null");
+      return 0;
+    }
   }
 
   private void addHashLabel(V1ObjectMeta metadata, String label, String hash) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -101,6 +101,21 @@ public class AdminPodHelperTest extends PodHelperTestBase {
     getServerTopology().setAdminPort(port);
   }
 
+  @Override
+  String getExpectedPlainPortSha256Annotation() {
+    return ExpectedSHA256Values.ADMIN_SERVER_PLAINPORT_SHA256;
+  }
+
+  @Override
+  String getExpectedSslPortSha256Annotation() {
+    return ExpectedSHA256Values.ADMIN_SERVER_SSLPORT_SHA256;
+  }
+
+  @Override
+  String getExpectedMiiSha256Annotation() {
+    return ExpectedSHA256Values.ADMIN_SERVER_MIIDOMAIN_SHA256;
+  }
+
   String getDomainValidationFailedKey() {
     return DOMAIN_VALIDATION_FAILED;
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ExpectedSHA256Values.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ExpectedSHA256Values.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+/**
+ * To present pods from rolling when a customer upgrades the operator, we must ensure that the computed SHA256 hash
+ * will not change. To do this, we capture the hash for some representative cases and test that those cases
+ * continue to result in the same values as we make changes.
+ *
+ * The changes here are taken from 3.1.0.
+ */
+interface ExpectedSHA256Values {
+
+  String MANAGED_SERVER_PLAINPORT_SHA256 = "6e1c6a716a9e0078a56c2df86ffe1cd2f0f9bdbe271f169dc1d548d026aa52b7";
+  String MANAGED_SERVER_SSLPORT_SHA256 = "368b26eaf1645f966d4c350906b59a0afcc0fbdf9ed30779b71a6d044eb480dd";
+  String MANAGED_SERVER_MIIDOMAIN_SHA256 = "bdebf4e8152fea393e06f037bbb4ed243a938f2f9e1aeeffe20768724a0b32cc";
+  String ADMIN_SERVER_PLAINPORT_SHA256 = "fc735cf7c34bc1492a237149c4e27c9bb27575de463dbc55e953588862098df4";
+  String ADMIN_SERVER_SSLPORT_SHA256 = "854c2ce0b646268a7e72f601f625a8466f45d71f7f635a65ad3740ecb9bdf39a";
+  String ADMIN_SERVER_MIIDOMAIN_SHA256 = "98ac04bc5ddbc792ee37912ea5efe8097016ed10ce93b13f8e57013547429e6c";
+}


### PR DESCRIPTION
This changes verifies some cases of SHA256 hash computations and ensures that they don't change over time. The hash values used as references are those generated by operator version 3.1.0.