### PR TITLE
Owls 87012 - Domain processing completed event generated after domain scaling operation integration test

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -169,7 +169,6 @@ public class ItKubernetesEvents {
     // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
     // this secret is used only for non-kind cluster
     createSecretForBaseImages(domainNamespace1);
-
   }
 
   /**
@@ -183,7 +182,6 @@ public class ItKubernetesEvents {
   @DisplayName("Test domain events for various successful domain life cycle changes")
   public void testDomainK8SEventsSuccess() {
     DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
-
     logger.info("Creating domain");
     createDomain();
 
@@ -382,7 +380,7 @@ public class ItKubernetesEvents {
    */
   @Order(7)
   @Test
-  public void testK8sEventsScaleDomainAndVerifyDomainProcessingCompleted() {
+  public void testScaleDomainAndVerifyCompletedEvent() {
     try {
       scaleDomainAndVerifyCompletedEvent(1, "scale down", true);
       scaleDomainAndVerifyCompletedEvent(2, "scale up", true);
@@ -393,12 +391,9 @@ public class ItKubernetesEvents {
 
   private void scaleDomainAndVerifyCompletedEvent(int replicaCount, String testType, boolean verify) {
     DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
-    String patchStr
-            = "["
-            + "{\"op\": \"replace\", \"path\": \"/spec/clusters/0/replicas\", \"value\": " + replicaCount + "}"
-            + "]";
-    logger.info("Updating replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
-    V1Patch patch = new V1Patch(patchStr);
+    logger.info("Updating domain resource to set the replicas for cluster " + cluster1Name + " to " + replicaCount);
+    V1Patch patch = new V1Patch("["
+            + "{\"op\": \"replace\", \"path\": \"/spec/clusters/0/replicas\", \"value\": " + replicaCount + "}" + "]");
     assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
             "Failed to patch domain");
     if (verify) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -380,6 +380,7 @@ public class ItKubernetesEvents {
    */
   @Order(7)
   @Test
+  @DisplayName("Test domain completed event when domain is scaled.")
   public void testScaleDomainAndVerifyCompletedEvent() {
     try {
       scaleDomainAndVerifyCompletedEvent(1, "scale down", true);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -403,8 +403,8 @@ public class ItKubernetesEvents {
       logger.info("Verify the DomainProcessingCompleted event is generated after " + testType);
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_COMPLETED, "Normal", timestamp);
       int countAfter = getDomainEventCount(domainNamespace1, domainUid, DOMAIN_PROCESSING_COMPLETED, "Normal");
-      assertTrue(countAfter == countBefore + 1, "Event count doesn't match expected event count, " +
-              "Count before scaling is -> " + countBefore + " and count after scaling is -> " + countAfter);
+      assertTrue(countAfter == countBefore + 1, "Event count doesn't match expected event count, "
+              + "Count before scaling is -> " + countBefore + " and count after scaling is -> " + countAfter);
     }
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
@@ -76,7 +76,6 @@ public class K8sEvents {
    */
   public static int getDomainEventCount(
           String domainNamespace, String domainUid, String reason, String type) {
-    int count = 0;
     try {
       List<CoreV1Event> events = Kubernetes.listNamespacedEvents(domainNamespace);
       for (CoreV1Event event : events) {
@@ -85,13 +84,13 @@ public class K8sEvents {
                 && event.getType().equals(type)
                 && labels.containsKey("weblogic.createdByOperator")
                 && labels.get("weblogic.domainUID").equals(domainUid)) {
-          count = event.getCount();
+          return event.getCount();
         }
       }
     } catch (ApiException ex) {
       Logger.getLogger(ItKubernetesEvents.class.getName()).log(Level.SEVERE, null, ex);
     }
-    return count;
+    return 0;
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
@@ -66,6 +66,35 @@ public class K8sEvents {
   }
 
   /**
+   * Get the count for a particular event with specified reason, type and domainUid in a given namespace.
+   *
+   * @param domainNamespace namespace in which the domain exists
+   * @param domainUid       UID of the domain
+   * @param reason          event reason to get the count for
+   * @param type            type of event, Normal of Warning
+   * @return count          Event count
+   */
+  public static int getDomainEventCount(
+          String domainNamespace, String domainUid, String reason, String type) {
+    int count = 0;
+    try {
+      List<CoreV1Event> events = Kubernetes.listNamespacedEvents(domainNamespace);
+      for (CoreV1Event event : events) {
+        Map<String, String> labels = event.getMetadata().getLabels();
+        if (event.getReason().equals(reason)
+                && event.getType().equals(type)
+                && labels.containsKey("weblogic.createdByOperator")
+                && labels.get("weblogic.domainUID").equals(domainUid)) {
+          count = event.getCount();
+        }
+      }
+    } catch (ApiException ex) {
+      Logger.getLogger(ItKubernetesEvents.class.getName()).log(Level.SEVERE, null, ex);
+    }
+    return count;
+  }
+
+  /**
    * Get the event count between a specific timestamp.
    *
    * @param domainNamespace namespace in which the domain exists


### PR DESCRIPTION
Integration test to verify that domain processing completed event is generated after the domain is scaled. The test performs scale down and scale up Integration test run URL - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4285. I'm rerunning the integration test and update the latest URL when the test finishes.