### PR TITLE
Use JDK 16 and Kubernetes Java Client 12.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN set -eux; \
 ENV LANG="en_US.UTF-8" \
     JAVA_HOME="/usr/local/java" \
     PATH="/operator:$JAVA_HOME/bin:$PATH" \
-    JAVA_VERSION="15" \
-    JAVA_URL="https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz"
+    JAVA_VERSION="16" \
+    JAVA_URL="https://download.java.net/java/GA/jdk16/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-16_linux-x64_bin.tar.gz"
 
 # Install Java and make the operator run with a non-root user id (1000 is the `oracle` user)
 RUN set -eux; \

--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -224,10 +224,6 @@
         }
       }
     },
-    "DateTime": {
-      "format": "date-time",
-      "type": "string"
-    },
     "DomainCondition": {
       "type": "object",
       "properties": {
@@ -247,7 +243,7 @@
         },
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "message": {
           "description": "Human-readable message indicating details about last transition.",
@@ -255,7 +251,7 @@
         },
         "lastProbeTime": {
           "description": "Last time we probed the condition.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "status": {
           "description": "The status of the condition. Can be True, False, Unknown.",
@@ -458,7 +454,7 @@
         },
         "startTime": {
           "description": "RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "conditions": {
           "description": "Current service state of the domain.",
@@ -609,6 +605,10 @@
         }
       }
     },
+    "OffsetDateTime": {
+      "format": "date-time",
+      "type": "string"
+    },
     "OnlineUpdate": {
       "type": "object",
       "properties": {
@@ -668,7 +668,7 @@
         },
         "activationTime": {
           "description": "RFC 3339 date and time at which the server started.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "subsystems": {
           "description": "Status of unhealthy subsystems, if any.",

--- a/docs/domains/Domain.json
+++ b/docs/domains/Domain.json
@@ -224,6 +224,10 @@
         }
       }
     },
+    "DateTime": {
+      "format": "date-time",
+      "type": "string"
+    },
     "DomainCondition": {
       "type": "object",
       "properties": {
@@ -243,7 +247,7 @@
         },
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "message": {
           "description": "Human-readable message indicating details about last transition.",
@@ -251,7 +255,7 @@
         },
         "lastProbeTime": {
           "description": "Last time we probed the condition.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "status": {
           "description": "The status of the condition. Can be True, False, Unknown.",
@@ -454,7 +458,7 @@
         },
         "startTime": {
           "description": "RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "conditions": {
           "description": "Current service state of the domain.",
@@ -605,10 +609,6 @@
         }
       }
     },
-    "OffsetDateTime": {
-      "format": "date-time",
-      "type": "string"
-    },
     "OnlineUpdate": {
       "type": "object",
       "properties": {
@@ -668,7 +668,7 @@
         },
         "activationTime": {
           "description": "RFC 3339 date and time at which the server started.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "subsystems": {
           "description": "Status of unhealthy subsystems, if any.",

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -59,7 +59,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `reason` | string | A brief CamelCase message indicating details about why the domain is in this state. |
 | `replicas` | number | The number of running cluster member Managed Servers in the WebLogic cluster if there is exactly one cluster defined in the domain configuration and where the `replicas` field is set at the `spec` level rather than for the specific cluster under `clusters`. This field is provided to support use of Kubernetes scaling for this limited use case. |
 | `servers` | array of [Server Status](#server-status) | Status of WebLogic Servers in this domain. |
-| `startTime` | DateTime | RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available. |
+| `startTime` | OffsetDateTime | RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available. |
 
 ### Admin Server
 
@@ -171,8 +171,8 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `lastProbeTime` | DateTime | Last time we probed the condition. |
-| `lastTransitionTime` | DateTime | Last time the condition transitioned from one status to another. |
+| `lastProbeTime` | OffsetDateTime | Last time we probed the condition. |
+| `lastTransitionTime` | OffsetDateTime | Last time the condition transitioned from one status to another. |
 | `message` | string | Human-readable message indicating details about last transition. |
 | `reason` | string | Unique, one-word, CamelCase reason for the condition's last transition. |
 | `status` | string | The status of the condition. Can be True, False, Unknown. |
@@ -248,7 +248,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `activationTime` | DateTime | RFC 3339 date and time at which the server started. |
+| `activationTime` | OffsetDateTime | RFC 3339 date and time at which the server started. |
 | `overallHealth` | string | Server health of this WebLogic Server instance. If the value is "Not available", the operator has failed to read the health. If the value is "Not available (possibly overloaded)", the operator has failed to read the health of the server possibly due to the server is in the overloaded state. |
 | `subsystems` | array of [Subsystem Health](#subsystem-health) | Status of unhealthy subsystems, if any. |
 

--- a/docs/domains/Domain.md
+++ b/docs/domains/Domain.md
@@ -59,7 +59,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `reason` | string | A brief CamelCase message indicating details about why the domain is in this state. |
 | `replicas` | number | The number of running cluster member Managed Servers in the WebLogic cluster if there is exactly one cluster defined in the domain configuration and where the `replicas` field is set at the `spec` level rather than for the specific cluster under `clusters`. This field is provided to support use of Kubernetes scaling for this limited use case. |
 | `servers` | array of [Server Status](#server-status) | Status of WebLogic Servers in this domain. |
-| `startTime` | OffsetDateTime | RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available. |
+| `startTime` | DateTime | RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available. |
 
 ### Admin Server
 
@@ -171,8 +171,8 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `lastProbeTime` | OffsetDateTime | Last time we probed the condition. |
-| `lastTransitionTime` | OffsetDateTime | Last time the condition transitioned from one status to another. |
+| `lastProbeTime` | DateTime | Last time we probed the condition. |
+| `lastTransitionTime` | DateTime | Last time the condition transitioned from one status to another. |
 | `message` | string | Human-readable message indicating details about last transition. |
 | `reason` | string | Unique, one-word, CamelCase reason for the condition's last transition. |
 | `status` | string | The status of the condition. Can be True, False, Unknown. |
@@ -248,7 +248,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `activationTime` | OffsetDateTime | RFC 3339 date and time at which the server started. |
+| `activationTime` | DateTime | RFC 3339 date and time at which the server started. |
 | `overallHealth` | string | Server health of this WebLogic Server instance. If the value is "Not available", the operator has failed to read the health. If the value is "Not available (possibly overloaded)", the operator has failed to read the health of the server possibly due to the server is in the overloaded state. |
 | `subsystems` | array of [Subsystem Health](#subsystem-health) | Status of unhealthy subsystems, if any. |
 

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1145,6 +1145,10 @@ window.onload = function() {
         }
       }
     },
+    "DateTime": {
+      "format": "date-time",
+      "type": "string"
+    },
     "DomainCondition": {
       "type": "object",
       "properties": {
@@ -1164,7 +1168,7 @@ window.onload = function() {
         },
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "message": {
           "description": "Human-readable message indicating details about last transition.",
@@ -1172,7 +1176,7 @@ window.onload = function() {
         },
         "lastProbeTime": {
           "description": "Last time we probed the condition.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "status": {
           "description": "The status of the condition. Can be True, False, Unknown.",
@@ -1375,7 +1379,7 @@ window.onload = function() {
         },
         "startTime": {
           "description": "RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "conditions": {
           "description": "Current service state of the domain.",
@@ -1526,10 +1530,6 @@ window.onload = function() {
         }
       }
     },
-    "OffsetDateTime": {
-      "format": "date-time",
-      "type": "string"
-    },
     "OnlineUpdate": {
       "type": "object",
       "properties": {
@@ -1589,7 +1589,7 @@ window.onload = function() {
         },
         "activationTime": {
           "description": "RFC 3339 date and time at which the server started.",
-          "$ref": "#/definitions/OffsetDateTime"
+          "$ref": "#/definitions/DateTime"
         },
         "subsystems": {
           "description": "Status of unhealthy subsystems, if any.",

--- a/docs/domains/index.html
+++ b/docs/domains/index.html
@@ -1145,10 +1145,6 @@ window.onload = function() {
         }
       }
     },
-    "DateTime": {
-      "format": "date-time",
-      "type": "string"
-    },
     "DomainCondition": {
       "type": "object",
       "properties": {
@@ -1168,7 +1164,7 @@ window.onload = function() {
         },
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "message": {
           "description": "Human-readable message indicating details about last transition.",
@@ -1176,7 +1172,7 @@ window.onload = function() {
         },
         "lastProbeTime": {
           "description": "Last time we probed the condition.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "status": {
           "description": "The status of the condition. Can be True, False, Unknown.",
@@ -1379,7 +1375,7 @@ window.onload = function() {
         },
         "startTime": {
           "description": "RFC 3339 date and time at which the operator started the domain. This will be when the operator begins processing and will precede when the various servers or clusters are available.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "conditions": {
           "description": "Current service state of the domain.",
@@ -1530,6 +1526,10 @@ window.onload = function() {
         }
       }
     },
+    "OffsetDateTime": {
+      "format": "date-time",
+      "type": "string"
+    },
     "OnlineUpdate": {
       "type": "object",
       "properties": {
@@ -1589,7 +1589,7 @@ window.onload = function() {
         },
         "activationTime": {
           "description": "RFC 3339 date and time at which the server started.",
-          "$ref": "#/definitions/DateTime"
+          "$ref": "#/definitions/OffsetDateTime"
         },
         "subsystems": {
           "description": "Status of unhealthy subsystems, if any.",

--- a/integration-tests/src/test/java/oracle/weblogic/domain/DomainCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/DomainCondition.java
@@ -3,12 +3,13 @@
 
 package oracle.weblogic.domain;
 
+import java.time.OffsetDateTime;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 @ApiModel(
     description = "DomainCondition contains details for the current condition of this domain.")
@@ -20,10 +21,10 @@ public class DomainCondition {
   private String type;
 
   @ApiModelProperty("Last time we probed the condition.")
-  private DateTime lastProbeTime;
+  private OffsetDateTime lastProbeTime;
 
   @ApiModelProperty("Last time the condition transitioned from one status to another.")
-  private DateTime lastTransitionTime;
+  private OffsetDateTime lastTransitionTime;
 
   @ApiModelProperty("Human-readable message indicating details about last transition.")
   private String message;
@@ -51,37 +52,37 @@ public class DomainCondition {
     this.type = type;
   }
 
-  public DomainCondition lastProbeTime(DateTime lastProbeTime) {
+  public DomainCondition lastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
     return this;
   }
 
-  public DateTime lastProbeTime() {
+  public OffsetDateTime lastProbeTime() {
     return lastProbeTime;
   }
 
-  public DateTime getLastProbeTime() {
+  public OffsetDateTime getLastProbeTime() {
     return lastProbeTime;
   }
 
-  public void setLastProbeTime(DateTime lastProbeTime) {
+  public void setLastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
   }
 
-  public DomainCondition lastTransitionTime(DateTime lastTransitionTime) {
+  public DomainCondition lastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
     return this;
   }
 
-  public DateTime lastTransitionTime() {
+  public OffsetDateTime lastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 
-  public void setLastTransitionTime(DateTime lastTransitionTime) {
+  public void setLastTransitionTime(OffsetDateTime lastTransitionTime) {
     this.lastTransitionTime = lastTransitionTime;
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/domain/DomainStatus.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/DomainStatus.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.domain;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +12,6 @@ import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 @ApiModel(
     description =
@@ -40,7 +40,7 @@ public class DomainStatus {
       "RFC 3339 date and time at which the operator started the domain. This will be when "
           + "the operator begins processing and will precede when the various servers "
           + "or clusters are available.")
-  private DateTime startTime;
+  private OffsetDateTime startTime;
 
   @ApiModelProperty(
       value =
@@ -174,20 +174,20 @@ public class DomainStatus {
     this.clusters = clusters;
   }
 
-  public DomainStatus startTime(DateTime startTime) {
+  public DomainStatus startTime(OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
 
-  public DateTime startTime() {
+  public OffsetDateTime startTime() {
     return startTime;
   }
 
-  public DateTime getStartTime() {
+  public OffsetDateTime getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(DateTime startTime) {
+  public void setStartTime(OffsetDateTime startTime) {
     this.startTime = startTime;
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/domain/ServerHealth.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/ServerHealth.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.domain;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +12,6 @@ import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 @ApiModel(
     description =
@@ -19,7 +19,7 @@ import org.joda.time.DateTime;
 public class ServerHealth {
 
   @ApiModelProperty("RFC 3339 date and time at which the server started.")
-  private DateTime activationTime;
+  private OffsetDateTime activationTime;
 
   @ApiModelProperty(
       "Server health of this WebLogic Server. If the value is \"Not available\", the operator has "
@@ -31,20 +31,20 @@ public class ServerHealth {
   @ApiModelProperty("Status of unhealthy subsystems, if any.")
   private List<SubsystemHealth> subsystems = new ArrayList<>();
 
-  public ServerHealth activationTime(DateTime activationTime) {
+  public ServerHealth activationTime(OffsetDateTime activationTime) {
     this.activationTime = activationTime;
     return this;
   }
 
-  public DateTime activationTime() {
+  public OffsetDateTime activationTime() {
     return activationTime;
   }
 
-  public DateTime getActivationTime() {
+  public OffsetDateTime getActivationTime() {
     return activationTime;
   }
 
-  public void setActivationTime(DateTime activationTime) {
+  public void setActivationTime(OffsetDateTime activationTime) {
     this.activationTime = activationTime;
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCoherenceTests.java
@@ -5,6 +5,7 @@ package oracle.weblogic.kubernetes;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -30,7 +31,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import oracle.weblogic.kubernetes.utils.FileUtils;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -374,9 +374,9 @@ class ItCoherenceTests {
   }
 
   private void rollingRestartDomainAndVerify() {
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the server pods before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     for (int i = 1; i <= replicaCount; i++) {
       pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace, managedServerPrefix + i));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -47,7 +48,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.OracleHttpClient;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,7 +138,7 @@ public class ItConfigDistributionStrategy {
 
   static Path clusterViewAppPath;
   String overridecm = "configoverride-cm";
-  LinkedHashMap<String, DateTime> podTimestamps;
+  LinkedHashMap<String, OffsetDateTime> podTimestamps;
 
   static int mysqlDBPort1;
   static int mysqlDBPort2;
@@ -746,7 +746,7 @@ public class ItConfigDistributionStrategy {
     // get the pod creation time stamps
     podTimestamps = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     podTimestamps.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -758,9 +758,9 @@ public class ItConfigDistributionStrategy {
   //check if the pods are restarted by comparing the pod creationtimestamp.
   private void verifyPodsStateNotChanged() {
     logger.info("Verifying the WebLogic server pod states are not changed");
-    for (Map.Entry<String, DateTime> entry : podTimestamps.entrySet()) {
+    for (Map.Entry<String, OffsetDateTime> entry : podTimestamps.entrySet()) {
       String podName = (String) entry.getKey();
-      DateTime creationTimestamp = (DateTime) entry.getValue();
+      OffsetDateTime creationTimestamp = (OffsetDateTime) entry.getValue();
       assertTrue(podStateNotChanged(podName, domainUid, domainNamespace,
           creationTimestamp), "Pod is restarted");
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Target;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,7 +49,6 @@ import oracle.weblogic.kubernetes.utils.OracleHttpClient;
 import org.awaitility.core.ConditionEvaluationListener;
 import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.EvaluatedCondition;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -148,7 +148,7 @@ public class ItIntrospectVersion {
       : WEBLOGIC_IMAGE_NAME + ":" + WLS_UPDATE_IMAGE_TAG;
   private final String wlSecretName = "weblogic-credentials";
 
-  private Map<String, DateTime> podsWithTimeStamps = null;
+  private Map<String, OffsetDateTime> podsWithTimeStamps = null;
 
   // create standard, reusable retry/backoff policy
   private static final ConditionFactory withStandardRetryPolicy
@@ -394,9 +394,9 @@ public class ItIntrospectVersion {
     verifyMemberHealth(adminServerPodName, managedServerNames, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
 
     // get the pod creation time stamps
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(introDomainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(introDomainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -546,9 +546,9 @@ public class ItIntrospectVersion {
     }
 
     // get the pod creation time stamps
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(introDomainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(introDomainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -669,9 +669,9 @@ public class ItIntrospectVersion {
     assertNotEquals(-1, adminServerPort, "Couldn't get valid port for default channel");
 
     // get the pod creation time stamps
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(introDomainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(introDomainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
@@ -5,6 +5,7 @@ package oracle.weblogic.kubernetes;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -278,9 +278,9 @@ class ItIstioMiiDomain {
   @Order(2)
   @DisplayName("Add a work manager to a model-in-image domain using dynamic update")
   public void testMiiIstioDynamicUpdate() {
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -7,7 +7,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +33,6 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -182,7 +181,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain events for various successful domain life cycle changes")
   public void testDomainK8SEventsSuccess() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     logger.info("Creating domain");
     createDomain();
 
@@ -201,7 +200,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain DomainValidationError event for non-existing managed server")
   public void testDomainK8sEventsNonExistingManagedServer() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     logger.info("patch the domain resource with non-existing managed server");
     String patchStr
         = "[{\"op\": \"add\",\"path\": \""
@@ -218,7 +217,7 @@ public class ItKubernetesEvents {
     checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
 
     // remove the managed server from domain resource
-    timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    timestamp = OffsetDateTime.now();
     patchStr
         = "[{\"op\": \"remove\",\"path\": \""
         + "/spec/managedServers\""
@@ -240,7 +239,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain DomainValidationError event for non-existing cluster")
   public void testDomainK8sEventsNonExistingCluster() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     logger.info("patch the domain resource with new cluster");
     String patchStr
         = "["
@@ -255,7 +254,7 @@ public class ItKubernetesEvents {
     checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
 
     //remove the cluster from domain resource
-    timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    timestamp = OffsetDateTime.now();
     patchStr = "[{\"op\": \"remove\",\"path\": \"/spec/clusters/1\"}]";
     logger.info("Updating domain configuration using patch string: {0}\n", patchStr);
     patch = new V1Patch(patchStr);
@@ -282,7 +281,7 @@ public class ItKubernetesEvents {
     V1Patch patch;
     String patchStr;
 
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     try {
       logger.info("remove the webLogicCredentialsSecret to verify the following events"
           + " DomainChanged, DomainProcessingRetrying and DomainProcessingAborted are logged");
@@ -302,7 +301,7 @@ public class ItKubernetesEvents {
       logger.info("verify domain processing aborted event");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_ABORTED, "Warning", timestamp);
     } finally {
-      timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+      timestamp = OffsetDateTime.now();
       // add back the webLogicCredentialsSecret
       patchStr = "[{\"op\": \"add\", \"path\": \"/spec/webLogicCredentialsSecret\", "
           + "\"value\" : {\"name\":\"" + wlSecretName + "\" , \"namespace\":\"" + domainNamespace1 + "\"}"
@@ -329,7 +328,7 @@ public class ItKubernetesEvents {
   @Test
   public void testK8SEventsMultiClusterEvents() {
     createNewCluster();
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     scaleClusterWithRestApi(domainUid, cluster2Name, 1,
         externalRestHttpsPort, opNamespace, opServiceAccount);
     logger.info("verify the DomainProcessing Starting/Completed event is generated");
@@ -347,7 +346,7 @@ public class ItKubernetesEvents {
   @Order(6)
   @Test
   public void testDomainK8sEventsScalePastMax() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     try {
       logger.info("Scaling cluster using patching");
       String patchStr
@@ -362,7 +361,7 @@ public class ItKubernetesEvents {
       logger.info("verify the DomainValidationError event is generated");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
     } finally {
-      timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+      timestamp = OffsetDateTime.now();
       logger.info("Updating domain resource to set correct replicas size");
       String patchStr
           = "["
@@ -392,7 +391,7 @@ public class ItKubernetesEvents {
   }
 
   private void scaleDomainAndVerifyCompletedEvent(int replicaCount, String testType, boolean verify) {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     logger.info("Updating domain resource to set the replicas for cluster " + cluster1Name + " to " + replicaCount);
     int countBefore = getDomainEventCount(domainNamespace1, domainUid, DOMAIN_PROCESSING_COMPLETED, "Normal");
     V1Patch patch = new V1Patch("["
@@ -419,7 +418,7 @@ public class ItKubernetesEvents {
   @Order(8)
   @Test
   public void testDomainK8sEventsScaleBelowMin() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     try {
       String patchStr
           = "["
@@ -434,7 +433,7 @@ public class ItKubernetesEvents {
       logger.info("verify the DomainValidationError event is generated");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
     } finally {
-      timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+      timestamp = OffsetDateTime.now();
       logger.info("Updating domain resource to set correct replicas size");
       String patchStr
           = "["
@@ -454,7 +453,7 @@ public class ItKubernetesEvents {
   @Order(9)
   @Test
   public void testDomainK8sEventsProcessingFailed() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     try {
       createPV("sample-pv", domainUid, this.getClass().getSimpleName());
       createPVC("sample-pv", "sample-pvc", domainUid, domainNamespace1);
@@ -486,7 +485,7 @@ public class ItKubernetesEvents {
           + "]";
       logger.info("Updating pv/pvcs in domain resource using patch string: {0}", patchStr);
       V1Patch patch = new V1Patch(patchStr);
-      timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+      timestamp = OffsetDateTime.now();
       assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
           "Failed to patch domain");
 
@@ -504,7 +503,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain events for various domain life cycle changes")
   public void testDomainK8SEventsDelete() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
 
     deleteDomainCustomResource(domainUid, domainNamespace1);
     checkPodDoesNotExist(adminServerPodName, domainUid, domainNamespace1);
@@ -537,7 +536,7 @@ public class ItKubernetesEvents {
   @Order(11)
   @Test
   public void testK8SEventsStartWatchingNS() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     logger.info("Adding a new domain namespace in the operator watch list");
     upgradeAndVerifyOperator(opNamespace, domainNamespace1, domainNamespace2);
     logger.info("verify NamespaceWatchingStarted event is logged");
@@ -567,7 +566,7 @@ public class ItKubernetesEvents {
   @Test
   @Disabled("Bug - OWLS-87181")
   public void testK8SEventsStopWatchingNS() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
     logger.info("Removing domain namespace in the operator watch list");
     upgradeAndVerifyOperator(opNamespace, domainNamespace1);
     logger.info("verify NamespaceWatchingStopped event is logged");
@@ -576,7 +575,8 @@ public class ItKubernetesEvents {
 
   // Utility method to check event
   private static void checkEvent(
-      String opNamespace, String domainNamespace, String domainUid, String reason, String type, DateTime timestamp) {
+      String opNamespace, String domainNamespace, String domainUid,
+      String reason, String type, OffsetDateTime timestamp) {
     withStandardRetryPolicy
         .conditionEvaluationListener(condition -> logger.info("Waiting for domain event {0} to be logged "
         + "(elapsed time {1}ms, remaining time {2}ms)",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -57,6 +57,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVol
 import static oracle.weblogic.kubernetes.actions.TestActions.getNextIntrospectVersion;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServicePort;
+import static oracle.weblogic.kubernetes.actions.TestActions.now;
 import static oracle.weblogic.kubernetes.actions.TestActions.scaleClusterWithRestApi;
 import static oracle.weblogic.kubernetes.actions.impl.Domain.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodDoesNotExist;
@@ -181,7 +182,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain events for various successful domain life cycle changes")
   public void testDomainK8SEventsSuccess() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     logger.info("Creating domain");
     createDomain();
 
@@ -200,7 +201,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain DomainValidationError event for non-existing managed server")
   public void testDomainK8sEventsNonExistingManagedServer() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     logger.info("patch the domain resource with non-existing managed server");
     String patchStr
         = "[{\"op\": \"add\",\"path\": \""
@@ -217,7 +218,7 @@ public class ItKubernetesEvents {
     checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
 
     // remove the managed server from domain resource
-    timestamp = OffsetDateTime.now();
+    timestamp = now();
     patchStr
         = "[{\"op\": \"remove\",\"path\": \""
         + "/spec/managedServers\""
@@ -239,7 +240,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain DomainValidationError event for non-existing cluster")
   public void testDomainK8sEventsNonExistingCluster() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     logger.info("patch the domain resource with new cluster");
     String patchStr
         = "["
@@ -254,7 +255,7 @@ public class ItKubernetesEvents {
     checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
 
     //remove the cluster from domain resource
-    timestamp = OffsetDateTime.now();
+    timestamp = now();
     patchStr = "[{\"op\": \"remove\",\"path\": \"/spec/clusters/1\"}]";
     logger.info("Updating domain configuration using patch string: {0}\n", patchStr);
     patch = new V1Patch(patchStr);
@@ -281,7 +282,7 @@ public class ItKubernetesEvents {
     V1Patch patch;
     String patchStr;
 
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     try {
       logger.info("remove the webLogicCredentialsSecret to verify the following events"
           + " DomainChanged, DomainProcessingRetrying and DomainProcessingAborted are logged");
@@ -301,7 +302,7 @@ public class ItKubernetesEvents {
       logger.info("verify domain processing aborted event");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_ABORTED, "Warning", timestamp);
     } finally {
-      timestamp = OffsetDateTime.now();
+      timestamp = now();
       // add back the webLogicCredentialsSecret
       patchStr = "[{\"op\": \"add\", \"path\": \"/spec/webLogicCredentialsSecret\", "
           + "\"value\" : {\"name\":\"" + wlSecretName + "\" , \"namespace\":\"" + domainNamespace1 + "\"}"
@@ -328,7 +329,7 @@ public class ItKubernetesEvents {
   @Test
   public void testK8SEventsMultiClusterEvents() {
     createNewCluster();
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     scaleClusterWithRestApi(domainUid, cluster2Name, 1,
         externalRestHttpsPort, opNamespace, opServiceAccount);
     logger.info("verify the DomainProcessing Starting/Completed event is generated");
@@ -346,7 +347,7 @@ public class ItKubernetesEvents {
   @Order(6)
   @Test
   public void testDomainK8sEventsScalePastMax() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     try {
       logger.info("Scaling cluster using patching");
       String patchStr
@@ -361,7 +362,7 @@ public class ItKubernetesEvents {
       logger.info("verify the DomainValidationError event is generated");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
     } finally {
-      timestamp = OffsetDateTime.now();
+      timestamp = now();
       logger.info("Updating domain resource to set correct replicas size");
       String patchStr
           = "["
@@ -391,7 +392,7 @@ public class ItKubernetesEvents {
   }
 
   private void scaleDomainAndVerifyCompletedEvent(int replicaCount, String testType, boolean verify) {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     logger.info("Updating domain resource to set the replicas for cluster " + cluster1Name + " to " + replicaCount);
     int countBefore = getDomainEventCount(domainNamespace1, domainUid, DOMAIN_PROCESSING_COMPLETED, "Normal");
     V1Patch patch = new V1Patch("["
@@ -418,7 +419,7 @@ public class ItKubernetesEvents {
   @Order(8)
   @Test
   public void testDomainK8sEventsScaleBelowMin() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     try {
       String patchStr
           = "["
@@ -433,7 +434,7 @@ public class ItKubernetesEvents {
       logger.info("verify the DomainValidationError event is generated");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_VALIDATION_ERROR, "Warning", timestamp);
     } finally {
-      timestamp = OffsetDateTime.now();
+      timestamp = now();
       logger.info("Updating domain resource to set correct replicas size");
       String patchStr
           = "["
@@ -453,7 +454,7 @@ public class ItKubernetesEvents {
   @Order(9)
   @Test
   public void testDomainK8sEventsProcessingFailed() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     try {
       createPV("sample-pv", domainUid, this.getClass().getSimpleName());
       createPVC("sample-pv", "sample-pvc", domainUid, domainNamespace1);
@@ -485,7 +486,7 @@ public class ItKubernetesEvents {
           + "]";
       logger.info("Updating pv/pvcs in domain resource using patch string: {0}", patchStr);
       V1Patch patch = new V1Patch(patchStr);
-      timestamp = OffsetDateTime.now();
+      timestamp = now();
       assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
           "Failed to patch domain");
 
@@ -503,7 +504,7 @@ public class ItKubernetesEvents {
   @Test
   @DisplayName("Test domain events for various domain life cycle changes")
   public void testDomainK8SEventsDelete() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
 
     deleteDomainCustomResource(domainUid, domainNamespace1);
     checkPodDoesNotExist(adminServerPodName, domainUid, domainNamespace1);
@@ -536,7 +537,7 @@ public class ItKubernetesEvents {
   @Order(11)
   @Test
   public void testK8SEventsStartWatchingNS() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     logger.info("Adding a new domain namespace in the operator watch list");
     upgradeAndVerifyOperator(opNamespace, domainNamespace1, domainNamespace2);
     logger.info("verify NamespaceWatchingStarted event is logged");
@@ -566,7 +567,7 @@ public class ItKubernetesEvents {
   @Test
   @Disabled("Bug - OWLS-87181")
   public void testK8SEventsStopWatchingNS() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
     logger.info("Removing domain namespace in the operator watch list");
     upgradeAndVerifyOperator(opNamespace, domainNamespace1);
     logger.info("verify NamespaceWatchingStopped event is logged");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -6,6 +6,7 @@ package oracle.weblogic.kubernetes;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -22,7 +23,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -284,10 +284,10 @@ class ItMiiDynamicUpdate {
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -332,10 +332,10 @@ class ItMiiDynamicUpdate {
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -378,10 +378,10 @@ class ItMiiDynamicUpdate {
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -437,10 +437,10 @@ class ItMiiDynamicUpdate {
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -507,7 +507,7 @@ class ItMiiDynamicUpdate {
 
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
-    LinkedHashMap<String, DateTime> pods = addDataSourceAndVerify(false);
+    LinkedHashMap<String, OffsetDateTime> pods = addDataSourceAndVerify(false);
 
     // Replace contents of an existing configMap with cm config and application target as
     // there are issues with removing them, https://jira.oraclecorp.com/jira/browse/WDT-535
@@ -581,7 +581,7 @@ class ItMiiDynamicUpdate {
 
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
-    LinkedHashMap<String, DateTime> pods = addDataSourceAndVerify(false);
+    LinkedHashMap<String, OffsetDateTime> pods = addDataSourceAndVerify(false);
 
     // check the application myear is deployed using REST API
     int adminServiceNodePort
@@ -658,7 +658,7 @@ class ItMiiDynamicUpdate {
 
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
-    LinkedHashMap<String, DateTime> pods = addDataSourceAndVerify(false);
+    LinkedHashMap<String, OffsetDateTime> pods = addDataSourceAndVerify(false);
 
     // write sparse yaml to delete datasource to file
     Path pathToDeleteDSYaml = Paths.get(WORK_DIR + "/deleteds.yaml");
@@ -908,7 +908,7 @@ class ItMiiDynamicUpdate {
 
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
-    LinkedHashMap<String, DateTime> pods = addDataSourceAndVerify(false);
+    LinkedHashMap<String, OffsetDateTime> pods = addDataSourceAndVerify(false);
 
     // write sparse yaml to change ScatteredReadsEnabled for adminserver
     Path pathToChangReadsYaml = Paths.get(WORK_DIR + "/changereads.yaml");
@@ -1041,8 +1041,8 @@ class ItMiiDynamicUpdate {
     checkPodReadyAndServiceExists(managedServerPrefix + "1", domainUid, domainNamespace);
 
     // get the creation time of the server pods before patching
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     for (int i = 1; i <= replicaCount; i++) {
       pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace, managedServerPrefix + i));
@@ -1133,10 +1133,10 @@ class ItMiiDynamicUpdate {
     // This test uses the WebLogic domain created in BeforeAll method
     // BeforeEach method ensures that the server pods are running
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -1483,12 +1483,12 @@ class ItMiiDynamicUpdate {
     return false;
   }
 
-  private LinkedHashMap<String, DateTime> addDataSourceAndVerify(boolean introspectorRuns) {
+  private LinkedHashMap<String, OffsetDateTime> addDataSourceAndVerify(boolean introspectorRuns) {
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -5,6 +5,7 @@ package oracle.weblogic.kubernetes;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,7 +47,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -318,9 +318,9 @@ class ItMiiUpdateDomainConfig {
         configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.delete.sysresources.yaml"));
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace,adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace,adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -384,9 +384,9 @@ class ItMiiUpdateDomainConfig {
         configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.jdbc2.yaml", MODEL_DIR + "/model.jms2.yaml"));
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace,adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace,adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -454,10 +454,10 @@ class ItMiiUpdateDomainConfig {
     String configMapName = "noreplicaconfigmap";
     createClusterConfigMap(configMapName, "model.config.cluster.yaml");
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the server pods before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     for (int i = 1; i <= replicaCount; i++) {
       pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace, managedServerPrefix + i));
@@ -514,9 +514,9 @@ class ItMiiUpdateDomainConfig {
     String configMapName = "dynamicclusterconfigmap";
     createClusterConfigMap(configMapName, "model.dynamic.cluster.yaml");
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -591,10 +591,10 @@ class ItMiiUpdateDomainConfig {
     String configMapName = "configclusterconfigmap";
     createClusterConfigMap(configMapName, "model.config.cluster.yaml");
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     // get the creation time of the managed server pods before patching
     pods.put(adminServerPodName, adminPodCreationTime);
     for (int i = 1; i <= replicaCount; i++) {
@@ -659,9 +659,9 @@ class ItMiiUpdateDomainConfig {
     final boolean VALID = true;
     final boolean INVALID = false;
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace,adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace,adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -767,8 +767,8 @@ class ItMiiUpdateDomainConfig {
     checkPodReadyAndServiceExists(managedServerPrefix + "2", domainUid, domainNamespace);
 
     // get the creation time of the server pods before patching
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     pods.put(adminServerPodName, adminPodCreationTime);
     for (int i = 1; i <= replicaCount; i++) {
       pods.put(managedServerPrefix + i, getPodCreationTime(domainNamespace, managedServerPrefix + i));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestart.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.kubernetes;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -12,7 +13,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonPatchTestUtils;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -229,10 +229,10 @@ public class ItOperatorRestart {
     final boolean VALID = true;
     final boolean INVALID = false;
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime =
+    OffsetDateTime adminPodCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
         String.format("Failed to get creationTimestamp for pod %s", adminServerPodName));
     assertNotNull(adminPodCreationTime, "creationTimestamp of the admin server pod is null");
@@ -245,13 +245,13 @@ public class ItOperatorRestart {
 
     pods.put(adminServerPodName, adminPodCreationTime);
 
-    List<DateTime> msLastCreationTime = new ArrayList<DateTime>();
+    List<OffsetDateTime> msLastCreationTime = new ArrayList<OffsetDateTime>();
     // get the creation time of the managed server pods before patching
     assertDoesNotThrow(
         () -> {
             for (int i = 1; i <= replicaCount; i++) {
               String managedServerPodName = managedServerPrefix + i;
-              DateTime creationTime = getPodCreationTimestamp(domainNamespace, "", managedServerPodName);
+              OffsetDateTime creationTime = getPodCreationTimestamp(domainNamespace, "", managedServerPodName);
               msLastCreationTime.add(creationTime);
               pods.put(managedServerPodName, creationTime);
 
@@ -307,7 +307,7 @@ public class ItOperatorRestart {
 
     for (int i = 1; i <= replicaCount; i++) {
       final String podName = managedServerPrefix + i;
-      final DateTime lastCreationTime = msLastCreationTime.get(i - 1);
+      final OffsetDateTime lastCreationTime = msLastCreationTime.get(i - 1);
       // check that the managed server pod's label has been updated with the new restartVersion
       checkPodRestartVersionUpdated(podName, domainUid, domainNamespace, restartVersion);
     }
@@ -327,7 +327,7 @@ public class ItOperatorRestart {
         "Failed to get the name of the operator pod");
 
     // get the creation time of the admin server pod before patching
-    DateTime opPodCreationTime =
+    OffsetDateTime opPodCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(opNamespace, "", opPodName),
             String.format("Failed to get creationTimestamp for pod %s", opPodName));
     assertNotNull(opPodCreationTime, "creationTimestamp of the operator pod is null");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -9,7 +9,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,7 +59,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -687,7 +686,7 @@ class ItParameterizedDomain {
   @Test
   @DisplayName("Verify server pods are restarted only once by changing the imagePullPolicy in multi-cluster domain")
   public void testMultiClustersRollingRestart() {
-    DateTime timestamp = new DateTime(Instant.now().getEpochSecond() * 1000L);
+    OffsetDateTime timestamp = OffsetDateTime.now();
 
     // get the original domain resource before update
     Domain domain1 = assertDoesNotThrow(() -> getDomainCustomResource(miiDomainUid, miiDomainNamespace),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -109,6 +109,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServicePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
+import static oracle.weblogic.kubernetes.actions.TestActions.now;
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallNginx;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.copyFileToPod;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
@@ -686,7 +687,7 @@ class ItParameterizedDomain {
   @Test
   @DisplayName("Verify server pods are restarted only once by changing the imagePullPolicy in multi-cluster domain")
   public void testMultiClustersRollingRestart() {
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = now();
 
     // get the original domain resource before update
     Domain domain1 = assertDoesNotThrow(() -> getDomainCustomResource(miiDomainUid, miiDomainNamespace),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
@@ -4,6 +4,7 @@
 package oracle.weblogic.kubernetes;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,7 +28,6 @@ import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -82,7 +82,7 @@ class ItPodsRestart {
   private static final String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
   private static final String managedServerPrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
   private static LoggingFacade logger = null;
-  private Map<String, DateTime> podsWithTimeStamps = null;
+  private Map<String, OffsetDateTime> podsWithTimeStamps = null;
 
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItProductionSecureMode.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItProductionSecureMode.java
@@ -6,6 +6,7 @@ package oracle.weblogic.kubernetes;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,7 +29,6 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -251,7 +251,7 @@ class ItProductionSecureMode {
   @DisplayName("Verify MII dynamic update with SSL enabled")
   public void testMiiDynamicChangeWithSSLEnabled() {
 
-    LinkedHashMap<String, DateTime> pods = new LinkedHashMap<>();
+    LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();
 
     // get the creation time of the admin server pod before patching
     pods.put(adminServerPodName, getPodCreationTime(domainNamespace, adminServerPodName));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -6,6 +6,7 @@ package oracle.weblogic.kubernetes;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +38,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -278,8 +278,8 @@ class ItServerStartPolicy {
     String configServerPodName = domainUid + "-config-cluster-server1";
     String dynamicServerPodName = domainUid + "-managed-server1";
 
-    DateTime dynTs = getPodCreationTime(domainNamespace, dynamicServerPodName);
-    DateTime cfgTs = getPodCreationTime(domainNamespace, configServerPodName);
+    OffsetDateTime dynTs = getPodCreationTime(domainNamespace, dynamicServerPodName);
+    OffsetDateTime cfgTs = getPodCreationTime(domainNamespace, configServerPodName);
 
     assertTrue(patchServerStartPolicy(domainUid, domainNamespace,
          "/spec/adminServer/serverStartPolicy", "NEVER"),
@@ -344,7 +344,7 @@ class ItServerStartPolicy {
     String configServerPodName = domainUid + "-config-cluster-server1";
     String dynamicServerPodName = domainUid + "-managed-server1";
 
-    DateTime dynTs = getPodCreationTime(domainNamespace, dynamicServerPodName);
+    OffsetDateTime dynTs = getPodCreationTime(domainNamespace, dynamicServerPodName);
 
     checkPodReadyAndServiceExists(configServerPodName, 
               domainUid, domainNamespace);
@@ -396,7 +396,7 @@ class ItServerStartPolicy {
     String dynamicServerPodName = domainUid + "-managed-server1";
     String configServerPodName = domainUid + "-config-cluster-server1";
 
-    DateTime cfgTs = getPodCreationTime(domainNamespace, configServerPodName);
+    OffsetDateTime cfgTs = getPodCreationTime(domainNamespace, configServerPodName);
     checkPodReadyAndServiceExists(dynamicServerPodName, domainUid, domainNamespace);
     // startCluster.sh does not take any action on a running cluster
     String result = executeLifecycleScript(START_CLUSTER_SCRIPT, CLUSTER_LIFECYCLE, CLUSTER_1);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -38,7 +39,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.OracleHttpClient;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -110,7 +110,7 @@ public class ItSystemResOverrides {
 
   static Path sitconfigAppPath;
   String overridecm = "configoverride-cm";
-  LinkedHashMap<String, DateTime> podTimestamps;
+  LinkedHashMap<String, OffsetDateTime> podTimestamps;
 
   // create standard, reusable retry/backoff policy
   private static final ConditionFactory withStandardRetryPolicy
@@ -263,7 +263,7 @@ public class ItSystemResOverrides {
     // get the pod creation time stamps
     podTimestamps = new LinkedHashMap<>();
     // get the creation time of the admin server pod before patching
-    DateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
+    OffsetDateTime adminPodCreationTime = getPodCreationTime(domainNamespace, adminServerPodName);
     podTimestamps.put(adminServerPodName, adminPodCreationTime);
     // get the creation time of the managed server pods before patching
     for (int i = 1; i <= replicaCount; i++) {
@@ -275,9 +275,9 @@ public class ItSystemResOverrides {
   //check if the pods are restarted by comparing the pod creationtimestamp.
   private void verifyPodsStateNotChanged() {
     logger.info("Verifying the WebLogic server pod states are not changed");
-    for (Map.Entry<String, DateTime> entry : podTimestamps.entrySet()) {
-      String podName = (String) entry.getKey();
-      DateTime creationTimestamp = (DateTime) entry.getValue();
+    for (Map.Entry<String, OffsetDateTime> entry : podTimestamps.entrySet()) {
+      String podName = entry.getKey();
+      OffsetDateTime creationTimestamp = entry.getValue();
       assertTrue(podStateNotChanged(podName, domainUid, domainNamespace,
           creationTimestamp), "Pod is restarted");
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsLoadBalancers.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -70,7 +71,6 @@ import oracle.weblogic.kubernetes.utils.DeployUtil;
 import oracle.weblogic.kubernetes.utils.ExecCommand;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -218,9 +218,9 @@ public class ItTwoDomainsLoadBalancers {
   private int t3ChannelPort = 0;
   private int replicasAfterScale;
   private List<String> domainAdminServerPodNames = new ArrayList<>();
-  private List<DateTime> domainAdminPodOriginalTimestamps = new ArrayList<>();
-  private List<DateTime> domain1ManagedServerPodOriginalTimestampList = new ArrayList<>();
-  private List<DateTime> domain2ManagedServerPodOriginalTimestampList = new ArrayList<>();
+  private List<OffsetDateTime> domainAdminPodOriginalTimestamps = new ArrayList<>();
+  private List<OffsetDateTime> domain1ManagedServerPodOriginalTimestampList = new ArrayList<>();
+  private List<OffsetDateTime> domain2ManagedServerPodOriginalTimestampList = new ArrayList<>();
 
   private static ConditionFactory withStandardRetryPolicy =
       with().pollDelay(2, SECONDS)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItUsabilityOperatorHelmChart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItUsabilityOperatorHelmChart.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.kubernetes;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,7 +30,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecCommand;
 import oracle.weblogic.kubernetes.utils.ExecResult;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -207,14 +207,14 @@ class ItUsabilityOperatorHelmChart {
     // get the admin server pod original creation timestamp
     logger.info("Getting admin server pod original creation timestamp");
     String adminServerPodName = domain1Uid + adminServerPrefix;
-    DateTime adminPodOriginalTimestamp =
+    OffsetDateTime adminPodOriginalTimestamp =
         assertDoesNotThrow(() -> getPodCreationTimestamp(domain1Namespace, "", adminServerPodName),
             String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
                 adminServerPodName, domain1Namespace));
 
     // get the managed server pods original creation timestamps
     logger.info("Getting managed server pods original creation timestamps");
-    List<DateTime> managedServerPodOriginalTimestampList = new ArrayList<>();
+    List<OffsetDateTime> managedServerPodOriginalTimestampList = new ArrayList<>();
     for (int i = 1; i <= replicaCountDomain1; i++) {
       final String managedServerPodName = domain1Uid + managedServerPrefix + i;
       managedServerPodOriginalTimestampList.add(

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -4,6 +4,7 @@
 package oracle.weblogic.kubernetes.actions;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +70,6 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
 import oracle.weblogic.kubernetes.extensions.ImageBuilders;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
-import org.joda.time.DateTime;
 
 import static oracle.weblogic.kubernetes.actions.impl.Operator.start;
 import static oracle.weblogic.kubernetes.actions.impl.Operator.stop;
@@ -1174,7 +1174,7 @@ public class TestActions {
    * @return creationTimestamp from metadata section of the Pod
    * @throws ApiException if Kubernetes client API call fails
    **/
-  public static DateTime getPodCreationTimestamp(String namespace, String labelSelector, String podName)
+  public static OffsetDateTime getPodCreationTimestamp(String namespace, String labelSelector, String podName)
       throws ApiException {
     return Pod.getPodCreationTimestamp(namespace, labelSelector, podName);
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -5,6 +5,7 @@ package oracle.weblogic.kubernetes.actions;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
@@ -1562,5 +1563,14 @@ public class TestActions {
    */
   public static String helmValuesToString(Map<String, Object> helmValues) {
     return Helm.valuesToString(helmValues);
+  }
+
+  /**
+   * Return the current time, but truncated to the second so that comparisons with Kubernetes timestamps,
+   * which are often to the nearest second, work as expected.
+   * @return Current time.
+   */
+  public static OffsetDateTime now() {
+    return OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
   }
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Pod.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Pod.java
@@ -3,12 +3,13 @@
 
 package oracle.weblogic.kubernetes.actions.impl;
 
+import java.time.OffsetDateTime;
+
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
-import org.joda.time.DateTime;
 
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 
@@ -88,7 +89,7 @@ public class Pod {
    * @return creationTimestamp from metadata section of the pod
    * @throws ApiException if Kubernetes client API call fails
    */
-  public static DateTime getPodCreationTimestamp(String namespace, String labelSelector, String podName)
+  public static OffsetDateTime getPodCreationTimestamp(String namespace, String labelSelector, String podName)
       throws ApiException {
     return Kubernetes.getPodCreationTimestamp(namespace, labelSelector, podName);
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -12,6 +12,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -84,7 +85,6 @@ import oracle.weblogic.domain.DomainList;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -553,7 +553,7 @@ public class Kubernetes {
    * @return creationTimestamp DateTime from metadata of the Pod
    * @throws ApiException if Kubernetes client API call fail
    */
-  public static DateTime getPodCreationTimestamp(String namespace, String labelSelector, String podName)
+  public static OffsetDateTime getPodCreationTimestamp(String namespace, String labelSelector, String podName)
       throws ApiException {
 
     V1Pod pod = getPod(namespace, labelSelector, podName);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -4,6 +4,7 @@
 package oracle.weblogic.kubernetes.assertions;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -30,7 +31,6 @@ import oracle.weblogic.kubernetes.assertions.impl.Service;
 import oracle.weblogic.kubernetes.assertions.impl.Traefik;
 import oracle.weblogic.kubernetes.assertions.impl.Voyager;
 import oracle.weblogic.kubernetes.assertions.impl.WitAssertion;
-import org.joda.time.DateTime;
 
 import static oracle.weblogic.kubernetes.actions.TestActions.listSecrets;
 
@@ -315,7 +315,8 @@ public class TestAssertions {
    * @param namespace name of the namespace in which the pod restart status to be checked
    * @return true if pods are restarted in a rolling fashion
    */
-  public static boolean verifyRollingRestartOccurred(Map<String, DateTime> pods, int maxUnavailable, String namespace) {
+  public static boolean verifyRollingRestartOccurred(Map<String, OffsetDateTime> pods,
+                                                     int maxUnavailable, String namespace) {
     return Pod.verifyRollingRestartOccurred(pods, maxUnavailable, namespace);
   }
 
@@ -548,7 +549,7 @@ public class TestAssertions {
   public static Callable<Boolean> isPodRestarted(
       String podName,
       String namespace,
-      DateTime timestamp
+      OffsetDateTime timestamp
   ) {
     return () -> {
       return Kubernetes.isPodRestarted(podName, namespace,timestamp);
@@ -564,7 +565,7 @@ public class TestAssertions {
    */
   public static Callable<Boolean> isOperatorPodRestarted(
       String namespace,
-      DateTime timestamp
+      OffsetDateTime timestamp
   ) {
     return () -> {
       return Kubernetes.isOperatorPodRestarted(namespace, timestamp);
@@ -583,7 +584,7 @@ public class TestAssertions {
   public static boolean podStateNotChanged(String podName,
                                            String domainUid,
                                            String namespace,
-                                           DateTime podOriginalCreationTimestamp) {
+                                           OffsetDateTime podOriginalCreationTimestamp) {
     return Domain.podStateNotChanged(podName, domainUid, namespace, podOriginalCreationTimestamp);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Domain.java
@@ -4,6 +4,7 @@
 package oracle.weblogic.kubernetes.assertions.impl;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
@@ -19,7 +20,6 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
@@ -207,7 +207,7 @@ public class Domain {
   public static boolean podStateNotChanged(String podName,
                                            String domainUid,
                                            String domainNamespace,
-                                           DateTime podOriginalCreationTimestamp) {
+                                           OffsetDateTime podOriginalCreationTimestamp) {
 
     // if pod does not exist, return false
     if (assertDoesNotThrow(() -> doesPodNotExist(domainNamespace, domainUid, podName),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -4,6 +4,7 @@
 package oracle.weblogic.kubernetes.assertions.impl;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,7 +34,6 @@ import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceList;
 import io.kubernetes.client.util.ClientBuilder;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.joda.time.DateTime;
 
 import static io.kubernetes.client.util.Yaml.dump;
 import static oracle.weblogic.kubernetes.TestConstants.APACHE_RELEASE_NAME;
@@ -814,9 +814,9 @@ public class Kubernetes {
    */
   public static boolean isPodRestarted(
       String podName,
-      String namespace, DateTime timestamp) throws ApiException {
+      String namespace, OffsetDateTime timestamp) throws ApiException {
     LoggingFacade logger = getLogger();
-    DateTime newCreationTime = getPodCreationTimestamp(namespace, "", podName);
+    OffsetDateTime newCreationTime = getPodCreationTimestamp(namespace, "", podName);
 
     if (newCreationTime != null
         && newCreationTime.isAfter(timestamp)) {
@@ -896,7 +896,7 @@ public class Kubernetes {
    * @return true if the pod's creation timestamp is later than the initial PodCreationTimestamp
    * @throws ApiException when query fails
    */
-  public static Boolean isOperatorPodRestarted(String namespace, DateTime timestamp) throws ApiException {
+  public static Boolean isOperatorPodRestarted(String namespace, OffsetDateTime timestamp) throws ApiException {
     String labelSelector = String.format("weblogic.operatorName in (%s)", namespace);
     V1Pod pod = getPod(namespace, labelSelector, "weblogic-operator-");
     if (pod != null) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -818,7 +818,7 @@ public class Kubernetes {
     LoggingFacade logger = getLogger();
     OffsetDateTime newCreationTime = getPodCreationTimestamp(namespace, "", podName);
 
-    if (newCreationTime != null
+    if (newCreationTime != null && timestamp != null
         && newCreationTime.isAfter(timestamp)) {
       logger.info("Pod {0}: new creation time {1} is later than the last creation time {2}",
           podName, newCreationTime, timestamp);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.kubernetes.utils;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,7 +42,6 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -757,7 +757,7 @@ public class CommonMiiTestUtils {
    * @param domainNamespace namespace where pods exists
    * @param podsCreationTimes map of pods name and pod creation times
    */
-  public static void verifyPodsNotRolled(String domainNamespace, Map<String, DateTime> podsCreationTimes) {
+  public static void verifyPodsNotRolled(String domainNamespace, Map<String, OffsetDateTime> podsCreationTimes) {
     // wait for 2 minutes before checking the pods, make right decision logic
     // that runs every two minutes in the  Operator
     try {
@@ -766,7 +766,7 @@ public class CommonMiiTestUtils {
     } catch (InterruptedException ie) {
       getLogger().info("InterruptedException while sleeping for 2 minutes");
     }
-    for (Map.Entry<String, DateTime> entry : podsCreationTimes.entrySet()) {
+    for (Map.Entry<String, OffsetDateTime> entry : podsCreationTimes.entrySet()) {
       assertEquals(
           entry.getValue(),
           getPodCreationTime(domainNamespace, entry.getKey()),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -81,7 +82,6 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.awaitility.core.ConditionFactory;
-import org.joda.time.DateTime;
 
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.readString;
@@ -1596,7 +1596,7 @@ public class CommonTestUtils {
       String domainUid,
       String domNamespace,
       String podName,
-      DateTime lastCreationTime
+      OffsetDateTime lastCreationTime
   ) {
     LoggingFacade logger = getLogger();
     withStandardRetryPolicy
@@ -2400,10 +2400,10 @@ public class CommonTestUtils {
                                            List<String> expectedServerNames) {
     LoggingFacade logger = getLogger();
     // get the original managed server pod creation timestamp before scale
-    List<DateTime> listOfPodCreationTimestamp = new ArrayList<>();
+    List<OffsetDateTime> listOfPodCreationTimestamp = new ArrayList<>();
     for (int i = 1; i <= replicasBeforeScale; i++) {
       String managedServerPodName = manageServerPodNamePrefix + i;
-      DateTime originalCreationTimestamp =
+      OffsetDateTime originalCreationTimestamp =
           assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", managedServerPodName),
               String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",
                   managedServerPodName, domainNamespace));
@@ -2847,9 +2847,9 @@ public class CommonTestUtils {
    * @param podName name of the pod
    * @return PodCreationTimestamp of the pod
    */
-  public static DateTime getPodCreationTime(String namespace, String podName) {
+  public static OffsetDateTime getPodCreationTime(String namespace, String podName) {
     LoggingFacade logger = getLogger();
-    DateTime podCreationTime =
+    OffsetDateTime podCreationTime =
         assertDoesNotThrow(() -> getPodCreationTimestamp(namespace, "", podName),
             String.format("Couldn't get PodCreationTimestamp for pod %s", podName));
     assertNotNull(podCreationTime, "Got null PodCreationTimestamp");
@@ -3370,7 +3370,7 @@ public class CommonTestUtils {
        String managedServerPrefix, int replicaCount) {
 
     // create the map with server pods and their original creation timestamps
-    Map<String, DateTime> podsWithTimeStamps = new LinkedHashMap<>();
+    Map<String, OffsetDateTime> podsWithTimeStamps = new LinkedHashMap<>();
     podsWithTimeStamps.put(adminServerPodName,
         assertDoesNotThrow(() -> getPodCreationTimestamp(domainNamespace, "", adminServerPodName),
             String.format("getPodCreationTimestamp failed with ApiException for pod %s in namespace %s",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.kubernetes.utils;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -18,7 +19,6 @@ import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.actions.TestActions;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.joda.time.DateTime;
 
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -42,7 +42,8 @@ public class K8sEvents {
    * @param timestamp the timestamp after which to see events
    */
   public static Callable<Boolean> checkDomainEvent(
-      String opNamespace, String domainNamespace, String domainUid, String reason, String type, DateTime timestamp) {
+      String opNamespace, String domainNamespace, String domainUid, String reason,
+      String type, OffsetDateTime timestamp) {
     return () -> {
       logger.info("Verifying {0} event is logged by the operator in domain namespace {1}", reason, domainNamespace);
       try {
@@ -103,7 +104,7 @@ public class K8sEvents {
    * @return count number of events count
    */
   public static int getEventCount(
-      String domainNamespace, String domainUid, String reason, DateTime timestamp) {
+      String domainNamespace, String domainUid, String reason, OffsetDateTime timestamp) {
     int count = 0;
     try {
       List<CoreV1Event> events = Kubernetes.listNamespacedEvents(domainNamespace);
@@ -130,7 +131,7 @@ public class K8sEvents {
    * @param timestamp the timestamp after which to see events
    */
   public static Callable<Boolean> checkPodEventLoggedOnce(
-          String domainNamespace, String serverName, String reason, DateTime timestamp) {
+          String domainNamespace, String serverName, String reason, OffsetDateTime timestamp) {
     return () -> {
       logger.info("Verifying {0} event is logged for {1} pod in the domain namespace {2}",
               reason, serverName, domainNamespace);
@@ -146,9 +147,9 @@ public class K8sEvents {
     };
   }
 
-  private static boolean isEqualOrAfter(DateTime timestamp, CoreV1Event event) {
-    return event.getLastTimestamp().isEqual(timestamp.getMillis())
-            || event.getLastTimestamp().isAfter(timestamp.getMillis());
+  private static boolean isEqualOrAfter(OffsetDateTime timestamp, CoreV1Event event) {
+    return event.getLastTimestamp().isEqual(timestamp)
+            || event.getLastTimestamp().isAfter(timestamp);
   }
 
   private static Boolean isEventLoggedOnce(String serverName, int count) {

--- a/json-schema/src/main/java/oracle/kubernetes/json/SchemaGenerator.java
+++ b/json-schema/src/main/java/oracle/kubernetes/json/SchemaGenerator.java
@@ -381,6 +381,9 @@ public class SchemaGenerator {
   }
 
   private String getDefinitionKey(Class<?> type) {
+    if (isDateTime(type)) {
+      return "DateTime";
+    }
     return type.getSimpleName();
   }
 

--- a/json-schema/src/main/java/oracle/kubernetes/json/SchemaGenerator.java
+++ b/json-schema/src/main/java/oracle/kubernetes/json/SchemaGenerator.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,7 +32,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.joda.time.DateTime;
 
 public class SchemaGenerator {
 
@@ -248,7 +248,7 @@ public class SchemaGenerator {
   }
 
   private boolean isDateTime(Class<?> type) {
-    return type.equals(DateTime.class);
+    return type.equals(OffsetDateTime.class);
   }
 
   private boolean isNumeric(Class<?> type) {

--- a/json-schema/src/main/java/oracle/kubernetes/json/YamlDocGenerator.java
+++ b/json-schema/src/main/java/oracle/kubernetes/json/YamlDocGenerator.java
@@ -20,7 +20,7 @@ public class YamlDocGenerator {
   private static final String CLASS_TABLE_HEADER =
       "| Name | Type | Description |\n" + "| --- | --- | --- |";
   private static final String DEFINITION_PREFIX = "#/definitions/";
-  private static final List NON_REFERENCE_TYPES = Arrays.asList("Map", "OffsetDateTime");
+  private static final List<String> NON_REFERENCE_TYPES = Arrays.asList("Map", "DateTime");
   private final Map<String, Object> schema;
   private final List<String> referencesNeeded = new ArrayList<>();
   private final Set<String> referencesGenerated = new HashSet<>();
@@ -129,6 +129,7 @@ public class YamlDocGenerator {
     }
     Map<String, Object> fieldMap = subMap(subSchema, fieldName);
     Type type = new Type(fieldMap);
+
     String val = type.getString();
     if ("boolean".equals(val)) {
       val = "Boolean";

--- a/json-schema/src/main/java/oracle/kubernetes/json/YamlDocGenerator.java
+++ b/json-schema/src/main/java/oracle/kubernetes/json/YamlDocGenerator.java
@@ -20,7 +20,7 @@ public class YamlDocGenerator {
   private static final String CLASS_TABLE_HEADER =
       "| Name | Type | Description |\n" + "| --- | --- | --- |";
   private static final String DEFINITION_PREFIX = "#/definitions/";
-  private static final List NON_REFERENCE_TYPES = Arrays.asList("Map", "DateTime");
+  private static final List NON_REFERENCE_TYPES = Arrays.asList("Map", "OffsetDateTime");
   private final Map<String, Object> schema;
   private final List<String> referencesNeeded = new ArrayList<>();
   private final Set<String> referencesGenerated = new HashSet<>();

--- a/json-schema/src/test/java/oracle/kubernetes/json/YamlDocGeneratorTest.java
+++ b/json-schema/src/test/java/oracle/kubernetes/json/YamlDocGeneratorTest.java
@@ -5,11 +5,11 @@ package oracle.kubernetes.json;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Map.of;
@@ -25,7 +25,7 @@ public class YamlDocGeneratorTest {
   @Description("An annotated field")
   private Double annotatedDouble;
   @SuppressWarnings("unused")
-  private DateTime dateTime;
+  private OffsetDateTime dateTime;
   @SuppressWarnings("unused")
   private Map<String, String> notes;
   @SuppressWarnings("unused")
@@ -72,7 +72,7 @@ public class YamlDocGeneratorTest {
   @Test
   public void whenPropertyTypeIsDateTime_doNotGenerateReference() throws NoSuchFieldException {
     String markdown = generateForProperty(getClass().getDeclaredField("dateTime"));
-    assertThat(markdown, containsString(tableEntry("`dateTime`", "DateTime", "")));
+    assertThat(markdown, containsString(tableEntry("`dateTime`", "OffsetDateTime", "")));
   }
 
   @Test

--- a/json-schema/src/test/java/oracle/kubernetes/json/YamlDocGeneratorTest.java
+++ b/json-schema/src/test/java/oracle/kubernetes/json/YamlDocGeneratorTest.java
@@ -72,7 +72,7 @@ public class YamlDocGeneratorTest {
   @Test
   public void whenPropertyTypeIsDateTime_doNotGenerateReference() throws NoSuchFieldException {
     String markdown = generateForProperty(getClass().getDeclaredField("dateTime"));
-    assertThat(markdown, containsString(tableEntry("`dateTime`", "OffsetDateTime", "")));
+    assertThat(markdown, containsString(tableEntry("`dateTime`", "DateTime", "")));
   }
 
   @Test

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 2506914ab8c0aa9dac4f78964f5ef4e75e92a71ff56706953509df8e2e93b370
+    weblogic.sha256: 2cfe1523894f4f6f06b9b4bc11181eb0776225dd13fc5d3d13d3cf8706fdc4ad
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -780,8 +780,6 @@ spec:
                                         - path
                                 defaultMode:
                                   type: number
-                              required:
-                              - sources
                             cephfs:
                               type: object
                               properties:
@@ -3480,8 +3478,6 @@ spec:
                                           - path
                                   defaultMode:
                                     type: number
-                                required:
-                                - sources
                               cephfs:
                                 type: object
                                 properties:
@@ -6194,8 +6190,6 @@ spec:
                                     - path
                             defaultMode:
                               type: number
-                          required:
-                          - sources
                         cephfs:
                           type: object
                           properties:
@@ -8779,8 +8773,6 @@ spec:
                                           - path
                                   defaultMode:
                                     type: number
-                                required:
-                                - sources
                               cephfs:
                                 type: object
                                 properties:

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 2506914ab8c0aa9dac4f78964f5ef4e75e92a71ff56706953509df8e2e93b370
+    weblogic.sha256: 2cfe1523894f4f6f06b9b4bc11181eb0776225dd13fc5d3d13d3cf8706fdc4ad
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -778,8 +778,6 @@ spec:
                                       - path
                               defaultMode:
                                 type: number
-                            required:
-                            - sources
                           cephfs:
                             type: object
                             properties:
@@ -3468,8 +3466,6 @@ spec:
                                         - path
                                 defaultMode:
                                   type: number
-                              required:
-                              - sources
                             cephfs:
                               type: object
                               properties:
@@ -6175,8 +6171,6 @@ spec:
                                   - path
                           defaultMode:
                             type: number
-                        required:
-                        - sources
                       cephfs:
                         type: object
                         properties:
@@ -8757,8 +8751,6 @@ spec:
                                         - path
                                 defaultMode:
                                   type: number
-                              required:
-                              - sources
                             cephfs:
                               type: object
                               properties:

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -302,15 +302,6 @@
       <artifactId>client-java</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-ext-jdk15on</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-    </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>com.appscode.voyager</groupId>

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -3,6 +3,8 @@
 
 package oracle.kubernetes.operator;
 
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -223,7 +225,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
   }
 
   private class WaitForJobReadyStep extends WaitForReadyStep<V1Job> {
-    private final long jobCreationTime;
+    private final OffsetDateTime jobCreationTime;
 
     private WaitForJobReadyStep(V1Job job, Step next) {
       super(job, next);
@@ -247,11 +249,11 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
     }
 
     private boolean hasExpectedCreationTime(V1Job job) {
-      return getCreationTime(job) == jobCreationTime;
+      return getCreationTime(job).equals(jobCreationTime);
     }
 
-    private long getCreationTime(V1Job job) {
-      return job.getMetadata().getCreationTimestamp().toEpochSecond();
+    private OffsetDateTime getCreationTime(V1Job job) {
+      return job.getMetadata().getCreationTimestamp();
     }
 
     @Override
@@ -319,7 +321,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
 
     private long getJobStartedSeconds() {
       if (job.getStatus() != null && job.getStatus().getStartTime() != null) {
-        return (System.currentTimeMillis() - job.getStatus().getStartTime().toEpochSecond()) / 1000;
+        return ChronoUnit.SECONDS.between(job.getStatus().getStartTime(), OffsetDateTime.now());
       }
       return -1;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -251,7 +251,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
     }
 
     private long getCreationTime(V1Job job) {
-      return job.getMetadata().getCreationTimestamp().getMillis();
+      return job.getMetadata().getCreationTimestamp().toEpochSecond();
     }
 
     @Override
@@ -319,7 +319,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
 
     private long getJobStartedSeconds() {
       if (job.getStatus() != null && job.getStatus().getStartTime() != null) {
-        return (System.currentTimeMillis() - job.getStatus().getStartTime().getMillis()) / 1000;
+        return (System.currentTimeMillis() - job.getStatus().getStartTime().toEpochSecond()) / 1000;
       }
       return -1;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -56,7 +57,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
 
@@ -72,8 +72,8 @@ public class Main {
   private static final ThreadFactory threadFactory = new WrappedThreadFactory();
   private static final ScheduledExecutorService wrappedExecutorService =
       Engine.wrappedExecutorService("operator", container);
-  private static final AtomicReference<DateTime> lastFullRecheck =
-      new AtomicReference<>(DateTime.now());
+  private static final AtomicReference<OffsetDateTime> lastFullRecheck =
+      new AtomicReference<>(OffsetDateTime.now());
   private static final Semaphore shutdownSignal = new Semaphore(0);
   private static final int DEFAULT_STUCK_POD_RECHECK_SECONDS = 30;
 
@@ -400,10 +400,10 @@ public class Main {
 
 
   Step createDomainRecheckSteps() {
-    return createDomainRecheckSteps(DateTime.now());
+    return createDomainRecheckSteps(OffsetDateTime.now());
   }
 
-  private Step createDomainRecheckSteps(DateTime now) {
+  private Step createDomainRecheckSteps(OffsetDateTime now) {
     int recheckInterval = TuningParameters.getInstance().getMainTuning().domainPresenceRecheckIntervalSeconds;
     boolean isFullRecheck = false;
     if (lastFullRecheck.get().plusSeconds(recheckInterval).isBefore(now)) {

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,7 +39,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.OperatorUtils;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.KubernetesConstants.CONTAINER_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
@@ -149,7 +149,7 @@ public class ServerStatusReader {
       if (lastKnownStatus != null
           && !WebLogicConstants.UNKNOWN_STATE.equals(lastKnownStatus.getStatus())
           && lastKnownStatus.getUnchangedCount() >= main.unchangedCountToDelayStatusRecheck) {
-        if (DateTime.now()
+        if (OffsetDateTime.now()
             .isBefore(lastKnownStatus.getTime().plusSeconds((int) main.eventualLongDelay))) {
           String state = lastKnownStatus.getStatus();
           serverStateMap.put(serverName, state);

--- a/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +24,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.SystemClock;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.logging.MessageKeys.POD_FORCE_DELETED;
 
@@ -54,9 +54,9 @@ public class StuckPodProcessing {
 
   class PodListProcessing extends DefaultResponseStep<V1PodList> {
 
-    private final DateTime now;
+    private final OffsetDateTime now;
 
-    public PodListProcessing(String namespace, DateTime dateTime) {
+    public PodListProcessing(String namespace, OffsetDateTime dateTime) {
       super(new PodActionsStep(namespace));
       now = dateTime;
     }
@@ -70,11 +70,11 @@ public class StuckPodProcessing {
       return doContinueListOrNext(callResponse, packet);
     }
 
-    private boolean isStuck(V1Pod pod, DateTime now)  {
+    private boolean isStuck(V1Pod pod, OffsetDateTime now)  {
       return getExpectedDeleteTime(pod).isBefore(now);
     }
 
-    private DateTime getExpectedDeleteTime(V1Pod pod) {
+    private OffsetDateTime getExpectedDeleteTime(V1Pod pod) {
       return getDeletionTimeStamp(pod).plusSeconds((int) getDeletionGracePeriodSeconds(pod));
     }
 
@@ -82,7 +82,7 @@ public class StuckPodProcessing {
       return Optional.of(pod).map(V1Pod::getMetadata).map(V1ObjectMeta::getDeletionGracePeriodSeconds).orElse(1L);
     }
 
-    private DateTime getDeletionTimeStamp(V1Pod pod) {
+    private OffsetDateTime getDeletionTimeStamp(V1Pod pod) {
       return Optional.of(pod).map(V1Pod::getMetadata).map(V1ObjectMeta::getDeletionTimestamp).orElse(SystemClock.now());
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.helpers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +47,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.joda.time.DateTime;
 import org.yaml.snakeyaml.Yaml;
 
 import static java.lang.System.lineSeparator;
@@ -551,7 +551,7 @@ public class ConfigMapHelper {
 
     private void updatePacket() {
       ScanCache.INSTANCE.registerScan(
-            info.getNamespace(), info.getDomainUid(), new Scan(wlsDomainConfig, new DateTime()));
+            info.getNamespace(), info.getDomainUid(), new Scan(wlsDomainConfig, OffsetDateTime.now()));
       packet.put(ProcessingConstants.DOMAIN_TOPOLOGY, wlsDomainConfig);
 
       copyFileToPacketIfPresent(DOMAINZIP_HASH, DOMAINZIP_HASH);
@@ -867,7 +867,7 @@ public class ConfigMapHelper {
       ScanCache.INSTANCE.registerScan(
           info.getNamespace(),
           info.getDomainUid(),
-          new Scan(domainTopology.getDomain(), new DateTime()));
+          new Scan(domainTopology.getDomain(), OffsetDateTime.now()));
 
       packet.put(ProcessingConstants.DOMAIN_TOPOLOGY, domainTopology.getDomain());
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.Random;
 import javax.validation.constraints.NotNull;
@@ -23,7 +24,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.DomainProcessorImpl.getEventK8SObjects;
 import static oracle.kubernetes.operator.EventConstants.DOMAIN_CHANGED_EVENT;
@@ -556,8 +556,8 @@ public class EventHelper {
       return String.format(getPattern(), eventData.getResourceName());
     }
 
-    DateTime getCurrentTimestamp() {
-      return DateTime.now();
+    OffsetDateTime getCurrentTimestamp() {
+      return OffsetDateTime.now();
     }
 
     void addLabels(V1ObjectMeta metadata, EventData eventData) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.helpers;
 
 import java.lang.reflect.Field;
 import java.math.BigInteger;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -15,7 +16,6 @@ import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
 import static oracle.kubernetes.operator.KubernetesConstants.IFNOTPRESENT_IMAGEPULLPOLICY;
@@ -136,8 +136,8 @@ public class KubernetesUtils {
       return false;
     }
 
-    DateTime time1 = first.getCreationTimestamp();
-    DateTime time2 = second.getCreationTimestamp();
+    OffsetDateTime time1 = first.getCreationTimestamp();
+    OffsetDateTime time2 = second.getCreationTimestamp();
 
     if (time1.equals(time2)) {
       return getResourceVersion(first).compareTo(getResourceVersion(second)) > 0;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LastKnownStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LastKnownStatus.java
@@ -3,15 +3,16 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.OffsetDateTime;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 public class LastKnownStatus {
   private final String status;
   private final int unchangedCount;
-  private final DateTime time;
+  private final OffsetDateTime time;
 
   public LastKnownStatus(String status) {
     this(status, 0);
@@ -25,7 +26,7 @@ public class LastKnownStatus {
   public LastKnownStatus(String status, int unchangedCount) {
     this.status = status;
     this.unchangedCount = unchangedCount;
-    this.time = new DateTime();
+    this.time = OffsetDateTime.now();
   }
 
   public String getStatus() {
@@ -36,7 +37,7 @@ public class LastKnownStatus {
     return unchangedCount;
   }
 
-  public DateTime getTime() {
+  public OffsetDateTime getTime() {
     return time;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/Scan.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/Scan.java
@@ -3,14 +3,15 @@
 
 package oracle.kubernetes.operator.rest;
 
+import java.time.OffsetDateTime;
+
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
-import org.joda.time.DateTime;
 
 public class Scan {
   public final WlsDomainConfig domainConfig;
-  public final DateTime lastScanTime;
+  public final OffsetDateTime lastScanTime;
 
-  public Scan(WlsDomainConfig domainConfig, DateTime lastScanTime) {
+  public Scan(WlsDomainConfig domainConfig, OffsetDateTime lastScanTime) {
     this.domainConfig = domainConfig;
     this.lastScanTime = lastScanTime;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -370,7 +370,7 @@ public class ReadHealthStep extends Step {
               .withOverallHealth(healthState != null ? healthState.asText() : null)
               .withActivationTime(
                   activationTime != null ? OffsetDateTime.ofInstant(
-                      Instant.ofEpochSecond(activationTime.asLong()), ZoneId.of("UTC")) : null);
+                      Instant.ofEpochMilli(activationTime.asLong()), ZoneId.of("UTC")) : null);
       if (subName != null) {
         health
             .getSubsystems()

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -6,6 +6,9 @@ package oracle.kubernetes.operator.steps;
 import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -43,7 +46,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.SubsystemHealth;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ;
@@ -367,7 +369,8 @@ public class ReadHealthStep extends Step {
           new ServerHealth()
               .withOverallHealth(healthState != null ? healthState.asText() : null)
               .withActivationTime(
-                  activationTime != null ? new DateTime(activationTime.asLong()) : null);
+                  activationTime != null ? OffsetDateTime.ofInstant(
+                      Instant.ofEpochSecond(activationTime.asLong()), ZoneId.of("UTC")) : null);
       if (subName != null) {
         health
             .getSubsystems()

--- a/operator/src/main/java/oracle/kubernetes/utils/SystemClock.java
+++ b/operator/src/main/java/oracle/kubernetes/utils/SystemClock.java
@@ -3,7 +3,7 @@
 
 package oracle.kubernetes.utils;
 
-import org.joda.time.DateTime;
+import java.time.OffsetDateTime;
 
 /** A wrapper for the system clock that facilitates unit testing of time. */
 public abstract class SystemClock {
@@ -12,8 +12,8 @@ public abstract class SystemClock {
   @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"})
   private static SystemClock DELEGATE = new SystemClock() {
         @Override
-        public DateTime getCurrentTime() {
-          return DateTime.now();
+        public OffsetDateTime getCurrentTime() {
+          return OffsetDateTime.now();
         }
       };
 
@@ -22,7 +22,7 @@ public abstract class SystemClock {
    *
    * @return a time instance
    */
-  public static DateTime now() {
+  public static OffsetDateTime now() {
     return DELEGATE.getCurrentTime();
   }
 
@@ -31,5 +31,5 @@ public abstract class SystemClock {
    *
    * @return a time instance
    */
-  public abstract DateTime getCurrentTime();
+  public abstract OffsetDateTime getCurrentTime();
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import java.time.OffsetDateTime;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.Expose;
@@ -12,7 +13,6 @@ import oracle.kubernetes.utils.SystemClock;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
 
@@ -28,12 +28,12 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
   @Description("Last time we probed the condition.")
   @SerializedName("lastProbeTime")
   @Expose
-  private DateTime lastProbeTime;
+  private OffsetDateTime lastProbeTime;
 
   @Description("Last time the condition transitioned from one status to another.")
   @SerializedName("lastTransitionTime")
   @Expose
-  private DateTime lastTransitionTime;
+  private OffsetDateTime lastTransitionTime;
 
   @Description("Human-readable message indicating details about last transition.")
   @SerializedName("message")
@@ -86,7 +86,7 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
    *
    * @return time
    */
-  public DateTime getLastProbeTime() {
+  public OffsetDateTime getLastProbeTime() {
     return lastProbeTime;
   }
 
@@ -95,7 +95,7 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
    *
    * @param lastProbeTime time
    */
-  public void setLastProbeTime(DateTime lastProbeTime) {
+  public void setLastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
   }
 
@@ -105,7 +105,7 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
    * @param lastProbeTime time
    * @return this
    */
-  public DomainCondition withLastProbeTime(DateTime lastProbeTime) {
+  public DomainCondition withLastProbeTime(OffsetDateTime lastProbeTime) {
     this.lastProbeTime = lastProbeTime;
     return this;
   }
@@ -115,7 +115,7 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
    *
    * @return time
    */
-  public DateTime getLastTransitionTime() {
+  public OffsetDateTime getLastTransitionTime() {
     return lastTransitionTime;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -22,7 +23,6 @@ import oracle.kubernetes.utils.SystemClock;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
@@ -69,7 +69,7 @@ public class DomainStatus {
       "RFC 3339 date and time at which the operator started the domain. This will be when "
           + "the operator begins processing and will precede when the various servers "
           + "or clusters are available.")
-  private DateTime startTime = SystemClock.now();
+  private OffsetDateTime startTime = SystemClock.now();
 
   @Description(
       "The number of running cluster member Managed Servers in the WebLogic cluster if there is "
@@ -444,7 +444,7 @@ public class DomainStatus {
    *
    * @return start time
    */
-  DateTime getStartTime() {
+  OffsetDateTime getStartTime() {
     return startTime;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -247,12 +248,14 @@ class ObjectPatch<T> {
   }
 
   static class DateTimeField<T> extends StringField<T> {
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
     DateTimeField(String name, Function<T, OffsetDateTime> getter) {
       super(name, a -> toString(getter.apply(a)));
     }
 
     private static String toString(OffsetDateTime dateTime) {
-      return Optional.ofNullable(dateTime).map(OffsetDateTime::toString).orElse(null);
+      return Optional.ofNullable(dateTime).map(DATE_FORMAT::format).orElse(null);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ObjectPatch.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,10 +18,6 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonPatchBuilder;
 import javax.json.JsonValue;
-
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * A class which can create JSON patches from the difference of two objects.
@@ -61,7 +58,7 @@ class ObjectPatch<T> {
     return this;
   }
 
-  ObjectPatch<T> withDateTimeField(String fieldName, Function<T,DateTime> getter) {
+  ObjectPatch<T> withDateTimeField(String fieldName, Function<T,OffsetDateTime> getter) {
     fields.add(new DateTimeField<>(fieldName, getter));
     return this;
   }
@@ -250,15 +247,12 @@ class ObjectPatch<T> {
   }
 
   static class DateTimeField<T> extends StringField<T> {
-    private static final DateTimeFormatter DATE_FORMAT = ISODateTimeFormat.dateTime();
-
-
-    DateTimeField(String name, Function<T, DateTime> getter) {
+    DateTimeField(String name, Function<T, OffsetDateTime> getter) {
       super(name, a -> toString(getter.apply(a)));
     }
 
-    private static String toString(DateTime dateTime) {
-      return Optional.ofNullable(dateTime).map(DATE_FORMAT::print).orElse(null);
+    private static String toString(OffsetDateTime dateTime) {
+      return Optional.ofNullable(dateTime).map(OffsetDateTime::toString).orElse(null);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerHealth.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerHealth.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.weblogic.domain.model;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,7 +14,6 @@ import oracle.kubernetes.json.Description;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPatch;
 
@@ -22,7 +22,7 @@ public class ServerHealth {
 
   @Description("RFC 3339 date and time at which the server started.")
   @Expose
-  private DateTime activationTime;
+  private OffsetDateTime activationTime;
 
   @Description(
       "Server health of this WebLogic Server instance. If the value is \"Not available\", the operator has "
@@ -55,7 +55,7 @@ public class ServerHealth {
    *
    * @return activation time
    */
-  private DateTime getActivationTime() {
+  private OffsetDateTime getActivationTime() {
     return activationTime;
   }
 
@@ -65,7 +65,7 @@ public class ServerHealth {
    * @param activationTime activation time
    * @return this
    */
-  public ServerHealth withActivationTime(DateTime activationTime) {
+  public ServerHealth withActivationTime(OffsetDateTime activationTime) {
     this.activationTime = activationTime;
     return this;
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +31,6 @@ import oracle.kubernetes.operator.work.ThreadFactorySingleton;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,7 +106,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
                 .namespace(namespace)
                 .name(uid)
                 .resourceVersion("1")
-                .creationTimestamp(DateTime.now()));
+                .creationTimestamp(OffsetDateTime.now()));
   }
 
   private DomainPresenceInfo getDomainPresenceInfo(DomainProcessorStub dp, String uid) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -66,7 +67,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainConditionType;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -256,7 +256,7 @@ public class DomainProcessorTest {
     assertThat(getRunningPods().size(), equalTo(MIN_REPLICAS + NUM_ADMIN_SERVERS + NUM_JOB_PODS));
   }
 
-  private List<CoreV1Event> getEventsAfterTimestamp(long timestamp) {
+  private List<CoreV1Event> getEventsAfterTimestamp(OffsetDateTime timestamp) {
     return testSupport.<CoreV1Event>getResources(KubernetesTestSupport.EVENT).stream()
             .filter(e -> e.getLastTimestamp().isAfter(timestamp)).collect(Collectors.toList());
   }
@@ -323,7 +323,7 @@ public class DomainProcessorTest {
     assertThat(minAvailableMatches(getRunningPDBs(), 1), is(true));
 
     domainConfigurator.configureCluster(CLUSTER).withReplicas(3);
-    newDomain.getMetadata().setCreationTimestamp(new DateTime());
+    newDomain.getMetadata().setCreationTimestamp(OffsetDateTime.now());
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat(minAvailableMatches(getRunningPDBs(), 2), is(true));
@@ -339,7 +339,7 @@ public class DomainProcessorTest {
     assertThat(minAvailableMatches(getRunningPDBs(), 2), is(true));
 
     domainConfigurator.configureCluster(CLUSTER).withReplicas(2);
-    newDomain.getMetadata().setCreationTimestamp(new DateTime());
+    newDomain.getMetadata().setCreationTimestamp(OffsetDateTime.now());
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat(minAvailableMatches(getRunningPDBs(), 1), is(true));
@@ -473,7 +473,7 @@ public class DomainProcessorTest {
     processor.createMakeRightOperation(info).execute();
 
     // Run the make right flow again with explicit recheck and no domain updates
-    long timestamp = System.currentTimeMillis();
+    OffsetDateTime timestamp = OffsetDateTime.now();
     processor.createMakeRightOperation(info).withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_STARTED",
             doesNotContainEvent(getEventsAfterTimestamp(timestamp), DOMAIN_PROCESSING_STARTING_EVENT), is(true));
@@ -494,7 +494,7 @@ public class DomainProcessorTest {
     processor.createMakeRightOperation(info).execute();
 
     // Run the make right flow again with explicit recheck and no domain updates
-    long timestamp = System.currentTimeMillis();
+    OffsetDateTime timestamp = OffsetDateTime.now();
     processor.createMakeRightOperation(info).withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_STARTED",
             doesNotContainEvent(getEventsAfterTimestamp(timestamp), DOMAIN_PROCESSING_STARTING_EVENT), is(true));
@@ -519,8 +519,8 @@ public class DomainProcessorTest {
 
     // Scale up the cluster and execute the make right flow again with explicit recheck
     domainConfigurator.configureCluster(CLUSTER).withReplicas(3);
-    newDomain.getMetadata().setCreationTimestamp(new DateTime());
-    long timestamp = System.currentTimeMillis();
+    newDomain.getMetadata().setCreationTimestamp(OffsetDateTime.now());
+    OffsetDateTime timestamp = OffsetDateTime.now();
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_COMPLETED_EVENT",

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -11,7 +12,6 @@ import io.kubernetes.client.openapi.models.V1SecretReference;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
-import org.joda.time.DateTime;
 
 import static oracle.kubernetes.operator.helpers.SecretHelper.PASSWORD_KEY;
 import static oracle.kubernetes.operator.helpers.SecretHelper.USERNAME_KEY;
@@ -43,7 +43,7 @@ public class DomainProcessorTestSetup {
    * @return the original metadata object, updated
    */
   private static V1ObjectMeta withTimestamps(V1ObjectMeta meta) {
-    return meta.creationTimestamp(DateTime.now()).resourceVersion("1");
+    return meta.creationTimestamp(OffsetDateTime.now()).resourceVersion("1");
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -4,6 +4,9 @@
 package oracle.kubernetes.operator;
 
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,7 +23,6 @@ import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.watcher.WatchListener;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,8 +66,8 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
     return new V1Job().metadata(new V1ObjectMeta().name("test").creationTimestamp(getCurrentTime()));
   }
 
-  private DateTime getCurrentTime() {
-    return new DateTime(clock);
+  private OffsetDateTime getCurrentTime() {
+    return OffsetDateTime.ofInstant(Instant.ofEpochSecond(clock), ZoneId.of("UTC"));
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -4,9 +4,7 @@
 package oracle.kubernetes.operator;
 
 import java.math.BigInteger;
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,8 +39,8 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1Job> {
 
   private static final BigInteger INITIAL_RESOURCE_VERSION = new BigInteger("234");
+  private OffsetDateTime clock = OffsetDateTime.now();
   private final V1Job cachedJob = createJob();
-  private long clock;
 
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final TerminalStep terminalStep = new TerminalStep();
@@ -67,7 +65,7 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
   }
 
   private OffsetDateTime getCurrentTime() {
-    return OffsetDateTime.ofInstant(Instant.ofEpochSecond(clock), ZoneId.of("UTC"));
+    return clock;
   }
 
   @Override
@@ -377,7 +375,7 @@ public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1J
 
   @SuppressWarnings("unused")
   private V1Job createCompletedJobWithDifferentTimestamp(V1Job job) {
-    clock++;
+    clock = clock.plusSeconds(1);
     return markJobCompleted(createJob());
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator;
 
 import java.net.HttpURLConnection;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,7 +47,6 @@ import oracle.kubernetes.utils.TestUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.jetbrains.annotations.NotNull;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -465,7 +465,7 @@ public class MainTest extends ThreadFactoryTestBase {
     assertThat(getStartingNamespaces(), contains(NS_WEBLOGIC1, NS_WEBLOGIC3, NS_WEBLOGIC5));
   }
 
-  private V1ObjectMeta createMetadata(DateTime creationTimestamp) {
+  private V1ObjectMeta createMetadata(OffsetDateTime creationTimestamp) {
     return new V1ObjectMeta()
         .name(DOMAIN_UID)
         .namespace(NS)
@@ -558,7 +558,7 @@ public class MainTest extends ThreadFactoryTestBase {
 
   @Test
   public void deleteDomainPresenceWithTimeCheck_delete_with_same_DateTime() {
-    DateTime creationDatetime = DateTime.now();
+    OffsetDateTime creationDatetime = OffsetDateTime.now();
     V1ObjectMeta domainMeta = createMetadata(creationDatetime);
 
     V1ObjectMeta domain2Meta = createMetadata(creationDatetime);
@@ -568,10 +568,10 @@ public class MainTest extends ThreadFactoryTestBase {
 
   @Test
   public void deleteDomainPresenceWithTimeCheck_delete_with_newer_DateTime() {
-    DateTime creationDatetime = DateTime.now();
+    OffsetDateTime creationDatetime = OffsetDateTime.now();
     V1ObjectMeta domainMeta = createMetadata(creationDatetime);
 
-    DateTime deleteDatetime = creationDatetime.plusMinutes(1);
+    OffsetDateTime deleteDatetime = creationDatetime.plusMinutes(1);
     V1ObjectMeta domain2Meta = createMetadata(deleteDatetime);
 
     assertFalse(KubernetesUtils.isFirstNewer(domainMeta, domain2Meta));
@@ -579,10 +579,10 @@ public class MainTest extends ThreadFactoryTestBase {
 
   @Test
   public void deleteDomainPresenceWithTimeCheck_doNotDelete_with_older_DateTime() {
-    DateTime creationDatetime = DateTime.now();
+    OffsetDateTime creationDatetime = OffsetDateTime.now();
     V1ObjectMeta domainMeta = createMetadata(creationDatetime);
 
-    DateTime deleteDatetime = creationDatetime.minusMinutes(1);
+    OffsetDateTime deleteDatetime = creationDatetime.minusMinutes(1);
     V1ObjectMeta domain2Meta = createMetadata(deleteDatetime);
 
     assertTrue(KubernetesUtils.isFirstNewer(domainMeta, domain2Meta));

--- a/operator/src/test/java/oracle/kubernetes/operator/OperatorEventProcessingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/OperatorEventProcessingTest.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +23,6 @@ import oracle.kubernetes.operator.helpers.KubernetesEventObjects;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.utils.TestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -317,7 +317,7 @@ public class OperatorEventProcessingTest {
         .metadata(createMetadata(createDomainEventName(nameAppendix, item), NS, true))
         .reportingComponent(WEBLOGIC_OPERATOR_COMPONENT)
         .reportingInstance(OPERATOR_POD_NAME)
-        .lastTimestamp(DateTime.now())
+        .lastTimestamp(OffsetDateTime.now())
         .type(EventConstants.EVENT_NORMAL)
         .reason(item.getReason())
         .message(item.getMessage(new EventHelper.EventData(item, message)))
@@ -336,7 +336,7 @@ public class OperatorEventProcessingTest {
         .metadata(createMetadata(createNSEventName(nameAppendix, item), OP_NS, false))
         .reportingComponent(WEBLOGIC_OPERATOR_COMPONENT)
         .reportingInstance(OPERATOR_POD_NAME)
-        .lastTimestamp(DateTime.now())
+        .lastTimestamp(OffsetDateTime.now())
         .type(EventConstants.EVENT_NORMAL)
         .reason(item.getReason())
         .message(item.getMessage(new EventHelper.EventData(item, "")))

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,6 @@ import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import oracle.kubernetes.weblogic.domain.model.SubsystemHealth;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
@@ -311,7 +311,7 @@ public class DomainStatusPatchTest {
 
   @Test
   public void withHealthScalarsWhenOnlyNewStatusHasServers_addThem() {
-    DateTime activationTime = new DateTime();
+    OffsetDateTime activationTime = OffsetDateTime.now();
     DomainStatus status1 = new DomainStatus();
     DomainStatus status2 = new DomainStatus()
           .addServer(new ServerStatus()
@@ -333,7 +333,7 @@ public class DomainStatusPatchTest {
 
   @Test
   public void withHealthScalarsWhenBothStatusesHasServers_modifyThem() {
-    DateTime activationTime = new DateTime();
+    OffsetDateTime activationTime = OffsetDateTime.now();
     DomainStatus status1 = new DomainStatus()
           .addServer(new ServerStatus()
                 .withServerName("ms1").withClusterName("cluster1")
@@ -360,7 +360,7 @@ public class DomainStatusPatchTest {
 
   @Test
   public void withSubsystemHealthWhenOnlyNewStatusHasSubsystemValues_addThem() {
-    DateTime activationTime = new DateTime();
+    OffsetDateTime activationTime = OffsetDateTime.now();
     DomainStatus status1 = new DomainStatus()
           .addServer(new ServerStatus().withServerName("ms1"))
           .addServer(new ServerStatus().withServerName("ms2")
@@ -399,7 +399,7 @@ public class DomainStatusPatchTest {
 
   @Test
   public void whenSubsystemRemovedOrModified_patchAsNeeded() {
-    DateTime activationTime = new DateTime();
+    OffsetDateTime activationTime = OffsetDateTime.now();
     DomainStatus status1 = new DomainStatus()
           .addServer(new ServerStatus().withServerName("ms1")
                 .withHealth(new ServerHealth().withOverallHealth("Confused").withActivationTime(activationTime)

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -325,7 +326,8 @@ public class DomainStatusPatchTest {
     assertThat(builder.getPatches(),
           hasItemsInOrder(
                 "ADD /status/servers/- {'clusterName':'cluster1',"
-                      + "'health':{'activationTime':'" + activationTime + "','overallHealth':'AOK'},"
+                      + "'health':{'activationTime':'" + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(activationTime)
+                      + "','overallHealth':'AOK'},"
                       + "'serverName':'ms1'}",
                 "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
                 ));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.helpers;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -312,7 +313,9 @@ public class DomainStatusPatchTest {
 
   @Test
   public void withHealthScalarsWhenOnlyNewStatusHasServers_addThem() {
-    OffsetDateTime activationTime = OffsetDateTime.now();
+    // Truncate to seconds because we intermittently see a different number of trailing decimals
+    // that can cause the string comparison to fail
+    OffsetDateTime activationTime = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
     DomainStatus status1 = new DomainStatus();
     DomainStatus status2 = new DomainStatus()
           .addServer(new ServerStatus()

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -7,7 +7,6 @@ import java.io.StringReader;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,19 +28,11 @@ import javax.json.JsonException;
 import javax.json.JsonPatch;
 import javax.json.JsonStructure;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.JSON;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.CoreV1EventList;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -89,9 +80,6 @@ import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
 import org.jetbrains.annotations.NotNull;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -608,26 +596,6 @@ public class KubernetesTestSupport extends FiberTestSupport {
     }
   }
 
-  static class DateTimeSerializer implements JsonDeserializer<DateTime>, JsonSerializer<DateTime> {
-    private static final DateTimeFormatter DATE_FORMAT = ISODateTimeFormat.dateTime();
-
-    @Override
-    public DateTime deserialize(
-        final JsonElement je, final Type type, final JsonDeserializationContext jdc)
-        throws JsonParseException {
-      return je.isJsonObject()
-            ? new DateTime(Long.parseLong(je.getAsJsonObject().get("iMillis").getAsString()))
-            : DateTime.parse(je.getAsString());
-    }
-
-    @Override
-    public JsonElement serialize(
-        final DateTime src, final Type typeOfSrc, final JsonSerializationContext context) {
-      String retVal = src == null ? "" : DATE_FORMAT.print(src);
-      return new JsonPrimitive(retVal);
-    }
-  }
-
   private class DataRepository<T> {
     private final Map<String, T> data = new HashMap<>();
     private final Class<?> resourceType;
@@ -891,13 +859,11 @@ public class KubernetesTestSupport extends FiberTestSupport {
 
     @SuppressWarnings("unchecked")
     T fromJsonStructure(JsonStructure jsonStructure) {
-      final GsonBuilder builder =
-          new GsonBuilder().registerTypeAdapter(DateTime.class, new DateTimeSerializer());
-      return (T) builder.create().fromJson(jsonStructure.toString(), resourceType);
+      return new JSON().deserialize(jsonStructure.toString(), resourceType);
     }
 
     JsonStructure toJsonStructure(T src) {
-      String json = new Gson().toJson(src);
+      String json = new JSON().getGson().toJson(src);
       return Json.createReader(new StringReader(json)).read();
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupportTest.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainConditionType;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -292,7 +292,7 @@ public class KubernetesTestSupportTest {
     assertThat(updatedDomain.getSpec().getReplicas(), equalTo(5));
   }
 
-  private DateTime getCreationTimestamp(Domain domain) {
+  private OffsetDateTime getCreationTimestamp(Domain domain) {
     return domain.getMetadata().getCreationTimestamp();
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
@@ -4,9 +4,11 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -16,8 +18,10 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenCreationTimesDiffer_metadataWithLaterTimeIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(new DateTime(2)).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(new DateTime(1)).resourceVersion("1");
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(2), ZoneId.of("UTC"))).resourceVersion("2");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("1");
 
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(true));
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
@@ -25,8 +29,10 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenCreationTimesMatch_metadataWithHigherResourceVersionIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(new DateTime(1)).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(new DateTime(1)).resourceVersion("1");
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("2");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("1");
 
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(true));
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
@@ -34,8 +40,10 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenCreationTimesAndResourceVersionsMatch_neitherIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(new DateTime(1)).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(new DateTime(1)).resourceVersion("2");
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("2");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("2");
 
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(false));
@@ -43,7 +51,7 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenHaveLargeResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    DateTime now = DateTime.now();
+    OffsetDateTime now = OffsetDateTime.now();
 
     // This needs to be a value bigger than 2147483647
     String resVersion = "2733280673";
@@ -57,7 +65,7 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenHaveNonParsableResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    DateTime now = DateTime.now();
+    OffsetDateTime now = OffsetDateTime.now();
 
     String resVersion = "ThisIsNotANumber";
     String differentResVersion = "SomeOtherValueAlsoNotANumber";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
@@ -4,9 +4,7 @@
 package oracle.kubernetes.operator.helpers;
 
 import java.math.BigInteger;
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import org.junit.jupiter.api.Test;
@@ -16,12 +14,14 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class KubernetesUtilsTest {
 
+  private static final OffsetDateTime startTime = OffsetDateTime.now();
+  private static final OffsetDateTime time1 = startTime.plusSeconds(1);
+  private static final OffsetDateTime time2 = startTime.plusSeconds(2);
+
   @Test
   public void whenCreationTimesDiffer_metadataWithLaterTimeIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(
-        OffsetDateTime.ofInstant(Instant.ofEpochSecond(2), ZoneId.of("UTC"))).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(
-        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("1");
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time2).resourceVersion("2");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("1");
 
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(true));
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
@@ -29,10 +29,8 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenCreationTimesMatch_metadataWithHigherResourceVersionIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(
-        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(
-        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("1");
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("1");
 
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(true));
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
@@ -40,10 +38,8 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenCreationTimesAndResourceVersionsMatch_neitherIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(
-        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(
-        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.of("UTC"))).resourceVersion("2");
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
 
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(false));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -3,6 +3,9 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,7 +32,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import org.hamcrest.junit.MatcherAssert;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -404,7 +406,7 @@ public class PodPresenceTest {
     return pod;
   }
 
-  private DateTime getDateTime() {
-    return new DateTime(++clock);
+  private OffsetDateTime getDateTime() {
+    return OffsetDateTime.ofInstant(Instant.ofEpochSecond(++clock), ZoneId.of("UTC"));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -3,9 +3,7 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,7 +66,7 @@ public class PodPresenceTest {
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final DomainProcessorImpl processor =
       new DomainProcessorImpl(DomainProcessorDelegateStub.createDelegate(testSupport));
-  private long clock;
+  private OffsetDateTime clock = OffsetDateTime.now();
   private final Packet packet = new Packet();
   private final V1Pod pod =
       new V1Pod()
@@ -407,6 +405,7 @@ public class PodPresenceTest {
   }
 
   private OffsetDateTime getDateTime() {
-    return OffsetDateTime.ofInstant(Instant.ofEpochSecond(++clock), ZoneId.of("UTC"));
+    clock = clock.plusSeconds(1);
+    return clock;
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
@@ -3,9 +3,7 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +59,7 @@ public class ServicePresenceTest {
   private final DomainProcessorImpl processor =
       new DomainProcessorImpl(createStrictStub(DomainProcessorDelegate.class));
   private final Packet packet = new Packet();
-  private long clock;
+  private OffsetDateTime clock = OffsetDateTime.now();
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -541,7 +539,8 @@ public class ServicePresenceTest {
   }
 
   private OffsetDateTime getDateTime() {
-    return OffsetDateTime.ofInstant(Instant.ofEpochSecond(++clock), ZoneId.of("UTC"));
+    clock = clock.plusSeconds(1);
+    return clock;
   }
 
   private V1ObjectMeta createMetadata() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
@@ -3,6 +3,9 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +29,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -538,8 +540,8 @@ public class ServicePresenceTest {
     return service;
   }
 
-  private DateTime getDateTime() {
-    return new DateTime(++clock);
+  private OffsetDateTime getDateTime() {
+    return OffsetDateTime.ofInstant(Instant.ofEpochSecond(++clock), ZoneId.of("UTC"));
   }
 
   private V1ObjectMeta createMetadata() {

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.steps;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,6 @@ import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -292,7 +292,7 @@ public class MonitoringExporterStepsTest {
   }
 
   private void setDeletingState(V1ObjectMeta meta) {
-    meta.setDeletionTimestamp(DateTime.now());
+    meta.setDeletionTimestamp(OffsetDateTime.now());
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -547,11 +547,6 @@
         <version>${jackson-version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-joda</artifactId>
-        <version>${jackson-version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson-databind-version}</version>
@@ -600,16 +595,6 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${awaitility-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-ext-jdk15on</artifactId>
-        <version>${bouncycastle.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>${bouncycastle.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -671,7 +656,7 @@
     <assertj.core.version>3.19.0</assertj.core.version>
     <commons.io.version>2.8.0</commons.io.version>
     <awaitility-version>4.0.3</awaitility-version>
-    <client-java-version>11.0.0</client-java-version>
+    <client-java-version>12.0.0</client-java-version>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <junit.vintage.version>5.7.1</junit.vintage.version>
     <junit.platform.version>1.7.0</junit.platform.version>
@@ -688,7 +673,6 @@
     <skip.dependency-check>false</skip.dependency-check>
     <jacoco.version>0.8.6</jacoco.version>
     <git-commit-id-plugin-version>4.0.0</git-commit-id-plugin-version>
-    <bouncycastle.version>1.68</bouncycastle.version>
     <aggregate.report.dir>buildtime-reports/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
     <checkstyle.config.location>${root.basedir}/build-tools/checkstyle/customized_google_checks.xml</checkstyle.config.location>
   </properties>


### PR DESCRIPTION
* JDK 16 is now GA
* Kubernetes Java Client 12.0.0 now available: the big change is that use of Joda library is removed in favor of standard java.time.* types