### PR TITLE
Fix to avoid intrsopector rebuild the domain after upgrading to 3.2.0

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -293,23 +293,25 @@ public class JobHelper {
       addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_ENABLED, Boolean.toString(isIstioEnabled()));
       addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_READINESS_PORT, Integer.toString(getIstioReadinessPort()));
       addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_POD_NAMESPACE, getNamespace());
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_USE_ONLINE_UPDATE, Boolean.toString(isUseOnlineUpdate()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_ACTIVATE_TIMEOUT,
-          Long.toString(getDomain().getWDTActivateTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_CONNECT_TIMEOUT,
-          Long.toString(getDomain().getWDTConnectTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_DEPLOY_TIMEOUT,
-          Long.toString(getDomain().getWDTDeployTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_REDEPLOY_TIMEOUT,
-          Long.toString(getDomain().getWDTReDeployTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_UNDEPLOY_TIMEOUT,
-          Long.toString(getDomain().getWDTUnDeployTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_START_APPLICATION_TIMEOUT,
-          Long.toString(getDomain().getWDTStartApplicationTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_STOP_APPLICAITON_TIMEOUT,
-          Long.toString(getDomain().getWDTStopApplicationTimeoutMillis()));
-      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_SET_SERVERGROUPS_TIMEOUT,
-          Long.toString(getDomain().getWDTSetServerGroupsTimeoutMillis()));
+      if (isUseOnlineUpdate()) {
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_USE_ONLINE_UPDATE, "true");
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_ACTIVATE_TIMEOUT,
+            Long.toString(getDomain().getWDTActivateTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_CONNECT_TIMEOUT,
+            Long.toString(getDomain().getWDTConnectTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_DEPLOY_TIMEOUT,
+            Long.toString(getDomain().getWDTDeployTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_REDEPLOY_TIMEOUT,
+            Long.toString(getDomain().getWDTReDeployTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_UNDEPLOY_TIMEOUT,
+            Long.toString(getDomain().getWDTUnDeployTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_START_APPLICATION_TIMEOUT,
+            Long.toString(getDomain().getWDTStartApplicationTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_STOP_APPLICAITON_TIMEOUT,
+            Long.toString(getDomain().getWDTStopApplicationTimeoutMillis()));
+        addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_SET_SERVERGROUPS_TIMEOUT,
+            Long.toString(getDomain().getWDTSetServerGroupsTimeoutMillis()));
+      }
 
 
       String dataHome = getDataHome();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -74,10 +74,20 @@ import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createSecretK
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createSecurityContext;
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createToleration;
 import static oracle.kubernetes.operator.utils.ChecksumUtils.getMD5Hash;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_USE_ONLINE_UPDATE;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_ACTIVATE_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_CONNECT_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_DEPLOY_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_REDEPLOY_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_SET_SERVERGROUPS_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_START_APPLICATION_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_STOP_APPLICAITON_TIMEOUT;
+import static oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars.MII_WDT_UNDEPLOY_TIMEOUT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
@@ -254,6 +264,48 @@ public class JobHelperTest extends DomainValidationBaseTest {
             envVarOEVNContains("item2"),
             envVarOEVNContains("WL_HOME"),
             envVarOEVNContains("MW_HOME")));
+  }
+
+  @Test
+  public void whenDomainIsOnlineUpdate_introspectorPodStartupWithThem() {
+    configureDomain()
+        .withMIIOnlineUpdate();
+
+    V1JobSpec jobSpec = createJobSpec();
+
+    assertThat(
+        getMatchingContainerEnv(domainPresenceInfo, jobSpec),
+        allOf(
+            hasEnvVar(MII_USE_ONLINE_UPDATE, "true"),
+            envVarOEVNContains(MII_WDT_ACTIVATE_TIMEOUT),
+            envVarOEVNContains(MII_WDT_CONNECT_TIMEOUT),
+            envVarOEVNContains(MII_WDT_DEPLOY_TIMEOUT),
+            envVarOEVNContains(MII_WDT_REDEPLOY_TIMEOUT),
+            envVarOEVNContains(MII_WDT_UNDEPLOY_TIMEOUT),
+            envVarOEVNContains(MII_WDT_START_APPLICATION_TIMEOUT),
+            envVarOEVNContains(MII_WDT_STOP_APPLICAITON_TIMEOUT),
+            envVarOEVNContains(MII_WDT_SET_SERVERGROUPS_TIMEOUT)
+            ));
+  }
+
+  @Test
+  public void whenDomainIsNotOnlineUpdate_introspectorPodStartupWithoutThem() {
+
+    V1JobSpec jobSpec = createJobSpec();
+
+    assertThat(
+        getMatchingContainerEnv(domainPresenceInfo, jobSpec),
+        not(anyOf(envVarOEVNContains(MII_USE_ONLINE_UPDATE),
+            envVarOEVNContains(MII_WDT_ACTIVATE_TIMEOUT),
+            envVarOEVNContains(MII_WDT_CONNECT_TIMEOUT),
+            envVarOEVNContains(MII_WDT_DEPLOY_TIMEOUT),
+            envVarOEVNContains(MII_WDT_REDEPLOY_TIMEOUT),
+            envVarOEVNContains(MII_WDT_UNDEPLOY_TIMEOUT),
+            envVarOEVNContains(MII_WDT_START_APPLICATION_TIMEOUT),
+            envVarOEVNContains(MII_WDT_STOP_APPLICAITON_TIMEOUT),
+            envVarOEVNContains(MII_WDT_SET_SERVERGROUPS_TIMEOUT)
+            )));
+
   }
 
   private V1JobSpec createJobSpec() {


### PR DESCRIPTION
This fix is to avoid introspector job rebuild the domain when nothing changed after upgrading to 3.2.0.  The online update environment variables should only be set when it s online update. 