### PR TITLE
Ready for Review - add Remote Console doc

### DIFF
--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -88,7 +88,7 @@ For more information, see [T3 channels]({{<relref "/security/domain-security/web
    ```
    Where:
 
-     * `${HOSTNAME}` is where the ingress load balancer is running, in this case, the `External-IP` address of the Traefik load balancer.
+     * `${HOSTNAME}` is where the ingress load balancer is running.
 
      * To determine the `${LB_PORT}` when using a Traefik load balancer:
 

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -7,12 +7,13 @@ description: "Use the Oracle WebLogic Server Remote Console to manage a domain r
 ---
 
 The Oracle WebLogic Server Remote Console is a lightweight, open source console that does not need to be collocated with a WebLogic Server domain.
-You can install and run the Remote Console anywhere. For an introduction, read the blog, "The NEW WebLogic Server Remote Console."
+You can install and run the Remote Console anywhere. For an introduction, read the blog, ["The NEW WebLogic Server Remote Console"](https://blogs.oracle.com/weblogicserver/new-weblogic-server-remote-console).
+
 For detailed documentation, see the [Oracle WebLogic Server Remote Console](https://github.com/oracle/weblogic-remote-console) GitHub project.
 
 A major benefit of using the Remote Console is that you don't need to install or run the WebLogic Server Administration Console on WebLogic Server instances.
-You can use the Remote Console with WebLogic Server **slim** installers, available on the Oracle Technology Network [(OTN)](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
-or Oracle Software Delivery Cloud [(OSDC)](https://edelivery.oracle.com/osdc/faces/Home.jspx;jsessionid=LchBX6sgzwv5MwSaamMxrIIk-etWJLb0IyCet9mcnqAYnINXvWzi!-1201085350).
+You can use the Remote Console with WebLogic Server **slim** installers, available on the [OTN](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
+or [OSDC](https://edelivery.oracle.com/osdc/faces/Home.jspx;jsessionid=LchBX6sgzwv5MwSaamMxrIIk-etWJLb0IyCet9mcnqAYnINXvWzi!-1201085350).
 Slim installers reduce the size of WebLogic Server downloads, installations, Docker images, and Kubernetes pods.
 For example, a WebLogic Server 12.2.1.4 slim installer download is approximately 180 MB.
 
@@ -33,52 +34,51 @@ To access WebLogic Server domains running in Kubernetes:
 
 Access the REST interface of the WebLogic Server Administration Server to verify the connection and that the correct `hostname:port` is being used:
 
-```shell
+```
 $ curl --user username:password http://host:lbport/console/login/LoginForm.jsp
 ```
 
 ### Use the Administration Server `NodePort`
 
-To connect to the Remote Console, use the Kubernetes WebLogic Server Administration Server’s `NodePort` :
+For the Remote Console to connect to the Kubernetes WebLogic Server Administration Server’s `NodePort`:
 
-```shell
-$ http://hostname:adminserver-NodePort/
+```
+http://hostname:adminserver-NodePort/
 ```
 
 ### Configure ingress path routing rules
 
-See the following example `path-routing` YAML file:
+1. Configure an ingress path routing rule. For example, see the following `path-routing` YAML file.
 
-```
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-annotations:
-kubernetes.io/ingress.class: traefik
-name: traefik-pathrouting-1
-namespace: weblogic-domain
-spec:
-routes:
+   ```
+   apiVersion: traefik.containo.us/v1alpha1
+   kind: IngressRoute
+   metadata:
+   annotations:
+   kubernetes.io/ingress.class: traefik
+   name: traefik-pathrouting-1
+   namespace: weblogic-domain
+   spec:
+   routes:
 
-    kind: Rule
-    match: PathPrefix(`/domain1`)
-    services:
-    kind: Service
-    name: domain1-cluster-dockercluster
-    namespace: weblogic-domain
-    port: 8001
-    kind: Rule
-    match: PathPrefix(`/console`)
-    services:
-    kind: Service
-    name: domain1-adminserver
-    namespace: weblogic-domain
-    port: 7001
-    kind: Rule
-    match: PathPrefix(`/`)
-    services:
-    kind: Service
-    name: domain1-adminserver
-    namespace: weblogic-domain
-    port: 7001
-```
+       kind: Rule
+       match: PathPrefix(`/domain1`)
+       services:
+       kind: Service
+       name: domain1-cluster-dockercluster
+       namespace: weblogic-domain
+       port: 8001
+       kind: Rule
+       match: PathPrefix(`/`)
+       services:
+       kind: Service
+       name: domain1-adminserver
+       namespace: weblogic-domain
+       port: 7001
+   ```
+
+1. To connect to the Remote Console:
+
+   ```
+   http://${HOSTNAME}:${LB_PORT}/
+   ```

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -1,6 +1,25 @@
 ---
-title: "Administration Console"
+title: "Use the Remote Console"
 date: 2019-02-23T17:39:15-05:00
-draft: true
+draft: false
 weight: 2
+description: "Use the Oracle WebLogic Server Remote Console to manage a domain running in Kubernetes."
 ---
+Use the Remote Console to access WebLogic domains running in Kubernetes.
+
+The Oracle WebLogic Server Remote Console is a lightweight, open source console that does not need to be collocated with a WebLogic Server domain.
+You can install and run the Remote Console anywhere. For an introduction, read the blog, "The NEW WebLogic Server Remote Console."
+For detailed documentation, see the [Oracle WebLogic Server Remote Console](https://github.com/oracle/weblogic-remote-console) GitHub project.
+
+A major benefit of using the Remote Console is that you don't need to install or run the WebLogic Server Administration Console on WebLogic Server instances.
+You can use the Remote Console with WebLogic Server slim installers, available on the Oracle Technology Network [(OTN)](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
+or Oracle Software Delivery Cloud [(OSDC)](https://edelivery.oracle.com/osdc/faces/Home.jspx;jsessionid=LchBX6sgzwv5MwSaamMxrIIk-etWJLb0IyCet9mcnqAYnINXvWzi!-1201085350).
+Slim installers reduce the size of WebLogic Server downloads, installations, Docker images, and Kubernetes pods.
+For example, a WebLogic Server 12.2.1.4 slim installer download is approximately 180 MB.
+
+
+For the Remote Console to access the Administration Server running in Kubernetes, you can:
+
+* Use curl to access the REST interface of WebLogic Server Administration Server to verify the connection and that the correct `hostname:port` is being used.
+* Configure Ingress path routing rules.
+* Use the Administration Server `NodePort`.

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -22,15 +22,13 @@ The Remote Console is deployed as a standalone Java program, which can connect t
 You connect to the Remote Console using a web browser and, when prompted, supply the WebLogic Server login credentials
 along with the URL of the WebLogic Server Administration Server's administration port to which you want to connect.
 
-**Note**:  An Administration Server administration port is typically the same as its default port unless either an SSL port or an administration port is configured and enabled.
+**Note**:  An Administration Server administration port typically is the same as its default port unless either an SSL port or an administration port is configured and enabled.
 
 ### Setup
 
 To set up access to WebLogic Server domains running in Kubernetes using the Remote Console:
 
-1. Install and configure the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
-
-1. Start the Remote Console and connect to a domain, as described [here](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md#start-connect).
+1. Install, configure, and start the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
 
 1. To give the Remote Console access to an Administration Server running in Kubernetes, you can:
 
@@ -50,7 +48,9 @@ http://hostname:adminserver-NodePort/
 
 ### Configure ingress path routing rules
 
-1. Configure an ingress path routing rule. For an example, see the following `path-routing` YAML file for a Traefik load balancer:
+1. Configure an ingress path routing rule. For more information about ingresses, see the [Ingress]({{< relref "/userguide/managing-domains/ingress/_index.md" >}}) documentation.
+
+   For an example, see the following `path-routing` YAML file for a Traefik load balancer:
 
    ```yaml
    apiVersion: traefik.containo.us/v1alpha1

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -8,46 +8,41 @@ description: "Use the Oracle WebLogic Server Remote Console to manage a domain r
 
 The Oracle WebLogic Server Remote Console is a lightweight, open source console that does not need to be collocated with a WebLogic Server domain.
 You can install and run the Remote Console anywhere. For an introduction, read the blog, ["The NEW WebLogic Server Remote Console"](https://blogs.oracle.com/weblogicserver/new-weblogic-server-remote-console).
-
 For detailed documentation, see the [Oracle WebLogic Server Remote Console](https://github.com/oracle/weblogic-remote-console) GitHub project.
 
-A major benefit of using the Remote Console is that you don't need to install or run the WebLogic Server Administration Console on WebLogic Server instances.
-You can use the Remote Console with WebLogic Server **slim** installers, available on the [OTN](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
+You can use the Remote Console with WebLogic Server _slim_ installers, available on the [OTN](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
 or [OSDC](https://edelivery.oracle.com/osdc/faces/Home.jspx;jsessionid=LchBX6sgzwv5MwSaamMxrIIk-etWJLb0IyCet9mcnqAYnINXvWzi!-1201085350).
 Slim installers reduce the size of WebLogic Server downloads, installations, container images, and Kubernetes pods.
 For example, a WebLogic Server 12.2.1.4 slim installer download is approximately 180 MB smaller.
 
-## Use the Remote Console
+A major benefit of using the Remote Console is that it runs in your browser and can be used to connect to different WebLogic Server instances.
+Also, when accessing the Remote Console through a load balancer, it's easier to set up access to multiple different domains than when using WebLogic Server Administration Console.
 
-To access WebLogic Server domains running in Kubernetes:
+The Remote Console is deployed as a standalone Java program, which can connect to multiple WebLogic Server Administration Servers using REST APIs.
+You connect to the Remote Console using a web browser and, when prompted, supply the WebLogic Server login credentials
+along with the URL of the WebLogic Server Administration Server's administration port to which you want to connect.
 
-1. Install, configure, and start the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
+**Note**:  An Administration Server administration port is typically the same as its default port unless either an SSL port or an administration port is configured and enabled.
 
-1. For the Remote Console to access the Administration Server running in Kubernetes, you can:
+### Setup
 
-   * Use [curl](#use-curl).
-   * Use the [Administration Server `NodePort`](#use-the-administration-server-nodeport).
-   * Configure [ingress path routing rules](#configure-ingress-path-routing-rules).
+To set up access to WebLogic Server domains running in Kubernetes using the Remote Console:
 
+1. Install and configure the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
 
-### Use curl
+1. Start the Remote Console and connect to a domain, as described [here](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md#start-connect).
 
-Access the REST interface of the WebLogic Server Administration Server to verify the connection and that the correct `hostname:port` is being used:
+1. To give the Remote Console access to an Administration Server running in Kubernetes, you can:
 
-```
-$ curl --user username:password http://${HOSTNAME}:${LB_PORT}/console/login/LoginForm.jsp
-```
+   * Use an [Administration Server `NodePort`](#use-an-administration-server-nodeport).
 
-* `${HOSTNAME}` is where you start up the WebLogic domain.
-
-* To determine `${LB_PORT}` when using a Traefik load balancer:
-
-   `$ export LB_PORT=$(kubectl -n traefik get service traefik-operator -o jsonpath='{.spec.ports[?(@.name=="web")].nodePort}')`
+   * Deploy a load balancer with [ingress path routing rules](#configure-ingress-path-routing-rules).
 
 
-### Use the Administration Server `NodePort`
 
-For the Remote Console to connect to the Kubernetes WebLogic Server Administration Server’s `NodePort`:
+### Use an Administration Server `NodePort`
+
+For the Remote Console to connect to the Kubernetes WebLogic Server Administration Server’s `NodePort`, use the URL:
 
 ```
 http://hostname:adminserver-NodePort/
@@ -55,7 +50,7 @@ http://hostname:adminserver-NodePort/
 
 ### Configure ingress path routing rules
 
-1. Configure an ingress path routing rule. For example, see the following `path-routing` YAML file for a Traefik load balancer:
+1. Configure an ingress path routing rule. For an example, see the following `path-routing` YAML file for a Traefik load balancer:
 
    ```yaml
    apiVersion: traefik.containo.us/v1alpha1
@@ -88,3 +83,10 @@ http://hostname:adminserver-NodePort/
    ```
    http://${HOSTNAME}:${LB_PORT}/
    ```
+   Where:
+
+     * `${HOSTNAME}` is where you start up the WebLogic domain.
+
+     * To determine the `${LB_PORT}` when using a Traefik load balancer:
+
+        `$ export LB_PORT=$(kubectl -n traefik get service traefik-operator -o jsonpath='{.spec.ports[?(@.name=="web")].nodePort}')`

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -29,7 +29,9 @@ To set up access to WebLogic Server domains running in Kubernetes using the Remo
 
 1. Install, configure, and start the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
 
-1. To give the Remote Console access to an Administration Server running in Kubernetes, you can:
+   **NOTE**: These instructions assume that you are installing and running the Remote Console Java program externally to your Kubernetes cluster.
+
+1. When you first connect your browser to the Remote Console, which is at `http://localhost:8012` by default, the console will prompt you with a login dialog for a WebLogic Server Administration Server URL. To give the Remote Console access to an Administration Server running in Kubernetes, you can:
 
    * Use an [Administration Server `NodePort`](#use-an-administration-server-nodeport).
 
@@ -56,7 +58,7 @@ For more information, see [T3 channels]({{<relref "/security/domain-security/web
 
 #### Configure ingress path routing rules
 
-1. Configure an ingress path routing rule. For more information about ingresses, see the [Ingress]({{< relref "/userguide/managing-domains/ingress/_index.md" >}}) documentation.
+1. Configure an ingress path routing rule. For information about ingresses, see the [Ingress]({{< relref "/userguide/managing-domains/ingress/_index.md" >}}) documentation.
 
    For an example, see the following `path-routing` YAML file for a Traefik load balancer:
 
@@ -79,14 +81,14 @@ For more information, see [T3 channels]({{<relref "/security/domain-security/web
          port: 7001
    ```
 
-1. For the Remote Console to connect to the Kubernetes WebLogic Server Administration Server, use the URL:
+1. For the Remote Console to connect to the Kubernetes WebLogic Server Administration Server, supply a URL that resolves to the load balancer host and ingress that you supplied in the previous step. For example:
 
    ```
    http://${HOSTNAME}:${LB_PORT}/
    ```
    Where:
 
-     * `${HOSTNAME}` is where you start up the WebLogic domain.
+     * `${HOSTNAME}` is where the ingress load balancer is running, in this case, the `External-IP` address of the Traefik load balancer.
 
      * To determine the `${LB_PORT}` when using a Traefik load balancer:
 
@@ -94,8 +96,20 @@ For more information, see [T3 channels]({{<relref "/security/domain-security/web
 
 ### Test
 
-To verify the connection and that the correct `hostname:port` is being used, use the following curl command to access the REST interface of WebLogic Server Administration Server:
+To verify that your WebLogic Server Administration Server URL is correct, and to verify that that your load balancer
+or `NodePort` are working as expected, run the following curl commands at the same location as your browser:
+
 
 ```
-curl --user username:password http://${HOSTNAME}:${LB_PORT}/management/weblogic/latest/
+$ curl --user username:password \
+     http://${HOSTNAME}:${LB_PORT}/management/weblogic/latest/domainRuntime?fields=name\&links=none ; echo
+
+$ curl --user username:password \
+     http://${HOSTNAME}:${LB_PORT}/management/weblogic/latest/serverRuntime?fields=name\&links=none ; echo
 ```
+
+These commands access the REST interface of the WebLogic Server Administration Server in a way that is similar to the Remote Console's use of REST.
+If successful, then the output from the two commands will be `{"name": "your-weblogic-domain-name"}` and `{"name": "your-weblogic-admin-server-name"}`, respectively.
+
+If you want to see the full content of the domainRuntime and serverRuntime beans, then rerun the commands
+but remove `?fields=name\&links=none`, which is appended at the end of each URL.

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -5,21 +5,80 @@ draft: false
 weight: 2
 description: "Use the Oracle WebLogic Server Remote Console to manage a domain running in Kubernetes."
 ---
-Use the Remote Console to access WebLogic domains running in Kubernetes.
 
 The Oracle WebLogic Server Remote Console is a lightweight, open source console that does not need to be collocated with a WebLogic Server domain.
 You can install and run the Remote Console anywhere. For an introduction, read the blog, "The NEW WebLogic Server Remote Console."
 For detailed documentation, see the [Oracle WebLogic Server Remote Console](https://github.com/oracle/weblogic-remote-console) GitHub project.
 
 A major benefit of using the Remote Console is that you don't need to install or run the WebLogic Server Administration Console on WebLogic Server instances.
-You can use the Remote Console with WebLogic Server slim installers, available on the Oracle Technology Network [(OTN)](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
+You can use the Remote Console with WebLogic Server **slim** installers, available on the Oracle Technology Network [(OTN)](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html)
 or Oracle Software Delivery Cloud [(OSDC)](https://edelivery.oracle.com/osdc/faces/Home.jspx;jsessionid=LchBX6sgzwv5MwSaamMxrIIk-etWJLb0IyCet9mcnqAYnINXvWzi!-1201085350).
 Slim installers reduce the size of WebLogic Server downloads, installations, Docker images, and Kubernetes pods.
 For example, a WebLogic Server 12.2.1.4 slim installer download is approximately 180 MB.
 
+## Use the Remote Console
 
-For the Remote Console to access the Administration Server running in Kubernetes, you can:
+To access WebLogic Server domains running in Kubernetes:
 
-* Use curl to access the REST interface of WebLogic Server Administration Server to verify the connection and that the correct `hostname:port` is being used.
-* Configure Ingress path routing rules.
-* Use the Administration Server `NodePort`.
+1. Install and configure the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
+
+1. For the Remote Console to access the Administration Server running in Kubernetes, you can:
+
+   * Use [curl](#use-curl).
+   * Use the [Administration Server `NodePort`](#use-the-administration-server-nodeport).
+   * Configure [ingress path routing rules](#configure-ingress-path-routing-rules).
+
+
+### Use curl
+
+Access the REST interface of the WebLogic Server Administration Server to verify the connection and that the correct `hostname:port` is being used:
+
+```shell
+$ curl --user username:password http://host:lbport/console/login/LoginForm.jsp
+```
+
+### Use the Administration Server `NodePort`
+
+To connect to the Remote Console, use the Kubernetes WebLogic Server Administration Server’s `NodePort` :
+
+```shell
+$ http://hostname:adminserver-NodePort/
+```
+
+### Configure ingress path routing rules
+
+See the following example `path-routing` YAML file:
+
+```
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+annotations:
+kubernetes.io/ingress.class: traefik
+name: traefik-pathrouting-1
+namespace: weblogic-domain
+spec:
+routes:
+
+    kind: Rule
+    match: PathPrefix(`/domain1`)
+    services:
+    kind: Service
+    name: domain1-cluster-dockercluster
+    namespace: weblogic-domain
+    port: 8001
+    kind: Rule
+    match: PathPrefix(`/console`)
+    services:
+    kind: Service
+    name: domain1-adminserver
+    namespace: weblogic-domain
+    port: 7001
+    kind: Rule
+    match: PathPrefix(`/`)
+    services:
+    kind: Service
+    name: domain1-adminserver
+    namespace: weblogic-domain
+    port: 7001
+```

--- a/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
+++ b/docs-source/content/userguide/managing-domains/accessing-the-domain/admin-console.md
@@ -21,7 +21,7 @@ For example, a WebLogic Server 12.2.1.4 slim installer download is approximately
 
 To access WebLogic Server domains running in Kubernetes:
 
-1. Install and configure the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
+1. Install, configure, and start the Remote Console according to these [instructions](https://github.com/oracle/weblogic-remote-console/blob/master/site/install_config.md).
 
 1. For the Remote Console to access the Administration Server running in Kubernetes, you can:
 
@@ -40,7 +40,7 @@ $ curl --user username:password http://${HOSTNAME}:${LB_PORT}/console/login/Logi
 
 * `${HOSTNAME}` is where you start up the WebLogic domain.
 
-* To determine `${LB_PORT}`:
+* To determine `${LB_PORT}` when using a Traefik load balancer:
 
    `$ export LB_PORT=$(kubectl -n traefik get service traefik-operator -o jsonpath='{.spec.ports[?(@.name=="web")].nodePort}')`
 
@@ -55,7 +55,7 @@ http://hostname:adminserver-NodePort/
 
 ### Configure ingress path routing rules
 
-1. Configure an ingress path routing rule. For example, see the following `path-routing` YAML file.
+1. Configure an ingress path routing rule. For example, see the following `path-routing` YAML file for a Traefik load balancer:
 
    ```yaml
    apiVersion: traefik.containo.us/v1alpha1
@@ -83,7 +83,7 @@ http://hostname:adminserver-NodePort/
          port: 7001
    ```
 
-1. To connect to the Remote Console:
+1. For the Remote Console to connect to the Kubernetes WebLogic Server Administration Server, use the URL:
 
    ```
    http://${HOSTNAME}:${LB_PORT}/


### PR DESCRIPTION
First draft of doc for using the Remote Console with WLS in Kubernetes. 
@maggiehe00 and @mriccell The bulleted items at the end of the doc, should include cross-references to how to configure those items either in this doc or in a sample doc.