### PR TITLE
Exponential back off in retry logic in case of http status code 0 (no response)

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/calls/AsyncRequestStep.java
@@ -430,8 +430,6 @@ public class AsyncRequestStep<T> extends Step implements RetryStrategyListener {
         NextAction na = new NextAction();
         if (!retriesLeft()) {
           return null;
-        } else if (statusCode == 0) {
-          na.invoke(retryStep, packet);
         } else {
           LOGGER.finer(MessageKeys.ASYNC_RETRY, identityHash(), String.valueOf(waitTime),
               requestParams.call, requestParams.namespace, requestParams.name);

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
@@ -159,9 +159,7 @@ public class AsyncRequestStepTest {
   @Test
   public void afterMultipleRetriesAndSuccessfulCallback_nextStepAppliedWithValue() {
     sendMultipleFailedCallbackWithSetTime(0, 2);
-
     testSupport.schedule(() -> callFactory.sendSuccessfulCallback(smallList));
-
     assertThat(nextStep.result, equalTo(smallList));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
@@ -104,7 +104,7 @@ public class AsyncRequestStepTest {
   public void afterTimeout_newRequestSent() {
     callFactory.clearRequest();
 
-    testSupport.setTime(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    testSupport.setTime(TIMEOUT_SECONDS + 1, TimeUnit.SECONDS);
 
     assertTrue(callFactory.invokedWith(requestParams));
   }
@@ -158,22 +158,16 @@ public class AsyncRequestStepTest {
 
   @Test
   public void afterMultipleRetriesAndSuccessfulCallback_nextStepAppliedWithValue() {
-    sendMultipleFailedCallback(0, 2);
-    testSupport.schedule(() -> callFactory.sendSuccessfulCallback(smallList));
-    assertThat(nextStep.result, equalTo(smallList));
-  }
+    sendMultipleFailedCallbackWithSetTime(0, 2);
 
-  @SuppressWarnings("SameParameterValue")
-  private void sendMultipleFailedCallback(int statusCode, int maxRetries) {
-    for (int retryCount = 0; retryCount < maxRetries; retryCount++) {
-      testSupport.schedule(
-          () -> callFactory.sendFailedCallback(new ApiException("test failure"), statusCode));
-    }
+    testSupport.schedule(() -> callFactory.sendSuccessfulCallback(smallList));
+
+    assertThat(nextStep.result, equalTo(smallList));
   }
 
   @Test
   public void afterRetriesExhausted_fiberTerminatesWithException() {
-    sendMultipleFailedCallback(0, 3);
+    sendMultipleFailedCallbackWithSetTime(0, 3);
 
     testSupport.verifyCompletionThrowable(FailureStatusSourceException.class);
   }


### PR DESCRIPTION
AsyncRequestStep change to make sure that API calls are retried after an exponential backoff for status code 0 (timeout or no response).