### PR TITLE
fix domain in image sample to start the initial replica servers

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -213,11 +213,9 @@ function createDomainHome {
     sleep 30
     max=30
     count=0
-    kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
     kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domaincreate.yaml"
     while [ $? -eq 1 -a $count -lt $max ]; do
       sleep 5
-      kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
       count=`expr $count + 1`
       kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domaincreate.yaml"
     done

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
@@ -207,11 +207,9 @@ function updateDomainHome {
   sleep 30
   max=30
   count=0
-  kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
   kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domainupdate.yaml"
   while [ $? -eq 1 -a $count -lt $max ]; do
     sleep 5
-    #kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
     count=`expr $count + 1`
     kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domainupdate.yaml"
   done

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
@@ -10,7 +10,7 @@ topology:
         '@@PROP:clusterName@@':
             DynamicServers:
                 CalculatedListenPorts: false
-                DynamicClusterSize: '@@PROP:initialManagedServerReplicas@@'
+                DynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
                 MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
                 ServerNamePrefix: '@@PROP:managedServerNameBase@@'
                 ServerTemplate: '@@PROP:clusterName@@-template'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -52,6 +52,8 @@ kubernetes:
     # If not specified or the value is either not set or empty (e.g. dataHome: "") then the
     # data storage directories are determined from the WebLogic domain home configuration.
     dataHome: "%DATA_HOME%"
+    
+    replicas: 2
 
     # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
     # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
@@ -90,6 +92,12 @@ kubernetes:
       # Uncomment to export the T3Channel as a service
       %EXPOSE_T3_CHANNEL_PREFIX%     T3Channel:
 
+    # clusters is used to configure the desired behavior for starting member servers of a cluster.
+    # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
+    clusters:
+     '@@PROP:clusterName@@':
+       serverStartState: "RUNNING"
+       replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
     # Istio service mesh support is experimental.
     %ISTIO_PREFIX%configuration:
     %ISTIO_PREFIX%  istio:


### PR DESCRIPTION
When updating the domain-on-pv using wdt sample, DynamicClusterSize was mistakenly set to DynamicClusterSize to initialReplicaCountServers. This caused only 2 servers to be configured. But setting it to ConfiguredManagedServerCount, all the servers were started. The fix is to set DynamicClusterSize to ConfiguredManagedServerCount in the topology section of the model file. Also, set replicas to 2 and added a cluster section with the initial cluster (cluster-1) and its replicas in the kubernetes section. This started the replica count of cluster-1 servers and when a second cluster was added, started 2 server in the second cluster. I also verified scaling up and down both the clusters and they work as expected.