### PR TITLE
ItMiiDynamicUpdate - maintain model changes in the tests

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -57,6 +57,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomR
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteConfigMap;
 import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPod;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
@@ -752,6 +753,20 @@ public class CommonMiiTestUtils {
     logger.info("Verifying introspector pod is created, runs and deleted");
     String introspectJobName = getIntrospectJobName(domainUid);
     checkPodExists(introspectJobName, domainUid, domainNamespace);
+
+    String labelSelector = String.format("weblogic.domainUID in (%s)", domainUid);
+    V1Pod introspectorPod = assertDoesNotThrow(() -> getPod(domainNamespace, labelSelector, introspectJobName),
+        "Could not get introspector pod");
+    assertTrue(introspectorPod != null && introspectorPod.getMetadata() != null,
+        "introspector pod or metadata is null");
+    try {
+      String introspectorLog = getPodLog(introspectorPod.getMetadata().getName(), domainNamespace);
+      logger.info("Introspector pod log START***********************************");
+      logger.info(introspectorLog);
+      logger.info("Introspector pod log END***********************************");
+    } catch (Exception ex) {
+      logger.info("Failed to get introspector pod log", ex);
+    }
     checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -761,9 +761,9 @@ public class CommonMiiTestUtils {
         "introspector pod or metadata is null");
     try {
       String introspectorLog = getPodLog(introspectorPod.getMetadata().getName(), domainNamespace);
-      logger.info("Introspector pod log START***********************************");
+      logger.info("Introspector pod log START");
       logger.info(introspectorLog);
-      logger.info("Introspector pod log END***********************************");
+      logger.info("Introspector pod log END");
     } catch (Exception ex) {
       logger.info("Failed to get introspector pod log", ex);
     }


### PR DESCRIPTION
Couple of tests currently doesn't carry the domain model changes made in the previous tests, that can cause domain restart for some cases, fixing that with these changes.

Jenkins results - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4599/
testMiiRemoveTarget - known failure, Johnny is working on it
