### PR TITLE
fix domain on pv with wdt sample

### DIFF
--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -102,6 +102,12 @@ function parseCommonInputs {
     fail 'The file ${exportValuesFile} could not be found.'
   fi
 
+  # Pass the https_proxy value to the job pod. We might need it to download WDT zip file
+  echo https_proxy = ${https_proxy}
+  proxyStr="https_proxy=${https_proxy}"
+  echo proxyStr=${proxyStr}
+  echo ${proxyStr} >> ${exportValuesFile}
+
   # Define the environment variables that will be used to fill in template values
   echo Input parameters being used
   cat ${exportValuesFile}
@@ -128,6 +134,23 @@ function parseCommonInputs {
   # We exclude javaOptions from the exportValuesFile
   grep -v "javaOptions" ${exportValuesFile} > ${tmpFile}
   source ${tmpFile}
+
+  echo PRINTING ${valuesInputFile}
+  echo ===========================
+  cat ${valuesInputFile}
+  echo
+  echo
+  echo PRINTING ${exportValuesFile}
+  echo ===========================
+  cat ${exportValuesFile}
+  echo
+  echo
+  echo PRINTING ${tmpFile}
+  echo ===========================
+  cat ${tmpFile}
+  echo
+  echo
+  
   rm ${exportValuesFile} ${tmpFile}
 }
 
@@ -448,6 +471,7 @@ function createFiles {
     # we're in the domain in PV case
 
     wdtVersion="${WDT_VERSION:-${wdtVersion}}"
+    httpsProxy="${https_proxy}"
 
     createJobOutput="${domainOutputDir}/create-domain-job.yaml"
     deleteJobOutput="${domainOutputDir}/delete-domain-job.yaml"
@@ -473,6 +497,8 @@ function createFiles {
 
     # Generate the yaml to create the kubernetes job that will create the weblogic domain
     echo Generating ${createJobOutput}
+
+    echo httpsProxy=${httpsProxy}
 
     cp ${createJobInput} ${createJobOutput}
     sed -i -e "s:%NAMESPACE%:$namespace:g" ${createJobOutput}
@@ -515,6 +541,7 @@ function createFiles {
     sed -i -e "s:%ISTIO_ENABLED%:${istioEnabled}:g" ${createJobOutput}
     sed -i -e "s:%ISTIO_READINESS_PORT%:${istioReadinessPort}:g" ${createJobOutput}
     sed -i -e "s:%WDT_VERSION%:${wdtVersion}:g" ${createJobOutput}
+    sed -i -e "s|%PROXY_VAL%|${httpsProxy}|g" ${createJobOutput}
 
     # Generate the yaml to create the kubernetes job that will delete the weblogic domain_home folder
     echo Generating ${deleteJobOutput}

--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -134,22 +134,6 @@ function parseCommonInputs {
   # We exclude javaOptions from the exportValuesFile
   grep -v "javaOptions" ${exportValuesFile} > ${tmpFile}
   source ${tmpFile}
-
-  echo PRINTING ${valuesInputFile}
-  echo ===========================
-  cat ${valuesInputFile}
-  echo
-  echo
-  echo PRINTING ${exportValuesFile}
-  echo ===========================
-  cat ${exportValuesFile}
-  echo
-  echo
-  echo PRINTING ${tmpFile}
-  echo ===========================
-  cat ${tmpFile}
-  echo
-  echo
   
   rm ${exportValuesFile} ${tmpFile}
 }

--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -38,8 +38,6 @@ function checkInputFiles {
        valuesInputFile=${temp[1]}
        valuesInputFile1=${temp[0]}
     fi
-  else
-    echo "Found only 1 input file"
   fi
 }
 
@@ -101,12 +99,6 @@ function parseCommonInputs {
     echo Unable to locate the parsed output of ${valuesInputFile}.
     fail 'The file ${exportValuesFile} could not be found.'
   fi
-
-  # Pass the https_proxy value to the job pod. We might need it to download WDT zip file
-  echo https_proxy = ${https_proxy}
-  proxyStr="https_proxy=${https_proxy}"
-  echo proxyStr=${proxyStr}
-  echo ${proxyStr} >> ${exportValuesFile}
 
   # Define the environment variables that will be used to fill in template values
   echo Input parameters being used
@@ -482,8 +474,6 @@ function createFiles {
     # Generate the yaml to create the kubernetes job that will create the weblogic domain
     echo Generating ${createJobOutput}
 
-    echo httpsProxy=${httpsProxy}
-
     cp ${createJobInput} ${createJobOutput}
     sed -i -e "s:%NAMESPACE%:$namespace:g" ${createJobOutput}
     sed -i -e "s:%WEBLOGIC_CREDENTIALS_SECRET_NAME%:${weblogicCredentialsSecretName}:g" ${createJobOutput}
@@ -544,8 +534,6 @@ function createFiles {
     sed -i -e "s:%DOMAIN_ROOT_DIR%:${domainPVMountPath}:g" ${deleteJobOutput}
   fi
 
-  echo Printing domainHomeSourceType
-  echo domainHomeSourceType is ${domainHomeSourceType}
   if [ "${domainHomeSourceType}" == "FromModel" ]; then
     echo domainHomeSourceType is FromModel
     # leave domainHomeSourceType to FromModel
@@ -556,7 +544,6 @@ function createFiles {
     fi
   elif [ "${domainHomeInImage}" == "true" ]; then
     domainHomeSourceType="Image"
-    echo domainHomeSourceType is Image
     if [ "${logHomeOnPV}" == "true" ]; then
       logHomeOnPVPrefix="${enabledPrefix}"
     else
@@ -564,7 +551,6 @@ function createFiles {
     fi
   else
     domainHomeSourceType="PersistentVolume"
-    echo domainHomeSourceType is PV
     logHomeOnPVPrefix="${enabledPrefix}"
     logHomeOnPV=true
   fi
@@ -572,9 +558,6 @@ function createFiles {
   # Generate the yaml file for creating the domain resource
   # We want to use wdt's extractDomainResource.sh to get the domain resource
   # for domain on pv use case. For others, generate domain resource here
-  echo domainHomeSourceType is ${domainHomeSourceType}
-  echo wdtDomainType is ${wdtDomainType}
-  echo useWdt is ${useWdt}
 
   if [ "${domainHomeSourceType}" != "PersistentVolume" ] || [ "${wdtDomainType}" != "WLS" ] ||
          [ "${useWdt}" != true ]; then

--- a/kubernetes/samples/scripts/common/validate.sh
+++ b/kubernetes/samples/scripts/common/validate.sh
@@ -358,7 +358,6 @@ function validateDomainFilesDir {
   if [ -z "${createDomainFilesDir}" ] || [ "${createDomainFilesDir}" == "wlst" ]; then
     useWdt=false
   fi
-  echo useWdt is ${useWdt}
 }
 
 #

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain-job-template.yaml
@@ -85,6 +85,8 @@ spec:
               value: "%ISTIO_READINESS_PORT%"
             - name: WDT_VERSION
               value: %WDT_VERSION%
+            - name: PROXY_VAL
+              value: "%PROXY_VAL%"
       volumes:
         - name: create-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -213,11 +213,9 @@ function createDomainHome {
     sleep 30
     max=30
     count=0
-    kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
     kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domaincreate.yaml"
     while [ $? -eq 1 -a $count -lt $max ]; do
       sleep 5
-      kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
       count=`expr $count + 1`
       kubectl exec $POD_NAME -c create-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domaincreate.yaml"
     done

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain-job-template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain-job-template.yaml
@@ -86,6 +86,8 @@ spec:
               value: "%ISTIO_READINESS_PORT%"
             - name: WDT_VERSION
               value: %WDT_VERSION%
+            - name: PROXY_VAL
+              value: "%PROXY_VAL%"
       volumes:
         - name: update-weblogic-sample-domain-job-cm-volume
           configMap:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
@@ -207,11 +207,9 @@ function updateDomainHome {
   sleep 30
   max=30
   count=0
-  kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
   kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domainupdate.yaml"
   while [ $? -eq 1 -a $count -lt $max ]; do
     sleep 5
-    #kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt"
     count=`expr $count + 1`
     kubectl exec $POD_NAME -c update-weblogic-sample-domain-job -n ${namespace} -- bash -c "ls -l ${domainPVMountPath}/wdt" | grep "domainupdate.yaml"
   done

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
@@ -81,7 +81,7 @@ WDT_INSTALL_ZIP_URL=${WDT_INSTALL_ZIP_URL:-"https://github.com/oracle/weblogic-d
 
 
 # using "-" instead of ":-" in case proxy vars are explicitly set to "".
-https_proxy=${https_proxy-""}
+https_proxy=${PROXY_VAL-""}
 https_proxy2=${https_proxy2-""}
 
 # Define functions
@@ -100,22 +100,22 @@ function install_wdt {
   cd $WDT_DIR || return 1
 
   local curl_res=1
-  max=20
-  count=0
-  while [ $curl_res -ne 0 -a $count -lt $max ] ; do
-    sleep 10
-    count=`expr $count + 1`
-    for proxy in "${https_proxy}" "${https_proxy2}"; do
-	  echo @@ "Info:  Downloading $WDT_INSTALL_ZIP_URL with https_proxy=\"$proxy\""
-	  https_proxy="${proxy}" \
-	    curl --silent --show-error --connect-timeout 10 -O -L $WDT_INSTALL_ZIP_URL 
-	  curl_res=$?
-	  [ $curl_res -eq 0 ] && break
-	done
+  #max=20
+  #count=0
+  #while [ $curl_res -ne 0 -a $count -lt $max ] ; do
+    #sleep 10
+  #  count=`expr $count + 1`
+  for proxy in "${https_proxy}" "${https_proxy2}"; do
+    echo @@ "Info:  Downloading $WDT_INSTALL_ZIP_URL with https_proxy=\"$proxy\""
+    https_proxy="${proxy}" \
+       curl --silent --show-error --connect-timeout 10 -O -L $WDT_INSTALL_ZIP_URL 
+    curl_res=$?
+    [ $curl_res -eq 0 ] && break
   done
+ # done
   if [ $curl_res -ne 0 ] || [ ! -f $WDT_INSTALL_ZIP_FILE ]; then
     cd $save_dir
-    echo @@ "Error: Download failed or $WDT_INSTALL_ZIP_FILE not found."
+    echo @@ "Error: Download failed or $WDT_INSTALL_ZIP_FILE not found. Check if https_proxy is set in your environment"
     return 1
   fi
 
@@ -280,12 +280,15 @@ fi
 action=$1
 
 echo @@ "Info: action is $action"
+echo @@ "Info: https_proxy is $https_proxy"
 
 if [ "$action" = "create" ]; then
    setup_wdt_shared_dir || exit 1
 fi
 
-install_wdt || exit 1
+if [ "${action}" = "create" ]; then
+   install_wdt || exit 1
+fi
 
 if [ "${action}" = "update" ]; then
    run_wdt "update"|| exit 1

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
@@ -100,19 +100,19 @@ function install_wdt {
   cd $WDT_DIR || return 1
 
   local curl_res=1
-  #max=20
-  #count=0
-  #while [ $curl_res -ne 0 -a $count -lt $max ] ; do
-    #sleep 10
-  #  count=`expr $count + 1`
-  for proxy in "${https_proxy}" "${https_proxy2}"; do
-    echo @@ "Info:  Downloading $WDT_INSTALL_ZIP_URL with https_proxy=\"$proxy\""
-    https_proxy="${proxy}" \
-       curl --silent --show-error --connect-timeout 10 -O -L $WDT_INSTALL_ZIP_URL 
-    curl_res=$?
-    [ $curl_res -eq 0 ] && break
+  max=20
+  count=0
+  while [ $curl_res -ne 0 -a $count -lt $max ] ; do
+    sleep 10
+    count=`expr $count + 1`
+    for proxy in "${https_proxy}" "${https_proxy2}"; do
+      echo @@ "Info:  Downloading $WDT_INSTALL_ZIP_URL with https_proxy=\"$proxy\""
+      https_proxy="${proxy}" \
+         curl --silent --show-error --connect-timeout 10 -O -L $WDT_INSTALL_ZIP_URL 
+      curl_res=$?
+      [ $curl_res -eq 0 ] && break
+    done
   done
- # done
   if [ $curl_res -ne 0 ] || [ ! -f $WDT_INSTALL_ZIP_FILE ]; then
     cd $save_dir
     echo @@ "Error: Download failed or $WDT_INSTALL_ZIP_FILE not found. Check if https_proxy is set in your environment"

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
@@ -10,10 +10,17 @@ topology:
         '@@PROP:clusterName@@':
             DynamicServers:
                 CalculatedListenPorts: false
-                DynamicClusterSize: '@@PROP:initialManagedServerReplicas@@'
+                DynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
                 MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
                 ServerNamePrefix: '@@PROP:managedServerNameBase@@'
                 ServerTemplate: '@@PROP:clusterName@@-template'
+        '@@PROP:clusterName2@@':
+            DynamicServers:
+                CalculatedListenPorts: false
+                DynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
+                MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
+                ServerNamePrefix: '@@PROP:managedServerNameBaseC2@@'
+                ServerTemplate: '@@PROP:clusterName2@@-template'
     Server:
         '@@PROP:adminServerName@@':
             NetworkAccessPoint:
@@ -27,3 +34,8 @@ topology:
             ListenPort: '@@PROP:managedServerPort@@'
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'
+        '@@PROP:clusterName2@@-template':
+            Cluster: '@@PROP:clusterName2@@'
+            ListenPort: '@@PROP:managedServerPort@@'
+            JTAMigratableTarget:
+                Cluster: '@@PROP:clusterName2@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/wdt_model_dynamic.yaml
@@ -14,13 +14,6 @@ topology:
                 MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
                 ServerNamePrefix: '@@PROP:managedServerNameBase@@'
                 ServerTemplate: '@@PROP:clusterName@@-template'
-        '@@PROP:clusterName2@@':
-            DynamicServers:
-                CalculatedListenPorts: false
-                DynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
-                MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
-                ServerNamePrefix: '@@PROP:managedServerNameBaseC2@@'
-                ServerTemplate: '@@PROP:clusterName2@@-template'
     Server:
         '@@PROP:adminServerName@@':
             NetworkAccessPoint:
@@ -34,8 +27,3 @@ topology:
             ListenPort: '@@PROP:managedServerPort@@'
             JTAMigratableTarget:
                 Cluster: '@@PROP:clusterName@@'
-        '@@PROP:clusterName2@@-template':
-            Cluster: '@@PROP:clusterName2@@'
-            ListenPort: '@@PROP:managedServerPort@@'
-            JTAMigratableTarget:
-                Cluster: '@@PROP:clusterName2@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -53,6 +53,7 @@ kubernetes:
     # data storage directories are determined from the WebLogic domain home configuration.
     dataHome: "%DATA_HOME%"
 
+    replicas: 2
     # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
     # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
     # - "NEVER" will not start any server in the domain
@@ -89,6 +90,13 @@ kubernetes:
       %EXPOSE_ADMIN_PORT_PREFIX%       nodePort: %ADMIN_NODE_PORT%
       # Uncomment to export the T3Channel as a service
       %EXPOSE_T3_CHANNEL_PREFIX%     T3Channel:
+
+    # clusters is used to configure the desired behavior for starting member servers of a cluster.
+    # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
+    clusters:
+     '@@PROP:clusterName@@':
+       serverStartState: "RUNNING"
+       replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
 
     # Istio service mesh support is experimental.
     %ISTIO_PREFIX%configuration:


### PR DESCRIPTION
When updating the domain-on-pv using wdt sample, DynamicClusterSize was mistakenly set to DynamicClusterSize to initialReplicaCountServers. This caused only 2 servers to be configured. But setting it to ConfiguredManagedServerCount, all the servers were started. The fix is to set DynamicClusterSize to ConfiguredManagedServerCount in the topology section of the model file. Also, set replicas to 2 and added a cluster section with the initial cluster (cluster-1) and its replicas in the kubernetes section. This started the replica count of cluster-1 servers and when a second cluster was added, started 2 server in the second cluster. I also verified scaling up and down both the clusters and they work as expected.
Also fixed the issue - weblogic-deploy.zip fails to download because the proxy is not set int he job pod that creates the domain