### PR TITLE
Fix testMiiRemoveTarget by not setting datahome on domain resource

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCustomSslStore.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCustomSslStore.java
@@ -144,7 +144,8 @@ class ItMiiCustomSslStore {
     createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
         adminSecretName, OCIR_SECRET_NAME, encryptionSecretName,
-        replicaCount, pvName, pvcName, "cluster-1", configMapName, null, false, false);
+        replicaCount, pvName, pvcName, "cluster-1", configMapName,
+        null, false, false, false);
 
     // wait for the domain to exist
     logger.info("Check for domain custom resource in namespace {0}", domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -204,7 +204,7 @@ class ItMiiDynamicUpdate {
 
     // create the domain CR with a pre-defined configmap
     // setting setDataHome to false, testMiiRemoveTarget fails when data home is set at domain resource level
-    // because of bug https://jira.oraclecorp.com/jira/browse/OWLS-88679
+    // because of bug OWLS-88679
     // testMiiRemoveTarget should work fine after the bug is fixed with setDataHome set to true
     createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
@@ -461,7 +461,7 @@ class ItMiiDynamicUpdate {
     }
 
     // Replace contents of an existing configMap with cm config and application target as
-    // there are issues with removing them, https://jira.oraclecorp.com/jira/browse/WDT-535
+    // there are issues with removing them, WDT-535
     replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.config.wm.yaml",
             pathToAddClusterYaml.toString()), withStandardRetryPolicy);
@@ -523,7 +523,7 @@ class ItMiiDynamicUpdate {
     LinkedHashMap<String, OffsetDateTime> pods = addDataSourceAndVerify(false);
 
     // Replace contents of an existing configMap with cm config and application target as
-    // there are issues with removing them, https://jira.oraclecorp.com/jira/browse/WDT-535
+    // there are issues with removing them, WDT-535
     replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.config.wm.yaml", pathToAddClusterYaml.toString(),
             MODEL_DIR + "/model.update.jdbc2.yaml"), withStandardRetryPolicy);
@@ -614,7 +614,7 @@ class ItMiiDynamicUpdate {
     assertDoesNotThrow(() -> Files.write(pathToUndeployAppYaml, yamlToUndeployApp.getBytes()));
 
     // Replace contents of an existing configMap with cm config and application target as
-    // there are issues with removing them, https://jira.oraclecorp.com/jira/browse/WDT-535
+    // there are issues with removing them, WDT-535
     replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.config.wm.yaml", pathToAddClusterYaml.toString(),
             MODEL_DIR + "/model.jdbc2.update2.yaml", pathToUndeployAppYaml.toString()), withStandardRetryPolicy);
@@ -1503,7 +1503,7 @@ class ItMiiDynamicUpdate {
     }
 
     // Replace contents of an existing configMap with cm config and application target as
-    // there are issues with removing them, https://jira.oraclecorp.com/jira/browse/WDT-535
+    // there are issues with removing them, WDT-535
     replaceConfigMapWithModelFiles(configMapName, domainUid, domainNamespace,
         Arrays.asList(MODEL_DIR + "/model.config.wm.yaml", pathToAddClusterYaml.toString(),
             MODEL_DIR + "/model.jdbc2.yaml"), withStandardRetryPolicy);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -203,9 +203,9 @@ class ItMiiDynamicUpdate {
     createJobToChangePermissionsOnPvHostPath(pvName, pvcName, domainNamespace);
 
     // create the domain CR with a pre-defined configmap
-    // setting usePvForDataHome to false, testMiiRemoveTarget fails when data home is set at domain resource level
+    // setting setDataHome to false, testMiiRemoveTarget fails when data home is set at domain resource level
     // because of bug https://jira.oraclecorp.com/jira/browse/OWLS-88679
-    // testMiiRemoveTarget should work fine after the bug is fixed with usePvForDataHome set to true
+    // testMiiRemoveTarget should work fine after the bug is fixed with setDataHome set to true
     createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
         adminSecretName, OCIR_SECRET_NAME, encryptionSecretName,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -206,7 +206,8 @@ class ItMiiDynamicUpdate {
     createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
         adminSecretName, OCIR_SECRET_NAME, encryptionSecretName,
-        replicaCount, pvName, pvcName, "cluster-1", configMapName, dbSecretName, false, true);
+        replicaCount, pvName, pvcName, "cluster-1", configMapName,
+        dbSecretName, false, true, false);
 
     // wait for the domain to exist
     logger.info("Check for domain custom resource in namespace {0}", domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -203,6 +203,9 @@ class ItMiiDynamicUpdate {
     createJobToChangePermissionsOnPvHostPath(pvName, pvcName, domainNamespace);
 
     // create the domain CR with a pre-defined configmap
+    // setting usePvForDataHome to false, testMiiRemoveTarget fails when data home is set at domain resource level
+    // because of bug https://jira.oraclecorp.com/jira/browse/OWLS-88679
+    // testMiiRemoveTarget should work fine after the bug is fixed with usePvForDataHome set to true
     createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
         adminSecretName, OCIR_SECRET_NAME, encryptionSecretName,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiJmsRecovery.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiJmsRecovery.java
@@ -186,7 +186,8 @@ class ItMiiJmsRecovery {
     createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
         adminSecretName, OCIR_SECRET_NAME, encryptionSecretName,
-        replicaCount, pvName, pvcName, "cluster-1", configMapName, dbSecretName, false, false);
+        replicaCount, pvName, pvcName, "cluster-1", configMapName,
+        dbSecretName, false, false, true);
 
     // wait for the domain to exist
     logger.info("Check for domain custom resource in namespace {0}", domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -57,6 +57,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomR
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteConfigMap;
 import static oracle.weblogic.kubernetes.actions.TestActions.getJob;
+import static oracle.weblogic.kubernetes.actions.TestActions.getPod;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.listPods;
@@ -752,6 +753,20 @@ public class CommonMiiTestUtils {
     logger.info("Verifying introspector pod is created, runs and deleted");
     String introspectJobName = getIntrospectJobName(domainUid);
     checkPodExists(introspectJobName, domainUid, domainNamespace);
+
+    String labelSelector = String.format("weblogic.domainUID in (%s)", domainUid);
+    V1Pod introspectorPod = assertDoesNotThrow(() -> getPod(domainNamespace, labelSelector, introspectJobName),
+        "Could not get introspector pod");
+    assertTrue(introspectorPod != null && introspectorPod.getMetadata() != null,
+        "introspector pod or metadata is null");
+    try {
+      String introspectorLog = getPodLog(introspectorPod.getMetadata().getName(), domainNamespace);
+      logger.info("Introspector pod log START***********************************");
+      logger.info(introspectorLog);
+      logger.info("Introspector pod log END***********************************");
+    } catch (Exception ex) {
+      logger.info("Failed to get introspector pod log", ex);
+    }
     checkPodDoesNotExist(introspectJobName, domainUid, domainNamespace);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -259,6 +259,7 @@ public class CommonMiiTestUtils {
    * @param dbSecretName name of the Secret for WebLogic configuration overrides
    * @param allowReplicasBelowMinDynClusterSize whether to allow scaling below min dynamic cluster size
    * @param onlineUpdateEnabled whether to enable onlineUpdate feature for mii dynamic update
+   * @param usePvForDataHome whether to use PV for data home
    * @return domain object of the domain resource
    */
   public static Domain createDomainResourceWithLogHome(
@@ -275,7 +276,8 @@ public class CommonMiiTestUtils {
       String configMapName,
       String dbSecretName,
       boolean allowReplicasBelowMinDynClusterSize,
-      boolean onlineUpdateEnabled) {
+      boolean onlineUpdateEnabled,
+      boolean usePvForDataHome) {
     LoggingFacade logger = getLogger();
 
     List<String> securityList = new ArrayList<>();
@@ -283,6 +285,57 @@ public class CommonMiiTestUtils {
       securityList.add(dbSecretName);
     }
 
+    DomainSpec domainSpec = new DomainSpec()
+        .domainUid(domainResourceName)
+        .domainHomeSourceType("FromModel")
+        .allowReplicasBelowMinDynClusterSize(allowReplicasBelowMinDynClusterSize)
+        .image(imageName)
+        .addImagePullSecretsItem(new V1LocalObjectReference()
+            .name(repoSecretName))
+        .webLogicCredentialsSecret(new V1SecretReference()
+            .name(adminSecretName)
+            .namespace(domNamespace))
+        .includeServerOutInPodLog(true)
+        .logHomeEnabled(Boolean.TRUE)
+        .logHome("/shared/logs")
+        .serverStartPolicy("IF_NEEDED")
+        .serverPod(new ServerPod()
+            .addEnvItem(new V1EnvVar()
+                .name("JAVA_OPTIONS")
+                .value("-Dweblogic.security.SSL.ignoreHostnameVerification=true"))
+            .addEnvItem(new V1EnvVar()
+                .name("USER_MEM_ARGS")
+                .value("-Djava.security.egd=file:/dev/./urandom "))
+            .addVolumesItem(new V1Volume()
+                .name(pvName)
+                .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
+                    .claimName(pvcName)))
+            .addVolumeMountsItem(new V1VolumeMount()
+                .mountPath("/shared")
+                .name(pvName)))
+        .adminServer(new AdminServer()
+            .serverStartState("RUNNING")
+            .adminService(new AdminService()
+                .addChannelsItem(new Channel()
+                    .channelName("default")
+                    .nodePort(0))))
+        .addClustersItem(new Cluster()
+            .clusterName(clusterName)
+            .replicas(replicaCount)
+            .serverStartState("RUNNING"))
+        .configuration(new Configuration()
+            .secrets(securityList)
+            .model(new Model()
+                .domainType("WLS")
+                .configMap(configMapName)
+                .runtimeEncryptionSecret(encryptionSecretName)
+                .onlineUpdate(new OnlineUpdate()
+                    .enabled(onlineUpdateEnabled)))
+            .introspectorJobActiveDeadlineSeconds(300L));
+
+    if (usePvForDataHome) {
+      domainSpec.dataHome("/shared/data");
+    }
     // create the domain CR
     Domain domain = new Domain()
         .apiVersion(DOMAIN_API_VERSION)
@@ -290,54 +343,7 @@ public class CommonMiiTestUtils {
         .metadata(new V1ObjectMeta()
             .name(domainResourceName)
             .namespace(domNamespace))
-        .spec(new DomainSpec()
-            .domainUid(domainResourceName)
-            .domainHomeSourceType("FromModel")
-            .allowReplicasBelowMinDynClusterSize(allowReplicasBelowMinDynClusterSize)
-            .image(imageName)
-            .addImagePullSecretsItem(new V1LocalObjectReference()
-                .name(repoSecretName))
-            .webLogicCredentialsSecret(new V1SecretReference()
-                .name(adminSecretName)
-                .namespace(domNamespace))
-            .includeServerOutInPodLog(true)
-            .logHomeEnabled(Boolean.TRUE)
-            .logHome("/shared/logs")
-            .dataHome("/shared/data")
-            .serverStartPolicy("IF_NEEDED")
-            .serverPod(new ServerPod()
-                .addEnvItem(new V1EnvVar()
-                    .name("JAVA_OPTIONS")
-                    .value("-Dweblogic.security.SSL.ignoreHostnameVerification=true"))
-                .addEnvItem(new V1EnvVar()
-                    .name("USER_MEM_ARGS")
-                    .value("-Djava.security.egd=file:/dev/./urandom "))
-                .addVolumesItem(new V1Volume()
-                    .name(pvName)
-                    .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
-                        .claimName(pvcName)))
-                .addVolumeMountsItem(new V1VolumeMount()
-                    .mountPath("/shared")
-                    .name(pvName)))
-            .adminServer(new AdminServer()
-                .serverStartState("RUNNING")
-                .adminService(new AdminService()
-                    .addChannelsItem(new Channel()
-                        .channelName("default")
-                        .nodePort(0))))
-            .addClustersItem(new Cluster()
-                .clusterName(clusterName)
-                .replicas(replicaCount)
-                .serverStartState("RUNNING"))
-            .configuration(new Configuration()
-                .secrets(securityList)
-                .model(new Model()
-                    .domainType("WLS")
-                    .configMap(configMapName)
-                    .runtimeEncryptionSecret(encryptionSecretName)
-                    .onlineUpdate(new OnlineUpdate()
-                        .enabled(onlineUpdateEnabled)))
-                .introspectorJobActiveDeadlineSeconds(300L)));
+        .spec(domainSpec);
 
     logger.info("Create domain custom resource for domainUid {0} in namespace {1}",
         domainResourceName, domNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -259,7 +259,7 @@ public class CommonMiiTestUtils {
    * @param dbSecretName name of the Secret for WebLogic configuration overrides
    * @param allowReplicasBelowMinDynClusterSize whether to allow scaling below min dynamic cluster size
    * @param onlineUpdateEnabled whether to enable onlineUpdate feature for mii dynamic update
-   * @param usePvForDataHome whether to use PV for data home
+   * @param setDataHome whether to set data home at domain resource
    * @return domain object of the domain resource
    */
   public static Domain createDomainResourceWithLogHome(
@@ -277,7 +277,7 @@ public class CommonMiiTestUtils {
       String dbSecretName,
       boolean allowReplicasBelowMinDynClusterSize,
       boolean onlineUpdateEnabled,
-      boolean usePvForDataHome) {
+      boolean setDataHome) {
     LoggingFacade logger = getLogger();
 
     List<String> securityList = new ArrayList<>();
@@ -333,7 +333,7 @@ public class CommonMiiTestUtils {
                     .enabled(onlineUpdateEnabled)))
             .introspectorJobActiveDeadlineSeconds(300L));
 
-    if (usePvForDataHome) {
+    if (setDataHome) {
       domainSpec.dataHome("/shared/data");
     }
     // create the domain CR

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -761,9 +761,9 @@ public class CommonMiiTestUtils {
         "introspector pod or metadata is null");
     try {
       String introspectorLog = getPodLog(introspectorPod.getMetadata().getName(), domainNamespace);
-      logger.info("Introspector pod log START***********************************");
+      logger.info("Introspector pod log START");
       logger.info(introspectorLog);
-      logger.info("Introspector pod log END***********************************");
+      logger.info("Introspector pod log END");
     } catch (Exception ex) {
       logger.info("Failed to get introspector pod log", ex);
     }


### PR DESCRIPTION
testMiiRemoveTarget fails when data home is set at domain resource level because of bug 
https://jira.oraclecorp.com/jira/browse/OWLS-88679

Jenkins results - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4615/
