### PR TITLE
Remove the exitcode check and add retry

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -277,7 +277,7 @@ class ItMiiUpdateDomainConfig {
       logger.info("Command to send HTTP request and get HTTP response {0} ", curlCmd);
       ExecResult execResult = assertDoesNotThrow(() -> execCommand(domainNamespace, pod, null, true,
           "/bin/sh", "-c", curlCmd));
-      assertFalse(execResult.exitValue() != 0 && execResult.stderr() != null && !execResult.stderr().isEmpty(),
+      assertTrue(execResult.exitValue() == 0 || execResult.stderr() == null || execResult.stderr().isEmpty(),
           String.format("Command %s failed with exit value %s, stderr %s, stdout %s",
               curlCmd, execResult.exitValue(), execResult.stderr(), execResult.stdout()));
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -270,7 +270,6 @@ class ItMiiUpdateDomainConfig {
   @Order(2)
   @DisplayName("Check the HTTP server logs are written to PersistentVolume")
   public void testMiiHttpServerLogsAreOnPV() {
-    final int MAX_RETRIES = 10;
     String[] podNames = {managedServerPrefix + "1", managedServerPrefix + "2"};
     for (String pod : podNames) {
       String curlCmd = "for i in {1..100}; "
@@ -286,7 +285,7 @@ class ItMiiUpdateDomainConfig {
           .until((Callable<Boolean>) () -> {
             ExecResult execResult = assertDoesNotThrow(() -> execCommand(domainNamespace, pod, null, true,
                 "/bin/sh", "-c", curlCmd));
-            return execResult.exitValue() == 0;
+            return execResult.exitValue() == 0 && execResult.toString().contains("HTTP/1.1 200 OK");
           });
     }
     String[] servers = {"managed-server1", "managed-server2"};

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -108,7 +108,6 @@ import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.FileUtils.copyFileToPod;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -278,14 +277,9 @@ class ItMiiUpdateDomainConfig {
       logger.info("Command to send HTTP request and get HTTP response {0} ", curlCmd);
       ExecResult execResult = assertDoesNotThrow(() -> execCommand(domainNamespace, pod, null, true,
           "/bin/sh", "-c", curlCmd));
-      if (execResult.exitValue() == 0) {
-        logger.info("\n HTTP response is \n " + execResult.toString());
-        assertAll("Check that the HTTP response is 200",
-            () -> assertTrue(execResult.toString().contains("HTTP/1.1 200 OK"))
-        );
-      } else {
-        fail("Failed to access sample application " + execResult.stderr());
-      }
+      assertFalse(execResult.exitValue() != 0 && execResult.stderr() != null && !execResult.stderr().isEmpty(),
+          String.format("Command %s failed with exit value %s, stderr %s, stdout %s",
+              curlCmd, execResult.exitValue(), execResult.stderr(), execResult.stdout()));
     }
     String[] servers = {"managed-server1", "managed-server2"};
     for (String server : servers) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -278,14 +278,14 @@ class ItMiiUpdateDomainConfig {
           + "done";
       withStandardRetryPolicy
           .conditionEvaluationListener(
-              condition -> logger.info("Sending HTTP requests to populate http access log "
+              condition -> logger.info("Sending HTTP requests to populate the http access log "
                   + "(elapsed time {0} ms, remaining time {1} ms)",
                   condition.getElapsedTimeInMS(),
                   condition.getRemainingTimeInMS()))
           .until((Callable<Boolean>) () -> {
             ExecResult execResult = assertDoesNotThrow(() -> execCommand(domainNamespace, pod, null, true,
                 "/bin/sh", "-c", curlCmd));
-            return execResult.exitValue() == 0 && execResult.toString().contains("HTTP/1.1 200 OK");
+            return execResult.toString().contains("HTTP/1.1 200 OK");
           });
     }
     String[] servers = {"managed-server1", "managed-server2"};


### PR DESCRIPTION
Remove the exit code status check for the curl command. A for loop is used to recursively send http requests to the weblogic servers to populate the http access logs. Retry until the HTTP response code is 200.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4699/