### PR TITLE
Owls88781 continue retry start a namespace in non-fullcheck case after hitting 403

### DIFF
--- a/documentation/staging/content/userguide/managing-domains/domain-events.md
+++ b/documentation/staging/content/userguide/managing-domains/domain-events.md
@@ -38,6 +38,7 @@ The operator also generates these event types in the operator's namespace, which
 
 *  `StartManagingNamespace`: The operator has started managing domains in a namespace.
 *  `StopManagingNamespace`: The operator has stopped managing domains in a namespace. 
+*  `StartManagingNamespaceFailed`: The operator failed to start managing domains in a namespace because it does not have the required privileges.
 
 #### Operator-generated event details
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainNamespaces.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainNamespaces.java
@@ -183,6 +183,10 @@ public class DomainNamespaces {
     return getNamespaceStatus(ns).shouldStartNamespace();
   }
 
+  public void clearIsNamespaceStartingFlag(String ns) {
+    getNamespaceStatus(ns).clearIsNamespaceStartingFlag();
+  }
+
   interface WatcherFactory<T, W extends Watcher<T>> {
     W create(
           ThreadFactory threadFactory,

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainNamespaces.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainNamespaces.java
@@ -179,12 +179,12 @@ public class DomainNamespaces {
     return Step.chain(ConfigMapHelper.createScriptConfigMapStep(ns), resources.createListSteps());
   }
 
-  boolean shouldStartNamespace(String ns) {
+  public boolean shouldStartNamespace(String ns) {
     return getNamespaceStatus(ns).shouldStartNamespace();
   }
 
-  public void clearIsNamespaceStartingFlag(String ns) {
-    getNamespaceStatus(ns).clearIsNamespaceStartingFlag();
+  public void clearNamespaceStartingFlag(String ns) {
+    getNamespaceStatus(ns).clearNamespaceStartingFlag();
   }
 
   interface WatcherFactory<T, W extends Watcher<T>> {

--- a/operator/src/main/java/oracle/kubernetes/operator/EventConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/EventConstants.java
@@ -45,4 +45,6 @@ public interface EventConstants {
   String START_MANAGING_NAMESPACE_PATTERN = "Start managing namespace %s";
   String STOP_MANAGING_NAMESPACE_EVENT = "StopManagingNamespace";
   String STOP_MANAGING_NAMESPACE_PATTERN = "Stop managing namespace %s";
+  String START_MANAGING_NAMESPACE_FAILED_EVENT = "StartManagingNamespaceFailed";
+  String START_MANAGING_NAMESPACE_FAILED_PATTERN = "Start managing namespace %s failed due to an authorization error";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/NamespaceStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/NamespaceStatus.java
@@ -34,7 +34,7 @@ public class NamespaceStatus {
     return !isNamespaceStarting.getAndSet(true);
   }
 
-  public void clearIsNamespaceStartingFlag() {
+  public void clearNamespaceStartingFlag() {
     isNamespaceStarting.set(false);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/NamespaceStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/NamespaceStatus.java
@@ -33,4 +33,8 @@ public class NamespaceStatus {
   boolean shouldStartNamespace() {
     return !isNamespaceStarting.getAndSet(true);
   }
+
+  public void clearIsNamespaceStartingFlag() {
+    isNamespaceStarting.set(false);
+  }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -202,20 +202,27 @@ public class EventHelper {
         }
 
         if (NAMESPACE_WATCHING_STARTED == eventData.eventItem) {
-          if (domainNamespaces != null) {
-            domainNamespaces.clearNamespaceStartingFlag(eventData.getNamespace());
-          }
+          clearNamespaceStartingFlag();
           if (isForbidden(callResponse)) {
             LOGGER.warning(MessageKeys.CREATING_EVENT_FORBIDDEN,
                 eventData.eventItem.getReason(), eventData.getNamespace());
-            return doNext(createEventStep(
-                new EventData(EventItem.START_MANAGING_NAMESPACE_FAILED)
-                    .namespace(getOperatorNamespace()).resourceName(eventData.getNamespace())), packet);
+            return doNext(createStartManagingNSFailedEventStep(), packet);
           }
-          return super.onFailure(packet, callResponse);
         }
 
         return super.onFailure(packet, callResponse);
+      }
+
+      private Step createStartManagingNSFailedEventStep() {
+        return createEventStep(
+            new EventData(EventItem.START_MANAGING_NAMESPACE_FAILED)
+                .namespace(getOperatorNamespace()).resourceName(eventData.getNamespace()));
+      }
+
+      private void clearNamespaceStartingFlag() {
+        if (domainNamespaces != null) {
+          domainNamespaces.clearNamespaceStartingFlag(eventData.getNamespace());
+        }
       }
 
       private boolean isForbiddenForNamespaceWatchingStoppedEvent(CallResponse<CoreV1Event> callResponse) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -11,6 +11,7 @@ import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import jakarta.validation.constraints.NotNull;
+import oracle.kubernetes.operator.DomainNamespaces;
 import oracle.kubernetes.operator.DomainProcessorImpl;
 import oracle.kubernetes.operator.EventConstants;
 import oracle.kubernetes.operator.KubernetesConstants;
@@ -52,10 +53,12 @@ import static oracle.kubernetes.operator.EventConstants.WEBLOGIC_OPERATOR_COMPON
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_PROCESSING_ABORTED;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_PROCESSING_COMPLETED;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_PROCESSING_STARTING;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.NAMESPACE_WATCHING_STARTED;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.NAMESPACE_WATCHING_STOPPED;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorPodName;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorPodUID;
+import static oracle.kubernetes.operator.logging.MessageKeys.BEGIN_MANAGING_NAMESPACE;
 
 /** A Helper Class for the operator to create Kubernetes Events at the key points in the operator's workflow. */
 public class EventHelper {
@@ -84,24 +87,38 @@ public class EventHelper {
   /**
    * Factory for {@link Step} that asynchronously create an event.
    *
+   * @param domainNamespaces DomainSpaces instance
+   * @param eventData event item
+   * @param next next step
+   * @return Step for creating an event
+   */
+  public static Step createEventStep(DomainNamespaces domainNamespaces, EventData eventData, Step next) {
+    return new CreateEventStep(domainNamespaces, eventData, next);
+  }
+
+  /**
+   * Factory for {@link Step} that asynchronously create an event.
+   *
    * @param eventData event item
    * @param next next step
    * @return Step for creating an event
    */
   public static Step createEventStep(EventData eventData, Step next) {
-    return new CreateEventStep(eventData, next);
+    return new CreateEventStep(null, eventData, next);
   }
 
   public static class CreateEventStep extends Step {
     private final EventData eventData;
+    private final DomainNamespaces domainNamespaces;
 
     CreateEventStep(EventData eventData) {
-      this(eventData, null);
+      this(null, eventData, null);
     }
 
-    CreateEventStep(EventData eventData, Step next) {
+    CreateEventStep(DomainNamespaces domainNamespaces, EventData eventData, Step next) {
       super(next);
       this.eventData = eventData;
+      this.domainNamespaces = domainNamespaces;
     }
 
     @Override
@@ -166,6 +183,9 @@ public class EventHelper {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<CoreV1Event> callResponse) {
+        if (NAMESPACE_WATCHING_STARTED == eventData.eventItem) {
+          LOGGER.info(BEGIN_MANAGING_NAMESPACE, eventData.getNamespace());
+        }
         Optional.ofNullable(packet.getSpi(DomainPresenceInfo.class))
             .ifPresent(dpi -> dpi.setLastEventItem(eventData.eventItem));
         return doNext(packet);
@@ -178,11 +198,23 @@ public class EventHelper {
               eventData.eventItem.getReason(), eventData.getNamespace());
           return doNext(packet);
         }
+
+        if (domainNamespaces != null && isForbiddenForNamespaceWatchingStartedEvent(callResponse)) {
+          LOGGER.info(MessageKeys.CREATING_EVENT_FORBIDDEN,
+              eventData.eventItem.getReason(), eventData.getNamespace());
+          domainNamespaces.clearIsNamespaceStartingFlag(eventData.getNamespace());
+          return super.onFailure(packet, callResponse);
+        }
+
         return super.onFailure(packet, callResponse);
       }
 
       private boolean isForbiddenForNamespaceWatchingStoppedEvent(CallResponse<CoreV1Event> callResponse) {
         return isForbidden(callResponse) && NAMESPACE_WATCHING_STOPPED == eventData.eventItem;
+      }
+
+      private boolean isForbiddenForNamespaceWatchingStartedEvent(CallResponse<CoreV1Event> callResponse) {
+        return isForbidden(callResponse) && NAMESPACE_WATCHING_STARTED == eventData.eventItem;
       }
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -223,7 +223,7 @@ public class NamespaceTest {
     defineNamespaces(namespace);
     specifyDomainNamespaces(namespace);
 
-    loggerControl.withLogLevel(Level.INFO).collectLogMessages(logRecords, CREATING_EVENT_FORBIDDEN);
+    loggerControl.collectLogMessages(logRecords, CREATING_EVENT_FORBIDDEN);
     testSupport.failOnCreate(KubernetesTestSupport.EVENT, null, namespace, HTTP_FORBIDDEN);
     testSupport.runSteps(new DomainRecheck(delegate).createStartNamespaceBeforeStep(namespace));
     testSupport.cancelFailures();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -53,7 +53,9 @@ import static oracle.kubernetes.operator.EventConstants.DOMAIN_PROCESSING_FAILED
 import static oracle.kubernetes.operator.EventConstants.DOMAIN_PROCESSING_RETRYING_PATTERN;
 import static oracle.kubernetes.operator.EventConstants.DOMAIN_PROCESSING_STARTING_EVENT;
 import static oracle.kubernetes.operator.EventConstants.DOMAIN_PROCESSING_STARTING_PATTERN;
+import static oracle.kubernetes.operator.EventConstants.NAMESPACE_WATCHING_STARTED_EVENT;
 import static oracle.kubernetes.operator.EventConstants.NAMESPACE_WATCHING_STOPPED_EVENT;
+import static oracle.kubernetes.operator.EventConstants.START_MANAGING_NAMESPACE_FAILED_EVENT;
 import static oracle.kubernetes.operator.EventConstants.STOP_MANAGING_NAMESPACE_EVENT;
 import static oracle.kubernetes.operator.EventTestUtils.containsEvent;
 import static oracle.kubernetes.operator.EventTestUtils.containsEventWithComponent;
@@ -85,6 +87,7 @@ import static oracle.kubernetes.operator.helpers.EventHelper.createEventStep;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.EVENT;
 import static oracle.kubernetes.operator.logging.MessageKeys.CREATING_EVENT_FORBIDDEN;
 import static oracle.kubernetes.utils.LogMatcher.containsInfo;
+import static oracle.kubernetes.utils.LogMatcher.containsWarning;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -521,7 +524,7 @@ public class EventHelperTest {
     testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
     assertThat("Found NAMESPACE_WATCHING_STARTED event with expected namespace",
         containsEventWithNamespace(getEvents(testSupport),
-            EventConstants.NAMESPACE_WATCHING_STARTED_EVENT, NS), is(true));
+            NAMESPACE_WATCHING_STARTED_EVENT, NS), is(true));
   }
 
   @Test
@@ -532,7 +535,7 @@ public class EventHelperTest {
     expectedLabels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
     assertThat("Found NAMESPACE_WATCHING_STARTED event with expected labels",
         containsEventWithLabels(getEvents(testSupport),
-            EventConstants.NAMESPACE_WATCHING_STARTED_EVENT, expectedLabels), is(true));
+            NAMESPACE_WATCHING_STARTED_EVENT, expectedLabels), is(true));
   }
 
   @Test
@@ -543,7 +546,7 @@ public class EventHelperTest {
 
     assertThat("Found 1 NAMESPACE_WATCHING_STARTED event with expected count",
         containsOneEventWithCount(getEvents(testSupport),
-            EventConstants.NAMESPACE_WATCHING_STARTED_EVENT, 2), is(true));
+            NAMESPACE_WATCHING_STARTED_EVENT, 2), is(true));
   }
 
   @Test
@@ -555,7 +558,67 @@ public class EventHelperTest {
 
     assertThat("Found 2 NAMESPACE_WATCHING_STARTED events",
         containsEventsWithCountOne(getEvents(testSupport),
-            EventConstants.NAMESPACE_WATCHING_STARTED_EVENT, 2), is(true));
+            NAMESPACE_WATCHING_STARTED_EVENT, 2), is(true));
+  }
+
+  @Test
+  public void whenNSWatchStartedEventCreated_fail403OnCreate_foundExpectedLogMessage() {
+    loggerControl.collectLogMessages(logRecords, CREATING_EVENT_FORBIDDEN);
+    testSupport.failOnCreate(EVENT, null, NS, HTTP_FORBIDDEN);
+
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
+
+    assertThat(logRecords,
+        containsWarning(String.format(CREATING_EVENT_FORBIDDEN, NAMESPACE_WATCHING_STARTED_EVENT, NS)));
+  }
+
+  @Test
+  public void whenNSWatchStartedEventCreated_fail403OnCreate_startManagingNSFailedEventGenerated() {
+    testSupport.failOnCreate(EVENT, null, NS, HTTP_FORBIDDEN);
+
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
+
+    assertThat("Found 1 NAMESPACE_WATCHING_STARTED_FAILED event",
+        containsEventsWithCountOne(getEvents(testSupport),
+            START_MANAGING_NAMESPACE_FAILED_EVENT, 1), is(true));
+  }
+
+  @Test
+  public void whenNSWatchStartedEventCreated_fail403OnCreate_startManagingNSFailedEventGeneratedWithExpectedMessage() {
+    testSupport.failOnCreate(EVENT, null, NS, HTTP_FORBIDDEN);
+
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
+
+    assertThat("Found 1 NAMESPACE_WATCHING_STARTED_FAILED event with expected message",
+        containsEventWithMessage(getEvents(testSupport),
+            EventConstants.START_MANAGING_NAMESPACE_FAILED_EVENT,
+            String.format(EventConstants.START_MANAGING_NAMESPACE_FAILED_PATTERN, NS)), is(true));
+  }
+
+  @Test
+  public void whenNSWatchStartedEventCreated_fail403OnCreate_startManagingNSFailedEventGeneratedWithExpectedLabel() {
+    testSupport.failOnCreate(EVENT, null, NS, HTTP_FORBIDDEN);
+
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
+    Map<String, String> expectedLabels = new HashMap<>();
+    expectedLabels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
+
+    assertThat("Found 1 NAMESPACE_WATCHING_STARTED_FAILED event with expected label",
+        containsEventWithLabels(getEvents(testSupport),
+            START_MANAGING_NAMESPACE_FAILED_EVENT, expectedLabels), is(true));
+  }
+
+  @Test
+  public void whenNSWatchStartedEventCreated_fail403OnCreate_startManagingNSFailedEventGeneratedWithExpectedNS() {
+    testSupport.failOnCreate(EVENT, null, NS, HTTP_FORBIDDEN);
+
+    testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
+    Map<String, String> expectedLabels = new HashMap<>();
+    expectedLabels.put(LabelConstants.CREATEDBYOPERATOR_LABEL, "true");
+
+    assertThat("Found 1 NAMESPACE_WATCHING_STARTED_FAILED event with expected namespace",
+        containsEventWithNamespace(getEvents(testSupport),
+            EventConstants.START_MANAGING_NAMESPACE_FAILED_EVENT, OP_NS), is(true));
   }
 
   @Test
@@ -609,7 +672,7 @@ public class EventHelperTest {
     testSupport.runSteps(createEventStep(new EventData(NAMESPACE_WATCHING_STARTED).namespace(NS).resourceName(NS)));
     assertThat("Found START_MANAGING_NAMESPACE event with expected message",
         containsEventWithMessage(getEvents(testSupport),
-            EventConstants.NAMESPACE_WATCHING_STARTED_EVENT,
+            NAMESPACE_WATCHING_STARTED_EVENT,
             String.format(EventConstants.NAMESPACE_WATCHING_STARTED_PATTERN, NS)), is(true));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventRetryStrategyStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventRetryStrategyStub.java
@@ -8,7 +8,7 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
-abstract class EventRetryStrategyStub implements RetryStrategy {
+public abstract class EventRetryStrategyStub implements RetryStrategy {
   @Override
   public NextAction doPotentialRetry(Step conflictStep, Packet packet, int statusCode) {
     NextAction na = new NextAction();


### PR DESCRIPTION
DomainNamespaces keeps the status of each namespace that the operator manages, which includes a flag to indicate the namespace is starting already. During a regular recheck domain cycle (fullCheck = false), the isNamespaceStarting flag (AtomicBoolean) is set using getAndSet method, and once it is set, the operator never unset it until the namespace is removed from the list of namespaces that the operator manages. 

As a result, when there is an "unrecoverable" failure, such as API server returns a http return code 403,  when the operator starts a namespace, the namespace will be skipped from the subsequent regular retry cycles because it is considered isStarting already. Eventually, a skipped namespace may be started in a fullCheck recheck. But the creation of NamespaceWatchingStarted event is only generated in the regular recheck cycle  when the flag is not set (because we only needs to create it once for each namespace), so it can be missed if there is a temporary failure condition. 

The change in this PR clears the isNamespaceStarting flag after the creation of NamespaceWatchingStarted event fails, and set it after the creation of the event succeeds. So the operator will attempt to start a previously failed namespace, as well as to generate the NamespaceWatchingStarted event, in each regular recheck cycle.

The PR also adds a new type of event in the operator's namespace to record that the creation of NamespaceWatchingStarted event failed in a domain's namespace with 403 error.

Integration test run on Jenkins (hit a known intermittent issue in ItMonitoringExporter): https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4734/.
A rerun of ItMonitoringExporter has passed: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4739/.
A full rerun has passed: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4742/.