### PR TITLE
Create FMW Domain DomainInPv with WDT

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -178,33 +178,27 @@ public class ItFmwDomainInPVUsingWDT {
     // create configmap and domain in persistent volume
     createDomainJobOnPv(wdtScript, wdtModelFile, fmwModelPropFile.toPath(), pvName, pvcName);
 
-    // create domain and verify
-    createDomainCrAndVerify(pvName, pvcName, t3ChannelPort);
-
-    // verify that all servers are ready and EM console is accessible
-    verifyDomainReady(domainNamespace, domainUid, replicaCount, "nosuffix");
-  }
-
-  private void createDomainCrAndVerify(String pvName,
-                                       String pvcName,
-                                       int t3ChannelPort) {
     // create a domain custom resource configuration object
     logger.info("Creating domain custom resource");
     Domain domain = createDomainResourceOnPv(domainUid,
-                             domainNamespace,
-                             wlSecretName,
-                             clusterName,
-                             pvName,
-                             pvcName,
-                             DOMAINHOMEPREFIX,
-                             "true",
-                             replicaCount,
-                             t3ChannelPort);
+                                             domainNamespace,
+                                             wlSecretName,
+                                             clusterName,
+                                             pvName,
+                                             pvcName,
+                                             DOMAINHOMEPREFIX,
+                                             "true",
+                                             replicaCount,
+                                             t3ChannelPort);
 
+    // Set the inter-pod anti-affinity for the domain custom resource
     setPodAntiAffinity(domain);
 
-    // verify the domain custom resource is created
+    // create a domain custom resource and verify domain is created
     createDomainAndVerify(domain, domainNamespace);
+
+    // verify that all servers are ready and EM console is accessible
+    verifyDomainReady(domainNamespace, domainUid, replicaCount, "nosuffix");
   }
 
   private void createDomainJobOnPv(Path domainCreationScriptFile,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -1,0 +1,385 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
+import io.kubernetes.client.openapi.models.V1SecretReference;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+import oracle.weblogic.domain.AdminServer;
+import oracle.weblogic.domain.AdminService;
+import oracle.weblogic.domain.Channel;
+import oracle.weblogic.domain.Cluster;
+import oracle.weblogic.domain.Domain;
+import oracle.weblogic.domain.DomainSpec;
+import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.annotations.IntegrationTest;
+import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import oracle.weblogic.kubernetes.utils.CommonTestUtils;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
+import static oracle.weblogic.kubernetes.TestConstants.DB_IMAGE_TO_USE_IN_SPEC;
+import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.FMWINFRA_IMAGE_TO_USE_IN_SPEC;
+import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WDT_VERSION;
+import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
+import static oracle.weblogic.kubernetes.actions.impl.primitive.Docker.getImageEnvVar;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretForBaseImages;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServicePodName;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.setPodAntiAffinity;
+import static oracle.weblogic.kubernetes.utils.DbUtils.setupDBandRCUschema;
+import static oracle.weblogic.kubernetes.utils.TestUtils.callWebAppAndWaitTillReady;
+import static oracle.weblogic.kubernetes.utils.TestUtils.getNextFreePort;
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
+import static org.awaitility.Awaitility.with;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test to creat a FMW domain in persistent volume using WDT.
+ */
+@DisplayName("Test to creat a FMW domain in persistent volume using WDT")
+@IntegrationTest
+public class ItFmwDomainInPVUsingWDT {
+
+  private static ConditionFactory withStandardRetryPolicy;
+
+  private static String opNamespace = null;
+  private static String domainNamespace = null;
+  private static String dbNamespace = null;
+  private static String oracle_home = null;
+  private static String java_home = null;
+
+  private static final String RCUSCHEMAPREFIX = "fmwdomainpv";
+  private static final String ORACLEDBURLPREFIX = "oracledb.";
+  private static final String ORACLEDBSUFFIX = ".svc.cluster.local:1521/devpdb.k8s";
+  private static final String RCUSYSUSERNAME = "sys";
+  private static final String RCUSYSPASSWORD = "Oradoc_db1";
+  private static final String RCUSCHEMAUSERNAME = "myrcuuser";
+  private static final String RCUSCHEMAPASSWORD = "Oradoc_db1";
+
+  private static final String DOMAINHOMEPREFIX = "/shared/domains/";
+
+  private static String dbUrl = null;
+  private static LoggingFacade logger = null;
+
+  private static final String domainUid = "fmw-domainonpv-wdt";
+  private static final String clusterName = "cluster-1";
+  private static final String adminServerName = "admin-server";
+  private static final String managedServerNameBase = "managed-server";
+  private static final String adminServerPodName = domainUid + "-" + adminServerName;
+  private static final String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
+  private static final int managedServerPort = 8001;
+  private final String wlSecretName = domainUid + "-weblogic-credentials";
+  private final String rcuSecretName = domainUid + "-rcu-credentials";
+  private static final int replicaCount = 2;
+
+  private final String wdtCreateDomainScript = "wdt-create-fmwdomain-onpv.sh";
+  private final String fmwModelFilePrefix = "model-fmwdomain-onpv-wdt";
+  private final String fmwModelFile = fmwModelFilePrefix + ".yaml";
+
+  /**
+   * Assigns unique namespaces for DB, operator and domain.
+   * Start DB service and create RCU schema.
+   * Pull FMW image and Oracle DB image if running tests in Kind cluster.
+   */
+  @BeforeAll
+  public static void initAll(@Namespaces(3) List<String> namespaces) {
+    logger = getLogger();
+    // create standard, reusable retry/backoff policy
+    withStandardRetryPolicy = with().pollDelay(10, SECONDS)
+        .and().with().pollInterval(10, SECONDS)
+        .atMost(5, MINUTES).await();
+
+    // get a new unique dbNamespace
+    logger.info("Assign a unique namespace for DB and RCU");
+    assertNotNull(namespaces.get(0), "Namespace is null");
+    dbNamespace = namespaces.get(0);
+    dbUrl = ORACLEDBURLPREFIX + dbNamespace + ORACLEDBSUFFIX;
+
+    // get a new unique opNamespace
+    logger.info("Assign a unique namespace for operator1");
+    assertNotNull(namespaces.get(1), "Namespace is null");
+    opNamespace = namespaces.get(1);
+
+    // get a new unique domainNamespace
+    logger.info("Assign a unique namespace for FMW domain");
+    assertNotNull(namespaces.get(2), "Namespace is null");
+    domainNamespace = namespaces.get(2);
+
+    // start DB and create RCU schema
+    logger.info("Start DB and create RCU schema for namespace: {0}, RCU prefix: {1}, "
+        + "dbUrl: {2}, dbImage: {3},  fmwImage: {4} ", dbNamespace, RCUSCHEMAPREFIX, dbUrl,
+        DB_IMAGE_TO_USE_IN_SPEC, FMWINFRA_IMAGE_TO_USE_IN_SPEC);
+    assertDoesNotThrow(() -> setupDBandRCUschema(DB_IMAGE_TO_USE_IN_SPEC, FMWINFRA_IMAGE_TO_USE_IN_SPEC,
+        RCUSCHEMAPREFIX, dbNamespace, 0, dbUrl),
+        String.format("Failed to create RCU schema for prefix %s in the namespace %s with "
+            + "dbUrl %s", RCUSCHEMAPREFIX, dbNamespace, dbUrl));
+    logger.info("DB image: {0}, FMW image {1} used in the test",
+        DB_IMAGE_TO_USE_IN_SPEC, FMWINFRA_IMAGE_TO_USE_IN_SPEC);
+
+    // install operator and verify its running in ready state
+    installAndVerifyOperator(opNamespace, domainNamespace);
+
+    // create pull secrets for domainNamespace when running in non Kind Kubernetes cluster
+    // this secret is used only for non-kind cluster
+    createSecretForBaseImages(domainNamespace);
+  }
+
+  /**
+   * Create a basic FMW domain on PV using WDT.
+   * Verify Pod is ready and service exists for both admin server and managed servers.
+   * Verify EM console is accessible.
+   */
+  @Test
+  @DisplayName("Create a FMW domainon on PV using WDT")
+  public void testFmwDomainOnPVUsingWdt() {
+    final String pvName = domainUid + "-" + domainNamespace + "-pv";
+    final String pvcName = domainUid + "-" + domainNamespace + "-pvc";
+    final int t3ChannelPort = getNextFreePort(30000, 32767);
+
+    // create FMW domain credential secret
+    createSecretWithUsernamePassword(wlSecretName, domainNamespace,
+        ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
+
+    // create RCU credential secret
+    CommonTestUtils.createRcuSecretWithUsernamePassword(rcuSecretName, domainNamespace,
+        RCUSCHEMAUSERNAME, RCUSCHEMAPASSWORD, RCUSYSUSERNAME, RCUSYSPASSWORD);
+
+    // create persistent volume and persistent volume claim for domain
+    CommonTestUtils.createPV(pvName, domainUid, this.getClass().getSimpleName());
+    CommonTestUtils.createPVC(pvName, pvcName, domainUid, domainNamespace);
+
+    // create a model property file
+    File fmwModelPropFile = createWdtPropertyFile(t3ChannelPort);
+
+    // use shell script to download WDT and run the WDT createDomain script to create FMW domain
+    Path wdtScript = Paths.get(RESOURCE_DIR, "bash-scripts", wdtCreateDomainScript);
+    // WDT model file containing WebLogic domain configuration
+    Path wdtModelFile = Paths.get(MODEL_DIR, fmwModelFile);
+
+    // create configmap and domain in persistent volume
+    createDomainJobOnPv(wdtScript, wdtModelFile, fmwModelPropFile.toPath(), pvName, pvcName);
+
+    // create domain and verify
+    createDomainCrAndVerify(pvName, pvcName, t3ChannelPort);
+
+    // verify that all servers are ready and EM console is accessible
+    verifyDomainReady();
+  }
+
+  private void createDomainCrAndVerify(String pvName,
+                                       String pvcName,
+                                       int t3ChannelPort) {
+    // create a domain custom resource configuration object
+    logger.info("Creating domain custom resource");
+    Domain domain = new Domain()
+        .apiVersion(DOMAIN_API_VERSION)
+        .kind("Domain")
+        .metadata(new V1ObjectMeta()
+            .name(domainUid)
+            .namespace(domainNamespace))
+        .spec(new DomainSpec()
+            .domainUid(domainUid)
+            .domainHome(DOMAINHOMEPREFIX + domainUid)
+            .domainHomeSourceType("PersistentVolume")
+            .image(FMWINFRA_IMAGE_TO_USE_IN_SPEC)
+            .imagePullPolicy("IfNotPresent")
+            .imagePullSecrets(Arrays.asList(
+                new V1LocalObjectReference()
+                    .name(BASE_IMAGES_REPO_SECRET)))
+            .webLogicCredentialsSecret(new V1SecretReference()
+                .name(wlSecretName)
+                .namespace(domainNamespace))
+            .includeServerOutInPodLog(true)
+            .logHomeEnabled(Boolean.TRUE)
+            .logHome("/shared/logs/" + domainUid)
+            .dataHome("")
+            .serverStartPolicy("IF_NEEDED")
+            .serverPod(new ServerPod() //serverpod
+                .addEnvItem(new V1EnvVar()
+                    .name("JAVA_OPTIONS")
+                    .value("-Dweblogic.StdoutDebugEnabled=false"))
+                .addEnvItem(new V1EnvVar()
+                    .name("USER_MEM_ARGS")
+                    .value("-Djava.security.egd=file:/dev/./urandom"))
+                .addEnvItem(new V1EnvVar()
+                    .name("ALLOW_DYNAMIC_CLUSTER_IN_FMW")
+                    .value("true"))
+                .addVolumesItem(new V1Volume()
+                    .name(pvName)
+                    .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
+                        .claimName(pvcName)))
+                .addVolumeMountsItem(new V1VolumeMount()
+                    .mountPath("/shared")
+                    .name(pvName)))
+            .adminServer(new AdminServer() //admin server
+                .serverStartState("RUNNING")
+                .adminService(new AdminService()
+                    .addChannelsItem(new Channel()
+                        .channelName("default")
+                        .nodePort(0))
+                    .addChannelsItem(new Channel()
+                        .channelName("T3Channel")
+                        .nodePort(t3ChannelPort))))
+            .addClustersItem(new Cluster()
+                .clusterName(clusterName)
+                .replicas(replicaCount)
+                .serverStartState("RUNNING")
+                ));
+    setPodAntiAffinity(domain);
+
+    // verify the domain custom resource is created
+    createDomainAndVerify(domain, domainNamespace);
+  }
+
+  private void createDomainJobOnPv(Path domainCreationScriptFile,
+                                   Path modelFile,
+                                   Path domainPropertiesFile,
+                                   String pvName,
+                                   String pvcName) {
+
+    logger.info("Preparing to run create domain job using WDT");
+    List<Path> domainScriptFiles = new ArrayList<>();
+    domainScriptFiles.add(domainCreationScriptFile);
+    domainScriptFiles.add(domainPropertiesFile);
+    domainScriptFiles.add(modelFile);
+
+    logger.info("Creating a config map to hold domain creation scripts");
+    String domainScriptConfigMapName = "create-domain-scripts-cm";
+    assertDoesNotThrow(
+        () -> CommonTestUtils.createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles,
+            domainNamespace, this.getClass().getSimpleName()),
+        "Create configmap for domain creation failed");
+
+    // create a V1Container with specific scripts and properties for creating domain
+    V1Container jobCreationContainer = new V1Container()
+        .addCommandItem("/bin/sh")
+        .addArgsItem("/u01/weblogic/" + domainCreationScriptFile.getFileName())
+        .addEnvItem(new V1EnvVar()
+            .name("WDT_VERSION")
+            .value(WDT_VERSION))
+        .addEnvItem(new V1EnvVar()
+            .name("WDT_MODEL_FILE")
+            .value("/u01/weblogic/" + modelFile.getFileName()))
+        .addEnvItem(new V1EnvVar()
+            .name("WDT_VAR_FILE")
+            .value("/u01/weblogic/" + domainPropertiesFile.getFileName()))
+        .addEnvItem(new V1EnvVar()
+            .name("WDT_DIR")
+            .value("/u01/shared/wdt"))
+        .addEnvItem(new V1EnvVar()
+            .name("DOMAIN_HOME_DIR")
+            .value(DOMAINHOMEPREFIX + domainUid))
+        .addEnvItem(new V1EnvVar()
+            .name("http_proxy")
+            .value(System.getenv("http_proxy")))
+        .addEnvItem(new V1EnvVar()
+            .name("https_proxy")
+            .value(System.getenv("http_proxy")));
+
+    logger.info("Running a Kubernetes job to create the domain");
+    CommonTestUtils.createDomainJob(FMWINFRA_IMAGE_TO_USE_IN_SPEC, pvName, pvcName, domainScriptConfigMapName,
+        domainNamespace, jobCreationContainer);
+  }
+
+  private File createWdtPropertyFile(int t3ChannelPort) {
+    //get ENV variable from the image
+    assertNotNull(getImageEnvVar(FMWINFRA_IMAGE_TO_USE_IN_SPEC, "ORACLE_HOME"),
+        "envVar ORACLE_HOME from image is null");
+    oracle_home = getImageEnvVar(FMWINFRA_IMAGE_TO_USE_IN_SPEC, "ORACLE_HOME");
+    logger.info("ORACLE_HOME in image {0} is: {1}", FMWINFRA_IMAGE_TO_USE_IN_SPEC, oracle_home);
+    assertNotNull(getImageEnvVar(FMWINFRA_IMAGE_TO_USE_IN_SPEC, "JAVA_HOME"),
+        "envVar JAVA_HOME from image is null");
+    java_home = getImageEnvVar(FMWINFRA_IMAGE_TO_USE_IN_SPEC, "JAVA_HOME");
+    logger.info("JAVA_HOME in image {0} is: {1}", FMWINFRA_IMAGE_TO_USE_IN_SPEC, java_home);
+
+    // create wlst property file object
+    Properties p = new Properties();
+    p.setProperty("oracleHome", oracle_home); //default $ORACLE_HOME
+    p.setProperty("javaHome", java_home); //default $JAVA_HOME
+    p.setProperty("rcuDb", dbUrl);
+    p.setProperty("rcuSchemaPrefix", RCUSCHEMAPREFIX);
+    p.setProperty("rcuSchemaPassword", RCUSCHEMAPASSWORD);
+    p.setProperty("adminUsername", ADMIN_USERNAME_DEFAULT);
+    p.setProperty("adminPassword", ADMIN_PASSWORD_DEFAULT);
+    p.setProperty("domainName", domainUid);
+    p.setProperty("adminServerName", adminServerName);
+    p.setProperty("productionModeEnabled", "true");
+    p.setProperty("clusterName", clusterName);
+    p.setProperty("managedServerNameBase", managedServerNameBase);
+    p.setProperty("t3ChannelPort", Integer.toString(t3ChannelPort));
+    p.setProperty("t3PublicAddress", K8S_NODEPORT_HOST);
+    p.setProperty("managedServerPort", Integer.toString(managedServerPort));
+
+    // create a model property file
+    File domainPropertiesFile = assertDoesNotThrow(() ->
+        File.createTempFile(fmwModelFilePrefix, "properties"),
+        "Failed to create FMW model properties file");
+
+    // create the property file
+    assertDoesNotThrow(() ->
+        p.store(new FileOutputStream(domainPropertiesFile), "FMW properties file"),
+        "Failed to write FMW properties file");
+
+    return domainPropertiesFile;
+  }
+
+  /**
+   * Verify Pod is ready and service exists for both admin server and managed servers.
+   * Verify EM console is accessible.
+   */
+  private void verifyDomainReady() {
+    checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+    for (int i = 1; i <= replicaCount; i++) {
+      logger.info("Checking managed server service {0} is created in namespace {1}",
+          managedServerPodNamePrefix + i, domainNamespace);
+      checkPodReadyAndServiceExists(managedServerPodNamePrefix + i, domainUid, domainNamespace);
+    }
+
+    //check access to the em console: http://hostname:port/em
+    int nodePort = getServiceNodePort(
+        domainNamespace, getExternalServicePodName(adminServerPodName), "default");
+    assertTrue(nodePort != -1,
+        "Could not get the default external service node port");
+    logger.info("Found the default service nodePort {0}", nodePort);
+    String curlCmd1 = "curl -s -L --show-error --noproxy '*' "
+        + " http://" + K8S_NODEPORT_HOST + ":" + nodePort
+        + "/em --write-out %{http_code} -o /dev/null";
+    logger.info("Executing default nodeport curl command {0}", curlCmd1);
+    assertTrue(callWebAppAndWaitTillReady(curlCmd1, 5), "Calling web app failed");
+    logger.info("EM console is accessible thru default service");
+  }
+}
+

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -30,7 +30,6 @@ import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import oracle.weblogic.kubernetes.utils.CommonTestUtils;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -51,9 +50,12 @@ import static oracle.weblogic.kubernetes.actions.ActionConstants.WDT_VERSION;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Docker.getImageEnvVar;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createRcuSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServicePodName;
@@ -176,7 +178,7 @@ public class ItFmwDomainInPVUsingWDT {
         ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
 
     // create RCU credential secret
-    CommonTestUtils.createRcuSecretWithUsernamePassword(rcuSecretName, domainNamespace,
+    createRcuSecretWithUsernamePassword(rcuSecretName, domainNamespace,
         RCUSCHEMAUSERNAME, RCUSCHEMAPASSWORD, RCUSYSUSERNAME, RCUSYSPASSWORD);
 
     // create persistent volume and persistent volume claim for domain
@@ -281,7 +283,7 @@ public class ItFmwDomainInPVUsingWDT {
     logger.info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm";
     assertDoesNotThrow(
-        () -> CommonTestUtils.createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles,
+        () -> createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles,
             domainNamespace, this.getClass().getSimpleName()),
         "Create configmap for domain creation failed");
 
@@ -315,7 +317,7 @@ public class ItFmwDomainInPVUsingWDT {
             .value("JRF"));
 
     logger.info("Running a Kubernetes job to create the domain");
-    CommonTestUtils.createDomainJob(FMWINFRA_IMAGE_TO_USE_IN_SPEC, pvName, pvcName, domainScriptConfigMapName,
+    createDomainJob(FMWINFRA_IMAGE_TO_USE_IN_SPEC, pvName, pvcName, domainScriptConfigMapName,
         domainNamespace, jobCreationContainer);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -52,6 +52,8 @@ import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Docker.getImageEnvVar;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPV;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPVC;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServicePodName;
@@ -105,7 +107,7 @@ public class ItFmwDomainInPVUsingWDT {
   private final String rcuSecretName = domainUid + "-rcu-credentials";
   private static final int replicaCount = 2;
 
-  private final String wdtCreateDomainScript = "wdt-create-fmwdomain-onpv.sh";
+  private final String wdtCreateDomainScript = "setup_wdt.sh";
   private final String fmwModelFilePrefix = "model-fmwdomain-onpv-wdt";
   private final String fmwModelFile = fmwModelFilePrefix + ".yaml";
 
@@ -178,8 +180,8 @@ public class ItFmwDomainInPVUsingWDT {
         RCUSCHEMAUSERNAME, RCUSCHEMAPASSWORD, RCUSYSUSERNAME, RCUSYSPASSWORD);
 
     // create persistent volume and persistent volume claim for domain
-    CommonTestUtils.createPV(pvName, domainUid, this.getClass().getSimpleName());
-    CommonTestUtils.createPVC(pvName, pvcName, domainUid, domainNamespace);
+    createPV(pvName, domainUid, this.getClass().getSimpleName());
+    createPVC(pvName, pvcName, domainUid, domainNamespace);
 
     // create a model property file
     File fmwModelPropFile = createWdtPropertyFile(t3ChannelPort);
@@ -307,7 +309,10 @@ public class ItFmwDomainInPVUsingWDT {
             .value(System.getenv("http_proxy")))
         .addEnvItem(new V1EnvVar()
             .name("https_proxy")
-            .value(System.getenv("http_proxy")));
+            .value(System.getenv("http_proxy")))
+        .addEnvItem(new V1EnvVar()
+            .name("DOMAIN_TYPE")
+            .value("JRF"));
 
     logger.info("Running a Kubernetes job to create the domain");
     CommonTestUtils.createDomainJob(FMWINFRA_IMAGE_TO_USE_IN_SPEC, pvName, pvcName, domainScriptConfigMapName,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
@@ -66,7 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @DisplayName("Verify the WebLogic server pods can run with domain created in persistent volume")
 @IntegrationTest
-public class ItFmwDomainInPV {
+public class ItFmwDomainInPVUsingWLST {
 
   private static String dbNamespace = null;
   private static String opNamespace = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FmwUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FmwUtils.java
@@ -3,10 +3,15 @@
 
 package oracle.weblogic.kubernetes.utils;
 
+import java.util.Arrays;
+
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
 import io.kubernetes.client.openapi.models.V1SecretReference;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.domain.AdminServer;
 import oracle.weblogic.domain.AdminService;
 import oracle.weblogic.domain.Channel;
@@ -19,7 +24,9 @@ import oracle.weblogic.domain.Opss;
 import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 
+import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
+import static oracle.weblogic.kubernetes.TestConstants.FMWINFRA_IMAGE_TO_USE_IN_SPEC;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
@@ -98,22 +105,108 @@ public class FmwUtils {
   }
 
   /**
+   * Construct a domain object with the given parameters that can be used to create a domain resource.
+   * @param domainUid unique Uid of the domain
+   * @param domNamespace  namespace where the domain exists
+   * @param adminSecretName  name of admin secret
+   * @param clusterName name of the WebLogic cluster to be created in the domain
+   * @param pvName name of the persistent volume to create
+   * @param pvcName name of the persistent volume claim to create
+   * @param domainInHomePrefix prefix of path of domain in home
+   * @param allowDynClusterInFmw true to create a FMW dynamic domain, false otherwise
+   * @param replicaCount count of replicas
+   * @param t3ChannelPort port number of t3 channel
+   * @return Domain WebLogic domain
+   */
+  public static Domain createDomainResourceOnPv(String domainUid,
+                                                String domNamespace,
+                                                String adminSecretName,
+                                                String clusterName,
+                                                String pvName,
+                                                String pvcName,
+                                                String domainInHomePrefix,
+                                                String allowDynClusterInFmw,
+                                                int replicaCount,
+                                                int t3ChannelPort) {
+    // create a domain custom resource configuration object
+    Domain domain = new Domain()
+        .apiVersion(DOMAIN_API_VERSION)
+        .kind("Domain")
+        .metadata(new V1ObjectMeta()
+            .name(domainUid)
+            .namespace(domNamespace))
+        .spec(new DomainSpec()
+            .domainUid(domainUid)
+            .domainHome(domainInHomePrefix + domainUid)
+            .domainHomeSourceType("PersistentVolume")
+            .image(FMWINFRA_IMAGE_TO_USE_IN_SPEC)
+            .imagePullPolicy("IfNotPresent")
+            .imagePullSecrets(Arrays.asList(
+                new V1LocalObjectReference()
+                    .name(BASE_IMAGES_REPO_SECRET)))
+            .webLogicCredentialsSecret(new V1SecretReference()
+                .name(adminSecretName)
+                .namespace(domNamespace))
+            .includeServerOutInPodLog(true)
+            .logHomeEnabled(Boolean.TRUE)
+            .logHome("/shared/logs/" + domainUid)
+            .dataHome("")
+            .serverStartPolicy("IF_NEEDED")
+            .serverPod(new ServerPod() //serverpod
+                .addEnvItem(new V1EnvVar()
+                    .name("JAVA_OPTIONS")
+                    .value("-Dweblogic.StdoutDebugEnabled=false"))
+                .addEnvItem(new V1EnvVar()
+                    .name("USER_MEM_ARGS")
+                    .value("-Djava.security.egd=file:/dev/./urandom"))
+                .addEnvItem(new V1EnvVar()
+                    .name("ALLOW_DYNAMIC_CLUSTER_IN_FMW")
+                    .value(allowDynClusterInFmw))
+                .addVolumesItem(new V1Volume()
+                    .name(pvName)
+                    .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
+                        .claimName(pvcName)))
+                .addVolumeMountsItem(new V1VolumeMount()
+                    .mountPath("/shared")
+                    .name(pvName)))
+            .adminServer(new AdminServer() //admin server
+                .serverStartState("RUNNING")
+                .adminService(new AdminService()
+                    .addChannelsItem(new Channel()
+                        .channelName("default")
+                        .nodePort(0))
+                    .addChannelsItem(new Channel()
+                        .channelName("T3Channel")
+                        .nodePort(t3ChannelPort))))
+            .addClustersItem(new Cluster()
+                .clusterName(clusterName)
+                .replicas(replicaCount)
+                .serverStartState("RUNNING")));
+
+    return domain;
+  }
+
+  /**
    * Verify Pod is ready and service exists for both admin server and managed servers.
    * Verify EM console is accessible.
    * @param domainUid unique Uid of the domain
    * @param domainNamespace  namespace where the domain exists
    * @param replicaCount number of running managed servers
+   * @param args arguments to determine append -c1 to managed server name or not.
+   *             append -c1 if it's not set. Otherwise not appending -c1
    */
-  public static void verifyDomainReady(String domainNamespace, String domainUid, int replicaCount) {
+  public static void verifyDomainReady(String domainNamespace, String domainUid, int replicaCount, String... args) {
     LoggingFacade logger = getLogger();
     String adminServerPodName = domainUid + "-admin-server";
     String managedServerPrefix = domainUid + "-managed-server";
+
     checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
 
     for (int i = 1; i <= replicaCount; i++) {
+      String managedServerName = (args.length == 0) ? managedServerPrefix + i + "-c1" : managedServerPrefix + i;
       logger.info("Checking managed server service {0} is created in namespace {1}",
-          managedServerPrefix + i + "-c1", domainNamespace);
-      checkPodReadyAndServiceExists(managedServerPrefix + i + "-c1", domainUid, domainNamespace);
+          managedServerName, domainNamespace);
+      checkPodReadyAndServiceExists(managedServerName, domainUid, domainNamespace);
     }
 
     //check access to the em console: http://hostname:port/em

--- a/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
+++ b/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
@@ -48,7 +48,7 @@
 #                  default:  https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.7/$WDT_INSTALL_ZIP_FILE
 #
 #   https_proxy    Proxy for downloading WDT_INSTALL_ZIP_URL.
-#                  default: "http://www-proxy-hqdc.us.oracle.com:80"
+#                  default: ""
 #                  (If set to empty the script will try with no proxy.)
 #
 #   https_proxy2   Alternate proxy for downloading WDT_INSTALL_ZIP_URL

--- a/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
+++ b/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
@@ -62,7 +62,9 @@
 #   WDT_VERSION    WDT version to download.
 #                  default:  latest
 #
-#   DOMAIN_HOME_DIR  Target location for generated domain. 
+#   DOMAIN_HOME_DIR  Target location for generated domain.
+#
+#   DOMAIN_TYPE    Domain type. It can be WLS, JRF or RestrictedJRF. Default is WLS
 #
 
 # Initialize globals
@@ -102,9 +104,10 @@ else
 WDT_BASE_URL="https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-$WDT_VERSION"
 fi
 
-
 WDT_INSTALL_ZIP_FILE="${WDT_INSTALL_ZIP_FILE:-weblogic-deploy.zip}"
 WDT_INSTALL_ZIP_URL=${WDT_INSTALL_ZIP_URL:-"$WDT_BASE_URL/$WDT_INSTALL_ZIP_FILE"}
+
+DOMAIN_TYPE="${DOMAIN_TYPE:-WLS}"
 
 # Define functions
 
@@ -198,7 +201,9 @@ function run_wdt {
   local out_file=$WDT_DIR/createDomain.sh.out
   local wdt_log_dir="$WDT_DIR/weblogic-deploy/logs"
 
-  echo @@ "Info:  About to run WDT createDomain.sh"
+  local domain_type="$DOMAIN_TYPE"
+
+  echo @@ "Info:  About to run WDT createDomain.sh to create a $domain_type Domain"
 
   for directory in wdt_bin_dir SCRIPTPATH WDT_DIR oracle_home; do
     if [ ! -d "${!directory}" ]; then
@@ -224,7 +229,7 @@ function run_wdt {
 
   $wdt_createDomain_script \
      -oracle_home $oracle_home \
-     -domain_type JRF \
+     -domain_type $domain_type \
      -domain_home $domain_home_dir \
      -model_file $model_final \
      -variable_file $inputs_final > $out_file 2>&1

--- a/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
+++ b/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
@@ -71,7 +71,7 @@
 
 # using "-" instead of ":-" in case proxy vars are explicitly set to "".
 https_proxy=${https_proxy-""}
-https_proxy2=${https_proxy2-"http://www-proxy-hqdc.us.oracle.com:80"}
+https_proxy2=${https_proxy2-""}
 
 export ORACLE_HOME=${ORACLE_HOME:-/u01/oracle}
 

--- a/integration-tests/src/test/resources/bash-scripts/wdt-create-fmwdomain-onpv.sh
+++ b/integration-tests/src/test/resources/bash-scripts/wdt-create-fmwdomain-onpv.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Description:
+#
+#   This script generates a domain by calling the WebLogic Deploy Tool (WDT)
+#   bin/createDomain.sh script.
+#
+#   It first installs WDT using the given download URLs, and then runs it using the
+#   given Oracle home, WDT model file, WDT vars file, etc.
+#
+# Usage:
+#
+#   Export customized values for the input shell environment variables as needed
+#   before calling this script.   
+#
+# Outputs:
+#
+#   WDT install:           WDT_DIR/weblogic-deploy/...
+#
+#   Copy of wdt model:     WDT_DIR/$(basename WDT_MODEL_FILE)
+#   Copy of wdt vars:      WDT_DIR/$(basename WDT_VAR_FILE)
+#
+#   WDT logs:              WDT_DIR/weblogic-deploy/logs/...
+#   WDT stdout:            WDT_DIR/createDomain.sh.out
+#
+#   WebLogic domain home:  DOMAIN_HOME_DIR
+#                          default: /shared/domains/<domainUID>
+#
+# Input environment variables:
+#
+#   ORACLE_HOME    Oracle home with a WebLogic install.
+#                  default:  /u01/oracle
+#
+#   WDT_MODEL_FILE Full path to WDT model file.
+#                  default:  the directory that contains this script
+#                            plus "/wdt_model.yaml"
+#
+#   WDT_VAR_FILE   Full path to WDT variable file (java properties format).
+#                  default:  the directory that contains this script
+#                            plus "/create-domain-inputs.yaml"
+#
+#   WDT_INSTALL_ZIP_FILE  Filename of WDT install zip.
+#                  default:  weblogic-deploy.zip
+#
+#   WDT_INSTALL_ZIP_URL   URL for downloading WDT install zip
+#                  default:  https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.7/$WDT_INSTALL_ZIP_FILE
+#
+#   https_proxy    Proxy for downloading WDT_INSTALL_ZIP_URL.
+#                  default: "http://www-proxy-hqdc.us.oracle.com:80"
+#                  (If set to empty the script will try with no proxy.)
+#
+#   https_proxy2   Alternate proxy for downloading WDT_INSTALL_ZIP_URL
+#                  default: ""
+#                  (If set to empty the script will try with no proxy.)
+#
+#   WDT_DIR        Target location to install and run WDT, and to keep a copy of
+#                  $WDT_MODEL_FILE and $WDT_MODEL_VARS. Also the location
+#                  of WDT log files.
+#                  default:  /shared/wdt
+#   WDT_VERSION    WDT version to download.
+#                  default:  latest
+#
+#   DOMAIN_HOME_DIR  Target location for generated domain. 
+#
+
+# Initialize globals
+
+# using "-" instead of ":-" in case proxy vars are explicitly set to "".
+https_proxy=${https_proxy-""}
+https_proxy2=${https_proxy2-"http://www-proxy-hqdc.us.oracle.com:80"}
+
+export ORACLE_HOME=${ORACLE_HOME:-/u01/oracle}
+
+SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
+WDT_MODEL_FILE=${WDT_MODEL_FILE:-"$SCRIPTPATH/wdt_model.yaml"}
+WDT_VAR_FILE=${WDT_VAR_FILE:-"$SCRIPTPATH/create-domain-inputs.yaml"}
+
+WDT_DIR=${WDT_DIR:-/shared/wdt}
+if [ -z "${WDT_VERSION+x}" ] || [ ${WDT_VERSION} == "latest" ]; then
+  curl_res=1
+  max=20
+  count=0
+  while [ $curl_res -ne 0 -a $count -lt $max ] ; do
+    sleep 1
+    for proxy in "${https_proxy2}" "${https_proxy}"; do
+      echo @@ "Info: Getting latest release WDT url with https_proxy=\"$proxy\""
+      https_proxy="${proxy}" \
+        curl -Ls -w %{url_effective} --connect-timeout 30 -o /dev/null \
+          https://github.com/oracle/weblogic-deploy-tooling/releases/latest > out
+      curl_res=$?
+      if [ $curl_res -eq 0 ]; then
+        echo "Got URL $(cat out)"
+        WDT_BASE_URL=$(cat out | sed -e "s/tag/download/g")
+        rm out
+        break
+      fi
+    done
+  done
+else
+WDT_BASE_URL="https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-$WDT_VERSION"
+fi
+
+
+WDT_INSTALL_ZIP_FILE="${WDT_INSTALL_ZIP_FILE:-weblogic-deploy.zip}"
+WDT_INSTALL_ZIP_URL=${WDT_INSTALL_ZIP_URL:-"$WDT_BASE_URL/$WDT_INSTALL_ZIP_FILE"}
+
+# Define functions
+
+function setup_wdt_shared_dir {
+  mkdir -p $WDT_DIR || return 1
+}
+
+function install_wdt {
+  #
+  # Download $WDT_INSTALL_ZIP_FILE from $WDT_INSTALL_ZIP_URL into $WDT_DIR using
+  # proxies https_proxy or https_proxy2, then unzip the zip file in $WDT_DIR.
+  #
+
+  local save_dir=`pwd`
+  cd $WDT_DIR || return 1
+
+  local curl_res=1
+  max=20
+  count=0
+  while [ $curl_res -ne 0 -a $count -lt $max ] ; do
+    sleep 10
+    count=`expr $count + 1`
+    for proxy in "${https_proxy}" "${https_proxy2}"; do
+	  echo @@ "Info:  Downloading $WDT_INSTALL_ZIP_URL with https_proxy=\"$proxy\""
+	  https_proxy="${proxy}" \
+	    curl --silent --show-error --connect-timeout 10 -O -L $WDT_INSTALL_ZIP_URL 
+	  curl_res=$?
+	  [ $curl_res -eq 0 ] && break
+	done
+  done
+  if [ $curl_res -ne 0 ] || [ ! -f $WDT_INSTALL_ZIP_FILE ]; then
+    cd $save_dir
+    echo @@ "Error: Download failed or $WDT_INSTALL_ZIP_FILE not found."
+    return 1
+  fi
+
+  echo @@ "Info: Archive downloaded to $WDT_DIR/$WDT_INSTALL_ZIP_FILE, about to unzip via 'jar xf'."
+
+  jar xf $WDT_INSTALL_ZIP_FILE
+  local jar_res=$?
+
+  cd $save_dir
+
+  if [ $jar_res -ne 0 ]; then
+    echo @@ "Error: Install failed while unzipping $WDT_DIR/$WDT_INSTALL_ZIP_FILE"
+    return $jar_res
+  fi
+
+  if [ ! -d "$WDT_DIR/weblogic-deploy/bin" ]; then
+    echo @@ "Error: Install failed: directory '$WDT_DIR/weblogic-deploy/bin' not found."
+    return 1
+  fi
+
+  chmod 775 $WDT_DIR/weblogic-deploy/bin/* || return 1
+
+  echo @@ "Info: Install succeeded, wdt install is in the $WDT_DIR/weblogic-deploy directory."
+  return 0
+}
+
+function run_wdt {
+  #
+  # Run WDT using WDT_VAR_FILE, WDT_MODEL_FILE, and ORACLE_HOME.  
+  # Output:
+  # - result domain will be in DOMAIN_HOME_DIR
+  # - logging output is in $WDT_DIR/createDomain.sh.out and $WDT_DIR/weblogic-deploy/logs
+  # - WDT_VAR_FILE & WDT_MODEL_FILE will be copied to WDT_DIR.
+  #
+
+  # Input files and directories.
+
+  local inputs_orig="$WDT_VAR_FILE"
+  local model_orig="$WDT_MODEL_FILE"
+  local oracle_home="$ORACLE_HOME"
+  local wdt_bin_dir="$WDT_DIR/weblogic-deploy/bin"
+  local wdt_createDomain_script="$wdt_bin_dir/createDomain.sh"
+
+  local domain_home_dir="$DOMAIN_HOME_DIR"
+  if [ -z "${domain_home_dir}" ]; then
+    local domain_dir="/shared/domains"
+    local domain_uid=`egrep 'domainUID' $inputs_orig | awk '{print $2}'`
+    local domain_home_dir=$domain_dir/$domain_uid
+  fi 
+
+  echo domain_home_dir = $domain_home_dir
+  mkdir -p $domain_home_dir
+
+  # Output files and directories.
+
+  local inputs_final=$WDT_DIR/$(basename "$inputs_orig")
+  local model_final=$WDT_DIR/$(basename "$model_orig")
+  local out_file=$WDT_DIR/createDomain.sh.out
+  local wdt_log_dir="$WDT_DIR/weblogic-deploy/logs"
+
+  echo @@ "Info:  About to run WDT createDomain.sh"
+
+  for directory in wdt_bin_dir SCRIPTPATH WDT_DIR oracle_home; do
+    if [ ! -d "${!directory}" ]; then
+       echo @@ "Error:  Could not find ${directory} directory ${!directory}."    
+       return 1
+    fi
+  done
+
+  for fil in inputs_orig model_orig wdt_createDomain_script; do
+    if [ ! -f "${!fil}" ]; then
+       echo @@ "Error:  Could not find ${fil} file ${!fil}."
+       return 1
+    fi
+  done
+
+  cp $model_orig $model_final   || return 1
+  cp $inputs_orig $inputs_final || return 1
+
+  local save_dir=`pwd`
+  cd $WDT_DIR || return 1
+
+  echo @@ "Info:  WDT createDomain.sh output will be in $out_file and $wdt_log_dir"
+
+  $wdt_createDomain_script \
+     -oracle_home $oracle_home \
+     -domain_type JRF \
+     -domain_home $domain_home_dir \
+     -model_file $model_final \
+     -variable_file $inputs_final > $out_file 2>&1
+
+  local wdt_res=$?
+
+  cd $save_dir
+
+  if [ $wdt_res -ne 0 ]; then
+    cat $WDT_DIR/createDomain.sh.out
+    echo @@ "Info:  WDT createDomain.sh output is in $out_file and $wdt_log_dir"
+    echo @@ "Error:  WDT createDomain.sh failed." 
+    return 1
+  fi
+
+  echo @@ "Info:  WDT createDomain.sh succeeded."
+  return 0
+}
+
+# Run
+
+setup_wdt_shared_dir || exit 1
+
+install_wdt || exit 1
+
+run_wdt || exit 1

--- a/integration-tests/src/test/resources/wdt-models/model-fmwdomain-onpv-wdt.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-fmwdomain-onpv-wdt.yaml
@@ -15,12 +15,6 @@ topology:
     Name: "fmw-domaininimage-inpv"
     Log:
         FileName: domain1.log
-    NMProperties:
-        JavaHome: /usr/java/jdk1.8.0_211
-        LogFile: "/u01/oracle/user_projects/domains/fmw-domaininimage-inpv/nodemanager/nodemanager.log"
-        DomainsFile: "/u01/oracle/user_projects/domains/fmw-domaininimage-inpv/nodemanager/nodemanager.domains"
-        NodeManagerHome: "/u01/oracle/user_projects/domains/fmw-domaininimage-inpv/nodemanager"
-        weblogic.StartScriptName: startWebLogic.sh
     Cluster:
         "cluster-1":
             FrontendHost: "fmw-domaininimage-inpv-cluster-cluster-1"

--- a/integration-tests/src/test/resources/wdt-models/model-fmwdomain-onpv-wdt.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-fmwdomain-onpv-wdt.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@PROP:adminUsername@@'
+    AdminPassword: '@@PROP:adminPassword@@'
+    ServerStartMode: 'prod'
+    RCUDbInfo:
+        rcu_prefix: '@@PROP:rcuSchemaPrefix@@'
+        rcu_schema_password: '@@PROP:rcuSchemaPassword@@'
+        rcu_db_conn_string: '@@PROP:rcuDb@@'
+
+topology:
+    AdminServerName: "admin-server"
+    Name: "fmw-domaininimage-inpv"
+    Log:
+        FileName: domain1.log
+    NMProperties:
+        JavaHome: /usr/java/jdk1.8.0_211
+        LogFile: "/u01/oracle/user_projects/domains/fmw-domaininimage-inpv/nodemanager/nodemanager.log"
+        DomainsFile: "/u01/oracle/user_projects/domains/fmw-domaininimage-inpv/nodemanager/nodemanager.domains"
+        NodeManagerHome: "/u01/oracle/user_projects/domains/fmw-domaininimage-inpv/nodemanager"
+        weblogic.StartScriptName: startWebLogic.sh
+    Cluster:
+        "cluster-1":
+            FrontendHost: "fmw-domaininimage-inpv-cluster-cluster-1"
+            DynamicServers:
+                ServerTemplate:  "cluster-1-template"
+                ServerNamePrefix: "managed-server"
+                DynamicClusterSize: 5
+                MaxDynamicClusterSize: 5
+                CalculatedListenPorts: false
+    Server:
+        "admin-server":
+            ListenPort: 7001
+    ServerTemplate:
+        "cluster-1-template":
+            Cluster: "cluster-1"
+            ListenPort : 8001


### PR DESCRIPTION
usecase:

   * Create a basic FMW domain on PV using WDT.
   * Verify Pod is ready and service exists for both admin server and managed servers.
   * Verify EM console is accessible.

Jenkins job:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4867/ (parallel)

latest Jenkins job:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4872/ (parallel)