### PR TITLE
Cache secret for a configurable time period and reset on auth/authz failure

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -34,6 +34,7 @@ import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.watcher.WatchListener;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
 
 /** Watches for Jobs to become Ready or leave Ready state. */
 public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, JobAwaiterStepFactory {
@@ -322,7 +323,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
 
     private long getJobStartedSeconds() {
       if (job.getStatus() != null && job.getStatus().getStartTime() != null) {
-        return ChronoUnit.SECONDS.between(job.getStatus().getStartTime(), OffsetDateTime.now());
+        return ChronoUnit.SECONDS.between(job.getStatus().getStartTime(), SystemClock.now());
       }
       return -1;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -57,6 +57,7 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
 
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
@@ -74,7 +75,7 @@ public class Main {
   private static final ScheduledExecutorService wrappedExecutorService =
       Engine.wrappedExecutorService("operator", container);
   private static final AtomicReference<OffsetDateTime> lastFullRecheck =
-      new AtomicReference<>(OffsetDateTime.now());
+      new AtomicReference<>(SystemClock.now());
   private static final Semaphore shutdownSignal = new Semaphore(0);
   private static final int DEFAULT_STUCK_POD_RECHECK_SECONDS = 30;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -6,7 +6,6 @@ package oracle.kubernetes.operator;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,6 +37,7 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.OperatorUtils;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 
 import static oracle.kubernetes.operator.KubernetesConstants.CONTAINER_NAME;
@@ -149,7 +149,7 @@ public class ServerStatusReader {
       if (lastKnownStatus != null
           && !WebLogicConstants.UNKNOWN_STATE.equals(lastKnownStatus.getStatus())
           && lastKnownStatus.getUnchangedCount() >= main.unchangedCountToDelayStatusRecheck) {
-        if (OffsetDateTime.now()
+        if (SystemClock.now()
             .isBefore(lastKnownStatus.getTime().plusSeconds((int) main.eventualLongDelay))) {
           String state = lastKnownStatus.getStatus();
           serverStateMap.put(serverName, state);

--- a/operator/src/main/java/oracle/kubernetes/operator/TuningParameters.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/TuningParameters.java
@@ -40,6 +40,7 @@ public interface TuningParameters extends Map<String, String> {
     public final int stuckPodRecheckSeconds;
     public final long initialShortDelay;
     public final long eventualLongDelay;
+    public final int weblogicCredentialsSecretRereadIntervalSeconds;
 
     /**
      * create main tuning.
@@ -53,6 +54,7 @@ public interface TuningParameters extends Map<String, String> {
      * @param stuckPodRecheckSeconds time between checks for stuck pods
      * @param initialShortDelay initial short delay
      * @param eventualLongDelay eventual long delay
+     * @param weblogicCredentialsSecretRereadIntervalSeconds credentials secret reread interval
      */
     public MainTuning(
           int initializationRetryDelaySeconds,
@@ -64,7 +66,8 @@ public interface TuningParameters extends Map<String, String> {
           int unchangedCountToDelayStatusRecheck,
           int stuckPodRecheckSeconds,
           long initialShortDelay,
-          long eventualLongDelay) {
+          long eventualLongDelay,
+          int weblogicCredentialsSecretRereadIntervalSeconds) {
       this.initializationRetryDelaySeconds = initializationRetryDelaySeconds;
       this.domainPresenceFailureRetrySeconds = domainPresenceFailureRetrySeconds;
       this.domainPresenceFailureRetryMaxCount = domainPresenceFailureRetryMaxCount;
@@ -75,6 +78,7 @@ public interface TuningParameters extends Map<String, String> {
       this.stuckPodRecheckSeconds = stuckPodRecheckSeconds;
       this.initialShortDelay = initialShortDelay;
       this.eventualLongDelay = eventualLongDelay;
+      this.weblogicCredentialsSecretRereadIntervalSeconds = weblogicCredentialsSecretRereadIntervalSeconds;
     }
 
     @Override
@@ -88,6 +92,7 @@ public interface TuningParameters extends Map<String, String> {
           .append("unchangedCountToDelayStatusRecheck", unchangedCountToDelayStatusRecheck)
           .append("initialShortDelay", initialShortDelay)
           .append("eventualLongDelay", eventualLongDelay)
+          .append("weblogicCredentialsSecretRereadIntervalSeconds", weblogicCredentialsSecretRereadIntervalSeconds)
           .toString();
     }
 
@@ -102,6 +107,7 @@ public interface TuningParameters extends Map<String, String> {
           .append(unchangedCountToDelayStatusRecheck)
           .append(initialShortDelay)
           .append(eventualLongDelay)
+          .append(weblogicCredentialsSecretRereadIntervalSeconds)
           .toHashCode();
     }
 
@@ -123,6 +129,7 @@ public interface TuningParameters extends Map<String, String> {
           .append(unchangedCountToDelayStatusRecheck, mt.unchangedCountToDelayStatusRecheck)
           .append(initialShortDelay, mt.initialShortDelay)
           .append(eventualLongDelay, mt.eventualLongDelay)
+          .append(weblogicCredentialsSecretRereadIntervalSeconds, mt.weblogicCredentialsSecretRereadIntervalSeconds)
           .isEquals();
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/TuningParametersImpl.java
@@ -57,7 +57,8 @@ public class TuningParametersImpl extends ConfigMapConsumer implements TuningPar
             (int) readTuningParameter("statusUpdateUnchangedCountToDelayStatusRecheck", 10),
             (int) readTuningParameter("stuckPodRecheckSeconds", 30),
             readTuningParameter("statusUpdateInitialShortDelay", 5),
-            readTuningParameter("statusUpdateEventualLongDelay", 30));
+            readTuningParameter("statusUpdateEventualLongDelay", 30),
+            (int) readTuningParameter("weblogicCredentialsSecretRereadIntervalSeconds", 120));
 
     CallBuilderTuning callBuilder =
         new CallBuilderTuning(

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -6,7 +6,6 @@ package oracle.kubernetes.operator.helpers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,6 +44,7 @@ import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.yaml.snakeyaml.Yaml;
@@ -551,7 +551,7 @@ public class ConfigMapHelper {
 
     private void updatePacket() {
       ScanCache.INSTANCE.registerScan(
-            info.getNamespace(), info.getDomainUid(), new Scan(wlsDomainConfig, OffsetDateTime.now()));
+            info.getNamespace(), info.getDomainUid(), new Scan(wlsDomainConfig, SystemClock.now()));
       packet.put(ProcessingConstants.DOMAIN_TOPOLOGY, wlsDomainConfig);
 
       copyFileToPacketIfPresent(DOMAINZIP_HASH, DOMAINZIP_HASH);
@@ -867,7 +867,7 @@ public class ConfigMapHelper {
       ScanCache.INSTANCE.registerScan(
           info.getNamespace(),
           info.getDomainUid(),
-          new Scan(domainTopology.getDomain(), OffsetDateTime.now()));
+          new Scan(domainTopology.getDomain(), SystemClock.now()));
 
       packet.put(ProcessingConstants.DOMAIN_TOPOLOGY, domainTopology.getDomain());
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1beta1PodDisruptionBudget;
 import oracle.kubernetes.operator.WebLogicConstants;
@@ -55,6 +56,7 @@ public class DomainPresenceInfo {
   private final ConcurrentMap<String, ServerKubernetesObjects> servers = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, V1Service> clusters = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, V1beta1PodDisruptionBudget> podDisruptionBudgets = new ConcurrentHashMap<>();
+  private final AtomicReference<V1Secret> webLogicCredentialsSecret = new AtomicReference<>(null);
 
   private final List<String> validationWarnings = Collections.synchronizedList(new ArrayList<>());
   private EventItem lastEventItem;
@@ -452,6 +454,14 @@ public class DomainPresenceInfo {
         clusters,
         clusterName,
         s -> !KubernetesUtils.isFirstNewer(getMetadata(s), getMetadata(event)));
+  }
+
+  public V1Secret getWebLogicCredentialsSecret() {
+    return webLogicCredentialsSecret.get();
+  }
+
+  public void setWebLogicCredentialsSecret(V1Secret webLogicCredentialsSecret) {
+    this.webLogicCredentialsSecret.set(webLogicCredentialsSecret);
   }
 
   private V1Service getNewerService(V1Service first, V1Service second) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -24,6 +24,7 @@ import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 
 import static oracle.kubernetes.operator.DomainProcessorImpl.getEventK8SObjects;
@@ -632,7 +633,7 @@ public class EventHelper {
     }
 
     OffsetDateTime getCurrentTimestamp() {
-      return OffsetDateTime.now();
+      return SystemClock.now();
     }
 
     void addLabels(V1ObjectMeta metadata, EventData eventData) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LastKnownStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LastKnownStatus.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.helpers;
 
 import java.time.OffsetDateTime;
 
+import oracle.kubernetes.utils.SystemClock;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -26,7 +27,7 @@ public class LastKnownStatus {
   public LastKnownStatus(String status, int unchangedCount) {
     this.status = status;
     this.unchangedCount = unchangedCount;
-    this.time = OffsetDateTime.now();
+    this.time = SystemClock.now();
   }
 
   public String getStatus() {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/HttpRequestProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/HttpRequestProcessing.java
@@ -14,7 +14,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceSpec;
-import oracle.kubernetes.operator.helpers.AuthorizationHeaderFactory;
+import oracle.kubernetes.operator.helpers.AuthorizationSource;
 import oracle.kubernetes.operator.helpers.SecretHelper;
 import oracle.kubernetes.operator.http.HttpAsyncRequestStep;
 import oracle.kubernetes.operator.http.HttpResponseStep;
@@ -53,14 +53,14 @@ abstract class HttpRequestProcessing {
     return packet;
   }
 
-  AuthorizationHeaderFactory getAuthorizationHeaderFactory() {
-    return SecretHelper.getAuthorizationHeaderFactory(packet);
+  AuthorizationSource getAuthorizationSource() {
+    return SecretHelper.getAuthorizationSource(packet);
   }
 
   final HttpRequest.Builder createRequestBuilder(String url) {
     return HttpRequest.newBuilder()
           .uri(URI.create(url))
-          .header("Authorization", getAuthorizationHeaderFactory().createBasicAuthorizationString())
+          .header("Authorization", getAuthorizationSource().createBasicAuthorizationString())
           .header("Accept", "application/json")
           .header("Content-Type", "application/json")
           .header("X-Requested-By", "WebLogic Operator");

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/MonitorExporterSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/MonitorExporterSteps.java
@@ -63,7 +63,7 @@ public class MonitorExporterSteps {
           return getNext();
         } else {
           return Step.chain(
-                SecretHelper.createAuthorizationHeaderFactoryStep(),
+                SecretHelper.createAuthorizationSourceStep(),
                 RunInParallel.perServer(serverNames, ConfigurationVerificationStartStep::new));
         }
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -93,7 +93,7 @@ public class ReadHealthStep extends Step {
     } else {
       return doNext(
             Step.chain(
-                SecretHelper.createAuthorizationHeaderFactoryStep(),
+                SecretHelper.createAuthorizationSourceStep(),
                 new ReadHealthWithHttpStep(service, info.getServerPod(serverName), getNext())),
             packet);
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -3,7 +3,6 @@
 
 package oracle.kubernetes.operator;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +29,7 @@ import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.OperatorServiceType;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
@@ -134,7 +134,7 @@ public class DomainPresenceTest extends ThreadFactoryTestBase {
                 .namespace(namespace)
                 .name(uid)
                 .resourceVersion("1")
-                .creationTimestamp(OffsetDateTime.now()))
+                .creationTimestamp(SystemClock.now()))
         .withStatus(new DomainStatus());
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -59,6 +59,7 @@ import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
@@ -325,7 +326,7 @@ public class DomainProcessorTest {
     assertThat(minAvailableMatches(getRunningPDBs(), 1), is(true));
 
     domainConfigurator.configureCluster(CLUSTER).withReplicas(3);
-    newDomain.getMetadata().setCreationTimestamp(OffsetDateTime.now());
+    newDomain.getMetadata().setCreationTimestamp(SystemClock.now());
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat(minAvailableMatches(getRunningPDBs(), 2), is(true));
@@ -341,7 +342,7 @@ public class DomainProcessorTest {
     assertThat(minAvailableMatches(getRunningPDBs(), 2), is(true));
 
     domainConfigurator.configureCluster(CLUSTER).withReplicas(2);
-    newDomain.getMetadata().setCreationTimestamp(OffsetDateTime.now());
+    newDomain.getMetadata().setCreationTimestamp(SystemClock.now());
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat(minAvailableMatches(getRunningPDBs(), 1), is(true));
@@ -475,7 +476,7 @@ public class DomainProcessorTest {
     processor.createMakeRightOperation(info).execute();
 
     // Run the make right flow again with explicit recheck and no domain updates
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = SystemClock.now();
     processor.createMakeRightOperation(info).withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_STARTED",
             doesNotContainEvent(getEventsAfterTimestamp(timestamp), DOMAIN_PROCESSING_STARTING_EVENT), is(true));
@@ -496,7 +497,7 @@ public class DomainProcessorTest {
     processor.createMakeRightOperation(info).execute();
 
     // Run the make right flow again with explicit recheck and no domain updates
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    OffsetDateTime timestamp = SystemClock.now();
     processor.createMakeRightOperation(info).withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_STARTED",
             doesNotContainEvent(getEventsAfterTimestamp(timestamp), DOMAIN_PROCESSING_STARTING_EVENT), is(true));
@@ -521,8 +522,8 @@ public class DomainProcessorTest {
 
     // Scale up the cluster and execute the make right flow again with explicit recheck
     domainConfigurator.configureCluster(CLUSTER).withReplicas(3);
-    newDomain.getMetadata().setCreationTimestamp(OffsetDateTime.now());
-    OffsetDateTime timestamp = OffsetDateTime.now();
+    newDomain.getMetadata().setCreationTimestamp(SystemClock.now());
+    OffsetDateTime timestamp = SystemClock.now();
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain))
             .withExplicitRecheck().execute();
     assertThat("Event DOMAIN_PROCESSING_COMPLETED_EVENT",

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTestSetup.java
@@ -3,13 +3,13 @@
 
 package oracle.kubernetes.operator;
 
-import java.time.OffsetDateTime;
 import java.util.Map;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretReference;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
@@ -44,7 +44,7 @@ public class DomainProcessorTestSetup {
    * @return the original metadata object, updated
    */
   private static V1ObjectMeta withTimestamps(V1ObjectMeta meta) {
-    return meta.creationTimestamp(OffsetDateTime.now()).resourceVersion("1");
+    return meta.creationTimestamp(SystemClock.now()).resourceVersion("1");
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -21,6 +21,7 @@ import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.watcher.WatchListener;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
+import oracle.kubernetes.utils.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 public class JobWatcherTest extends WatcherTestBase implements WatchListener<V1Job> {
 
   private static final BigInteger INITIAL_RESOURCE_VERSION = new BigInteger("234");
-  private OffsetDateTime clock = OffsetDateTime.now();
+  private OffsetDateTime clock = SystemClock.now();
   private final V1Job cachedJob = createJob();
 
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();

--- a/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/MainTest.java
@@ -43,6 +43,7 @@ import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -558,7 +559,7 @@ public class MainTest extends ThreadFactoryTestBase {
 
   @Test
   public void deleteDomainPresenceWithTimeCheck_delete_with_same_DateTime() {
-    OffsetDateTime creationDatetime = OffsetDateTime.now();
+    OffsetDateTime creationDatetime = SystemClock.now();
     V1ObjectMeta domainMeta = createMetadata(creationDatetime);
 
     V1ObjectMeta domain2Meta = createMetadata(creationDatetime);
@@ -568,7 +569,7 @@ public class MainTest extends ThreadFactoryTestBase {
 
   @Test
   public void deleteDomainPresenceWithTimeCheck_delete_with_newer_DateTime() {
-    OffsetDateTime creationDatetime = OffsetDateTime.now();
+    OffsetDateTime creationDatetime = SystemClock.now();
     V1ObjectMeta domainMeta = createMetadata(creationDatetime);
 
     OffsetDateTime deleteDatetime = creationDatetime.plusMinutes(1);
@@ -579,7 +580,7 @@ public class MainTest extends ThreadFactoryTestBase {
 
   @Test
   public void deleteDomainPresenceWithTimeCheck_doNotDelete_with_older_DateTime() {
-    OffsetDateTime creationDatetime = OffsetDateTime.now();
+    OffsetDateTime creationDatetime = SystemClock.now();
     V1ObjectMeta domainMeta = createMetadata(creationDatetime);
 
     OffsetDateTime deleteDatetime = creationDatetime.minusMinutes(1);

--- a/operator/src/test/java/oracle/kubernetes/operator/OperatorEventProcessingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/OperatorEventProcessingTest.java
@@ -3,7 +3,6 @@
 
 package oracle.kubernetes.operator;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +20,7 @@ import oracle.kubernetes.operator.helpers.EventHelper.EventItem;
 import oracle.kubernetes.operator.helpers.HelmAccessStub;
 import oracle.kubernetes.operator.helpers.KubernetesEventObjects;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
@@ -317,7 +317,7 @@ public class OperatorEventProcessingTest {
         .metadata(createMetadata(createDomainEventName(nameAppendix, item), NS, true))
         .reportingComponent(WEBLOGIC_OPERATOR_COMPONENT)
         .reportingInstance(OPERATOR_POD_NAME)
-        .lastTimestamp(OffsetDateTime.now())
+        .lastTimestamp(SystemClock.now())
         .type(EventConstants.EVENT_NORMAL)
         .reason(item.getReason())
         .message(item.getMessage(new EventHelper.EventData(item, message)))
@@ -336,7 +336,7 @@ public class OperatorEventProcessingTest {
         .metadata(createMetadata(createNSEventName(nameAppendix, item), OP_NS, false))
         .reportingComponent(WEBLOGIC_OPERATOR_COMPONENT)
         .reportingInstance(OPERATOR_POD_NAME)
-        .lastTimestamp(OffsetDateTime.now())
+        .lastTimestamp(SystemClock.now())
         .type(EventConstants.EVENT_NORMAL)
         .reason(item.getReason())
         .message(item.getMessage(new EventHelper.EventData(item, "")))

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -19,6 +19,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonPatchBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainConditionType;
@@ -314,7 +315,7 @@ public class DomainStatusPatchTest {
   private OffsetDateTime now() {
     // Truncate to seconds because we intermittently see a different number of trailing decimals
     // that can cause the string comparison to fail
-    return OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+    return SystemClock.now().truncatedTo(ChronoUnit.SECONDS);
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
@@ -7,6 +7,7 @@ import java.math.BigInteger;
 import java.time.OffsetDateTime;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import oracle.kubernetes.utils.SystemClock;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -14,7 +15,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class KubernetesUtilsTest {
 
-  private static final OffsetDateTime startTime = OffsetDateTime.now();
+  private static final OffsetDateTime startTime = SystemClock.now();
   private static final OffsetDateTime time1 = startTime.plusSeconds(1);
   private static final OffsetDateTime time2 = startTime.plusSeconds(2);
 
@@ -47,7 +48,7 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenHaveLargeResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime now = SystemClock.now();
 
     // This needs to be a value bigger than 2147483647
     String resVersion = "2733280673";
@@ -61,7 +62,7 @@ public class KubernetesUtilsTest {
 
   @Test
   public void whenHaveNonParsableResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime now = SystemClock.now();
 
     String resVersion = "ThisIsNotANumber";
     String differentResVersion = "SomeOtherValueAlsoNotANumber";

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -27,6 +27,7 @@ import oracle.kubernetes.operator.utils.InMemoryCertificates;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import org.hamcrest.junit.MatcherAssert;
@@ -66,7 +67,7 @@ public class PodPresenceTest {
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final DomainProcessorImpl processor =
       new DomainProcessorImpl(DomainProcessorDelegateStub.createDelegate(testSupport));
-  private OffsetDateTime clock = OffsetDateTime.now();
+  private OffsetDateTime clock = SystemClock.now();
   private final Packet packet = new Packet();
   private final V1Pod pod =
       new V1Pod()

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/SecretHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/SecretHelperTest.java
@@ -24,7 +24,7 @@ import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.SECRET_NAME;
 import static oracle.kubernetes.operator.helpers.SecretHelper.PASSWORD_KEY;
 import static oracle.kubernetes.operator.helpers.SecretHelper.USERNAME_KEY;
-import static oracle.kubernetes.operator.helpers.SecretHelper.getAuthorizationHeaderFactory;
+import static oracle.kubernetes.operator.helpers.SecretHelper.getAuthorizationSource;
 import static oracle.kubernetes.operator.logging.MessageKeys.SECRET_DATA_NOT_FOUND;
 import static oracle.kubernetes.operator.logging.MessageKeys.SECRET_NOT_FOUND;
 import static oracle.kubernetes.utils.LogMatcher.containsWarning;
@@ -67,7 +67,7 @@ public class SecretHelperTest {
   }
 
   private Packet runSteps() {
-    return testSupport.runSteps(SecretHelper.createAuthorizationHeaderFactoryStep());
+    return testSupport.runSteps(SecretHelper.createAuthorizationSourceStep());
   }
 
   @Test
@@ -93,7 +93,7 @@ public class SecretHelperTest {
   }
 
   @Test
-  void afterStepsRun_packetContainsAuthorizationHeaderFactoryWithCredentials() {
+  void afterStepsRun_packetContainsAuthorizationSourceWithCredentials() {
     testSupport.defineResources(new V1Secret()
                       .metadata(new V1ObjectMeta().namespace(NS).name(SECRET_NAME))
                       .data(Map.of(
@@ -102,7 +102,7 @@ public class SecretHelperTest {
 
     Packet packet = runSteps();
 
-    assertThat(getAuthorizationHeaderFactory(packet).createBasicAuthorizationString(),
+    assertThat(getAuthorizationSource(packet).createBasicAuthorizationString(),
           equalTo(createExpectedBasicAuthorizationString()));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
@@ -24,6 +24,7 @@ import oracle.kubernetes.operator.builders.WatchEvent;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.Domain;
@@ -59,7 +60,7 @@ public class ServicePresenceTest {
   private final DomainProcessorImpl processor =
       new DomainProcessorImpl(createStrictStub(DomainProcessorDelegate.class));
   private final Packet packet = new Packet();
-  private OffsetDateTime clock = OffsetDateTime.now();
+  private OffsetDateTime clock = SystemClock.now();
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TuningParametersStub.java
@@ -65,7 +65,7 @@ public abstract class TuningParametersStub implements TuningParameters {
 
   @Override
   public MainTuning getMainTuning() {
-    return new MainTuning(5, 2, 2, 2, 2, 2, 2, 30, 2L, 2L);
+    return new MainTuning(5, 2, 2, 2, 2, 2, 2, 30, 2L, 2L, 120);
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
@@ -173,7 +173,7 @@ public class MonitoringExporterStepsTest {
 
     testSupport.runSteps(
           Step.chain(
-                SecretHelper.createAuthorizationHeaderFactoryStep(),
+                SecretHelper.createAuthorizationSourceStep(),
                 MonitorExporterSteps.createConfigurationUpdateStep()));
 
     assertThat(httpSupport.getLastRequestContents(),
@@ -204,7 +204,7 @@ public class MonitoringExporterStepsTest {
 
     testSupport.runSteps(
           Step.chain(
-                SecretHelper.createAuthorizationHeaderFactoryStep(),
+                SecretHelper.createAuthorizationSourceStep(),
                 MonitorExporterSteps.createConfigurationTestAndUpdateSteps()));
 
 
@@ -240,7 +240,7 @@ public class MonitoringExporterStepsTest {
 
     testSupport.runSteps(
           Step.chain(
-                SecretHelper.createAuthorizationHeaderFactoryStep(),
+                SecretHelper.createAuthorizationSourceStep(),
                 MonitorExporterSteps.createConfigurationTestAndUpdateSteps()));
 
     assertThat(httpSupport.getLastRequest().method(), equalTo("GET"));

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
@@ -5,7 +5,6 @@ package oracle.kubernetes.operator.steps;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +34,7 @@ import oracle.kubernetes.operator.http.HttpResponseStub;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
@@ -292,7 +292,7 @@ public class MonitoringExporterStepsTest {
   }
 
   private void setDeletingState(V1ObjectMeta meta) {
-    meta.setDeletionTimestamp(OffsetDateTime.now());
+    meta.setDeletionTimestamp(SystemClock.now());
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ReadHealthStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ReadHealthStepTest.java
@@ -22,6 +22,7 @@ import io.kubernetes.client.openapi.models.V1ServiceSpec;
 import oracle.kubernetes.operator.DomainProcessorTestSetup;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.TuningParametersStub;
 import oracle.kubernetes.operator.http.HttpAsyncTestSupport;
 import oracle.kubernetes.operator.http.HttpResponseStub;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
@@ -31,6 +32,7 @@ import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
+import oracle.kubernetes.utils.SystemClockTestSupport;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
@@ -113,6 +115,8 @@ public class ReadHealthStepTest {
         .withLogLevel(Level.FINE));
     mementos.add(testSupport.install());
     mementos.add(httpSupport.install());
+    mementos.add(SystemClockTestSupport.installClock());
+    mementos.add(TuningParametersStub.install());
 
     testSupport.addDomainPresenceInfo(info);
     testSupport.addToPacket(SERVER_HEALTH_MAP, serverHealthMap);
@@ -392,6 +396,21 @@ public class ReadHealthStepTest {
     testSupport.runSteps(readHealthStep);
 
     assertThat(info.getWebLogicCredentialsSecret(), is(notNullValue()));
+  }
+
+  @Test
+  public void whenAuthorizedToReadHealthAndThenWait_verifySecretCleared() {
+    selectServer(MANAGED_SERVER1);
+
+    defineResponse(200, "", "http://127.0.0.1:8001");
+
+    testSupport.runSteps(readHealthStep);
+
+    assertThat(info.getWebLogicCredentialsSecret(), is(notNullValue()));
+
+    SystemClockTestSupport.increment(180);
+
+    assertThat(info.getWebLogicCredentialsSecret(), is(nullValue()));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/utils/SystemClockTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/SystemClockTestSupport.java
@@ -38,7 +38,7 @@ public class SystemClockTestSupport {
   }
 
   static class TestSystemClock extends SystemClock {
-    private final OffsetDateTime testStartTime = OffsetDateTime.now();
+    private final OffsetDateTime testStartTime = SystemClock.now();
     private OffsetDateTime currentTime = testStartTime;
 
     @Override


### PR DESCRIPTION
This resolves an observed increase in the operator's network utilization by not reading the webLogicCredentialsSecret every time that it is necessary and, instead, caching the value for a configurable time period. Additionally, the secret is cleared (and then reread on the next iteration) following an auth or authz failure.