### PR TITLE
Add NS and domainUID to log messages in more code paths

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
@@ -216,7 +216,7 @@ class DomainRecheck {
 
   private Step startNamespaceSteps(String ns) {
     try (LoggingContext ignored =
-             setThreadContext().namespace(ns).domainUid("")) {
+             setThreadContext().namespace(ns)) {
       return Step.chain(
           createNamespaceReview(ns),
           new StartNamespaceBeforeStep(ns),

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainRecheck.java
@@ -36,6 +36,7 @@ import oracle.kubernetes.operator.work.Step;
 
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.NAMESPACE_WATCHING_STARTED;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
+import static oracle.kubernetes.operator.logging.LoggingContext.setThreadContext;
 
 class DomainRecheck {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
@@ -93,9 +94,12 @@ class DomainRecheck {
 
       // we don't have the domain presence information yet
       // we add a logging context to pass the namespace information to the LoggingFormatter
-      packet.getComponents().put(
-          LoggingContext.LOGGING_CONTEXT_KEY,
-          Component.createFor(new LoggingContext().namespace(ns)));
+
+      if (isDomainNamespace) {
+        packet.getComponents().put(
+            LoggingContext.LOGGING_CONTEXT_KEY,
+            Component.createFor(new LoggingContext().namespace(ns)));
+      }
 
       V1SubjectRulesReviewStatus status = nss.getRulesReviewStatus().updateAndGet(prev -> {
         if (prev != null) {
@@ -211,10 +215,13 @@ class DomainRecheck {
   }
 
   private Step startNamespaceSteps(String ns) {
-    return Step.chain(
+    try (LoggingContext ignored =
+             setThreadContext().namespace(ns).domainUid("")) {
+      return Step.chain(
           createNamespaceReview(ns),
           new StartNamespaceBeforeStep(ns),
           domainNamespaces.readExistingResources(ns, domainProcessor));
+    }
   }
 
   // for testing

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -544,7 +544,7 @@ public class Main {
     }
   }
 
-  private static Packet createPacketWithLoggingContext(String ns) {
+  static Packet createPacketWithLoggingContext(String ns) {
     Packet packet = new Packet();
     packet.getComponents().put(
         LoggingContext.LOGGING_CONTEXT_KEY,

--- a/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/StuckPodProcessing.java
@@ -17,6 +17,7 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.PodHelper;
+import oracle.kubernetes.operator.logging.LoggingContext;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
@@ -25,6 +26,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.SystemClock;
 
+import static oracle.kubernetes.operator.logging.LoggingContext.setThreadContext;
 import static oracle.kubernetes.operator.logging.MessageKeys.POD_FORCE_DELETED;
 
 /**
@@ -44,7 +46,7 @@ public class StuckPodProcessing {
     Step step = new CallBuilder()
           .withLabelSelectors(LabelConstants.getCreatedByOperatorSelector())
           .listPodAsync(namespace, new PodListProcessing(namespace, SystemClock.now()));
-    mainDelegate.runSteps(step);
+    mainDelegate.runSteps(Main.createPacketWithLoggingContext(namespace), step, null);
   }
 
   @SuppressWarnings("unchecked")
@@ -123,7 +125,7 @@ public class StuckPodProcessing {
       return new CallBuilder()
             .withGracePeriodSeconds(0)
             .deletePodAsync(getName(pod), getNamespace(pod), getDomainUid(pod), null,
-                  new ForcedDeleteResponseStep(getName(pod), getNamespace(pod)));
+                  new ForcedDeleteResponseStep(getName(pod), getNamespace(pod), getDomainUid(pod)));
     }
 
     private String getName(V1Pod pod) {
@@ -143,15 +145,20 @@ public class StuckPodProcessing {
 
     private final String name;
     private final String namespace;
+    private final String domainUID;
 
-    public ForcedDeleteResponseStep(String name, String namespace) {
+    public ForcedDeleteResponseStep(String name, String namespace, String domainUID) {
       this.name = name;
       this.namespace = namespace;
+      this.domainUID = domainUID;
     }
 
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<Object> callResponse) {
-      LOGGER.info(POD_FORCE_DELETED, name, namespace);
+      try (LoggingContext ignored =
+               setThreadContext().namespace(namespace).domainUid(domainUID)) {
+        LOGGER.info(POD_FORCE_DELETED, name, namespace);
+      }
       return super.onSuccess(packet, callResponse);
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
@@ -18,6 +18,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
+import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.SystemClockTestSupport;
@@ -200,6 +201,11 @@ public class StuckPodTest {
     @Override
     public void runSteps(Step firstStep) {
       testSupport.runSteps(firstStep);
+    }
+
+    @Override
+    public void runSteps(Packet packet, Step firstStep,  Runnable completionAction) {
+      testSupport.runSteps(packet, firstStep);
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/FiberTestSupport.java
@@ -196,6 +196,19 @@ public class FiberTestSupport {
   }
 
   /**
+   * Starts a unit-test fiber with the specified packet and step.
+   *
+   * @param packet the packet to use
+   * @param step the first step to run
+   */
+  public Packet runSteps(Packet packet, Step step) {
+    fiber = engine.createFiber();
+    fiber.start(step, packet, completionCallback);
+
+    return packet;
+  }
+
+  /**
    * Starts a unit-test fiber with the specified step.
    *
    * @param nextStep the first step to run


### PR DESCRIPTION
Make sure the domain namespace and domainUID (when applicable) are in the log messages that are originated from the following code paths:
1) HttpAsyncRequest response code path;
2) Code path to create start namespaces steps when there is no fiber on the current thread;
3) StuckPodProcessing code path;
4) AsyncRequestStep where operator's namespace is accidentally used in the log messages.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4833/