### PR TITLE
Bug fix for ClusterIP admin service annotations and labels

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -268,12 +268,20 @@ public class ServiceHelper {
 
     @Override
     protected Map<String, String> getServiceLabels() {
-      return getServerSpec().getServiceLabels();
+      Map<String, String> serviceLabels = getServerSpec().getServiceLabels();
+      if (isForAdminServer()) {
+        serviceLabels.putAll(getDomain().getAdminServerSpec().getServiceLabels());
+      }
+      return serviceLabels;
     }
 
     @Override
     protected Map<String, String> getServiceAnnotations() {
-      return getServerSpec().getServiceAnnotations();
+      Map<String, String> serviceAnnotations = getServerSpec().getServiceAnnotations();
+      if (isForAdminServer()) {
+        serviceAnnotations.putAll(getDomain().getAdminServerSpec().getServiceAnnotations());
+      }
+      return serviceAnnotations;
     }
 
     String getServerName() {


### PR DESCRIPTION
Fix for issue reported in https://github.com/oracle/weblogic-kubernetes-operator/issues/2010

Added integration test covering the use case.

Jenkins results:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4843/ (after adding integration test)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4836/ (with just the product fix)