### PR TITLE
Update the release notes and versions in preparation for operator 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Oracle is finding ways for organizations using WebLogic Server to run important 
 The fastest way to experience the operator is to follow the [Quick Start guide](https://oracle.github.io/weblogic-kubernetes-operator/quickstart/), or you can peruse our [documentation](https://oracle.github.io/weblogic-kubernetes-operator), read our [blogs](https://blogs.oracle.com/weblogicserver/updated-weblogic-kubernetes-support-with-operator-20), or try out the [samples](https://oracle.github.io/weblogic-kubernetes-operator/samples/).
 
 ***
-The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 3.2.1.
-This release was published on April 5, 2021.
+The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 3.2.2.
+This release was published on April 26, 2021.
 ***
 
 # Documentation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The fastest way to experience the operator is to follow the [Quick Start guide](
 
 ***
 The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 3.2.2.
-This release was published on April 26, 2021.
+This release was published on April 27, 2021.
 ***
 
 # Documentation

--- a/buildDockerImage.sh
+++ b/buildDockerImage.sh
@@ -33,7 +33,7 @@ while getopts "t:" optname; do
   esac
 done
 
-IMAGE_NAME=${name:-ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1}
+IMAGE_NAME=${name:-ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2}
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 
 # Proxy settings

--- a/buildtime-reports/pom.xml
+++ b/buildtime-reports/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>operator-parent</artifactId>
         <groupId>oracle.kubernetes</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>buildtime-reports</artifactId>

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -590,7 +590,7 @@
       "type": "object",
       "properties": {
         "image": {
-          "description": "The WebLogic Monitoring Exporter sidecar image name. Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.1",
+          "description": "The WebLogic Monitoring Exporter sidecar image name. Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.2",
           "type": "string"
         },
         "imagePullPolicy": {

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -117,7 +117,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | Name | Type | Description |
 | --- | --- | --- |
 | `configuration` | Map | The configuration for the WebLogic Monitoring Exporter sidecar. If specified, the operator will deploy a sidecar alongside each server instance. See https://github.com/oracle/weblogic-monitoring-exporter |
-| `image` | string | The WebLogic Monitoring Exporter sidecar image name. Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.1 |
+| `image` | string | The WebLogic Monitoring Exporter sidecar image name. Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.2 |
 | `imagePullPolicy` | string | The image pull policy for the WebLogic Monitoring Exporter sidecar image. Legal values are Always, Never, and IfNotPresent. Defaults to Always if image ends in :latest; IfNotPresent, otherwise. |
 
 ### Server Pod

--- a/documentation/staging/content/_index.md
+++ b/documentation/staging/content/_index.md
@@ -24,7 +24,7 @@ using the operator to deploy and run a WebLogic domain container-packaged web ap
 #### Current production release
 
 The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 3.2.2.
-This release was published on April 26, 2021. See the operator prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction#operator-prerequisites" >}}).
+This release was published on April 27, 2021. See the operator prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction#operator-prerequisites" >}}).
 
 ***
 

--- a/documentation/staging/content/_index.md
+++ b/documentation/staging/content/_index.md
@@ -23,8 +23,8 @@ using the operator to deploy and run a WebLogic domain container-packaged web ap
 ***
 #### Current production release
 
-The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 3.2.1.
-This release was published on April 5, 2021. See the operator prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction#operator-prerequisites" >}}).
+The [current release of the operator](https://github.com/oracle/weblogic-kubernetes-operator/releases) is 3.2.2.
+This release was published on April 26, 2021. See the operator prerequisites and supported environments [here]({{< relref "/userguide/introduction/introduction#operator-prerequisites" >}}).
 
 ***
 

--- a/documentation/staging/content/faq/namespace-management.md
+++ b/documentation/staging/content/faq/namespace-management.md
@@ -45,7 +45,7 @@ elkIntegrationEnabled: false
 externalDebugHttpPort: 30999
 externalRestEnabled: false
 externalRestHttpsPort: 31001
-image: ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1
+image: ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2
 imagePullPolicy: IfNotPresent
 internalDebugHttpPort: 30999
 istioEnabled: false

--- a/documentation/staging/content/quickstart/get-images.md
+++ b/documentation/staging/content/quickstart/get-images.md
@@ -10,7 +10,7 @@ weight: 3
 1. Pull the operator image:
 
     ```shell
-    $ docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1
+    $ docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2
     ```
 
 1. Pull the Traefik ingress controller image:

--- a/documentation/staging/content/quickstart/install.md
+++ b/documentation/staging/content/quickstart/install.md
@@ -50,7 +50,7 @@ $ helm install traefik-operator traefik/traefik \
     ```shell
     $ helm install sample-weblogic-operator kubernetes/charts/weblogic-operator \
       --namespace sample-weblogic-operator-ns \
-      --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1 \
+      --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2 \
       --set serviceAccount=sample-weblogic-operator-sa \
       --set "enableClusterRoleBinding=true" \
       --set "domainNamespaceSelectionStrategy=LabelSelector" \

--- a/documentation/staging/content/quickstart/prerequisites.md
+++ b/documentation/staging/content/quickstart/prerequisites.md
@@ -12,5 +12,5 @@ The operator uses Helm to create and deploy the necessary resources and then run
 You should clone this repository to your local machine so that you have access to the
 various sample files mentioned throughout this guide:
 ```shell
-$ git clone --branch v3.2.1 https://github.com/oracle/weblogic-kubernetes-operator
+$ git clone --branch v3.2.2 https://github.com/oracle/weblogic-kubernetes-operator
 ```

--- a/documentation/staging/content/release-notes.md
+++ b/documentation/staging/content/release-notes.md
@@ -8,7 +8,7 @@ draft: false
 
 | Date | Version | Introduces backward incompatibilities? | Change |
 | --- | --- | --- | --- |
-| April 26, 2021 | v3.2.2 | no | Updated several dependencies, including the Oracle Linux base for the container image. |
+| April 27, 2021 | v3.2.2 | no | Resolved a set of issues with many related to reducing the operator's network utilization. |
 | April 5, 2021 | v3.2.1 | no | Updated several dependencies, including the Oracle Linux base for the container image. |
 | March 31, 2021 | v3.2.0 | no | Online updates for dynamic changes for Model in Image, injection of the WebLogic Monitoring Exporter, other features, and a significant number of additional fixes. |
 | March 1, 2021 | v3.1.4 | no | Resolved an issue where the operator would ignore live data that was older than cached data, such as following an etcd restore and updated Kubernetes Java Client and Bouncy Castle dependencies. |
@@ -43,7 +43,7 @@ draft: false
 
 * Resolved an issue where the operator would retry Kubernetes API requests that timed out without a backoff causing increased network utilization ([#2300](https://github.com/oracle/weblogic-kubernetes-operator/pull/2300)).
 * Resolved an issue where the operator would select the incorrect WebLogic Server port for administrative traffic ([#2301](https://github.com/oracle/weblogic-kubernetes-operator/pull/2301)).
-* Resolved an issue where the operator when running in a large and heavily loaded Kubernetes cluster would not properly detect when a domain had been deleted and recreated ([#2305](https://github.com/oracle/weblogic-kubernetes-operator/pull/2305) and [#2314](https://github.com/oracle/weblogic-kubernetes-operator/pull/2314)).
+* Resolved an issue where the operator, when running in a large and heavily loaded Kubernetes cluster, would not properly detect when a domain had been deleted and recreated ([#2305](https://github.com/oracle/weblogic-kubernetes-operator/pull/2305) and [#2314](https://github.com/oracle/weblogic-kubernetes-operator/pull/2314)).
 * Resolved an issue where the operator would fail to recover and begin processing in a namespace if the operator did not immediately have privileges in that namespace when it was first detected ([#2315](https://github.com/oracle/weblogic-kubernetes-operator/pull/2315)).
 * The operator logs a message when it cannot generate a `NamespaceWatchingStopped` Event in a namespace because the operator no longer has privileges in that namespace ([#2323](https://github.com/oracle/weblogic-kubernetes-operator/pull/2323)).
 * Resolved an issue where the operator would repeatedly replace a ConfigMap causing increased network utilization ([#2321](https://github.com/oracle/weblogic-kubernetes-operator/pull/2321)).

--- a/documentation/staging/content/release-notes.md
+++ b/documentation/staging/content/release-notes.md
@@ -8,6 +8,7 @@ draft: false
 
 | Date | Version | Introduces backward incompatibilities? | Change |
 | --- | --- | --- | --- |
+| April 26, 2021 | v3.2.2 | no | Updated several dependencies, including the Oracle Linux base for the container image. |
 | April 5, 2021 | v3.2.1 | no | Updated several dependencies, including the Oracle Linux base for the container image. |
 | March 31, 2021 | v3.2.0 | no | Online updates for dynamic changes for Model in Image, injection of the WebLogic Monitoring Exporter, other features, and a significant number of additional fixes. |
 | March 1, 2021 | v3.1.4 | no | Resolved an issue where the operator would ignore live data that was older than cached data, such as following an etcd restore and updated Kubernetes Java Client and Bouncy Castle dependencies. |
@@ -37,6 +38,17 @@ draft: false
 | March 20, 2018 |  | yes | Several files and input parameters have been renamed.  This affects how operators and domains are created.  It also changes generated Kubernetes artifacts, therefore customers must recreate their operators and domains.
 
 ### Change log
+
+#### Operator 3.2.2
+
+* Resolved an issue where the operator would retry Kubernetes API requests that timed out without a backoff causing increased network utilization ([#2300](https://github.com/oracle/weblogic-kubernetes-operator/pull/2300)).
+* Resolved an issue where the operator would select the incorrect WebLogic Server port for administrative traffic ([#2301](https://github.com/oracle/weblogic-kubernetes-operator/pull/2301)).
+* Resolved an issue where the operator when running in a large and heavily loaded Kubernetes cluster would not properly detect when a domain had been deleted and recreated ([#2305](https://github.com/oracle/weblogic-kubernetes-operator/pull/2305) and [#2314](https://github.com/oracle/weblogic-kubernetes-operator/pull/2314)).
+* Resolved an issue where the operator would fail to recover and begin processing in a namespace if the operator did not immediately have privileges in that namespace when it was first detected ([#2315](https://github.com/oracle/weblogic-kubernetes-operator/pull/2315)).
+* The operator logs a message when it cannot generate a `NamespaceWatchingStopped` Event in a namespace because the operator no longer has privileges in that namespace ([#2323](https://github.com/oracle/weblogic-kubernetes-operator/pull/2323)).
+* Resolved an issue where the operator would repeatedly replace a ConfigMap causing increased network utilization ([#2321](https://github.com/oracle/weblogic-kubernetes-operator/pull/2321)).
+* Resolved an issue where the operator would repeatedly read a Secret causing increased network utilization ([#2326](https://github.com/oracle/weblogic-kubernetes-operator/pull/2326)).
+* Resolved an issue where the operator was not honoring `domain.spec.adminServer.serverService` ([#2334](https://github.com/oracle/weblogic-kubernetes-operator/pull/2334)).
 
 #### Operator 3.2.1
 

--- a/documentation/staging/content/samples/simple/azure-kubernetes-service/domain-on-pv.md
+++ b/documentation/staging/content/samples/simple/azure-kubernetes-service/domain-on-pv.md
@@ -29,7 +29,7 @@ This sample demonstrates how to use the [Oracle WebLogic Server Kubernetes Opera
 Clone the [Oracle WebLogic Server Kubernetes Operator repository](https://github.com/oracle/weblogic-kubernetes-operator) to your machine. We will use several scripts in this repository to create a WebLogic domain. This sample was tested with v3.1.1, but should work with the latest release.
 
 ```shell
-$ git clone --branch v3.2.1 https://github.com/oracle/weblogic-kubernetes-operator.git
+$ git clone --branch v3.2.2 https://github.com/oracle/weblogic-kubernetes-operator.git
 ```
 
 {{% notice info %}} The following sections of the sample instructions will guide you, step-by-step, through the process of setting up a WebLogic cluster on AKS - remaining as close as possible to a native Kubernetes experience. This lets you understand and customize each step. If you wish to have a more automated experience that abstracts some lower level details, you can skip to the [Automation](#automation) section.

--- a/documentation/staging/content/samples/simple/azure-kubernetes-service/model-in-image.md
+++ b/documentation/staging/content/samples/simple/azure-kubernetes-service/model-in-image.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the [Oracle WebLogic Server Kubernetes Opera
 Clone the [Oracle WebLogic Server Kubernetes Operator repository](https://github.com/oracle/weblogic-kubernetes-operator) to your machine. We will use several scripts in this repository to create a WebLogic domain. This sample was tested with v3.1.1, but should work with the latest release.
 
 ```shell
-$ git clone --branch v3.2.1 https://github.com/oracle/weblogic-kubernetes-operator.git
+$ git clone --branch v3.2.2 https://github.com/oracle/weblogic-kubernetes-operator.git
 ```
 ```shell
 $ cd weblogic-kubernetes-operator

--- a/documentation/staging/content/samples/simple/domains/model-in-image/prerequisites.md
+++ b/documentation/staging/content/samples/simple/domains/model-in-image/prerequisites.md
@@ -23,7 +23,7 @@ weight: 1
    $ cd /tmp
    ```
    ```shell
-   $ git clone --branch v3.2.1 https://github.com/oracle/weblogic-kubernetes-operator.git
+   $ git clone --branch v3.2.2 https://github.com/oracle/weblogic-kubernetes-operator.git
    ```
 
    > **Note**: We will refer to the top directory of the operator source tree as `/tmp/weblogic-kubernetes-operator`; however, you can use a different location.

--- a/documentation/staging/content/samples/simple/tanzu-kubernetes-service/_index.md
+++ b/documentation/staging/content/samples/simple/tanzu-kubernetes-service/_index.md
@@ -63,7 +63,7 @@ Kubernetes Operators use [Helm](https://helm.sh/) to manage Kubernetes applicati
 Clone the repository.
 
 ```shell
-$ git clone --branch v3.2.1 https://github.com/oracle/weblogic-kubernetes-operator.git
+$ git clone --branch v3.2.2 https://github.com/oracle/weblogic-kubernetes-operator.git
 ```
 ```shell
 $ cd weblogic-kubernetes-operator

--- a/documentation/staging/content/userguide/introduction/architecture.md
+++ b/documentation/staging/content/userguide/introduction/architecture.md
@@ -17,7 +17,7 @@ The operator consists of the following parts:
 The operator is packaged in a [container image](https://github.com/orgs/oracle/packages/container/package/weblogic-kubernetes-operator) which you can access using the following `docker pull` commands:  
 
 ```shell
-$ docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1
+$ docker pull ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2
 ```
 
 For more details on acquiring the operator image and prerequisites for installing the operator, consult the [Quick Start guide]({{< relref "/quickstart/_index.md" >}}).

--- a/documentation/staging/content/userguide/introduction/introduction.md
+++ b/documentation/staging/content/userguide/introduction/introduction.md
@@ -16,7 +16,7 @@ Detailed instructions are available [here]({{< relref "/userguide/managing-opera
 
 ### Operator prerequisites
 
-For the current production release 3.2.1:
+For the current production release 3.2.2:
 
 * Kubernetes 1.16.15+, 1.17.13+, 1.18.10+, and 1.19.7+ (check with `kubectl version`).
 * Flannel networking v0.9.1-amd64 or later (check with `docker images | grep flannel`), Calico networking v3.16.1 or later,

--- a/documentation/staging/content/userguide/introduction/introduction.md
+++ b/documentation/staging/content/userguide/introduction/introduction.md
@@ -23,7 +23,7 @@ For the current production release 3.2.2:
  *or* OpenShift SDN on OpenShift 4.3 systems.
 * Docker 18.9.1 or 19.03.1+ (check with `docker version`) *or* CRI-O 1.14.7+ (check with `crictl version | grep RuntimeVersion`).
 * Helm 3.3.4+ (check with `helm version --client --short`).
-* For domain home source type `Model in Image`, WebLogic Deploy Tooling 1.9.10.
+* For domain home source type `Model in Image`, WebLogic Deploy Tooling 1.9.11.
 * Either Oracle WebLogic Server 12.2.1.3.0 with patch 29135930, Oracle WebLogic Server 12.2.1.4.0, or Oracle WebLogic Server 14.1.1.0.0.
    * The existing WebLogic Server image, `container-registry.oracle.com/middleware/weblogic:12.2.1.3`,
    has all the necessary patches applied.

--- a/documentation/staging/content/userguide/managing-domains/domain-lifecycle/restarting.md
+++ b/documentation/staging/content/userguide/managing-domains/domain-lifecycle/restarting.md
@@ -188,7 +188,7 @@ d. Update the `image` field of the Domain YAML file, specifying the new image na
      ```yaml
      domain:
        spec:
-         image: ghcr.io/oracle/weblogic-updated:3.2.1
+         image: ghcr.io/oracle/weblogic-updated:3.2.2
      ```
 e. The operator will now initiate a rolling restart, which will apply the updated image, for all the servers in the domain.
 

--- a/documentation/staging/content/userguide/managing-operators/installation/_index.md
+++ b/documentation/staging/content/userguide/managing-operators/installation/_index.md
@@ -113,7 +113,7 @@ the `helm upgrade` command requires that you supply a new Helm chart and image. 
 ```shell
 $ helm upgrade \
   --reuse-values \
-  --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1 \
+  --set image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2 \
   --namespace weblogic-operator-namespace \
   --wait \
   weblogic-operator \

--- a/documentation/staging/content/userguide/managing-operators/using-the-operator/using-helm.md
+++ b/documentation/staging/content/userguide/managing-operators/using-the-operator/using-helm.md
@@ -102,7 +102,7 @@ javaLoggingLevel:  "FINE"
 ##### `image`
 Specifies the container image containing the operator code.
 
-Defaults to `ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1`.
+Defaults to `ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2`.
 
 Example:
 ```yaml

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>oracle.kubernetes</groupId>
         <artifactId>operator-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>integration-tests</artifactId>

--- a/json-schema-generator/pom.xml
+++ b/json-schema-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>operator-parent</artifactId>
         <groupId>oracle.kubernetes</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>json-schema</artifactId>

--- a/kubernetes/charts/weblogic-operator/Chart.yaml
+++ b/kubernetes/charts/weblogic-operator/Chart.yaml
@@ -6,5 +6,5 @@ name: weblogic-operator
 description: Helm chart for configuring the WebLogic operator.
 
 type: application
-version: 3.2.1
-appVersion: 3.2.1
+version: 3.2.2
+appVersion: 3.2.2

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -63,7 +63,7 @@ domainNamespaces:
 enableClusterRoleBinding: false
 
 # image specifies the container image containing the operator.
-image: "ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1"
+image: "ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2"
 
 # imagePullPolicy specifies the image pull policy for the operator's container image.
 imagePullPolicy: IfNotPresent

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: de883bb3d965b09f91bc60c21481d6d61f441ac6ddf9952a9189f85eb887b507
+    weblogic.sha256: 8baaf8061fb45bcf1035ef0c7c40ccd056229d662921ad3ba5f6258f2de04720
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -32,7 +32,7 @@ spec:
                 properties:
                   image:
                     description: The WebLogic Monitoring Exporter sidecar image name.
-                      Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.1
+                      Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.2
                     type: string
                   imagePullPolicy:
                     description: The image pull policy for the WebLogic Monitoring

--- a/kubernetes/crd/domain-v1beta1-crd.yaml
+++ b/kubernetes/crd/domain-v1beta1-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: de883bb3d965b09f91bc60c21481d6d61f441ac6ddf9952a9189f85eb887b507
+    weblogic.sha256: 8baaf8061fb45bcf1035ef0c7c40ccd056229d662921ad3ba5f6258f2de04720
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -35,7 +35,7 @@ spec:
               properties:
                 image:
                   description: The WebLogic Monitoring Exporter sidecar image name.
-                    Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.1
+                    Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.2
                   type: string
                 imagePullPolicy:
                   description: The image pull policy for the WebLogic Monitoring Exporter

--- a/kubernetes/hands-on-lab/tutorials/install.operator.ocishell.md
+++ b/kubernetes/hands-on-lab/tutorials/install.operator.ocishell.md
@@ -7,7 +7,7 @@ An operator is an application-specific controller that extends Kubernetes to cre
 #### Clone the operator repository to a Cloud Shell instance ####
 First, clone the operator git repository to OCI Cloud Shell.
 ```shell
-$ git clone --branch v3.2.1 https://github.com/oracle/weblogic-kubernetes-operator.git
+$ git clone --branch v3.2.2 https://github.com/oracle/weblogic-kubernetes-operator.git
 ```
 The output should be similar to the following:
 ```shell
@@ -78,7 +78,7 @@ Execute the following `helm install`:
 $ helm install sample-weblogic-operator \
   kubernetes/charts/weblogic-operator \
   --namespace sample-weblogic-operator-ns \
-  --set "image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.1" \
+  --set "image=ghcr.io/oracle/weblogic-kubernetes-operator:3.2.2" \
   --set "serviceAccount=sample-weblogic-operator-sa" \
   --set "enableClusterRoleBinding=true" \
   --set "domainNamespaceSelectionStrategy=LabelSelector" \

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>oracle.kubernetes</groupId>
         <artifactId>operator-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>installation-tests</artifactId>

--- a/operator-build-maven-plugin/pom.xml
+++ b/operator-build-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>operator-parent</artifactId>
         <groupId>oracle.kubernetes</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>operator-build-maven-plugin</artifactId>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>oracle.kubernetes</groupId>
     <artifactId>operator-parent</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </parent>
 
   <artifactId>weblogic-kubernetes-operator</artifactId>

--- a/operator/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
@@ -6,7 +6,7 @@ package oracle.kubernetes.operator;
 /** Kubernetes constants. */
 public interface KubernetesConstants {
   String DEFAULT_IMAGE = "container-registry.oracle.com/middleware/weblogic:12.2.1.4";
-  String DEFAULT_EXPORTER_IMAGE = "ghcr.io/oracle/weblogic-monitoring-exporter:2.0.1";
+  String DEFAULT_EXPORTER_IMAGE = "ghcr.io/oracle/weblogic-monitoring-exporter:2.0.2";
   String EXPORTER_CONTAINER_NAME = "monitoring-exporter";
   String ALWAYS_IMAGEPULLPOLICY = ImagePullPolicy.Always.name();
   String IFNOTPRESENT_IMAGEPULLPOLICY = ImagePullPolicy.IfNotPresent.name();

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>oracle.kubernetes</groupId>
   <artifactId>operator-parent</artifactId>
-  <version>3.2.1</version>
+  <version>3.2.2</version>
 
   <modules>
     <module>operator</module>
@@ -24,7 +24,7 @@
     <developerConnection>scm:git:git@github.com:oracle/weblogic-kubernetes-operator.git
     </developerConnection>
     <url>https://github.com/oracle/weblogic-kubernetes-operator</url>
-    <tag>v3.2.1</tag>
+    <tag>v3.2.2</tag>
   </scm>
 
   <description>Oracle WebLogic Server Kubernetes Operator</description>

--- a/swagger-generator/pom.xml
+++ b/swagger-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>oracle.kubernetes</groupId>
         <artifactId>operator-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>operator-swagger</artifactId>


### PR DESCRIPTION
We have a bunch of good bug fixes now, including all of the stress bugs. I'm updating the release notes and version numbers so that we can be ready to release 3.2.2.

I'm thinking that we should wait for the documentation fixes that Rosemary is working on; however, I'm also thinking that we should release this minor version before we merge Lenny's work (likely sometime next week) and are thereafter working toward 3.3.0.
