### PR TITLE
Fix missing error output from WDT compareModel

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -609,11 +609,11 @@ function diff_model() {
   # $1 - new model, $2 original model
 
   # no need to redirect output, -output_dir for compareModel will generate the output file
-  ${WDT_BINDIR}/compareModel.sh -oracle_home ${ORACLE_HOME} -output_dir /tmp $1 $2 > /dev/null 2>&1
+  ${WDT_BINDIR}/compareModel.sh -oracle_home ${ORACLE_HOME} -output_dir /tmp $1 $2 >  ${WDT_OUTPUT} 2>&1
   ret=$?
   if [ $ret -ne 0 ]; then
     trace SEVERE "WDT Compare Model failed:"
-    cat ${WDT_ROOT}/logs/compareModel.log
+    cat ${WDT_OUTPUT}
     exitOrLoop
   fi
 

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -613,7 +613,7 @@ function diff_model() {
   ret=$?
   if [ $ret -ne 0 ]; then
     trace SEVERE "WDT Compare Model failed:"
-    cat /tmp/compare_model_stdout
+    cat ${WDT_ROOT}/logs/compareModel.log
     exitOrLoop
   fi
 

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -608,7 +608,6 @@ function diff_model() {
   export __WLSDEPLOY_STORE_MODEL__=1
   # $1 - new model, $2 original model
 
-  # no need to redirect output, -output_dir for compareModel will generate the output file
   ${WDT_BINDIR}/compareModel.sh -oracle_home ${ORACLE_HOME} -output_dir /tmp $1 $2 >  ${WDT_OUTPUT} 2>&1
   ret=$?
   if [ $ret -ne 0 ]; then

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -608,7 +608,7 @@ function diff_model() {
   export __WLSDEPLOY_STORE_MODEL__=1
   # $1 - new model, $2 original model
 
-  ${WDT_BINDIR}/compareModel.sh -oracle_home ${ORACLE_HOME} -output_dir /tmp $1 $2 >  ${WDT_OUTPUT} 2>&1
+  ${WDT_BINDIR}/compareModel.sh -oracle_home ${ORACLE_HOME} -output_dir /tmp $1 $2 > ${WDT_OUTPUT} 2>&1
   ret=$?
   if [ $ret -ne 0 ]; then
     trace SEVERE "WDT Compare Model failed:"


### PR DESCRIPTION
This fixes the missing output from WDT compareModel tool when the tool failed itself and not creating the compare_model_output file, using redirected terminal output instead.