### PR TITLE
Fix rcu schema password update logic

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -712,8 +712,8 @@ function createPrimordialDomain() {
       # recreate the domain if there is an unsafe security update such as admin password update or security roles
 
       # Always use the schema password in RCUDbInfo.  Since once the password is updated by the DBA.  The
-      # RCU cache table SCHEMA_COMPONENT_INFO stored password will never be correct,  and subsequenetly any
-      # other updates such as admin credenitals or security roles that caused the re-create of the primordial
+      # RCU cache table SCHEMA_COMPONENT_INFO stored password will never be correct,  and subsequently any
+      # other updates such as admin credentials or security roles that caused the re-create of the primordial
       # domain will fail since without this flag set, defaults is to use the RCU cached info. (aka. wlst
       # getDatabaseDefaults).
       #
@@ -724,12 +724,13 @@ function createPrimordialDomain() {
         fi
       fi
 
-      # if the domain is JRF and the schema password has been changed. Set this so that updateDomain will also update
-      # the RCU password using the RCUDnbinfo
+      # if the domain is JRF and the schema password has been changed. Set this so that the changes are persisted
+      # in the primordial domain.
 
       local rcu_password_updated="false"
       rcu_password_updated=$(contain_returncode ${diff_rc} ${RCU_PASSWORD_CHANGED})
       if [ ${WDT_DOMAIN_TYPE} == "JRF" ] && [ ${rcu_password_updated} == "true" ] ; then
+          recreate_domain=1
           UPDATE_RCUPWD_FLAG="-updateRCUSchemaPassword"
       fi
     fi


### PR DESCRIPTION
This fixes the issue the rcu schema password changes must be persisted in the primordial domain, otherwise in next model updates the config zip will inherit the from the primordial domain's rcu datasource configuration which still has the old passwords and it will fail in updateDomain. 