### PR TITLE
Include monitoring exporter sidecar and Prometheus annotations for admin server

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -61,7 +61,7 @@ import oracle.kubernetes.operator.steps.BeforeAdminServiceStep;
 import oracle.kubernetes.operator.steps.DeleteDomainStep;
 import oracle.kubernetes.operator.steps.DomainPresenceStep;
 import oracle.kubernetes.operator.steps.ManagedServersUpStep;
-import oracle.kubernetes.operator.steps.MonitorExporterSteps;
+import oracle.kubernetes.operator.steps.MonitoringExporterSteps;
 import oracle.kubernetes.operator.steps.WatchPodReadyAdminStep;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Fiber;
@@ -1154,7 +1154,7 @@ public class DomainProcessorImpl implements DomainProcessor {
         bringManagedServersUp(null),
         DomainStatusUpdater.createEndProgressingStep(null),
         EventHelper.createEventStep(EventItem.DOMAIN_PROCESSING_COMPLETED),
-        MonitorExporterSteps.updateExporterSidecars(),
+        MonitoringExporterSteps.updateExporterSidecars(),
         new TailStep());
 
     Step domainUpStrategy =

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/MonitoringExporterSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/MonitoringExporterSteps.java
@@ -37,7 +37,7 @@ import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.steps.HttpRequestProcessing.createRequestStep;
 import static oracle.kubernetes.weblogic.domain.model.MonitoringExporterSpecification.EXPORTER_PORT_NAME;
 
-public class MonitorExporterSteps {
+public class MonitoringExporterSteps {
 
   /** Time in seconds to wait to recheck for ready state. **/
   private static final int READY_RECHECK_INTERVAL = 2;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -14,7 +14,6 @@ import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1LabelSelectorRequirement;
@@ -26,7 +25,6 @@ import io.kubernetes.client.openapi.models.V1WeightedPodAffinityTerm;
 import oracle.kubernetes.operator.DomainStatusUpdater;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.wlsconfig.NetworkAccessPoint;
 import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step.StepAndPacket;
@@ -36,9 +34,6 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.jupiter.api.Test;
 
-import static oracle.kubernetes.operator.KubernetesConstants.ALWAYS_IMAGEPULLPOLICY;
-import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_EXPORTER_SIDECAR_PORT;
-import static oracle.kubernetes.operator.KubernetesConstants.EXPORTER_CONTAINER_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVERS_TO_ROLL;
 import static oracle.kubernetes.operator.WebLogicConstants.ADMIN_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
@@ -70,7 +65,6 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 @SuppressWarnings("ConstantConditions")
@@ -95,8 +89,6 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   private static final String RAW_VALUE_4 = "$(SERVER_NAME)-volume";
   private static final String END_VALUE_4_DNS1123 = "ess-server1-volume";
   private static final String CLUSTER_NAME = "test-cluster";
-  private static final String NOOP_EXPORTER_CONFIG = "queries:\n";
-  public static final String EXPORTER_IMAGE = "monexp:latest";
 
   public ManagedPodHelperTest() {
     super(SERVER_NAME, LISTEN_PORT);
@@ -882,29 +874,6 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
   }
 
   @Test
-  public void whenPodCreatedWithoutExportConfiguration_hasPrometheusAnnotations() {
-    assertThat(
-        getCreatedPod().getMetadata().getAnnotations(),
-        allOf(
-            hasEntry("prometheus.io/port", Integer.toString(getServerTopology().getListenPort())),
-            hasEntry("prometheus.io/path", "/wls-exporter/metrics"),
-            hasEntry("prometheus.io/scrape", "true")));
-  }
-
-  @Test
-  public void whenPodCreatedWithAdminNap_prometheusAnnotationsSpecifyPlainTextPort() {
-    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint("test", "admin", 8001, 8001));
-    getServerTopology().setListenPort(7001);
-    getServerTopology().setSslListenPort(7002);
-    assertThat(
-        getCreatedPod().getMetadata().getAnnotations(),
-        allOf(
-            hasEntry("prometheus.io/port", "7001"),
-            hasEntry("prometheus.io/path", "/wls-exporter/metrics"),
-            hasEntry("prometheus.io/scrape", "true")));
-  }
-
-  @Test
   public void whenPodHasDuplicateLabels_createManagedPodWithCombination() {
     getConfigurator()
         .withPodLabel("label1", "domain-label-value1")
@@ -1141,92 +1110,6 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
     assertThat(getExporterContainer(), is(notNullValue()));
   }
 
-  private void defineExporterConfiguration() {
-    configureDomain()
-          .withMonitoringExporterConfiguration(NOOP_EXPORTER_CONFIG)
-          .withMonitoringExporterImage(EXPORTER_IMAGE);
-  }
-
-  @Test
-  public void whenDomainHasMonitoringExporterConfiguration_hasPrometheusAnnotations() {
-    defineExporterConfiguration();
-
-    assertThat(
-        getCreatedPod().getMetadata().getAnnotations(),
-        allOf(
-            hasEntry("prometheus.io/port", Integer.toString(DEFAULT_EXPORTER_SIDECAR_PORT)),
-            hasEntry("prometheus.io/path", "/metrics"),
-            hasEntry("prometheus.io/scrape", "true")));
-  }
-
-  private V1Container getExporterContainer() {
-    return getCreatedPodSpecContainers().stream().filter(this::isMonitoringExporterContainer).findFirst().orElse(null);
-  }
-
-  private boolean isMonitoringExporterContainer(V1Container container) {
-    return container.getName().contains(EXPORTER_CONTAINER_NAME);
-  }
-
-  @Test
-  void monitoringExporterContainer_hasExporterName() {
-    defineExporterConfiguration();
-
-    assertThat(getExporterContainer().getName(), equalTo(EXPORTER_CONTAINER_NAME));
-  }
-
-  @Test
-  void monitoringExporterContainerCommand_isNotDefined() {
-    defineExporterConfiguration();
-
-    assertThat(getExporterContainer().getCommand(), nullValue());
-  }
-
-  @Test
-  void monitoringExporterContainer_hasDefaultImageName() {
-    defineExporterConfiguration();
-
-    assertThat(getExporterContainer().getImage(), equalTo(EXPORTER_IMAGE));
-  }
-
-  @Test
-  void monitoringExporterContainer_hasInferredPullPolicy() {
-    defineExporterConfiguration();
-
-    assertThat(getExporterContainer().getImagePullPolicy(), equalTo(ALWAYS_IMAGEPULLPOLICY));
-  }
-
-  @Test
-  void whenExporterContainerCreated_hasMetricsPortsItem() {
-    defineExporterConfiguration();
-
-    V1ContainerPort metricsPort = getExporterContainerPort("metrics");
-    assertThat(metricsPort, notNullValue());
-    assertThat(metricsPort.getProtocol(), equalTo("TCP"));
-    assertThat(metricsPort.getContainerPort(), equalTo(DEFAULT_EXPORTER_SIDECAR_PORT));
-  }
-
-  private V1ContainerPort getExporterContainerPort(@Nonnull String name) {
-    return Optional.ofNullable(getExporterContainer().getPorts()).orElse(Collections.emptyList()).stream()
-          .filter(p -> name.equals(p.getName())).findFirst().orElse(null);
-  }
-
-  @Test
-  void whenExporterContainerCreated_hasDebugPortsItem() {
-    defineExporterConfiguration();
-
-    V1ContainerPort metricsPort = getExporterContainerPort("debugger");
-    assertThat(metricsPort, notNullValue());
-    assertThat(metricsPort.getProtocol(), equalTo("TCP"));
-    assertThat(metricsPort.getContainerPort(), equalTo(30055));
-  }
-
-  @Test
-  void whenExporterContainerCreated_specifyOperatorDomain() {
-    defineExporterConfiguration();
-
-    assertThat(getExporterContainer(), hasJavaOption("-DDOMAIN=" + getDomain().getDomainUid()));
-  }
-
   @Test
   void whenPlaintextPortAvailable_monitoringExporterSpecifiesIt() {
     defineExporterConfiguration();
@@ -1255,33 +1138,6 @@ public class ManagedPodHelperTest extends PodHelperTestBase {
                both(hasJavaOption("-DWLS_PORT=8001")).and(hasJavaOption("-DWLS_SECURE=true")));
   }
 
-  @Test
-  void whenDefaultMonitorPortUsedByServer_relocateIt() {
-    getServerTopology().setListenPort(8080);
-    getServerTopology().setSslListenPort(8081);
-    getServerTopology().setAdminPort(8082);
-    defineExporterConfiguration();
-
-    assertThat(getExporterContainer(), hasJavaOption("-DEXPORTER_PORT=8083"));
-  }
-
-
-  @Test
-  public void whenDefaultMonitorPortUsedByServer_hasPrometheusAnnotations() {
-    getServerTopology().setListenPort(8080);
-    getServerTopology().setSslListenPort(8081);
-    getServerTopology().setAdminPort(8082);
-    defineExporterConfiguration();
-
-    assertThat(
-        getCreatedPod().getMetadata().getAnnotations(),
-        allOf(
-            hasEntry("prometheus.io/port", "8083"),
-            hasEntry("prometheus.io/path", "/metrics"),
-            hasEntry("prometheus.io/scrape", "true")));
-
-    assertThat(getExporterContainer().getPorts().get(0).getContainerPort(), equalTo(8083));
-  }
 
   @Override
   void setServerPort(int port) {

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
@@ -174,7 +174,7 @@ public class MonitoringExporterStepsTest {
     testSupport.runSteps(
           Step.chain(
                 SecretHelper.createAuthorizationSourceStep(),
-                MonitorExporterSteps.createConfigurationUpdateStep()));
+                MonitoringExporterSteps.createConfigurationUpdateStep()));
 
     assertThat(httpSupport.getLastRequestContents(),
           equalTo(domain.getMonitoringExporterConfiguration().asJsonString()));
@@ -205,7 +205,7 @@ public class MonitoringExporterStepsTest {
     testSupport.runSteps(
           Step.chain(
                 SecretHelper.createAuthorizationSourceStep(),
-                MonitorExporterSteps.createConfigurationTestAndUpdateSteps()));
+                MonitoringExporterSteps.createConfigurationTestAndUpdateSteps()));
 
 
     assertThat(httpSupport.getLastRequestContents(),
@@ -241,7 +241,7 @@ public class MonitoringExporterStepsTest {
     testSupport.runSteps(
           Step.chain(
                 SecretHelper.createAuthorizationSourceStep(),
-                MonitorExporterSteps.createConfigurationTestAndUpdateSteps()));
+                MonitoringExporterSteps.createConfigurationTestAndUpdateSteps()));
 
     assertThat(httpSupport.getLastRequest().method(), equalTo("GET"));
   }
@@ -253,7 +253,7 @@ public class MonitoringExporterStepsTest {
     expectConfigurationQueryAndReturn(MANAGED_SERVER3, OLD_CONFIGURATION);
     forEachServer(this::expectConfigurationUpdate);
 
-    testSupport.runSteps(MonitorExporterSteps.updateExporterSidecars());
+    testSupport.runSteps(MonitoringExporterSteps.updateExporterSidecars());
 
     assertThat(getServersUpdated(), containsInAnyOrder(POD_NODE1, POD_NODE3));
   }
@@ -277,7 +277,7 @@ public class MonitoringExporterStepsTest {
     forEachServer(this::expectConfigurationUpdate);
     setDeletingState(MANAGED_SERVER1);
 
-    testSupport.runSteps(MonitorExporterSteps.updateExporterSidecars());
+    testSupport.runSteps(MonitoringExporterSteps.updateExporterSidecars());
 
     assertThat(getServersUpdated(), containsInAnyOrder(POD_NODE2, POD_NODE3));
   }
@@ -302,7 +302,7 @@ public class MonitoringExporterStepsTest {
     setNotReadyState(MANAGED_SERVER1);
     setNotReadyState(MANAGED_SERVER3);
 
-    testSupport.runSteps(MonitorExporterSteps.updateExporterSidecars());
+    testSupport.runSteps(MonitoringExporterSteps.updateExporterSidecars());
 
     assertThat(getServersUpdated(), containsInAnyOrder(POD_NODE2));
   }
@@ -325,7 +325,7 @@ public class MonitoringExporterStepsTest {
 
     testSupport.schedule(() -> setReadyState(MANAGED_SERVER1), 1, TimeUnit.SECONDS);
     testSupport.schedule(() -> setReadyState(MANAGED_SERVER3), 1, TimeUnit.SECONDS);
-    testSupport.runSteps(MonitorExporterSteps.updateExporterSidecars());
+    testSupport.runSteps(MonitoringExporterSteps.updateExporterSidecars());
     testSupport.setTime(3, TimeUnit.SECONDS);
 
     assertThat(getServersUpdated(), containsInAnyOrder(POD_NODE1, POD_NODE2, POD_NODE3));
@@ -342,7 +342,7 @@ public class MonitoringExporterStepsTest {
     forEachServer(this::expectQueryAndReturnOldConfiguration);
     forEachServer(this::expectConfigurationUpdate);
 
-    testSupport.runSteps(MonitorExporterSteps.updateExporterSidecars());
+    testSupport.runSteps(MonitoringExporterSteps.updateExporterSidecars());
 
     assertThat(getServersUpdated(), empty());
   }


### PR DESCRIPTION
This is a fairly simple change based on an update to the requirements and expected behavior. Previously, the operator injected the monitoring exporter sidecar and created Prometheus annotations only for managed server instances. Now, all servers are included, specifically including the admin server.

The necessary changes were to 1) move tests up from the managed pod suite to the base class so that the tests are included for all servers, and then 2) make the similar change to push behavior up from the managed pod step context to the general pod step context classes.