### PR TITLE
Removing the cluster from the kubernetes spec section of the wdt k8s template file

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -93,10 +93,10 @@ kubernetes:
 
     # clusters is used to configure the desired behavior for starting member servers of a cluster.
     # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
-    clusters:
-     '@@PROP:clusterName@@':
-       serverStartState: "RUNNING"
-       replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
+    #clusters:
+    # '@@PROP:clusterName@@':
+    #   serverStartState: "RUNNING"
+    #   replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
 
     # Istio service mesh support is experimental.
     %ISTIO_PREFIX%configuration:


### PR DESCRIPTION
Our samples create a domain with 1 cluster by default, but one of our customers want to be able to create a domain with more than 1 cluster. If the cluster is specified in kubernetes spec section of the wdt model file, then the domain resource spec section only lists that 1 cluster even though MS's belonging to all the clusters do start. So, removing the cluster from the spec section, so that all the clusters will be listed in the domain resource spec section. 
I am commenting out the cluster instead of removing it in case anyone wants to know how to specify clusters in the k8s spec section of the wdt model file.