### PR TITLE
Restore role definition to match documentation

### DIFF
--- a/documentation/staging/content/security/rbac.md
+++ b/documentation/staging/content/security/rbac.md
@@ -65,7 +65,7 @@ $ kubectl -n weblogic-operator-ns \
 ```
 ```shell
 $ kubectl -n domain1-ns \
-  describe rolebinding weblogic-operator-rolebinding-namespace \
+  describe rolebinding weblogic-operator-rolebinding-namespace
 ```
 
 ##### Kubernetes Role and RoleBinding naming conventions

--- a/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
@@ -12,9 +12,6 @@ metadata:
     weblogic.operatorName: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: [""]
-  resources: ["secrets", "configmaps"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["events"]
+  resources: ["events", "secrets", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 {{- end }}


### PR DESCRIPTION
There was a previous effort to limit the permissions given to the operator. We apparently cut too close to the bone. This change restores some permissions. It happens that this makes the Helm chart match what we currently document ;). With these restored permissions then operator can record the internal certificate that it generates.