### PR TITLE
OWLS-89562 - Add option to create-domain.sh in FMW domain home in image sample for use in imagetool --buildNetwork parameter

### DIFF
--- a/documentation/staging/content/samples/simple/domains/fmw-domain-home-in-image/_index.md
+++ b/documentation/staging/content/samples/simple/domains/fmw-domain-home-in-image/_index.md
@@ -121,7 +121,7 @@ The usage of the create script is as follows:
 $ sh create-domain.sh -h
 ```
 ```text
-usage: create-domain.sh -o dir -i file -u username -p password [-q rcuSchemaPassword] [-n encryption-key] [-e] [-v] [-h]
+usage: create-domain.sh -o dir -i file -u username -p password [-q rcuSchemaPassword] [-b buildNetworkParam] [-n encryption-key] [-e] [-v] [-h]
   -i Parameter inputs file, must be specified.
   -o Output directory for the generated YAML files, must be specified.
   -u WebLogic administrator user name for the WebLogic domain.
@@ -130,6 +130,7 @@ usage: create-domain.sh -o dir -i file -u username -p password [-q rcuSchemaPass
   -e Also create the resources in the generated YAML files, optional.
   -v Validate the existence of persistentVolumeClaim, optional.
   -n Encryption key for encrypting passwords in the WDT model and properties files, optional.
+  -b Value to be used in the buildNetwork parameter when invoking WebLogic Image Tool, optional.
   -h Help
 ```
 

--- a/documentation/staging/content/samples/simple/domains/fmw-domain-home-in-image/_index.md
+++ b/documentation/staging/content/samples/simple/domains/fmw-domain-home-in-image/_index.md
@@ -532,3 +532,37 @@ By default, they are installed under `/tmp/dhii-sample/tools` directory.
 ```shell
 $ rm -rf /tmp/dhii-sample/tools/
 ```
+### Troubleshooting
+***Message***: `Failed to build JDBC Connection object`
+
+If the WebLogic Image Tool failed to create a domain, and the following error is seen in the output:
+```shell
+Configuring the Service Table DataSource...
+fmwDatabase  jdbc:oracle:thin:@172.18.0.2:30012/devpdb.k8s
+Getting Database Defaults...
+Error: getDatabaseDefaults() failed. Do dumpStack() to see details.
+Error: runCmd() failed. Do dumpStack() to see details.
+Problem invoking WLST - Traceback (innermost last):
+File "/u01/oracle/createFMWDomain.py", line 332, in ?
+File "/u01/oracle/createFMWDomain.py", line 44, in createInfraDomain
+File "/u01/oracle/createFMWDomain.py", line 151, in extendDomain
+File "/tmp/WLSTOfflineIni1609018487056199846.py", line 267, in getDatabaseDefaults
+File "/tmp/WLSTOfflineIni1609018487056199846.py", line 19, in command
+Failed to build JDBC Connection object:
+at com.oracle.cie.domain.script.jython.CommandExceptionHandler.handleException(CommandExceptionHandler.java:69)
+at com.oracle.cie.domain.script.jython.WLScriptContext.handleException(WLScriptContext.java:3085)
+at com.oracle.cie.domain.script.jython.WLScriptContext.runCmd(WLScriptContext.java:738)
+at sun.reflect.GeneratedMethodAccessor131.invoke(Unknown Source)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+
+com.oracle.cie.domain.script.jython.WLSTException: com.oracle.cie.domain.script.jython.WLSTException: Got exception when auto configuring the schema component(s) with data obtained from shadow table:
+Failed to build JDBC Connection object:
+```
+
+First verify that the JDBC connection URL shown in the output is correct. Update the `rcuDatabaseURL` parameter in the inputs YAML to the correct value if necessary.
+
+If the JDBC connection URL  is correct, it is possible that the container in which the WebLogic Image Tool is running for creating a WebLogic domain is not using the correct networking stack.
+The optional `-b` option in the `create-domain.sh` can be used to specify the networking mode for the RUN instruction during image build.
+For example, to use the host's network stack, invoke `create-domain.sh` with `-b host`.
+Please refer to Docker Network Settings references for supported networking options.

--- a/documentation/staging/content/samples/simple/domains/fmw-domain-home-in-image/_index.md
+++ b/documentation/staging/content/samples/simple/domains/fmw-domain-home-in-image/_index.md
@@ -535,7 +535,7 @@ $ rm -rf /tmp/dhii-sample/tools/
 ### Troubleshooting
 ***Message***: `Failed to build JDBC Connection object`
 
-If the WebLogic Image Tool failed to create a domain, and the following error is seen in the output:
+If the WebLogic Image Tool failed to create a domain and the following error is seen in the output:
 ```shell
 Configuring the Service Table DataSource...
 fmwDatabase  jdbc:oracle:thin:@172.18.0.2:30012/devpdb.k8s
@@ -560,9 +560,9 @@ com.oracle.cie.domain.script.jython.WLSTException: com.oracle.cie.domain.script.
 Failed to build JDBC Connection object:
 ```
 
-First verify that the JDBC connection URL shown in the output is correct. Update the `rcuDatabaseURL` parameter in the inputs YAML to the correct value if necessary.
+First, verify that the JDBC connection URL shown in the output is correct. Update the `rcuDatabaseURL` parameter in the inputs YAML file to the correct value if necessary.
 
-If the JDBC connection URL  is correct, it is possible that the container in which the WebLogic Image Tool is running for creating a WebLogic domain is not using the correct networking stack.
-The optional `-b` option in the `create-domain.sh` can be used to specify the networking mode for the RUN instruction during image build.
+If the JDBC connection URL is correct, it is possible that the container in which the WebLogic Image Tool is running for creating a WebLogic domain, is not using the correct networking stack.
+The optional `-b` option in the `create-domain.sh` script can be used to specify the networking mode for the RUN instruction during image build.
 For example, to use the host's network stack, invoke `create-domain.sh` with `-b host`.
 Please refer to Docker Network Settings references for supported networking options.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
@@ -192,6 +192,7 @@ public class ItFmwDiiSample {
             + " -u " + ADMIN_USERNAME_DEFAULT
             + " -p " + ADMIN_PASSWORD_DEFAULT
             + " -q " + RCUSYSPASSWORD
+            + " -b host"
             + " -o "
             + Paths.get(sampleBase.toString()));
 
@@ -287,9 +288,6 @@ public class ItFmwDiiSample {
       replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
           "domainHomeImageBase: container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.4",
           "domainHomeImageBase: " + FMWINFRA_IMAGE_TO_USE_IN_SPEC);
-      replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
-          "#buildNetwork: ",
-          "buildNetwork: host");
       replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
           "namespace: default", "namespace: " + domainNamespace);
       replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
@@ -287,9 +287,9 @@ public class ItFmwDiiSample {
       replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
           "domainHomeImageBase: container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.4",
           "domainHomeImageBase: " + FMWINFRA_IMAGE_TO_USE_IN_SPEC);
-      replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain.sh").toString(),
-          "imagetool.sh update",
-          "imagetool.sh update\n  --buildNetwork host");
+      replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
+          "#buildNetwork: ",
+          "buildNetwork: host");
       replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
           "namespace: default", "namespace: " + domainNamespace);
       replaceStringInFile(Paths.get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -174,6 +174,8 @@ domainHomeImageBase: container-registry.oracle.com/middleware/fmw-infrastructure
 # Defaults to "wdt" if not specified.
 mode: wdt
 
+#buildNetwork: 
+
 # Resource request for each server pod (Memory and CPU). This is minimum amount of compute
 # resources required for each server pod. Edit value(s) below as per pod sizing requirements.
 # These are optional. 

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain-inputs.yaml
@@ -174,8 +174,6 @@ domainHomeImageBase: container-registry.oracle.com/middleware/fmw-infrastructure
 # Defaults to "wdt" if not specified.
 mode: wdt
 
-#buildNetwork: 
-
 # Resource request for each server pod (Memory and CPU). This is minimum amount of compute
 # resources required for each server pod. Edit value(s) below as per pod sizing requirements.
 # These are optional. 

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
@@ -277,10 +277,11 @@ function createDomainHome {
       cmd="$cmd  --wdtEncryptionKeyFile \"${wdtEncryptionKeyFile}\"
       "
     fi
-    if [ -n "${buildNetwork}" ]; then
-      cmd="$cmd  --buildNetwork ${buildNetwork}
-      "
-    fi
+  fi
+
+  if [ -n "${buildNetwork}" ]; then
+    cmd="$cmd  --buildNetwork ${buildNetwork}
+    "
   fi
 
   echo @@ "Info: About to run the following WIT command:"

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
@@ -277,6 +277,10 @@ function createDomainHome {
       cmd="$cmd  --wdtEncryptionKeyFile \"${wdtEncryptionKeyFile}\"
       "
     fi
+    if [ -n "${buildNetwork}" ]; then
+      cmd="$cmd  --buildNetwork ${buildNetwork}
+      "
+    fi
   fi
 
   echo @@ "Info: About to run the following WIT command:"

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
@@ -26,7 +26,7 @@ source ${scriptDir}/../../common/wdt-and-wit-utility.sh
 source ${scriptDir}/../../common/validate.sh
 
 function usage {
-  echo usage: ${script} -o dir -i file -u username -p password [-q rcuSchemaPassword] [-b buildNetworkParam] [-e] [-v] [-n] [-h]
+  echo usage: ${script} -o dir -i file -u username -p password [-q rcuSchemaPassword] [-b buildNetworkParam] [-n encryption-key] [-e] [-v] [-h]
   echo "  -i Parameter inputs file, must be specified."
   echo "  -o Output directory for the generated properties and YAML files, must be specified."
   echo "  -u WebLogic administrator user name for the WebLogic domain."
@@ -35,7 +35,7 @@ function usage {
   echo "  -e Also create the resources in the generated YAML files, optional."
   echo "  -v Validate the existence of persistentVolumeClaim, optional."
   echo "  -n Encryption key for encrypting passwords in the WDT model and properties files, optional."
-  echo "  -b Value to be passed as buildNetwork parameter to WebLogic image tool, optional."
+  echo "  -b Value to be used in the buildNetwork parameter when invoking WebLogic Image Tool, optional."
   echo "  -h Help"
   exit $1
 }

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-in-image/create-domain.sh
@@ -26,7 +26,7 @@ source ${scriptDir}/../../common/wdt-and-wit-utility.sh
 source ${scriptDir}/../../common/validate.sh
 
 function usage {
-  echo usage: ${script} -o dir -i file -u username -p password [-q rcuSchemaPassword] [-e] [-v] [-n] [-h]
+  echo usage: ${script} -o dir -i file -u username -p password [-q rcuSchemaPassword] [-b buildNetworkParam] [-e] [-v] [-n] [-h]
   echo "  -i Parameter inputs file, must be specified."
   echo "  -o Output directory for the generated properties and YAML files, must be specified."
   echo "  -u WebLogic administrator user name for the WebLogic domain."
@@ -35,6 +35,7 @@ function usage {
   echo "  -e Also create the resources in the generated YAML files, optional."
   echo "  -v Validate the existence of persistentVolumeClaim, optional."
   echo "  -n Encryption key for encrypting passwords in the WDT model and properties files, optional."
+  echo "  -b Value to be passed as buildNetwork parameter to WebLogic image tool, optional."
   echo "  -h Help"
   exit $1
 }
@@ -44,7 +45,7 @@ function usage {
 #
 doValidation=false
 executeIt=false
-while getopts "evhi:o:u:p:n:q:" opt; do
+while getopts "evhi:o:u:p:n:b:q:" opt; do
   case $opt in
     i) valuesInputFile="${OPTARG}"
     ;;
@@ -61,6 +62,8 @@ while getopts "evhi:o:u:p:n:q:" opt; do
     q) rcuSchemaPassword="${OPTARG}"
     ;;
     n) wdtEncryptKey="${OPTARG}"
+    ;;
+    b) buildNetwork="${OPTARG}"
     ;;
     h) usage 0
     ;;
@@ -280,7 +283,7 @@ function createDomainHome {
   fi
 
   if [ -n "${buildNetwork}" ]; then
-    cmd="$cmd  --buildNetwork ${buildNetwork}
+    cmd="$cmd    --buildNetwork ${buildNetwork}
     "
   fi
 


### PR DESCRIPTION
- Add -b option to create-domain.sh in FMW domain home in image sample for passing value into -buildNetwork parameter of imagetool.sh:

usage: create-domain.sh -o dir -i file -u username -p password [-q rcuSchemaPassword] [-b buildNetworkParam] [-n encryption-key] [-e] [-v] [-h]

- Update ItFmwDiiSample to use this new option

- Update FMW domain home in image samples doc and add troubleshooting section

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5108/
