### PR TITLE
change nodeport in IT classes

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -785,7 +785,7 @@ public class ItConfigDistributionStrategy {
     createPV(pvName, domainUid, this.getClass().getSimpleName());
     createPVC(pvName, pvcName, domainUid, domainNamespace);
 
-    t3ChannelPort = getNextFreePort(31518, 32767);
+    t3ChannelPort = getNextFreePort(31115, 32767);
 
     // create a temporary WebLogic domain property file
     File domainPropertiesFile = assertDoesNotThrow(()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
@@ -277,8 +277,8 @@ public class ItFmwDiiSample {
     // in general the node port range has to be between 30,100 to 32,767
     // to avoid port conflict because of the delay in using it, the port here
     // starts with 31972
-    final int t3ChannelPort = getNextFreePort(31972, 32767);
-    final int adminNodePort = getNextFreePort(31901, 32767);
+    final int t3ChannelPort = getNextFreePort(31215, 32767);
+    final int adminNodePort = getNextFreePort(31315, 32767);
 
     // change namespace from default to custom, domain name, and t3PublicAddress
     assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
@@ -276,9 +276,9 @@ public class ItFmwDiiSample {
   private void updateDomainInputsFile(String domainUid, Path sampleBase, String script) {
     // in general the node port range has to be between 30,100 to 32,767
     // to avoid port conflict because of the delay in using it, the port here
-    // starts with 30172
-    final int t3ChannelPort = getNextFreePort(30172, 32767);
-    final int adminNodePort = getNextFreePort(30701, 32767);
+    // starts with 31972
+    final int t3ChannelPort = getNextFreePort(31972, 32767);
+    final int adminNodePort = getNextFreePort(31901, 32767);
 
     // change namespace from default to custom, domain name, and t3PublicAddress
     assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -153,7 +153,7 @@ public class ItFmwDomainInPVUsingWDT {
   public void testFmwDomainOnPVUsingWdt() {
     final String pvName = domainUid + "-" + domainNamespace + "-pv";
     final String pvcName = domainUid + "-" + domainNamespace + "-pvc";
-    final int t3ChannelPort = getNextFreePort(30000, 32767);
+    final int t3ChannelPort = getNextFreePort(31415, 32767);
 
     // create FMW domain credential secret
     createSecretWithUsernamePassword(wlSecretName, domainNamespace,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
@@ -151,7 +151,7 @@ public class ItFmwDomainInPVUsingWLST {
     final int managedServerPort = 8001;
     final String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
     final int replicaCount = 2;
-    final int t3ChannelPort = getNextFreePort(30000, 32767);
+    final int t3ChannelPort = getNextFreePort(31515, 32767);
 
     final String pvName = domainUid + "-pv";
     final String pvcName = domainUid + "-pvc";
@@ -281,7 +281,7 @@ public class ItFmwDomainInPVUsingWLST {
 
     // verify the admin server service created
     checkServiceExists(adminServerPodName, jrfDomainNamespace);
-    
+
     // verify admin server pod is ready
     checkPodReady(adminServerPodName, domainUid, jrfDomainNamespace);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDynamicDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDynamicDomainInPV.java
@@ -158,7 +158,7 @@ public class ItFmwDynamicDomainInPV {
   private void createFmwDomainAndVerify() {
     final String pvName = domainUid + "-" + domainNamespace + "-pv";
     final String pvcName = domainUid + "-" + domainNamespace + "-pvc";
-    final int t3ChannelPort = getNextFreePort(30000, 32767);
+    final int t3ChannelPort = getNextFreePort(31615, 32767);
 
     // create pull secrets for domainNamespace when running in non Kind Kubernetes cluster
     // this secret is used only for non-kind cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwSample.java
@@ -358,8 +358,8 @@ public class ItFmwSample {
     // in general the node port range has to be between 30,100 to 32,767
     // to avoid port conflict because of the delay in using it, the port here
     // starts with 30572
-    final int t3ChannelPort = getNextFreePort(30572, 32767);
-    final int adminNodePort = getNextFreePort(30701, 32767);
+    final int t3ChannelPort = getNextFreePort(31715, 32767);
+    final int adminNodePort = getNextFreePort(31815, 32767);
 
     // change namespace from default to custom, domain name, and t3PublicAddress
     assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwSample.java
@@ -357,8 +357,8 @@ public class ItFmwSample {
   private void updateDomainInputsFile(String domainUid, Path sampleBase) {
     // in general the node port range has to be between 30,100 to 32,767
     // to avoid port conflict because of the delay in using it, the port here
-    // starts with 30172
-    final int t3ChannelPort = getNextFreePort(30172, 32767);
+    // starts with 30572
+    final int t3ChannelPort = getNextFreePort(30572, 32767);
     final int adminNodePort = getNextFreePort(30701, 32767);
 
     // change namespace from default to custom, domain name, and t3PublicAddress

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -232,7 +232,7 @@ public class ItIntrospectVersion {
     // in general the node port range has to be between 30,000 to 32,767
     // to avoid port conflict because of the delay in using it, the port here
     // starts with 30100
-    final int t3ChannelPort = getNextFreePort(30172, 32767);
+    final int t3ChannelPort = getNextFreePort(31915, 32767);
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
@@ -147,7 +147,7 @@ public class ItIstioDomainInPV  {
 
   /**
    * Create a WebLogic domain using WLST in a persistent volume.
-   * Add istio configuration. 
+   * Add istio configuration.
    * Deploy istio gateways and virtual service.
    * Verify domain pods runs in ready state and services are created.
    * Verify login to WebLogic console is successful thru istio ingress Port.
@@ -161,7 +161,7 @@ public class ItIstioDomainInPV  {
     final String managedServerNameBase = "wlst-ms-";
     String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
     final int replicaCount = 2;
-    final int t3ChannelPort = getNextFreePort(31000, 32767);
+    final int t3ChannelPort = getNextFreePort(32015, 32767);
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
@@ -221,7 +221,7 @@ public class ItIstioDomainInPV  {
             .namespace(domainNamespace))
         .spec(new DomainSpec()
             .domainUid(domainUid)
-            .domainHome("/shared/domains/" + domainUid) 
+            .domainHome("/shared/domains/" + domainUid)
             .domainHomeSourceType("PersistentVolume")
             .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
@@ -308,24 +308,24 @@ public class ItIstioDomainInPV  {
     int istioIngressPort = getIstioHttpIngressPort();
     logger.info("Istio http ingress Port is {0}", istioIngressPort);
 
-    // We can not verify Rest Management console thru Adminstration NodePort 
+    // We can not verify Rest Management console thru Adminstration NodePort
     // in istio, as we can not enable Adminstration NodePort
     if (!WEBLOGIC_SLIM) {
       String consoleUrl = "http://" + K8S_NODEPORT_HOST + ":" + istioIngressPort + "/console/login/LoginForm.jsp";
-      boolean checkConsole = 
+      boolean checkConsole =
           checkAppUsingHostHeader(consoleUrl, domainNamespace + ".org");
       assertTrue(checkConsole, "Failed to access WebLogic console");
       logger.info("WebLogic console is accessible");
     } else {
       logger.info("Skipping WebLogic console in WebLogic slim image");
     }
-  
+
     Path archivePath = Paths.get(ITTESTS_DIR, "../operator/integration-tests/apps/testwebapp.war");
     ExecResult result = null;
     for (int i = 1; i <= 10; i++) {
-      result = deployToClusterUsingRest(K8S_NODEPORT_HOST, 
+      result = deployToClusterUsingRest(K8S_NODEPORT_HOST,
         String.valueOf(istioIngressPort),
-        ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, 
+        ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT,
         clusterName, archivePath, domainNamespace + ".org", "testwebapp");
       assertNotNull(result, "Application deployment failed");
       logger.info("(Loop:{0}) Application deployment returned {1}", i, result.toString());
@@ -393,7 +393,7 @@ public class ItIstioDomainInPV  {
     logger.info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm";
     assertDoesNotThrow(
-        () -> CommonTestUtils.createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles, 
+        () -> CommonTestUtils.createConfigMapForDomainCreation(domainScriptConfigMapName, domainScriptFiles,
            namespace, this.getClass().getSimpleName()),
         "Create configmap for domain creation failed");
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporter.java
@@ -813,7 +813,7 @@ class ItMonitoringExporter {
       Path fileTemp = Paths.get(RESULTS_ROOT, "ItMonitoringExporter", "createTempValueFile");
       FileUtils.deleteDirectory(fileTemp.toFile());
       Files.createDirectories(fileTemp);
-  
+
       logger.info("copy the promvalue.yaml to staging location");
       Path srcPromFile = Paths.get(RESOURCE_DIR, "exporter", "promvalues.yaml");
       Path targetPromFile = Paths.get(fileTemp.toString(), "promvalues.yaml");
@@ -827,7 +827,7 @@ class ItMonitoringExporter {
               "webhook.webhook.svc.cluster.local",
               String.format("webhook.%s.svc.cluster.local", webhookNS));
 
-    
+
       nodeportserver = getNextFreePort(32400, 32600);
       int nodeportalertmanserver = getNextFreePort(30400, 30600);
       promHelmParams = installAndVerifyPrometheus("prometheus",
@@ -836,7 +836,7 @@ class ItMonitoringExporter {
               promChartVersion,
               nodeportserver,
               nodeportalertmanserver);
-    
+
       prometheusDomainRegexValue = prometheusRegexValue;
     }
     //if prometheus already installed change CM for specified domain
@@ -1560,7 +1560,7 @@ class ItMonitoringExporter {
     appList.add(app1Path);
     appList.add(app2Path);
 
-    int t3ChannelPort = getNextFreePort(31600, 32767);  // the port range has to be between 31,000 to 32,767
+    int t3ChannelPort = getNextFreePort(32115, 32767);  // the port range has to be between 31,000 to 32,767
 
     Properties p = new Properties();
     p.setProperty("ADMIN_USER", ADMIN_USERNAME_DEFAULT);
@@ -1693,7 +1693,7 @@ class ItMonitoringExporter {
                                               int replicaCount,
                                               boolean twoClusters,
                                               String monexpConfig) {
-    int t3ChannelPort = getNextFreePort(31570, 32767);
+    int t3ChannelPort = getNextFreePort(32215, 32767);
     // create the domain CR
     Domain domain = new Domain()
         .apiVersion(DOMAIN_API_VERSION)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItT3Channel.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItT3Channel.java
@@ -121,7 +121,7 @@ class ItT3Channel {
    * Test t3 channel access by deploying a app using WLST.
    * Test Creates a domain in persistent volume using WLST.
    * Verifies that the pods comes up and sample application deployment works.
-   * Verify the default service port is set to 7100 since ListenPort is not 
+   * Verify the default service port is set to 7100 since ListenPort is not
    * explicitly set on WLST offline script to create the domain configuration.
    */
   @Test
@@ -143,7 +143,7 @@ class ItT3Channel {
     // in general the node port range has to be between 30,000 to 32,767
     // to avoid port conflict because of the delay in using it, the port here
     // starts with 30100
-    final int t3ChannelPort = getNextFreePort(30172, 32767);
+    final int t3ChannelPort = getNextFreePort(32572, 32767);
 
     final String pvName = domainUid + "-pv"; // name of the persistent volume
     final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
@@ -295,23 +295,23 @@ class ItT3Channel {
     //verify admin server accessibility and the health of cluster members
     verifyMemberHealth(adminServerPodName, managedServerNames, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
 
-    // Since the ListenPort is not set explicitly on ServerTemplate 
-    // in wlst offline script wlst-create-domain-onpv.py, the default 
+    // Since the ListenPort is not set explicitly on ServerTemplate
+    // in wlst offline script wlst-create-domain-onpv.py, the default
     // ListenPort on each manged server is set to 7100. This can be confirmed
     // by intorospecting the corresponding cluster service port (default)
     int servicePort = assertDoesNotThrow(()
-        -> getServicePort(domainNamespace, 
+        -> getServicePort(domainNamespace,
               domainUid + "-cluster-" + clusterName, "default"),
               "Getting Cluster Service default port failed");
     assertEquals(DEFAULT_LISTEN_PORT, servicePort, "Default Service Port is not set to 7100");
     int napPort = assertDoesNotThrow(()
-        -> getServicePort(domainNamespace, 
+        -> getServicePort(domainNamespace,
               domainUid + "-cluster-" + clusterName, "ms-nap"),
               "Getting Cluster Service nap port failed");
     assertEquals(8011, napPort, "Nap Service Port is not set to 8011");
 
     servicePort = assertDoesNotThrow(()
-        -> getServicePort(domainNamespace, 
+        -> getServicePort(domainNamespace,
               domainUid + "-managed-server1", "default"),
               "Getting Managed Server Service default port failed");
     assertEquals(DEFAULT_LISTEN_PORT, servicePort, "Default Managed Service Port is not 7100");


### PR DESCRIPTION
Sometimes the IT tests were failing due to a port conflict from nodeports used by t3channel. This change different random ports in IT classes.
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5110/