### PR TITLE
Support clusterService.sessionAffinity

### DIFF
--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -155,7 +155,11 @@
       "properties": {
         "sessionAffinity": {
           "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "ClientIP",
+            "None"
+          ]
         },
         "annotations": {
           "description": "The annotations to be added to generated resources.",

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -121,7 +121,7 @@
         },
         "clusterService": {
           "description": "Customization affecting Kubernetes Service generated for this WebLogic cluster.",
-          "$ref": "#/definitions/KubernetesResource"
+          "$ref": "#/definitions/ClusterService"
         },
         "maxConcurrentShutdown": {
           "description": "The maximum number of WebLogic Server instances that will shut down in parallel for this cluster when it is being partially shut down by lowering its replica count. A value of 0 means there is no limit. Defaults to `spec.maxClusterConcurrentShutdown`, which defaults to 1.",
@@ -149,6 +149,29 @@
       "required": [
         "clusterName"
       ]
+    },
+    "ClusterService": {
+      "type": "object",
+      "properties": {
+        "sessionAffinity": {
+          "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
+          "type": "string"
+        },
+        "annotations": {
+          "description": "The annotations to be added to generated resources.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "$ref": "#/definitions/Map"
+        },
+        "labels": {
+          "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "$ref": "#/definitions/Map"
+        }
+      }
     },
     "ClusterStatus": {
       "type": "object",
@@ -490,25 +513,6 @@
         "enabled": {
           "description": "True, if this domain is deployed under an Istio service mesh. Defaults to true when the `istio` field is specified.",
           "type": "boolean"
-        }
-      }
-    },
-    "KubernetesResource": {
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "description": "The annotations to be added to generated resources.",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "$ref": "#/definitions/Map"
-        },
-        "labels": {
-          "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "$ref": "#/definitions/Map"
         }
       }
     },

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -78,7 +78,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | --- | --- | --- |
 | `allowReplicasBelowMinDynClusterSize` | Boolean | Specifies whether the number of running cluster members is allowed to drop below the minimum dynamic cluster size configured in the WebLogic domain configuration. Otherwise, the operator will ensure that the number of running cluster members is not less than the minimum dynamic cluster setting. This setting applies to dynamic clusters only. Defaults to true. |
 | `clusterName` | string | The name of the cluster. This value must match the name of a WebLogic cluster already defined in the WebLogic domain configuration. Required. |
-| `clusterService` | [Kubernetes Resource](#kubernetes-resource) | Customization affecting Kubernetes Service generated for this WebLogic cluster. |
+| `clusterService` | [Cluster Service](#cluster-service) | Customization affecting Kubernetes Service generated for this WebLogic cluster. |
 | `maxConcurrentShutdown` | number | The maximum number of WebLogic Server instances that will shut down in parallel for this cluster when it is being partially shut down by lowering its replica count. A value of 0 means there is no limit. Defaults to `spec.maxClusterConcurrentShutdown`, which defaults to 1. |
 | `maxConcurrentStartup` | number | The maximum number of Managed Servers instances that the operator will start in parallel for this cluster in response to a change in the `replicas` count. If more Managed Server instances must be started, the operator will wait until a Managed Server Pod is in the `Ready` state before starting the next Managed Server instance. A value of 0 means all Managed Server instances will start in parallel. Defaults to 0. |
 | `maxUnavailable` | number | The maximum number of cluster members that can be temporarily unavailable. Defaults to 1. |
@@ -197,12 +197,13 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `channels` | array of [Channel](#channel) | Specifies which of the Administration Server's WebLogic channels should be exposed outside the Kubernetes cluster via a NodePort Service, along with the port for each channel. If not specified, the Administration Server's NodePort Service will not be created. |
 | `labels` | Map | Labels to associate with the Administration Server's NodePort Service, if it is created. |
 
-### Kubernetes Resource
+### Cluster Service
 
 | Name | Type | Description |
 | --- | --- | --- |
 | `annotations` | Map | The annotations to be added to generated resources. |
 | `labels` | Map | The labels to be added to generated resources. The label names must not start with "weblogic.". |
+| `sessionAffinity` | string | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
 
 ### Istio
 

--- a/integration-tests/src/test/java/oracle/weblogic/domain/ClusterService.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/ClusterService.java
@@ -21,6 +21,12 @@ public class ClusterService {
   @ApiModelProperty("The annotations to be attached to generated resources.")
   private Map<String, String> annotations = new HashMap<>();
 
+  @ApiModelProperty(
+      "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. "
+          + "Must be ClientIP or None. Defaults to None. More info: "
+          + "https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies")
+  private String sessionAffinity;
+
   public ClusterService labels(Map<String, String> labels) {
     this.labels = labels;
     return this;
@@ -83,11 +89,20 @@ public class ClusterService {
     this.annotations = annotations;
   }
 
+  public String getSessionAffinity() {
+    return sessionAffinity;
+  }
+
+  public void setSessionAffinity(String sessionAffinity) {
+    this.sessionAffinity = sessionAffinity;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
         .append("labels", labels)
         .append("annotations", annotations)
+        .append("sessionAffinity", sessionAffinity)
         .toString();
   }
 
@@ -104,11 +119,13 @@ public class ClusterService {
     return new EqualsBuilder()
         .append(labels, rhs.labels)
         .append(annotations, rhs.annotations)
+        .append(sessionAffinity, rhs.sessionAffinity)
         .isEquals();
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(labels).append(annotations).toHashCode();
+    return new HashCodeBuilder(17, 37)
+        .append(labels).append(annotations).append(sessionAffinity).toHashCode();
   }
 }

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 3e2981c2a3c6057a30a7d22c0a969b992f3a36051a133b6ba4e9fe20121d3088
+    weblogic.sha256: 3849fd79f2fd85ababbb97db2faa400ec0de29ee7daf1558268a05d8a250ce65
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -5590,6 +5590,12 @@ spec:
                         for this WebLogic cluster.
                       type: object
                       properties:
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
                         annotations:
                           description: The annotations to be added to generated resources.
                           additionalProperties:

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 3849fd79f2fd85ababbb97db2faa400ec0de29ee7daf1558268a05d8a250ce65
+    weblogic.sha256: e091b25f525f2d1a6b90729dcee23d63ead5beb23660912acebf921d1c0499a7
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -5596,6 +5596,9 @@ spec:
                             Must be ClientIP or None. Defaults to None. More info:
                             https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                           type: string
+                          enum:
+                          - ClientIP
+                          - None
                         annotations:
                           description: The annotations to be added to generated resources.
                           additionalProperties:

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -401,11 +401,13 @@ public class ServiceHelper {
     }
 
     protected V1ServiceSpec createServiceSpec() {
-      return new V1ServiceSpec()
+      V1ServiceSpec spec = new V1ServiceSpec()
           .type(getSpecType())
           .putSelectorItem(LabelConstants.DOMAINUID_LABEL, getDomainUid())
           .putSelectorItem(LabelConstants.CREATEDBYOPERATOR_LABEL, "true")
           .ports(createServicePorts());
+      Optional.ofNullable(getSessionAffinity()).ifPresent(spec::setSessionAffinity);
+      return spec;
     }
 
     void addServicePorts(List<V1ServicePort> ports, WlsServerConfig serverConfig) {
@@ -526,6 +528,10 @@ public class ServiceHelper {
     abstract Map<String, String> getServiceLabels();
 
     abstract Map<String, String> getServiceAnnotations();
+
+    String getSessionAffinity() {
+      return null;
+    }
 
     protected abstract void logServiceCreated(String messageKey);
 
@@ -838,6 +844,11 @@ public class ServiceHelper {
     @Override
     Map<String, String> getServiceAnnotations() {
       return getClusterSpec().getClusterAnnotations();
+    }
+
+    @Override
+    String getSessionAffinity() {
+      return getClusterSpec().getClusterSessionAffinity();
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
@@ -68,7 +68,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
   @Description("Customization affecting Kubernetes Service generated for this WebLogic cluster.")
   @SerializedName("clusterService")
   @Expose
-  private KubernetesResource clusterService = new KubernetesResource();
+  private ClusterService clusterService = new ClusterService();
 
   @Description("Specifies whether the number of running cluster members is allowed to drop below the "
       + "minimum dynamic cluster size configured in the WebLogic domain configuration. "
@@ -167,11 +167,11 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
     this.serverStartPolicy = serverStartPolicy;
   }
 
-  public KubernetesResource getClusterService() {
+  public ClusterService getClusterService() {
     return clusterService;
   }
 
-  public void setClusterService(KubernetesResource clusterService) {
+  public void setClusterService(ClusterService clusterService) {
     this.clusterService = clusterService;
   }
 
@@ -189,6 +189,10 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
 
   void addClusterAnnotation(String name, String value) {
     clusterService.addAnnotations(name, value);
+  }
+
+  public String getClusterSessionAffinity() {
+    return clusterService.getSessionAffinity();
   }
 
   Integer getMaxUnavailable() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Cluster.java
@@ -112,7 +112,7 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
     this.clusterName = clusterName;
   }
 
-  Cluster withClusterName(@Nonnull String clusterName) {
+  public Cluster withClusterName(@Nonnull String clusterName) {
     setClusterName(clusterName);
     return this;
   }
@@ -173,6 +173,11 @@ public class Cluster extends BaseConfiguration implements Comparable<Cluster> {
 
   public void setClusterService(ClusterService clusterService) {
     this.clusterService = clusterService;
+  }
+
+  public Cluster withClusterService(ClusterService clusterService) {
+    this.setClusterService(clusterService);
+    return this;
   }
 
   public Map<String, String> getClusterLabels() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterService.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterService.java
@@ -6,12 +6,14 @@ package oracle.kubernetes.weblogic.domain.model;
 import java.util.Optional;
 
 import oracle.kubernetes.json.Description;
+import oracle.kubernetes.json.EnumClass;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class ClusterService extends KubernetesResource {
 
+  @EnumClass(SessionAffinity.class)
   @Description(
       "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. "
           + "Must be ClientIP or None. Defaults to None. More info: "

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterService.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterService.java
@@ -1,0 +1,73 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import java.util.Optional;
+
+import oracle.kubernetes.json.Description;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class ClusterService extends KubernetesResource {
+
+  @Description(
+      "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. "
+          + "Must be ClientIP or None. Defaults to None. More info: "
+          + "https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies")
+  private String sessionAffinity;
+
+  void fillInFrom(ClusterService clusterService1) {
+    super.fillInFrom(clusterService1);
+    this.sessionAffinity =
+        Optional.ofNullable(sessionAffinity).orElse(clusterService1.sessionAffinity);
+  }
+
+  public String getSessionAffinity() {
+    return sessionAffinity;
+  }
+
+  public void setSessionAffinity(String sessionAffinity) {
+    this.sessionAffinity = sessionAffinity;
+  }
+
+  public ClusterService withSessionAffinity(String sessionAffinity) {
+    this.sessionAffinity = sessionAffinity;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .appendSuper(super.toString())
+        .append("sessionAffinity", sessionAffinity)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ClusterService that = (ClusterService) o;
+
+    return new EqualsBuilder()
+        .appendSuper(super.equals(o))
+        .append(sessionAffinity, that.sessionAffinity)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .appendSuper(super.hashCode())
+        .append(sessionAffinity)
+        .toHashCode();
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpec.java
@@ -28,6 +28,8 @@ public abstract class ClusterSpec {
   @Nonnull
   public abstract Map<String, String> getClusterAnnotations();
 
+  public abstract String getClusterSessionAffinity();
+
   /**
    * Returns the list of initContainers.
    *

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpecCommonImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpecCommonImpl.java
@@ -31,6 +31,11 @@ public class ClusterSpecCommonImpl extends ClusterSpec {
   }
 
   @Override
+  public String getClusterSessionAffinity() {
+    return cluster.getClusterSessionAffinity();
+  }
+
+  @Override
   public List<V1Container> getInitContainers() {
     return cluster.getInitContainers();
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/SessionAffinity.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/SessionAffinity.java
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+public enum SessionAffinity {
+  ClientIP,
+  None
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ClusterServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ClusterServiceHelperTest.java
@@ -9,10 +9,13 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.ServiceConfigurator;
+import org.junit.jupiter.api.Test;
 
 import static oracle.kubernetes.operator.logging.MessageKeys.CLUSTER_SERVICE_CREATED;
 import static oracle.kubernetes.operator.logging.MessageKeys.CLUSTER_SERVICE_EXISTS;
 import static oracle.kubernetes.operator.logging.MessageKeys.CLUSTER_SERVICE_REPLACED;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class ClusterServiceHelperTest extends ServiceHelperTest {
 
@@ -105,4 +108,12 @@ public class ClusterServiceHelperTest extends ServiceHelperTest {
     }
   }
 
+  @Test
+  public void whenCreated_modelHasSessionAffinity() {
+    V1Service model = createService();
+
+    assertThat(
+        model.getSpec().getSessionAffinity(),
+        is("ClientIP"));
+  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTest.java
@@ -81,7 +81,6 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 @SuppressWarnings("ConstantConditions")
 abstract class ServiceHelperTest extends ServiceHelperTestBase {
 
-  private static final String TEST_CLUSTER = "cluster-1";
   private static final int TEST_NODE_PORT = 30001;
   private static final int TEST_NODE_SSL_PORT = 30002;
   private static final int NAP1_NODE_PORT = 30012;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServiceHelperTestBase.java
@@ -9,11 +9,14 @@ import java.util.List;
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.KubernetesConstants;
+import oracle.kubernetes.weblogic.domain.model.Cluster;
+import oracle.kubernetes.weblogic.domain.model.ClusterService;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import org.junit.jupiter.api.AfterEach;
 
 public class ServiceHelperTestBase {
+  protected static final String TEST_CLUSTER = "cluster-1";
   static final String DOMAIN_NAME = "domain1";
   static final String NS = "namespace";
   static final String UID = "uid1";
@@ -36,6 +39,8 @@ public class ServiceHelperTestBase {
   }
 
   private DomainSpec createDomainSpec() {
-    return new DomainSpec().withDomainUid(UID);
+    return new DomainSpec().withDomainUid(UID)
+        .withCluster(new Cluster().withClusterName(TEST_CLUSTER)
+            .withClusterService(new ClusterService().withSessionAffinity("ClientIP")));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
@@ -1281,6 +1281,24 @@ public class DomainV2Test extends DomainTestBase {
   }
 
   @Test
+  public void whenDomain2ReadFromYaml_sessionAffinityIsReadFromClusteredServerSpec()
+      throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_2);
+
+    String sessionAffinity = domain.getCluster("cluster1").getClusterSessionAffinity();
+    assertThat(sessionAffinity, is("ClientIP"));
+  }
+
+  @Test
+  public void whenDomain2ReadFromYaml_sessionAffinityIsNotPresent()
+      throws IOException {
+    Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_4);
+
+    String sessionAffinity = domain.getCluster("cluster2").getClusterSessionAffinity();
+    assertThat(sessionAffinity, nullValue());
+  }
+
+  @Test
   public void whenDomain2ReadFromYaml_serviceAnnotationsFound() throws IOException {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_2);
     ServerSpec serverSpec = domain.getServer("server2", "cluster1");

--- a/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample-2.yaml
+++ b/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample-2.yaml
@@ -53,6 +53,8 @@ spec:
   
   clusters:
   - clusterName: cluster1
+    clusterService:
+      sessionAffinity: ClientIP
     serverPod:
       readinessProbe:
         initialDelaySeconds: 10


### PR DESCRIPTION
A customer asked for us to support the `sessionAffinity` field for the per-cluster Service. While we've recommended setting session affinity at the ingress controller or load balancer, there is nothing inappropriate about a customer wanting to expose the per-cluster service and doing session affinity at this level. 

While we've had the `cluster.clusterService` field for a long time, this is the first time that it has fields that aren't present under the `serverService` field, so the implementation is introducing a ClusterService class for the first time.