### PR TITLE
OWLS-89535 - scalingAction.sh script fails if multiple domains are running in the same namespace

### DIFF
--- a/operator/src/test/sh/scaling/2clusters.json
+++ b/operator/src/test/sh/scaling/2clusters.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "weblogic.oracle/v8",
+  "kind": "Domain",
+  "spec": {
+    "clusters": [
+        {
+            "clusterName": "cluster-1",
+            "replicas": 1,
+            "serverStartState": "RUNNING"
+        },
+        {
+            "clusterName": "cluster-2",
+            "replicas": 2,
+            "serverStartState": "RUNNING"
+        }
+    ],
+    "dataHome": "",
+    "domainHome": "/shared/domains/domain1",
+    "domainHomeSourceType": "PersistentVolume",
+    "httpAccessLogInLogHome": true,
+    "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
+    "imagePullPolicy": "IfNotPresent",
+    "includeServerOutInPodLog": false,
+    "logHome": "/shared/logs/domain1",
+    "logHomeEnabled": true,
+    "replicas": 2
+  },
+  "status": {
+    "clusters": [
+       {
+            "clusterName": "cluster-1",
+            "minimumReplicas": 1
+       },
+       {
+            "clusterName": "cluster-2",
+            "minimumReplicas": 2
+       }
+    ]
+  }
+}

--- a/operator/src/test/sh/scaling/cluster1.json
+++ b/operator/src/test/sh/scaling/cluster1.json
@@ -1,36 +1,31 @@
 {
-  "apiVersion":"weblogic.oracle/v8",
-  "items":[
-    {
-      "apiVersion": "weblogic.oracle/v8",
-      "kind": "Domain",
-      "spec": {
-        "clusters": [
-            {
-                "clusterName": "cluster-1",
-                "replicas": 1,
-                "serverStartState": "RUNNING"
-            }
-        ],
-        "dataHome": "",
-        "domainHome": "/shared/domains/domain1",
-        "domainHomeSourceType": "PersistentVolume",
-        "httpAccessLogInLogHome": true,
-        "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
-        "imagePullPolicy": "IfNotPresent",
-        "includeServerOutInPodLog": false,
-        "logHome": "/shared/logs/domain1",
-        "logHomeEnabled": true,
-        "replicas": 2
-      },
-      "status": {
-        "clusters": [
-           {
-                "clusterName": "cluster-1",
-                "minimumReplicas": 1
-           }
-        ]
-      }
-    }
-  ]
+  "apiVersion": "weblogic.oracle/v8",
+  "kind": "Domain",
+  "spec": {
+    "clusters": [
+        {
+            "clusterName": "cluster-1",
+            "replicas": 1,
+            "serverStartState": "RUNNING"
+        }
+    ],
+    "dataHome": "",
+    "domainHome": "/shared/domains/domain1",
+    "domainHomeSourceType": "PersistentVolume",
+    "httpAccessLogInLogHome": true,
+    "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
+    "imagePullPolicy": "IfNotPresent",
+    "includeServerOutInPodLog": false,
+    "logHome": "/shared/logs/domain1",
+    "logHomeEnabled": true,
+    "replicas": 2
+  },
+  "status": {
+    "clusters": [
+       {
+            "clusterName": "cluster-1",
+            "minimumReplicas": 1
+       }
+    ]
+  }
 }

--- a/operator/src/test/sh/scaling/cluster_min3.json
+++ b/operator/src/test/sh/scaling/cluster_min3.json
@@ -1,36 +1,31 @@
 {
-  "apiVersion":"weblogic.oracle/v8",
-  "items":[
-    {
-      "apiVersion": "weblogic.oracle/v8",
-      "kind": "Domain",
-      "spec": {
-        "clusters": [
-            {
-                "clusterName": "cluster-1",
-                "replicas": 1,
-                "serverStartState": "RUNNING"
-            }
-        ],
-        "dataHome": "",
-        "domainHome": "/shared/domains/domain1",
-        "domainHomeSourceType": "PersistentVolume",
-        "httpAccessLogInLogHome": true,
-        "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
-        "imagePullPolicy": "IfNotPresent",
-        "includeServerOutInPodLog": false,
-        "logHome": "/shared/logs/domain1",
-        "logHomeEnabled": true,
-        "replicas": 2
-      },
-      "status": {
-        "clusters": [
-           {
-                "clusterName": "cluster-1",
-                "minimumReplicas": 3
-           }
-        ]
-      }
-    }
-  ]
+  "apiVersion": "weblogic.oracle/v8",
+  "kind": "Domain",
+  "spec": {
+    "clusters": [
+        {
+            "clusterName": "cluster-1",
+            "replicas": 1,
+            "serverStartState": "RUNNING"
+        }
+    ],
+    "dataHome": "",
+    "domainHome": "/shared/domains/domain1",
+    "domainHomeSourceType": "PersistentVolume",
+    "httpAccessLogInLogHome": true,
+    "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
+    "imagePullPolicy": "IfNotPresent",
+    "includeServerOutInPodLog": false,
+    "logHome": "/shared/logs/domain1",
+    "logHomeEnabled": true,
+    "replicas": 2
+  },
+  "status": {
+    "clusters": [
+       {
+            "clusterName": "cluster-1",
+            "minimumReplicas": 3
+       }
+    ]
+  }
 }

--- a/operator/src/test/sh/scaling/cluster_noreplicas.json
+++ b/operator/src/test/sh/scaling/cluster_noreplicas.json
@@ -1,26 +1,21 @@
 {
-  "apiVersion":"weblogic.oracle/v8",
-  "items":[
-    {
-      "apiVersion": "weblogic.oracle/v8",
-      "kind": "Domain",
-      "spec": {
-        "clusters": [
-            {
-                "clusterName": "cluster-1",
-                "serverStartState": "RUNNING"
-            }
-        ],
-        "dataHome": "",
-        "domainHome": "/shared/domains/domain1",
-        "domainHomeSourceType": "PersistentVolume",
-        "httpAccessLogInLogHome": true,
-        "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
-        "imagePullPolicy": "IfNotPresent",
-        "includeServerOutInPodLog": false,
-        "logHome": "/shared/logs/domain1",
-        "logHomeEnabled": true
-      }
-    }
-  ]
+  "apiVersion": "weblogic.oracle/v8",
+  "kind": "Domain",
+  "spec": {
+    "clusters": [
+        {
+            "clusterName": "cluster-1",
+            "serverStartState": "RUNNING"
+        }
+    ],
+    "dataHome": "",
+    "domainHome": "/shared/domains/domain1",
+    "domainHomeSourceType": "PersistentVolume",
+    "httpAccessLogInLogHome": true,
+    "image": "container-registry.oracle.com/middleware/weblogic:12.2.1.4",
+    "imagePullPolicy": "IfNotPresent",
+    "includeServerOutInPodLog": false,
+    "logHome": "/shared/logs/domain1",
+    "logHomeEnabled": true
+  }
 }

--- a/operator/src/test/sh/scaling/scalingActionTest.sh
+++ b/operator/src/test/sh/scaling/scalingActionTest.sh
@@ -129,6 +129,39 @@ test_is_defined_in_clusters_jq() {
   assertEquals 'True' "${result}"
 }
 
+test_is_defined_in_clusters_2clusters() {
+
+  DOMAIN_FILE="${testdir}/2clusters.json"
+
+  domain_json=`command cat ${DOMAIN_FILE}`
+
+  wls_cluster_name='cluster-1'
+  result1=$(is_defined_in_clusters "${domain_json}")
+
+  wls_cluster_name='cluster-2'
+  result2=$(is_defined_in_clusters "${domain_json}")
+
+  assertEquals 'True' "${result1}"
+  assertEquals 'True' "${result2}"
+}
+
+test_is_defined_in_clusters_2clusters_jq() {
+  skip_if_jq_not_installed
+
+  DOMAIN_FILE="${testdir}/2clusters.json"
+
+  domain_json=`command cat ${DOMAIN_FILE}`
+
+  wls_cluster_name='cluster-1'
+  result1=$(is_defined_in_clusters "${domain_json}")
+
+  wls_cluster_name='cluster-2'
+  result2=$(is_defined_in_clusters "${domain_json}")
+
+  assertEquals 'True' "${result1}"
+  assertEquals 'True' "${result2}"
+}
+
 test_is_defined_in_clusters_no_matching() {
 
   DOMAIN_FILE="${testdir}/cluster1.json"
@@ -183,6 +216,37 @@ test_get_num_ms_in_cluster_jq() {
   result=$(get_num_ms_in_cluster "${domain_json}")
 
   assertEquals '1' "${result}"
+}
+
+test_get_num_ms_in_cluster_2clusters() {
+
+  DOMAIN_FILE="${testdir}/2clusters.json"
+
+  domain_json=`command cat ${DOMAIN_FILE}`
+
+  wls_cluster_name='cluster-1'
+  result=$(get_num_ms_in_cluster "${domain_json}")
+  assertEquals '1' "${result}"
+
+  wls_cluster_name='cluster-2'
+  result=$(get_num_ms_in_cluster "${domain_json}")
+  assertEquals '2' "${result}"
+}
+
+test_get_num_ms_in_cluster_2clusters_jq() {
+  skip_if_jq_not_installed
+
+  DOMAIN_FILE="${testdir}/2clusters.json"
+
+  domain_json=`command cat ${DOMAIN_FILE}`
+
+  wls_cluster_name='cluster-1'
+  result=$(get_num_ms_in_cluster "${domain_json}")
+  assertEquals '1' "${result}"
+
+  wls_cluster_name='cluster-2'
+  result=$(get_num_ms_in_cluster "${domain_json}")
+  assertEquals '2' "${result}"
 }
 
 test_get_num_ms_in_cluster_no_replics() {
@@ -322,6 +386,37 @@ test_get_replica_count_from_cluster_jq() {
   result=$(get_replica_count 'True' "${domain_json}")
 
   assertEquals '1' "${result}"
+}
+
+test_get_replica_count_from_cluster_2clusters() {
+
+  DOMAIN_FILE="${testdir}/2clusters.json"
+
+  domain_json=`command cat ${DOMAIN_FILE}`
+
+  wls_cluster_name='cluster-1'
+  result=$(get_replica_count 'True' "${domain_json}")
+  assertEquals '1' "${result}"
+
+  wls_cluster_name='cluster-2'
+  result=$(get_replica_count 'True' "${domain_json}")
+  assertEquals '2' "${result}"
+}
+
+test_get_replica_count_from_cluster_2clusters_jq() {
+  skip_if_jq_not_installed
+
+  DOMAIN_FILE="${testdir}/2clusters.json"
+
+  domain_json=`command cat ${DOMAIN_FILE}`
+
+  wls_cluster_name='cluster-1'
+  result=$(get_replica_count 'True' "${domain_json}")
+  assertEquals '1' "${result}"
+
+  wls_cluster_name='cluster-2'
+  result=$(get_replica_count 'True' "${domain_json}")
+  assertEquals '2' "${result}"
 }
 
 test_get_replica_count_from_domain() {


### PR DESCRIPTION
It was caused by a typo in the variable name for domain uid in the Kubernetes API call to retrieve the domain info from Kubernetes. With the typo, info for all domains in the same namespace is being retrieved instead of that of a specified domain. This PR fixes the typo in the API call, and the parsing of the retrieved json.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5130/