### PR TITLE
use a different directory for temp sample path

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDiiSample.java
@@ -70,7 +70,7 @@ public class ItFmwDiiSample {
   private static String domainNamespace = null;
 
   private static final Path samplePath = Paths.get(ITTESTS_DIR, "../kubernetes/samples");
-  private static final Path tempSamplePath = Paths.get(WORK_DIR, "fmw-sample-testing");
+  private static final Path tempSamplePath = Paths.get(WORK_DIR, "fmw-diisample-testing");
 
   private static final String RCUSYSUSERNAME = "sys";
   private static final String RCUSYSPASSWORD = "Oradoc_db1";


### PR DESCRIPTION
The ItFmwDiiSample and ItFmwSample uses the same temp directory for copying the samples to change files. In sequential run when both these classes are run at the same time one test deletes the temp directory and the other class depending on this fails.
The fix is to use different temp path.