### PR TITLE
Fix for the common mounts sample domain resource generator test 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiSample.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiSample.java
@@ -164,7 +164,9 @@ public class ItMiiSample {
   @DisabledIfEnvironmentVariable(named = "SKIP_CHECK_SAMPLE", matches = "true")
   @DisplayName("Test to verify MII Sample source")
   public void testCheckMiiSampleSource() {
+    envMap.remove("BASE_IMAGE_NAME");
     execTestScriptAndAssertSuccess("-check-sample","Sample source doesn't match with the generated source");
+    envMap.put("BASE_IMAGE_NAME", WEBLOGIC_IMAGE_NAME);
   }
 
   /**


### PR DESCRIPTION
Minor fix for the common mounts sample generator test `ItMiiSample#testCheckMiiSampleSource` to unset the BASE_IMAGE_NAME parameter before running the test. The external jenkins uses OCIR repo for the BASE_IMAGE_NAME environment variable but the checked-in domain resource template uses OCR. If the BASE_IMAGE_NAME env variable is not set, then it is defaulted to use OCR repo. 
Test results are at https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5231/