### PR TITLE
Resolution to intermittent issue on IstioCrossDomain MDB usecase  

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
@@ -58,6 +58,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomR
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.utils.BuildApplication.buildApplication;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkAppIsActive;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
@@ -417,6 +418,14 @@ public class ItCrossDomainTransaction {
   @Test
   @DisplayName("Check cross domain transcated MDB communication ")
   public void testCrossDomainTranscatedMDB() {
+
+    // No extra header info 
+    assertTrue(checkAppIsActive(K8S_NODEPORT_HOST,domain1AdminServiceNodePort,
+                 "mdbtopic","cluster-1","",
+                 ADMIN_USERNAME_DEFAULT,ADMIN_PASSWORD_DEFAULT),
+             "MDB application can not be activated on domain1/cluster");
+
+    logger.info("MDB application is activated on domain1/cluster");
 
     String curlRequest = String.format("curl -v --show-error --noproxy '*' "
             + "\"http://%s:%s/jmsservlet/jmstest?"  

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
@@ -421,7 +421,7 @@ public class ItCrossDomainTransaction {
 
     // No extra header info 
     assertTrue(checkAppIsActive(K8S_NODEPORT_HOST,domain1AdminServiceNodePort,
-                 "mdbtopic","cluster-1","",
+                 "", "mdbtopic","cluster-1",
                  ADMIN_USERNAME_DEFAULT,ADMIN_PASSWORD_DEFAULT),
              "MDB application can not be activated on domain1/cluster");
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
@@ -59,6 +59,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.addLabelsToNamespac
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.utils.BuildApplication.buildApplication;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkAppIsActive;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkAppUsingHostHeader;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
@@ -455,7 +456,13 @@ public class ItIstioCrossDomainTransaction {
   @Test
   @DisplayName("Check cross domain transcated MDB communication with istio")
   public void testIstioCrossDomainTranscatedMDB() {
+    assertTrue(checkAppIsActive(K8S_NODEPORT_HOST,istioIngressPort, 
+                 "-H 'host: " + "domain1-" + domain1Namespace + ".org '",
+                "mdbtopic","cluster-1",
+                 ADMIN_USERNAME_DEFAULT,ADMIN_PASSWORD_DEFAULT),
+             "MDB application can not be activated on domain1/cluster");
 
+    logger.info("MDB application is activated on domain1/cluster");
     String curlRequest = String.format("curl -v --show-error --noproxy '*' "
             + "-H 'host:domain1-" + domain1Namespace + ".org' "
             + "\"http://%s:%s/jmsservlet/jmstest?"  

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -3249,6 +3249,51 @@ public class CommonTestUtils {
 
   }
 
+  /**
+   * Check if the the application is active for a given weblogic target.
+   * @param host hostname to construct the REST url
+   * @param port the port construct the REST url
+   * @param headers extra header info to pass to the REST url
+   * @param application name of the application
+   * @param target the weblogic target for the application
+   * @param username username to log into the system 
+   * @param password password for the username
+   */
+  public static boolean checkAppIsActive(
+      String host,
+      int    port,
+      String headers,
+      String application,
+      String target,
+      String username,
+      String password
+  ) {
+
+    LoggingFacade logger = getLogger();
+    String curlString = String.format("curl -v --show-error --noproxy '*' "
+           + "--user " + username + ":" + password + " " + headers  
+           + " -H X-Requested-By:MyClient -H Accept:application/json "
+           + "-H Content-Type:application/json " 
+           + " -d \"{ target: '" + target + "' }\" "
+           + " -X POST "
+           + "http://%s:%s/management/weblogic/latest/domainRuntime/deploymentManager/appDeploymentRuntimes/"
+           + application + "/getState", host, port);
+
+    logger.info("curl command {0}", curlString);
+    withStandardRetryPolicy 
+        .conditionEvaluationListener(
+            condition -> logger.info("Waiting for local queue to be updated "
+                + "(elapsed time {0} ms, remaining time {1} ms)",
+                condition.getElapsedTimeInMS(),
+                condition.getRemainingTimeInMS()))
+        .until(assertDoesNotThrow(() -> {
+          return () -> {
+            return exec(new String(curlString), true).stdout().contains("STATE_ACTIVE");
+          };
+        }));
+    return true;
+  }
+
   /** Create a persistent volume.
    * @param pvName name of the persistent volume to create
    * @param domainUid domain UID

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -3282,8 +3282,9 @@ public class CommonTestUtils {
     logger.info("curl command {0}", curlString);
     withStandardRetryPolicy 
         .conditionEvaluationListener(
-            condition -> logger.info("Waiting for local queue to be updated "
-                + "(elapsed time {0} ms, remaining time {1} ms)",
+            condition -> logger.info("Waiting for Application {0} to be active "
+                + "(elapsed time {1} ms, remaining time {2} ms)",
+                application,
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
         .until(assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/resources/istio/istio-cdt-http-template-service.yaml
+++ b/integration-tests/src/test/resources/istio/istio-cdt-http-template-service.yaml
@@ -36,6 +36,8 @@ spec:
             prefix: /cdttxservlet
         - uri:
             prefix: /jmsservlet
+        - uri:
+            prefix: /management
         - port: 7001
       route:
         - destination:


### PR DESCRIPTION
Here is the change made to the ItCrossDomain classes

a. Added an explicit check for the (mdb) application to active before sending message to distributed Topic
b. Added a new utility method to check if the application is active  by using REST API

Test result  
   https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5252/
   https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5259
   https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5260