### PR TITLE
Image name fix in non kind cluster

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
@@ -689,8 +689,7 @@ class ItPodsRestart {
   public void testRestartWithImageChange() {
 
     String newImage = KIND_REPO != null ? KIND_REPO + "mychangedimage:mii" : "mychangedimage:mii";
-    String originalImage = KIND_REPO != null ? miiImage : miiImage.substring(KIND_REPO.length());
-    dockerTag(originalImage, newImage);
+    dockerTag(miiImage, newImage);
     if (KIND_REPO != null) {
       dockerPush(newImage);
     }


### PR DESCRIPTION
When the tests are running in non-kind cluster use the image as is set in MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;

Test Result 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5261/
