### PR TITLE
Use tcp prefix for metrics exporter

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -1337,7 +1337,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     }
 
     private String getMetricsPortName() {
-      return getDomain().isIstioEnabled() ? "http-metrics" : "metrics";
+      return getDomain().isIstioEnabled() ? "tcp-metrics" : "metrics";
     }
 
     private String createJavaOptions() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -426,7 +426,7 @@ public class ServiceHelper {
     }
 
     private String getMetricsPortName() {
-      return getDomain().isIstioEnabled() ? "http-metrics" : "metrics";
+      return getDomain().isIstioEnabled() ? "tcp-metrics" : "metrics";
     }
 
     List<NetworkAccessPoint> getNetworkAccessPoints(@Nonnull WlsServerConfig config) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/MonitoringExporterSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/MonitoringExporterSteps.java
@@ -278,7 +278,7 @@ public class MonitoringExporterSteps {
     }
 
     private String getMetricsPortName() {
-      return getDomain().isIstioEnabled() ? "http-metrics" : "metrics";
+      return getDomain().isIstioEnabled() ? "tcp-metrics" : "metrics";
     }
 
     private HttpRequest createConfigurationQueryRequest() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagerServerServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagerServerServiceHelperTest.java
@@ -83,6 +83,6 @@ public class ManagerServerServiceHelperTest extends ServiceHelperTest {
 
     V1Service service = createService();
 
-    assertThat(service, containsPort("http-metrics", DEFAULT_EXPORTER_SIDECAR_PORT));
+    assertThat(service, containsPort("tcp-metrics", DEFAULT_EXPORTER_SIDECAR_PORT));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -453,7 +453,7 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   void whenExporterContainerCreatedAndIstioEnabled_hasMetricsPortsItem() {
     defineExporterConfiguration().withIstio();
 
-    V1ContainerPort metricsPort = getExporterContainerPort("http-metrics");
+    V1ContainerPort metricsPort = getExporterContainerPort("tcp-metrics");
     assertThat(metricsPort, notNullValue());
     assertThat(metricsPort.getProtocol(), equalTo("TCP"));
     assertThat(metricsPort.getContainerPort(), equalTo(DEFAULT_EXPORTER_SIDECAR_PORT));


### PR DESCRIPTION
After diagnosing with the V8o team, we've discovered that using the "tcp-" prefix works better because this works when the metrics exporter is addressed with either the DNS address or using the pod's ClusterIP value.