### PR TITLE
minor doc update

### DIFF
--- a/documentation/staging/content/faq/external-clients.md
+++ b/documentation/staging/content/faq/external-clients.md
@@ -153,7 +153,7 @@ is hosted outside of the Kubernetes cluster, then:
   requires each server in a cluster to be individually addressable,
   but this conflicts with the current operator requirement that
   a network channel in a cluster have the same port across all servers in the cluster.
-  If this is a requirement, then contact the WebLogic Kubenetes Operator team for potential solutions.
+  If this is a requirement, then contact the WebLogic Kubernetes Operator team for potential solutions.
 
 If a WebLogic EJB or JMS resource is hosted outside of
 a Kubernetes cluster, and the EJB or JMS applications

--- a/documentation/staging/content/faq/external-clients.md
+++ b/documentation/staging/content/faq/external-clients.md
@@ -148,6 +148,13 @@ is hosted outside of the Kubernetes cluster, then:
   This can significantly speedup connection creation for EJB and JMS clients.
   See [Configuring WebLogic Server affinity load balancing algorithms](#configuring-weblogic-server-affinity-load-balancing-algorithms).
 
+- __JTA NOTE__: The operator does not directly support external WebLogic JTA access
+  to a Kubernetes hosted WebLogic cluster. This is because external JTA access
+  requires each server in a cluster to be individually addressable,
+  but this conflicts with the current operator requirement that
+  a network channel in a cluster have the same port across all servers in the cluster.
+  If this is a requirement, then contact the WebLogic Operator team for potential solutions.
+
 If a WebLogic EJB or JMS resource is hosted outside of
 a Kubernetes cluster, and the EJB or JMS applications
 that call the resource are located within the cluster, then:
@@ -163,6 +170,11 @@ that call the resource are located within the cluster, then:
     JMS resources with a 'server affinity' default load balancer algorithm.
     This can significantly speedup tunneling connection creation for EJB and JMS clients.
     See [Configuring WebLogic Server affinity load balancing algorithms](#configuring-weblogic-server-affinity-load-balancing-algorithms).
+
+- __JTA NOTE__: WebLogic does not directly support JTA access to a cluster that is exposed
+  using a single port. This is because external JTA requires each server in a cluster
+  to be individually addressable.
+  If this is a requirement, then contact the WebLogic Operator team for potential solutions.
 
 {{% notice note %}}
 All DNS addresses must be 'DNS-1123' compliant;

--- a/documentation/staging/content/faq/external-clients.md
+++ b/documentation/staging/content/faq/external-clients.md
@@ -153,7 +153,7 @@ is hosted outside of the Kubernetes cluster, then:
   requires each server in a cluster to be individually addressable,
   but this conflicts with the current operator requirement that
   a network channel in a cluster have the same port across all servers in the cluster.
-  If this is a requirement, then contact the WebLogic Operator team for potential solutions.
+  If this is a requirement, then contact the WebLogic Kubenetes Operator team for potential solutions.
 
 If a WebLogic EJB or JMS resource is hosted outside of
 a Kubernetes cluster, and the EJB or JMS applications
@@ -174,7 +174,7 @@ that call the resource are located within the cluster, then:
 - __JTA NOTE__: WebLogic does not directly support JTA access to a cluster that is exposed
   using a single port. This is because external JTA requires each server in a cluster
   to be individually addressable.
-  If this is a requirement, then contact the WebLogic Operator team for potential solutions.
+  If this is a requirement, then contact the WebLogic Kubernetes Operator team for potential solutions.
 
 {{% notice note %}}
 All DNS addresses must be 'DNS-1123' compliant;


### PR DESCRIPTION
This is an interim JTA doc update that temporarily adds back JTA notes to the external client FAQ. 

Research continues in this area ([oracle internal link](https://proddev-paas-fmw.slack.com/archives/C998UPSCT/p1622665784137000)), and the doc in this area is blocked until this research completes, so the goal of this pull is to add a recommendation to contact the WKO team if JTA is required to be in the picture.