### PR TITLE
Owls 89909 - Fix for repeated introspection after a rolling restart of a MII domain because of image hash mismatch

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -328,6 +328,8 @@ public class ConfigMapHelper {
           return doNext(replaceConfigMap(getNext()), packet);
         } else if (mustPatchCurrentMap(existingMap)) {
           return doNext(patchCurrentMap(existingMap, getNext()), packet);
+        } else if (mustPatchImageVersionInMap(existingMap, packet)) {
+          return doNext(patchImageVersionInCurrentMap(existingMap, packet, getNext()), packet);
         } else {
           logConfigMapExists();
           recordCurrentMap(packet, existingMap);
@@ -354,6 +356,11 @@ public class ConfigMapHelper {
         return KubernetesUtils.isMissingValues(getMapLabels(currentMap), getLabels());
       }
 
+      private boolean mustPatchImageVersionInMap(V1ConfigMap currentMap, Packet packet) {
+        return (currentMap.getData() != null) && Optional.ofNullable((String)packet.get(DOMAIN_INPUTS_HASH))
+                .map(dih -> !dih.equals(currentMap.getData().get(DOMAIN_INPUTS_HASH))).orElse(false);
+      }
+
       private Map<String, String> getMapLabels(@NotNull V1ConfigMap map) {
         return Optional.ofNullable(map.getMetadata()).map(V1ObjectMeta::getLabels).orElseGet(Collections::emptyMap);
       }
@@ -372,6 +379,17 @@ public class ConfigMapHelper {
             .patchConfigMapAsync(name, namespace,
                 getDomainUidLabel(Optional.of(currentMap).map(V1ConfigMap::getMetadata).orElse(null)),
                 new V1Patch(patchBuilder.build().toString()), createPatchResponseStep(next));
+      }
+
+      private Step patchImageVersionInCurrentMap(V1ConfigMap currentMap, Packet packet, Step next) {
+        JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
+
+        patchBuilder.add("/data/" + DOMAIN_INPUTS_HASH, (String)packet.get(DOMAIN_INPUTS_HASH));
+
+        return new CallBuilder()
+                .patchConfigMapAsync(name, namespace,
+                        getDomainUidLabel(Optional.of(currentMap).map(V1ConfigMap::getMetadata).orElse(null)),
+                        new V1Patch(patchBuilder.build().toString()), createPatchResponseStep(next));
       }
 
       private boolean labelsNotDefined(V1ConfigMap currentMap) {
@@ -476,6 +494,7 @@ public class ConfigMapHelper {
       if (loader.isTopologyNotValid()) {
         return doNext(reportTopologyErrorsAndStop(), packet);
       } else if (loader.getDomainConfig() == null)  {
+        loader.updateImageHashInPacket();
         return doNext(loader.createIntrospectionVersionUpdateStep(), packet);
       } else {
         LOGGER.fine(MessageKeys.WLS_CONFIGURATION_READ, timeSinceJobStart(packet), loader.getDomainConfig());
@@ -551,6 +570,10 @@ public class ConfigMapHelper {
       copyFileToPacketIfPresent(DOMAINZIP_HASH, DOMAINZIP_HASH);
       copyFileToPacketIfPresent(SECRETS_MD_5, SECRETS_MD_5);
       copyToPacketAndFileIfPresent(DOMAIN_RESTART_VERSION, info.getDomain().getRestartVersion());
+      copyToPacketAndFileIfPresent(DOMAIN_INPUTS_HASH, getModelInImageSpecHash());
+    }
+
+    private void updateImageHashInPacket() {
       copyToPacketAndFileIfPresent(DOMAIN_INPUTS_HASH, getModelInImageSpecHash());
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -328,8 +328,8 @@ public class ConfigMapHelper {
           return doNext(replaceConfigMap(getNext()), packet);
         } else if (mustPatchCurrentMap(existingMap)) {
           return doNext(patchCurrentMap(existingMap, getNext()), packet);
-        } else if (mustPatchImageVersionInMap(existingMap, packet)) {
-          return doNext(patchImageVersionInCurrentMap(existingMap, packet, getNext()), packet);
+        } else if (mustPatchImageHashInMap(existingMap, packet)) {
+          return doNext(patchImageHashInCurrentMap(existingMap, packet, getNext()), packet);
         } else {
           logConfigMapExists();
           recordCurrentMap(packet, existingMap);
@@ -356,9 +356,9 @@ public class ConfigMapHelper {
         return KubernetesUtils.isMissingValues(getMapLabels(currentMap), getLabels());
       }
 
-      private boolean mustPatchImageVersionInMap(V1ConfigMap currentMap, Packet packet) {
+      private boolean mustPatchImageHashInMap(V1ConfigMap currentMap, Packet packet) {
         return (currentMap.getData() != null) && Optional.ofNullable((String)packet.get(DOMAIN_INPUTS_HASH))
-                .map(dih -> !dih.equals(currentMap.getData().get(DOMAIN_INPUTS_HASH))).orElse(false);
+                .map(hash -> !hash.equals(currentMap.getData().get(DOMAIN_INPUTS_HASH))).orElse(false);
       }
 
       private Map<String, String> getMapLabels(@NotNull V1ConfigMap map) {
@@ -381,7 +381,7 @@ public class ConfigMapHelper {
                 new V1Patch(patchBuilder.build().toString()), createPatchResponseStep(next));
       }
 
-      private Step patchImageVersionInCurrentMap(V1ConfigMap currentMap, Packet packet, Step next) {
+      private Step patchImageHashInCurrentMap(V1ConfigMap currentMap, Packet packet, Step next) {
         JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
 
         patchBuilder.add("/data/" + DOMAIN_INPUTS_HASH, (String)packet.get(DOMAIN_INPUTS_HASH));


### PR DESCRIPTION
Owls 89909 - In some cases, when the domain is updated with an image that doesn't make any actual changes to the domain, it's considered as a no-op in `modelInImage.sh`, and the domain config parsed from the introspector log is null. However, the domain is rolled because the image name is different. In such cases, the image hash stored in the introspector config map is different from the actual image hash. The make-right cycle checks if the image hash stored in the config map matches the actual image hash when deciding whether a new introspector job needs to be created. This causes the introspector job to be created multiple times. 

This change stores the new image hash in the packet and also patches the config map with the new hash when the introspection is a no-op. Integration test run at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5389/