### PR TITLE
OWLS-90180 Optimize detection of when to run introspection

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -303,8 +303,7 @@ public class DomainProcessorImpl implements DomainProcessor {
     return Step.chain(
           ConfigMapHelper.readIntrospectionVersionStep(info.getNamespace(), info.getDomainUid()),
           new IntrospectionRequestStep(info),
-          JobHelper.deleteDomainIntrospectorJobStep(null),
-          JobHelper.createDomainIntrospectorJobStep(null));
+          JobHelper.replaceOrCreateDomainIntrospectorJobStep(null));
   }
 
   private static class IntrospectionRequestStep extends Step {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -306,11 +306,11 @@ public class DomainProcessorImpl implements DomainProcessor {
           JobHelper.replaceOrCreateDomainIntrospectorJobStep(null));
   }
 
-  private static class IntrospectionRequestStep extends Step {
+  public static class IntrospectionRequestStep extends Step {
 
     private final String requestedIntrospectVersion;
 
-    IntrospectionRequestStep(DomainPresenceInfo info) {
+    public IntrospectionRequestStep(DomainPresenceInfo info) {
       this.requestedIntrospectVersion = info.getDomain().getIntrospectVersion();
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/LabelConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/LabelConstants.java
@@ -22,6 +22,7 @@ public interface LabelConstants {
   String MODEL_IN_IMAGE_DOMAINZIP_HASH = "weblogic.modelInImageDomainZipHash";
   String INTROSPECTION_STATE_LABEL = "weblogic.introspectVersion";
   String MII_UPDATED_RESTART_REQUIRED_LABEL = "weblogic.configChangesPendingRestart";
+  String INTROSPECTION_DOMAIN_SPEC_GENERATION = "weblogic.domainSpecGeneration";
 
   static String forDomainUidSelector(String uid) {
     return String.format("%s=%s", DOMAINUID_LABEL, uid);

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -27,7 +27,6 @@ public interface ProcessingConstants {
 
   String DOMAIN_TOPOLOGY = "domainTopology";
   String JOB_POD_NAME = "jobPodName";
-  String JOB_IMAGE_NAME = "jobImageName";
   String DOMAIN_INTROSPECTOR_JOB = "domainIntrospectorJob";
   String DOMAIN_INTROSPECTOR_LOG_RESULT = "domainIntrospectorLogResult";
   String DOMAIN_INTROSPECT_REQUESTED = "domainIntrospectRequested";

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -27,6 +27,7 @@ public interface ProcessingConstants {
 
   String DOMAIN_TOPOLOGY = "domainTopology";
   String JOB_POD_NAME = "jobPodName";
+  String JOB_IMAGE_NAME = "jobImageName";
   String DOMAIN_INTROSPECTOR_JOB = "domainIntrospectorJob";
   String DOMAIN_INTROSPECTOR_LOG_RESULT = "domainIntrospectorLogResult";
   String DOMAIN_INTROSPECT_REQUESTED = "domainIntrospectRequested";

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.helpers;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -49,6 +50,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.yaml.snakeyaml.Yaml;
 
 import static java.lang.System.lineSeparator;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static oracle.kubernetes.operator.DomainStatusUpdater.BAD_TOPOLOGY;
 import static oracle.kubernetes.operator.IntrospectorConfigMapConstants.DOMAINZIP_HASH;
 import static oracle.kubernetes.operator.IntrospectorConfigMapConstants.DOMAIN_INPUTS_HASH;
@@ -508,7 +510,7 @@ public class ConfigMapHelper {
     }
 
     private long timeSinceJobStart(Packet packet) {
-      return System.currentTimeMillis() - ((Long) packet.get(JobHelper.START_TIME));
+      return ((OffsetDateTime)packet.get(JobHelper.START_TIME)).until(OffsetDateTime.now(), MILLIS);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -504,13 +504,8 @@ public class ConfigMapHelper {
     }
 
     private long timeSinceJobStart(Packet packet) {
-      return System.currentTimeMillis() - getStartTime(packet);
+      return System.currentTimeMillis() - ((Long) packet.get(JobHelper.START_TIME));
     }
-
-    private Long getStartTime(Packet packet) {
-      return Optional.ofNullable((Long) packet.get(JobHelper.START_TIME)).orElse(0L);
-    }
-
   }
 
   static class IntrospectionLoader {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -325,7 +325,6 @@ public class ConfigMapHelper {
               .ifPresent(value -> addLabel(INTROSPECTION_STATE_LABEL, value));
         Optional.ofNullable(domain).map(Domain::getMetadata).map(V1ObjectMeta::getGeneration)
                 .ifPresent(value -> addLabel(INTROSPECTION_DOMAIN_SPEC_GENERATION, value.toString()));
-        LOGGER.info("DEBUG: After adding INTROSPECTION_DOMAIN_SPEC_GENERATION labels is  " + labels);
         V1ConfigMap existingMap = withoutTransientData(callResponse.getResult());
         if (existingMap == null) {
           return doNext(createConfigMap(getNext()), packet);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -504,7 +504,11 @@ public class ConfigMapHelper {
     }
 
     private long timeSinceJobStart(Packet packet) {
-      return System.currentTimeMillis() - ((Long) packet.get(JobHelper.START_TIME));
+      return System.currentTimeMillis() - getStartTime(packet);
+    }
+
+    private Long getStartTime(Packet packet) {
+      return Optional.ofNullable((Long) packet.get(JobHelper.START_TIME)).orElse(0L);
     }
 
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -537,10 +537,10 @@ public class JobHelper {
     }
 
     private Long getJobDeleteTime(V1Job domainIntrospectorJob) {
-      Long retryIntervalMillis = 120 * 1000L; //Retry interval is same as make-right interval
+      int retryIntervalSeconds = TuningParameters.getInstance().getMainTuning().domainPresenceRecheckIntervalSeconds;
       return Optional.ofNullable(domainIntrospectorJob.getMetadata())
               .map(m -> m.getCreationTimestamp()).map(t -> t.toInstant().toEpochMilli()).orElse(0L)
-              + retryIntervalMillis;
+              + (retryIntervalSeconds * 1000L);
     }
 
     private boolean isNotComplete(V1Job domainIntrospectorJob) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -408,19 +408,15 @@ public class JobHelper {
 
     private Step replaceOrCreateJob(Packet packet, Step next) {
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
-      java.lang.String domainUid = info.getDomain().getDomainUid();
-      java.lang.String namespace = info.getNamespace();
-      String jobName = JobHelper.createJobName(domainUid);
-      return new CallBuilder().readJobAsync(jobName, namespace, domainUid,
-              new ReplaceOrCreateStep(jobName, next));
+      return new CallBuilder().readJobAsync(JobHelper.createJobName(info.getDomain().getDomainUid()),
+              info.getNamespace(), info.getDomain().getDomainUid(),
+              new ReplaceOrCreateStep(next));
     }
 
     private class ReplaceOrCreateStep extends DefaultResponseStep {
-      private final String jobName;
 
-      ReplaceOrCreateStep(String jobName, Step next) {
+      ReplaceOrCreateStep(Step next) {
         super(next);
-        this.jobName = jobName;
       }
 
       @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -98,15 +98,13 @@ public class JobHelper {
     boolean retVal = topology == null
           || isBringingUpNewDomain(packet, info)
           || introspectionRequested(packet)
-          || isModelInImageUpdate(packet, info)
-          || isGenerationChanged(packet, info);
+          || isModelInImageUpdate(packet, info);
     LOGGER.fine("DEBUG: runIntrospector retVal is : " + retVal);
     return  retVal;
   }
 
   private static boolean isBringingUpNewDomain(Packet packet, DomainPresenceInfo info) {
-    return runningServersCount(info) == 0 && creatingServers(info) && isGenerationChanged(packet, info);
-    //return runningServersCount(info) == 0 && creatingServers(info);
+    return isGenerationChanged(packet, info) ^ (runningServersCount(info) > 0 && creatingServers(info));
   }
 
   private static boolean introspectionRequested(Packet packet) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -429,6 +429,8 @@ public class JobHelper {
         }
 
         if (job != null) {
+          packet.putIfAbsent(START_TIME, Optional.ofNullable(job.getMetadata())
+                  .map(m -> m.getCreationTimestamp()).map(t -> t.toInstant().toEpochMilli()).orElse(0L));
           return doNext(Step.chain(
                   createProgressingStartedEventStep(info, INSPECTING_DOMAIN_PROGRESS_REASON, true, null),
                   readDomainIntrospectorPodLogStep(null),

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -111,7 +111,7 @@ public class JobHelper {
 
   private static boolean isIntrospectVersionChanged(Packet packet, DomainPresenceInfo info) {
     return Optional.ofNullable(packet.get(INTROSPECTION_STATE_LABEL))
-            .map(gen -> !gen.equals(getIntrospectVersion(info))).orElse(false);
+            .map(introspectVersionLabel -> !introspectVersionLabel.equals(getIntrospectVersion(info))).orElse(false);
   }
 
   private static boolean isGenerationChanged(Packet packet, DomainPresenceInfo info) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -519,7 +519,7 @@ public class JobHelper {
         Step nextStep = null;
         if (System.currentTimeMillis() > getJobLazyDeletionTime(domainIntrospectorJob)) {
           //Introspector job is incomplete and current time is greater than the lazy deletion time for the job,
-          //execute the next step
+          //update the domain status and execute the next step
           nextStep = getNext();
         }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainUpPlanTest.java
@@ -137,7 +137,7 @@ public class DomainUpPlanTest {
         plan,
         hasChainWithStepsInOrder(
             "DomainPresenceStep",
-            "DomainIntrospectorJobStep",
+            "ReplaceOrCreateIntrospectorJobStep",
             "BeforeAdminServiceStep",
             "AdminPodStep",
             "ForServerStep",

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectorConfigMapTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectorConfigMapTest.java
@@ -3,6 +3,9 @@
 
 package oracle.kubernetes.operator.helpers;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,7 +94,8 @@ public class IntrospectorConfigMapTest {
 
     testSupport.defineResources(domain);
     testSupport.addDomainPresenceInfo(info);
-    testSupport.addToPacket(JobHelper.START_TIME, System.currentTimeMillis() - 10);
+    testSupport.addToPacket(JobHelper.START_TIME,
+            OffsetDateTime.ofInstant(Instant.now().minusMillis(10L), ZoneId.systemDefault()));
   }
 
   @AfterEach


### PR DESCRIPTION
The changes in this PR are to address the use case where the operator starts a long-running introspector job and then the operator dies and is restarted – the newly restarted operator finds the existing introspector job and waits for those results rather than deleting this job and replacing it. Previously, in this use case, the operator deleted the existing job and replaced it with a new job.

For the case when the operator restarts and finds a failed job with a SEVERE message, it checks if the current time is greater than the sum of job creation time and the `domainPresenceRecheckIntervalSeconds` interval. If so, it deletes the failed job and replaces it with a new job. 
Integration test results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5446/