### PR TITLE
Fixupdatedomainscript

### DIFF
--- a/integration-tests/src/test/resources/wdt-models/model-samples-update-domain.properties
+++ b/integration-tests/src/test/resources/wdt-models/model-samples-update-domain.properties
@@ -1,0 +1,2 @@
+clusterName2=cluster-2
+managedServerNameBaseC2=c2-managed-server

--- a/integration-tests/src/test/resources/wdt-models/model-samples-update-domain.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-samples-update-domain.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+  AdminUserName: '@@FILE:/weblogic-operator/secrets/username@@'
+  AdminPassword: '@@FILE:/weblogic-operator/secrets/password@@'
+  ServerStartMode: prod
+topology:
+  Name: '@@PROP:domainName@@'
+  AdminServerName: '@@PROP:adminServerName@@'
+  ProductionModeEnabled: '@@PROP:productionModeEnabled@@'
+  Cluster:
+    '@@PROP:clusterName@@':
+      DynamicServers:
+        CalculatedListenPorts: false
+        DynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
+        MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
+        ServerNamePrefix: '@@PROP:managedServerNameBase@@'
+        ServerTemplate: '@@PROP:clusterName@@-template'
+    '@@PROP:clusterName2@@':
+      DynamicServers:
+        CalculatedListenPorts: false
+        DynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
+        MaxDynamicClusterSize: '@@PROP:configuredManagedServerCount@@'
+        ServerNamePrefix: '@@PROP:managedServerNameBaseC2@@'
+        ServerTemplate: '@@PROP:clusterName2@@-template'
+  Server:
+    '@@PROP:adminServerName@@':
+      NetworkAccessPoint:
+        T3Channel:
+          ListenPort: '@@PROP:t3ChannelPort@@'
+          PublicAddress: '@@PROP:t3PublicAddress@@'
+          PublicPort: '@@PROP:t3ChannelPort@@'
+  ServerTemplate:
+    '@@PROP:clusterName@@-template':
+      Cluster: '@@PROP:clusterName@@'
+      ListenPort: '@@PROP:managedServerPort@@'
+      JTAMigratableTarget:
+        Cluster: '@@PROP:clusterName@@'
+    '@@PROP:clusterName2@@-template':
+      Cluster: '@@PROP:clusterName2@@'
+      ListenPort: '@@PROP:managedServerPort@@'
+      JTAMigratableTarget:
+        Cluster: '@@PROP:clusterName2@@'

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/README
@@ -15,9 +15,9 @@ with specific target environments, such as the WebLogic Kubernetes Operator. Als
 This Domain in PV sample provides the following new functionality:
 
 1. The create domain script, `create-domain.sh`, uses the Extract Domain Resource Tool to generate the domain CR YAML file (`domain.yaml`).
-1. Updates the domain configuration using the Update Domain Tool with a WDT full model and makes the equivalent change to the
+2. Updates the domain configuration using the Update Domain Tool with a WDT full model and makes the equivalent change to the
 domain CR using the Extract Domain Resource Tool.
-1. The [Create Domain Tool](https://github.com/oracle/weblogic-deploy-tooling/blob/master/site/create.md) and
+3. The [Create Domain Tool](https://github.com/oracle/weblogic-deploy-tooling/blob/master/site/create.md) and
 Update Domain Tool accept the following input files: a WDT model file and the WDT properties file
     (generated using the Discover Domain Tool).
 
@@ -40,7 +40,7 @@ To create a domain:
       those values it cannot generate. You must fill in the information identified by `--FIX ME--`
       in the domain resource output. Make sure that the `domain.yaml` file does not contain any `--FIX ME--` statements
       before proceeding to the next step.
-   1. `kubectl apply -f domain.yaml`
+   2. `kubectl apply -f domain.yaml`
 
 To update a domain:
 
@@ -61,10 +61,10 @@ To update a domain:
          With operator 3.0.1 and later, you need to add an `introspectVersion` field to your `domain.yaml` file so that
          the operator will roll the domain with the updates.
 
-   1. Edit the `outputdir1/weblogic-domain/domainname/domain.yaml` file and add or update the spec section as follows:
+   2. Edit the `outputdir1/weblogic-domain/domainname/domain.yaml` file and add or update the spec section as follows:
 
         `introspectVersion: "2"`
 
-   1. `kubectl apply -f domain.yaml`
+   3. `kubectl apply -f domain.yaml`
 
         The domain will be rolled and the updates will be applied. The changes will be reflected in the WebLogic configuration.

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
@@ -145,6 +145,10 @@ function createDomainConfigmap {
   if [ -d "${scriptDir}/common" ]; then
     cp ${scriptDir}/common/* ${externalFilesTmpDir}/
   fi
+  if [ -d "${scriptDir}/../../common" ]; then
+    cp ${scriptDir}/../../common/wdt-and-wit-utility.sh ${externalFilesTmpDir}/
+  fi
+
   cp ${domainOutputDir}/create-domain-inputs.yaml ${externalFilesTmpDir}/
  
   # Set the domainName in the inputs file that is contained in the configmap.

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/update-domain.sh
@@ -3,7 +3,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Description
-#  This sample script creates a WebLogic domain home on an existing PV/PVC, and generates the domain resource
+#  This sample script updates a WebLogic domain home on an existing PV/PVC, and generates the domain resource
 #  yaml file, which can be used to restart the Kubernetes artifacts of the corresponding domain.
 #
 #  The domain creation inputs can be customized by editing create-domain-inputs.yaml
@@ -126,6 +126,8 @@ function initialize {
 
   validateCommonInputs
 
+  useWdt=true
+
   initOutputDir
 }
 
@@ -190,6 +192,8 @@ function createDomainConfigmap {
 #
 function updateDomainHome {
 
+  # set createDomainFilesDir to wdt - so domain can be updated regardless of wdt or wlst is used for creation
+  createDomainFilesDir="wdt"
   # create the config map for the job
   createDomainConfigmap
 

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt/create-domain-script.sh
@@ -90,13 +90,9 @@ action=$1
 echo @@ "Info: action is $action"
 echo @@ "Info: https_proxy is $https_proxy"
 
-if [ "$action" = "create" ]; then
-   setup_wdt_shared_dir || exit 1
-fi
+setup_wdt_shared_dir || exit 1
 
-if [ "${action}" = "create" ]; then
-   install_wdt || exit 1
-fi
+install_wdt || exit 1
 
 if [ "${action}" = "update" ]; then
    run_wdt "update"|| exit 1


### PR DESCRIPTION
With the recent refactoring of samples, the update domain script on domain-on-pv no longer worked - the newly created wdt-and-wit-install script was not added to the config map. Also added a test to run the upgrade domain scenario to the existing It wls samples test.