### PR TITLE
Removed COMMON_MOUNT_STAGE build arg in common mounts docker-file and updated documentation

### DIFF
--- a/documentation/staging/content/userguide/managing-domains/model-in-image/common-mounts.md
+++ b/documentation/staging/content/userguide/managing-domains/model-in-image/common-mounts.md
@@ -210,7 +210,6 @@ Model In Image model files, application archives, and the WDT installation files
    ```shell
    $ docker build -f /tmp/mii-sample/cm-docker-file/Dockerfile \
      --build-arg COMMON_MOUNT_PATH=/common \
-     --build-arg COMMON_MOUNT_STAGE=. \
      --tag model-in-image:WLS-CM-v1 .
    ```
 
@@ -235,20 +234,15 @@ Model In Image model files, application archives, and the WDT installation files
    #     2) 'domain.spec.configuration.model.wdtInstallHome'
    #   Default '/common'.
    #
-   # COMMON_MOUNT_STAGE arg:
-   #   Local directory containing files to be copied to the COMMON_MOUNT_PATH.
-   #   Default '.'.
-   #
 
    FROM busybox
    ARG COMMON_MOUNT_PATH=/common
-   ARG COMMON_MOUNT_STAGE=.
    ARG USER=oracle
    ARG USERID=1000
    ARG GROUP=root
    ENV COMMON_MOUNT_PATH=${COMMON_MOUNT_PATH}
    RUN adduser -D -u ${USERID} -G $GROUP $USER
-   COPY ${COMMON_MOUNT_STAGE}/ ${COMMON_MOUNT_PATH}/
+   COPY ./ ${COMMON_MOUNT_PATH}/
    RUN chown -R $USER:$GROUP ${COMMON_MOUNT_PATH}
    USER $USER
    ```

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/cm-docker-file/Dockerfile
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/cm-docker-file/Dockerfile
@@ -15,19 +15,14 @@
 #     2) 'domain.spec.configuration.model.wdtInstallHome'
 #   Default '/common'.
 #
-# COMMON_MOUNT_STAGE arg:
-#   Local directory containing files to be copied to the COMMON_MOUNT_PATH.
-#   Default '.'.
-#
 
 FROM busybox
 ARG COMMON_MOUNT_PATH=/common
-ARG COMMON_MOUNT_STAGE=.
 ARG USER=oracle
 ARG USERID=1000
 ARG GROUP=root
 ENV COMMON_MOUNT_PATH=${COMMON_MOUNT_PATH}
 RUN adduser -D -u ${USERID} -G $GROUP $USER
-COPY ${COMMON_MOUNT_STAGE}/ ${COMMON_MOUNT_PATH}/
+COPY ./ ${COMMON_MOUNT_PATH}/
 RUN chown -R $USER:$GROUP ${COMMON_MOUNT_PATH}/
 USER $USER

--- a/operator/integration-tests/model-in-image/mii-sample-wrapper/build-model-image.sh
+++ b/operator/integration-tests/model-in-image/mii-sample-wrapper/build-model-image.sh
@@ -101,7 +101,6 @@ dryrun:
 dryrun:# see file $WORKDIR/cm-image/${MODEL_IMAGE_TAG}/Dockerfile for an explanation of each --build-arg
 dryrun:docker build -f $WORKDIR/$COMMON_MOUNT_DOCKER_FILE_SOURCEDIR/Dockerfile \\
 dryrun:             --build-arg COMMON_MOUNT_PATH=${COMMON_MOUNT_PATH} \\
-dryrun:             --build-arg COMMON_MOUNT_STAGE=. \\
 dryrun:             --tag ${MODEL_IMAGE_NAME}:${MODEL_IMAGE_TAG}  .
 EOF
 else


### PR DESCRIPTION
Removed COMMON_MOUNT_STAGE build arg in common mounts Docker file, `build-image.sh` script, and updated common mounts documentation to reflect this change. This is required since the source dir for the docker COPY command is relative to the docker build context. 