### PR TITLE
Allow build and test with JDK 16

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -92,6 +92,7 @@
           <includes>
             <exclude>**/*Test.java</exclude>
           </includes>
+          <argLine>--illegal-access=permit</argLine>
         </configuration>
       </plugin>
 
@@ -228,12 +229,18 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>package</phase>
             <configuration>
-              <mainClass>oracle.kubernetes.operator.helpers.CrdHelper</mainClass>
+              <executable>java</executable>
               <arguments>
+                <argument>--illegal-access=permit</argument>
+                <argument>-classpath</argument>
+                <!-- automatically creates the classpath using all project dependencies,
+                     also adding the project build directory -->
+                <classpath/>
+                <argument>oracle.kubernetes.operator.helpers.CrdHelper</argument>
                 <argument>${project.basedir}/../kubernetes/crd/domain-crd.yaml</argument>
               </arguments>
             </configuration>


### PR DESCRIPTION
This is a small one. Because of some changes to various libraries, you could no longer build the operator project using JDK 16 even though everything runs well with that JDK. The issue is that the Maven and Surefire plugin environments are more restrictive (with respect to Java modules) then our runtime environment.

We aren't presently using Java modules so instead this PR uses the options to remove these restrictions.