### PR TITLE
fix intermittent test issue in ItParameterizedDomain#testOperatorLogSevereMsg

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -31,8 +31,10 @@ import oracle.weblogic.kubernetes.assertions.impl.Service;
 import oracle.weblogic.kubernetes.assertions.impl.Traefik;
 import oracle.weblogic.kubernetes.assertions.impl.Voyager;
 import oracle.weblogic.kubernetes.assertions.impl.WitAssertion;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
 
 import static oracle.weblogic.kubernetes.actions.TestActions.listSecrets;
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 
 /**
  * General assertions needed by the tests to validate CRD, Domain, Pods etc.
@@ -375,12 +377,21 @@ public class TestAssertions {
    */
   public static Callable<Boolean> domainStatusReasonMatches(oracle.weblogic.domain.Domain domain,
                                                             String statusReason) {
+    LoggingFacade logger = getLogger();
     return () -> {
       if (domain != null && domain.getStatus() != null && domain.getStatus().getReason() != null) {
+        logger.info("DEBUG: domain status reason: {0}", domain.getStatus().getReason());
         return domain.getStatus().getReason().equalsIgnoreCase(statusReason);
+      } else {
+        if (domain == null) {
+          logger.info("DEBUG: domain is null");
+        } else if (domain.getStatus() == null) {
+          logger.info("DEBUG: domain status is null");
+        } else {
+          logger.info("DEBUG: domain status reason is null");
+        }
+        return false;
       }
-
-      return false;
     };
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -380,15 +380,15 @@ public class TestAssertions {
     LoggingFacade logger = getLogger();
     return () -> {
       if (domain != null && domain.getStatus() != null && domain.getStatus().getReason() != null) {
-        logger.info("DEBUG: domain status reason: {0}", domain.getStatus().getReason());
+        logger.info("domain status reason: {0}", domain.getStatus().getReason());
         return domain.getStatus().getReason().equalsIgnoreCase(statusReason);
       } else {
         if (domain == null) {
-          logger.info("DEBUG: domain is null");
+          logger.info("domain is null");
         } else if (domain.getStatus() == null) {
-          logger.info("DEBUG: domain status is null");
+          logger.info("domain status is null");
         } else {
-          logger.info("DEBUG: domain status reason is null");
+          logger.info("domain status reason is null");
         }
         return false;
       }


### PR DESCRIPTION
In the nightly run, ItParameterizedDomain#testOperatorLogSevereMsg failed intermittently when checking the domain status. Sometimes the domain status returns null. Change the test logic to check the operator log directly. 

https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/5508/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/5510/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/5511/