### PR TITLE
dynamically generate Apache Image URL from BASE_IMAGES_REPO variables

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -174,9 +174,15 @@ public interface TestConstants {
   public static final String VOYAGER_CHART_VERSION = "12.0.0";
 
   // Apache constants
-  public static final String APACHE_IMAGE_NAME = "phx.ocir.io/weblogick8s/oracle/apache";
-  public static final String APACHE_IMAGE_VERSION = "12.2.1.4";
-  public static final String APACHE_IMAGE = APACHE_IMAGE_NAME + ":" + APACHE_IMAGE_VERSION;
+  public static final String OCIR_APACHE_IMAGE_NAME = "weblogick8s/oracle/apache";
+  public static final String OCIR_APACHE_IMAGE_TAG = "12.2.1.4";
+
+  // Get APACHE_IMAGE_NAME/APACHE_IMAGE_TAG from env var, if it is not provided use OCIR default image values
+  public static final String APACHE_IMAGE_NAME = BASE_IMAGES_REPO + "/"
+      + Optional.ofNullable(System.getenv("APACHE_IMAGE_NAME")).orElse(OCIR_APACHE_IMAGE_NAME);
+  public static final String APACHE_IMAGE_TAG =
+      Optional.ofNullable(System.getenv("APACHE_IMAGE_TAG")).orElse(OCIR_APACHE_IMAGE_TAG);
+  public static final String APACHE_IMAGE = APACHE_IMAGE_NAME + ":" + APACHE_IMAGE_TAG;
   public static final String APACHE_RELEASE_NAME = "apache-release" + BUILD_ID;
   public static final String APACHE_SAMPLE_CHART_DIR = "../kubernetes/samples/charts/apache-webtier";
 


### PR DESCRIPTION
Required by upstream pipeline, we need to generate Apache image url from  BASE_IMAGES_REPO variables.

Jenkins result:
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/5543/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/5545/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/5538/