### PR TITLE
Integration Test : Upgrade Operartor from v3.2.4 and v3.2.5

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -292,7 +292,6 @@
                   **/ItPodsRestart,
                   **/ItUsabilityOperatorHelmChart,
                   **/ItInitContainers,
-                  **/ItOperatorWlsUpgrade,
                   **/ItOperatorRestart,
                   **/ItPodsShutdownOption,
                   **/ItOCILoadBalancer,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwMiiDomain.java
@@ -227,7 +227,7 @@ public class ItFmwMiiDomain {
   @Order(2)
   @Test
   @DisplayName("Reuse the same RCU schema to restart JRF domain")
-  public void testReuseRCUschemalToRestartDomain() {
+  public void testReuseRCUschemaToRestartDomain() {
     saveAndRestoreOpssWalletfileSecret(fmwDomainNamespace, domainUid, opsswalletfileSecretName);
     shutdownDomain();
     patchDomainWithWalletFileSecret(opsswalletfileSecretName);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOpUpgradeFmwDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOpUpgradeFmwDomainInPV.java
@@ -268,21 +268,21 @@ public class ItOpUpgradeFmwDomainInPV {
   }
 
   /**
-   * Operator upgrade from 3.2.1 to latest with a FMW Domain.
+   * Operator upgrade from 3.2.4 to latest with a FMW Domain.
    */
   @Test
-  @DisplayName("Upgrade Operator from 3.2.1 to main")
-  public void testOperatorFmwUpgradeFrom321ToMain() {
-    installAndUpgradeOperator("3.2.1", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+  @DisplayName("Upgrade Operator from 3.2.4 to main")
+  public void testOperatorFmwUpgradeFrom324ToMain() {
+    installAndUpgradeOperator("3.2.4", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   /**
-   * Operator upgrade from 3.2.2 to latest with a FMW Domain.
+   * Operator upgrade from 3.2.5 to latest with a FMW Domain.
    */
   @Test
-  @DisplayName("Upgrade Operator from 3.2.2 to main")
-  public void testOperatorFmwUpgradeFrom322ToMain() {
-    installAndUpgradeOperator("3.2.2", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+  @DisplayName("Upgrade Operator from 3.2.5 to main")
+  public void testOperatorFmwUpgradeFrom325ToMain() {
+    installAndUpgradeOperator("3.2.5", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   private void installAndUpgradeOperator(String operatorVersion,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -198,25 +198,25 @@ public class ItOperatorWlsUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.2.1 to latest.
+   * Operator upgrade from 3.2.4 to latest.
    */
   @ParameterizedTest
-  @DisplayName("Upgrade Operator from 3.2.1 to main")
+  @DisplayName("Upgrade Operator from 3.2.4 to main")
   @ValueSource(strings = { "domain-in-image", "model-in-image" })
-  public void testOperatorWlsUpgradeFrom321ToMain(String domainType) {
+  public void testOperatorWlsUpgradeFrom324ToMain(String domainType) {
     logger.info("Starting test testOperatorWlsUpgradeFrom321ToMain with domain type {0}", domainType);
-    upgradeOperator(domainType, "3.2.1", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+    upgradeOperator(domainType, "3.2.4", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   /**
-   * Operator upgrade from 3.2.2 to latest.
+   * Operator upgrade from 3.2.5 to latest.
    */
   @ParameterizedTest
-  @DisplayName("Upgrade Operator from 3.2.2 to main")
+  @DisplayName("Upgrade Operator from 3.2.5 to main")
   @ValueSource(strings = { "domain-in-image", "model-in-image" })
-  public void testOperatorWlsUpgradeFrom322ToMain(String domainType) {
+  public void testOperatorWlsUpgradeFrom325ToMain(String domainType) {
     logger.info("Starting test testOperatorWlsUpgradeFrom322ToMain with domain type {0}", domainType);
-    upgradeOperator(domainType, "3.2.2", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+    upgradeOperator(domainType, "3.2.5", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   /**

--- a/kubernetes/samples/charts/util/setupLoadBalancer.sh
+++ b/kubernetes/samples/charts/util/setupLoadBalancer.sh
@@ -164,7 +164,7 @@ function waitForIngressPod() {
   ns=$2
 
   printInfo "Wait until ${type} ingress controller pod is running."
-  ipod=$(${kubernetesCli} -o name get po -n ${ns})
+  ipod=$(${kubernetesCli} -o name get po -n ${ns} | grep -v admission-patch)
   if [[ "${ipod}" != *$chart* ]]; then
    printError "Couldn't find the pod associated with ${type} helm deployment. List helm deployment status on namespace [${ns}]. "
    helm list -n ${ns}

--- a/kubernetes/samples/charts/util/setupLoadBalancer.sh
+++ b/kubernetes/samples/charts/util/setupLoadBalancer.sh
@@ -229,6 +229,26 @@ function createVoyager() {
     exit 0;
   fi 
 
+  max=20
+  count=0
+  printInfo "Checking availability of voyager deployment [${chart}]"
+  while test $count -lt $max; do
+   status=$(${kubernetesCli} get deployment --namespace ${ns} -l "app.kubernetes.io/name=voyager,app.kubernetes.io/instance=${chart}" --no-headers 2> /dev/null | awk '{print $2}' || true)
+   if [ "${status}" == "1/1" ];  then
+      echo " "
+      printInfo "voyager deployment resource [${chart}] is available now."
+      ${kubernetesCli} get deployment --namespace ${ns} -l "app.kubernetes.io/name=voyager,app.kubernetes.io/instance=${chart}" 
+      break;
+   fi
+   count=`expr $count + 1`
+   echo -n "."
+   sleep 2
+  done
+  if test $count -eq $max; then
+    printError "voyager deployment resource can not be created" 
+    exit 1
+  fi
+
   waitForIngressPod voyager ${ns}
 
   max=20
@@ -293,20 +313,23 @@ function createTraefik() {
 # Remove ingress related resources from default Namespace ( if any )
 function purgeDefaultResources() {
    printInfo "Remove ingress related resources from default Namespace (if any)"
-   crole=$(${kubernetesCli} get ClusterRole | grep ${chart} | awk '{print $1}')
-   if [ "x${crole}" != "x" ]; then 
-   ${kubernetesCli} get ClusterRole | grep ${chart} | awk '{print $1}' | xargs kubectl delete ClusterRole --ignore-not-found
-   fi
+  croles=$(${kubernetesCli} get ClusterRole | grep ${chart} | awk '{print $1}')
+  for crole in ${croles}; do 
+   printInfo "Deleting ClusterRole ${crole} from default Namespace"
+   ${kubernetesCli} delete ClusterRole ${crole} 
+  done
 
-   crb=$(${kubernetesCli} get ClusterRoleBinding | grep ${chart} | awk '{print $1}')
-   if [ x${crb} != "x" ]; then 
-  ${kubernetesCli} get ClusterRoleBinding | grep ${chart} | awk '{print $1}' | xargs kubectl delete ClusterRoleBinding 
-   fi
+  crbs=$(${kubernetesCli} get ClusterRoleBinding | grep ${chart} | awk '{print $1}')
+  for crb in ${crbs}; do 
+   printInfo "Deleting ClusterRoleBinding ${crb} from default Namespace"
+   ${kubernetesCli} delete ClusterRoleBinding ${crb} 
+  done
 
-   vwc=$(${kubernetesCli} get ValidatingWebhookConfiguration | grep ${chart} | awk '{print $1}')
-   if [ x${vwc} != "x" ]; then 
-  ${kubernetesCli} get ValidatingWebhookConfiguration | grep ${chart} | awk '{print $1}' | xargs kubectl delete ValidatingWebhookConfiguration 
-   fi
+  vwcs=$(${kubernetesCli} get ValidatingWebhookConfiguration | grep ${chart} | awk '{print $1}')
+  for vwc in ${vwcs}; do 
+    printInfo "Deleting ValidatingWebhookConfiguration ${vwc} from default Namespace"
+    ${kubernetesCli} delete ValidatingWebhookConfiguration ${vwc} 
+  done
 }
 
 # Remove voyager related resources from default Namespace ( if any )
@@ -342,7 +365,7 @@ function purgeVoyagerResources() {
    ${kubernetesCli} delete ClusterRole/${chart} --ignore-not-found
    ${kubernetesCli} delete ClusterRoleBinding/${chart} --ignore-not-found
    ${kubernetesCli} delete ClusterRoleBinding/${chart}-apiserver-auth-delegator  --ignore-not-found
-   kubectl delete RoleBinding/${chart}-apiserver-extension-server-authentication-reader -n kube-system --ignore-not-found
+   ${kubernetesCli} delete RoleBinding/${chart}-apiserver-extension-server-authentication-reader -n kube-system --ignore-not-found
 }
 
 function deleteIngress() {


### PR DESCRIPTION
Add new test methods to upgrade Operator from v3.2.4 and v3.2.5 to main branch.
Removed Upgrade Tests for OKE Nightly Configuration.
 
Jenkins Results 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5542
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5574/

