### PR TITLE
Modify new image used by testUpdateImageName of ItIntrospectVersion 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -968,9 +968,10 @@ public class ItIntrospectVersion {
 
   /**
    * Modify the domain scope property
-   * From: "image: container-registry.oracle.com/middleware/weblogic:12.2.1.4" to
+   * From: "image: container-registry.oracle.com/middleware/weblogic:ImageTagBeingUsed" to
    * To: "image: container-registry.oracle.com/middleware/weblogic:DateAndTimeStamp"
-   * e.g, "image:container-registry.oracle.com/middleware/weblogic:2021-07-08-162571383699"
+   * e.g, From ""image: container-registry.oracle.com/middleware/weblogic:12.2.1.4"
+   * To: "image:container-registry.oracle.com/middleware/weblogic:2021-07-08-162571383699"
    * Verify all the pods are restarted and back to ready state
    * Verify the admin server is accessible and cluster members are healthy
    * This test will be skipped if the image tag is the latest WebLogic image tag

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -162,11 +162,6 @@ public class ItIntrospectVersion {
   private static String nginxNamespace = null;
   private static int nodeportshttp;
   private static HelmParams nginxHelmParams = null;
-  /*private static String imageUpdate = KIND_REPO != null ? KIND_REPO
-      + (WEBLOGIC_IMAGE_NAME + ":" + WLS_UPDATE_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
-      : WEBLOGIC_IMAGE_NAME + ":" + WLS_UPDATE_IMAGE_TAG;
-
-   */
 
   private final String wlSecretName = "weblogic-credentials";
 
@@ -974,7 +969,8 @@ public class ItIntrospectVersion {
   /**
    * Modify the domain scope property
    * From: "image: container-registry.oracle.com/middleware/weblogic:12.2.1.4" to
-   * To: "image: container-registry.oracle.com/middleware/weblogic:14.1.1.0-11"
+   * To: "image: container-registry.oracle.com/middleware/weblogic:DateAndTimeStamp"
+   * e.g, "image:container-registry.oracle.com/middleware/weblogic:2021-07-08-162571383699"
    * Verify all the pods are restarted and back to ready state
    * Verify the admin server is accessible and cluster members are healthy
    * This test will be skipped if the image tag is the latest WebLogic image tag
@@ -1015,7 +1011,6 @@ public class ItIntrospectVersion {
 
     //change image name to imageUpdate
     String imageTag = TestUtils.getDateAndTimeStamp();
-    //String imageUpdate = WEBLOGIC_IMAGE_NAME + ":" + tag;
     String imageUpdate = KIND_REPO != null ? KIND_REPO
         + (WEBLOGIC_IMAGE_NAME + ":" + imageTag).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
         : WEBLOGIC_IMAGE_NAME + ":" + imageTag;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -49,6 +49,7 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.BuildApplication;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import oracle.weblogic.kubernetes.utils.OracleHttpClient;
+import oracle.weblogic.kubernetes.utils.TestUtils;
 import org.awaitility.core.ConditionEvaluationListener;
 import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.EvaluatedCondition;
@@ -77,7 +78,6 @@ import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_PATCH;
 import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
-import static oracle.weblogic.kubernetes.TestConstants.KIND_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
@@ -89,6 +89,7 @@ import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteSecret;
+import static oracle.weblogic.kubernetes.actions.TestActions.dockerTag;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getCurrentIntrospectVersion;
 import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
@@ -118,6 +119,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createPVC;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getIntrospectJobName;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getPodCreationTime;
@@ -159,9 +161,11 @@ public class ItIntrospectVersion {
   private static String nginxNamespace = null;
   private static int nodeportshttp;
   private static HelmParams nginxHelmParams = null;
-  private static String imageUpdate = KIND_REPO != null ? KIND_REPO
+  /*private static String imageUpdate = KIND_REPO != null ? KIND_REPO
       + (WEBLOGIC_IMAGE_NAME + ":" + WLS_UPDATE_IMAGE_TAG).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
       : WEBLOGIC_IMAGE_NAME + ":" + WLS_UPDATE_IMAGE_TAG;
+
+   */
   private final String wlSecretName = "weblogic-credentials";
 
   private static String adminSvcExtHost = null;
@@ -1008,6 +1012,11 @@ public class ItIntrospectVersion {
     logger.info("Currently the image name used for the domain is: {0}", imageName);
 
     //change image name to imageUpdate
+    String tag = TestUtils.getDateAndTimeStamp();
+    String imageUpdate = WEBLOGIC_IMAGE_NAME + ":" + tag;
+    dockerTag(imageName, imageUpdate);
+    dockerLoginAndPushImageToRegistry(imageUpdate);
+
     StringBuffer patchStr = null;
     patchStr = new StringBuffer("[{");
     patchStr.append("\"op\": \"replace\",")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -78,6 +78,7 @@ import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_PATCH;
 import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.KIND_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
@@ -166,6 +167,7 @@ public class ItIntrospectVersion {
       : WEBLOGIC_IMAGE_NAME + ":" + WLS_UPDATE_IMAGE_TAG;
 
    */
+
   private final String wlSecretName = "weblogic-credentials";
 
   private static String adminSvcExtHost = null;
@@ -1012,8 +1014,11 @@ public class ItIntrospectVersion {
     logger.info("Currently the image name used for the domain is: {0}", imageName);
 
     //change image name to imageUpdate
-    String tag = TestUtils.getDateAndTimeStamp();
-    String imageUpdate = WEBLOGIC_IMAGE_NAME + ":" + tag;
+    String imageTag = TestUtils.getDateAndTimeStamp();
+    //String imageUpdate = WEBLOGIC_IMAGE_NAME + ":" + tag;
+    String imageUpdate = KIND_REPO != null ? KIND_REPO
+        + (WEBLOGIC_IMAGE_NAME + ":" + imageTag).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
+        : WEBLOGIC_IMAGE_NAME + ":" + imageTag;
     dockerTag(imageName, imageUpdate);
     dockerLoginAndPushImageToRegistry(imageUpdate);
 


### PR DESCRIPTION
From wko-pipeline meeting, "Do we need to verify WLS images which is not passed as parameter in Jenkin e.g. 14.1.1.0-11  even if the IMAGE TAG is 12.2.1.4.0".
Modify the new image name to address the issue.
Jenkins full suite:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5591/testReport/
Single test class:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5588/testReport/

OKE test passed at
https://build.weblogick8s.org:8443/job/wko-oke-nightly-seqential/338/testReport/