### PR TITLE
Add test to patch the domain with updated base image in a running AI domain

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -231,13 +231,6 @@ public class ItMiiAuxiliaryImage {
         adminServerPodName, managedServerPrefix, replicaCount);
 
     // check configuration for JMS
-    /*int adminServiceNodePort
-        = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
-    assertNotEquals(-1, adminServiceNodePort, "admin server default node port is not valid");
-    assertTrue(checkSystemResourceConfiguration(adminServiceNodePort, "JMSSystemResources",
-        "TestClusterJmsModule2", "200"), "JMSSystemResources not found");
-    logger.info("Found the JMSSystemResource configuration");
-    */
     checkConfiguredJMSresouce(domainNamespace, adminServerPodName);
   }
 
@@ -286,13 +279,6 @@ public class ItMiiAuxiliaryImage {
 
     patchDomainWithAuxiliaryImageAndVerify(miiAuxiliaryImage1, miiAuxiliaryImage3, domainUid, domainNamespace);
 
-    /*assertTrue(checkSystemResourceConfig(adminServiceNodePort,
-        "JDBCSystemResources/TestDataSource/JDBCResource/JDBCDriverParams",
-        "jdbc:oracle:thin:@\\/\\/localhost:7001\\/dbsvc"), "Can't find expected URL configuration for DataSource");
-
-    logger.info("Found the DataResource configuration");
-
-     */
     checkConfiguredJDBCresouce(domainNamespace, adminServerPodName);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -20,6 +20,7 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import oracle.weblogic.kubernetes.utils.TestUtils;
 import org.apache.commons.io.FileUtils;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,6 +35,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_IMAGES_REPO;
+import static oracle.weblogic.kubernetes.TestConstants.KIND_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
@@ -49,16 +51,20 @@ import static oracle.weblogic.kubernetes.actions.TestActions.buildAppArchive;
 import static oracle.weblogic.kubernetes.actions.TestActions.defaultAppParams;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteImage;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
+import static oracle.weblogic.kubernetes.actions.TestActions.dockerTag;
 import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResource;
+import static oracle.weblogic.kubernetes.utils.CommonPatchTestUtils.patchDomainResource;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkSystemResourceConfig;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkSystemResourceConfiguration;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createOcirRepoSecret;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getPodsWithTimeStamps;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.installAndVerifyOperator;
@@ -225,12 +231,14 @@ public class ItMiiAuxiliaryImage {
         adminServerPodName, managedServerPrefix, replicaCount);
 
     // check configuration for JMS
-    int adminServiceNodePort
+    /*int adminServiceNodePort
         = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
     assertNotEquals(-1, adminServiceNodePort, "admin server default node port is not valid");
     assertTrue(checkSystemResourceConfiguration(adminServiceNodePort, "JMSSystemResources",
         "TestClusterJmsModule2", "200"), "JMSSystemResources not found");
     logger.info("Found the JMSSystemResource configuration");
+    */
+    checkConfiguredJMSresouce(domainNamespace, adminServerPodName);
   }
 
   /**
@@ -278,11 +286,82 @@ public class ItMiiAuxiliaryImage {
 
     patchDomainWithAuxiliaryImageAndVerify(miiAuxiliaryImage1, miiAuxiliaryImage3, domainUid, domainNamespace);
 
-    assertTrue(checkSystemResourceConfig(adminServiceNodePort,
+    /*assertTrue(checkSystemResourceConfig(adminServiceNodePort,
         "JDBCSystemResources/TestDataSource/JDBCResource/JDBCDriverParams",
         "jdbc:oracle:thin:@\\/\\/localhost:7001\\/dbsvc"), "Can't find expected URL configuration for DataSource");
 
     logger.info("Found the DataResource configuration");
+
+     */
+    checkConfiguredJDBCresouce(domainNamespace, adminServerPodName);
+  }
+
+  /**
+   * Patch the domain with the different base image name.
+   * Verify all the pods are restarted and back to ready state.
+   * Verify configured JMS and JDBC resources.
+   */
+  @Test
+  @Order(3)
+  @DisplayName("Test to update Base Weblogic Image Name")
+  public void testUpdateBaseImageName() {
+    // get the original domain resource before update
+    Domain domain1 = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
+        String.format("getDomainCustomResource failed with ApiException when tried to get domain %s in namespace %s",
+            domainUid, domainNamespace));
+    assertNotNull(domain1, "Got null domain resource");
+    assertNotNull(domain1.getSpec(), domain1 + "/spec is null");
+
+    // get the map with server pods and their original creation timestamps
+    podsWithTimeStamps = getPodsWithTimeStamps(domainNamespace, adminServerPodName, managedServerPrefix,
+        replicaCount);
+
+    //print out the original image name
+    String imageName = domain1.getSpec().getImage();
+    logger.info("Currently the image name used for the domain is: {0}", imageName);
+
+    //change image name to imageUpdate
+    String imageTag = TestUtils.getDateAndTimeStamp();
+    String imageUpdate = KIND_REPO != null ? KIND_REPO
+        + (WEBLOGIC_IMAGE_NAME + ":" + imageTag).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
+        : WEBLOGIC_IMAGE_NAME + ":" + imageTag;
+    dockerTag(imageName, imageUpdate);
+    dockerLoginAndPushImageToRegistry(imageUpdate);
+
+    StringBuffer patchStr = null;
+    patchStr = new StringBuffer("[{");
+    patchStr.append("\"op\": \"replace\",")
+        .append(" \"path\": \"/spec/image\",")
+        .append("\"value\": \"")
+        .append(imageUpdate)
+        .append("\"}]");
+    logger.info("PatchStr for imageUpdate: {0}", patchStr.toString());
+
+    assertTrue(patchDomainResource(domainUid, domainNamespace, patchStr),
+        "patchDomainCustomResource(imageUpdate) failed");
+
+    domain1 = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
+        String.format("getDomainCustomResource failed with ApiException when tried to get domain %s in namespace %s",
+            domainUid, domainNamespace));
+    assertNotNull(domain1, "Got null domain resource after patching");
+    assertNotNull(domain1.getSpec(), domain1 + " /spec is null");
+
+    //print out image name in the new patched domain
+    logger.info("In the new patched domain image name is: {0}", domain1.getSpec().getImage());
+
+    // verify the server pods are rolling restarted and back to ready state
+    logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
+        domainUid, domainNamespace);
+    assertTrue(verifyRollingRestartOccurred(podsWithTimeStamps, 1, domainNamespace),
+        String.format("Rolling restart failed for domain %s in namespace %s", domainUid, domainNamespace));
+
+    checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+
+    // check configuration for JMS
+    checkConfiguredJMSresouce(domainNamespace, adminServerPodName);
+    //check configuration for JDBC
+    checkConfiguredJDBCresouce(domainNamespace, adminServerPodName);
+
   }
 
   private static void patchDomainWithAuxiliaryImageAndVerify(String oldImageName, String newImageName,
@@ -378,4 +457,25 @@ public class ItMiiAuxiliaryImage {
             .command(cmdToExecute))
         .execute(), String.format("Failed to execute", cmdToExecute));
   }
+
+  private void checkConfiguredJMSresouce(String domainNamespace, String adminServerPodName) {
+    int adminServiceNodePort
+        = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
+    assertNotEquals(-1, adminServiceNodePort, "admin server default node port is not valid");
+    assertTrue(checkSystemResourceConfiguration(adminServiceNodePort, "JMSSystemResources",
+        "TestClusterJmsModule2", "200"), "JMSSystemResources not found");
+    logger.info("Found the JMSSystemResource configuration");
+
+  }
+
+  private void checkConfiguredJDBCresouce(String domainNamespace, String adminServerPodName) {
+    int adminServiceNodePort
+        = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
+    assertNotEquals(-1, adminServiceNodePort, "admin server default node port is not valid");
+    assertTrue(checkSystemResourceConfig(adminServiceNodePort,
+        "JDBCSystemResources/TestDataSource/JDBCResource/JDBCDriverParams",
+        "jdbc:oracle:thin:@\\/\\/localhost:7001\\/dbsvc"), "Can't find expected URL configuration for DataSource");
+    logger.info("Found the DataResource configuration");
+  }
+
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -451,7 +451,6 @@ public class ItMiiAuxiliaryImage {
     assertTrue(checkSystemResourceConfiguration(adminServiceNodePort, "JMSSystemResources",
         "TestClusterJmsModule2", "200"), "JMSSystemResources not found");
     logger.info("Found the JMSSystemResource configuration");
-
   }
 
   private void checkConfiguredJDBCresouce(String domainNamespace, String adminServerPodName) {


### PR DESCRIPTION
Single ItMiiAuxiliaryImage Jenkins job passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5626/testReport/
Jenkins full suite with ItMiiAuxiliaryImage passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5627/testReport/
