### PR TITLE
OWLS-90857 - Create copy of init container env variables for each sever pod to avoid the roll issue

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -203,7 +203,7 @@ public class ConfigMapHelper {
 
   static synchronized Map<String, String> loadScriptsFromClasspath(String domainNamespace) {
     Map<String, String> scripts = scriptReader.loadFilesFromClasspath();
-    LOGGER.fine(MessageKeys.SCRIPT_LOADED, domainNamespace);
+    LOGGER.finer(MessageKeys.SCRIPT_LOADED, domainNamespace);
     return scripts;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -259,7 +259,7 @@ public class PodHelper {
     return new DeletePodStep(serverName, next);
   }
 
-  static List<V1EnvVar> createCopy(List<V1EnvVar> envVars) {
+  public static List<V1EnvVar> createCopy(List<V1EnvVar> envVars) {
     ArrayList<V1EnvVar> copy = new ArrayList<>();
     if (envVars != null) {
       for (V1EnvVar envVar : envVars) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1EnvVarBuilder;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodCondition;
@@ -272,10 +273,7 @@ public class PodHelper {
         // note that a deep copy of valueFrom is not needed here as, unlike with value, the
         // new V1EnvVarFrom objects would be created by the doDeepSubstitutions() method in
         // StepContextBase class.
-        copy.add(new V1EnvVar()
-            .name(envVar.getName())
-            .value(envVar.getValue())
-            .valueFrom(envVar.getValueFrom()));
+        copy.add(new V1EnvVarBuilder(envVar).build());
       }
     }
     return copy;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -259,6 +259,12 @@ public class PodHelper {
     return new DeletePodStep(serverName, next);
   }
 
+  /**
+   * Copy list of V1EnvVar environment variables.
+   *
+   * @param envVars list of environment variables to copy
+   * @return List containing a copy of the original list.
+   */
   public static List<V1EnvVar> createCopy(List<V1EnvVar> envVars) {
     ArrayList<V1EnvVar> copy = new ArrayList<>();
     if (envVars != null) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -260,7 +260,7 @@ public class PodHelper {
   }
 
   /**
-   * Copy list of V1EnvVar environment variables.
+   * Create a copy of the list of V1EnvVar environment variables.
    *
    * @param envVars list of environment variables to copy
    * @return List containing a copy of the original list.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -37,6 +37,7 @@ import io.kubernetes.client.openapi.models.V1Probe;
 import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.util.Yaml;
 import jakarta.json.Json;
 import jakarta.json.JsonPatchBuilder;
 import oracle.kubernetes.operator.DomainSourceType;
@@ -545,11 +546,11 @@ public abstract class PodStepContext extends BasePodStepContext {
 
     boolean useCurrent = hasCorrectPodHash(currentPod) && canUseNewDomainZip(currentPod);
 
-    if (!useCurrent && AnnotationHelper.getDebugString(currentPod).length() > 0) {
+    if (!useCurrent) {
       LOGGER.fine(
           MessageKeys.POD_DUMP,
-          AnnotationHelper.getDebugString(currentPod),
-          AnnotationHelper.getDebugString(getPodModel()));
+          Yaml.dump(currentPod),
+          Yaml.dump(getPodModel()));
     }
 
     return useCurrent;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -547,7 +547,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     boolean useCurrent = hasCorrectPodHash(currentPod) && canUseNewDomainZip(currentPod);
 
     if (!useCurrent) {
-      LOGGER.fine(
+      LOGGER.finer(
           MessageKeys.POD_DUMP,
           Yaml.dump(currentPod),
           Yaml.dump(getPodModel()));

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
@@ -38,12 +38,12 @@ import io.kubernetes.client.openapi.models.V1WeightedPodAffinityTerm;
 import jakarta.validation.Valid;
 import oracle.kubernetes.json.Description;
 import oracle.kubernetes.json.Feature;
+import oracle.kubernetes.operator.helpers.PodHelper;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import static java.util.Collections.emptyList;
-import static oracle.kubernetes.operator.helpers.PodHelper.createCopy;
 
 class ServerPod extends KubernetesResource {
 
@@ -444,7 +444,7 @@ class ServerPod extends KubernetesResource {
       addIfMissing(var);
     }
     for (V1Container c : serverPod1.getInitContainers()) {
-      addInitContainerIfMissing(copyContainer(c));
+      addInitContainerIfMissing(createWithEnvCopy(c));
     }
     for (V1Container c : serverPod1.getContainers()) {
       addContainerIfMissing(c);
@@ -493,8 +493,8 @@ class ServerPod extends KubernetesResource {
     }
   }
 
-  private V1Container copyContainer(V1Container c) {
-    return new V1Container().args(c.getArgs()).command(c.getCommand()).env(createCopy(c.getEnv()))
+  private V1Container createWithEnvCopy(V1Container c) {
+    return new V1Container().args(c.getArgs()).command(c.getCommand()).env(PodHelper.createCopy(c.getEnv()))
             .envFrom(c.getEnvFrom()).image(c.getImage()).imagePullPolicy(c.getImagePullPolicy())
             .lifecycle(c.getLifecycle()).livenessProbe(c.getLivenessProbe()).name(c.getName()).ports(c.getPorts())
             .readinessProbe(c.getReadinessProbe()).resources(c.getResources()).securityContext(c.getSecurityContext())

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import static java.util.Collections.emptyList;
+import static oracle.kubernetes.operator.helpers.PodHelper.createCopy;
 
 class ServerPod extends KubernetesResource {
 
@@ -443,7 +444,7 @@ class ServerPod extends KubernetesResource {
       addIfMissing(var);
     }
     for (V1Container c : serverPod1.getInitContainers()) {
-      addInitContainerIfMissing(c);
+      addInitContainerIfMissing(copyContainer(c));
     }
     for (V1Container c : serverPod1.getContainers()) {
       addContainerIfMissing(c);
@@ -490,6 +491,17 @@ class ServerPod extends KubernetesResource {
                 .collect(Collectors.toList());
       }
     }
+  }
+
+  private V1Container copyContainer(V1Container c) {
+    return new V1Container().args(c.getArgs()).command(c.getCommand()).env(createCopy(c.getEnv()))
+            .envFrom(c.getEnvFrom()).image(c.getImage()).imagePullPolicy(c.getImagePullPolicy())
+            .lifecycle(c.getLifecycle()).livenessProbe(c.getLivenessProbe()).name(c.getName()).ports(c.getPorts())
+            .readinessProbe(c.getReadinessProbe()).resources(c.getResources()).securityContext(c.getSecurityContext())
+            .startupProbe(c.getStartupProbe()).stdin(c.getStdin()).stdinOnce(c.getStdinOnce())
+            .terminationMessagePath(c.getTerminationMessagePath())
+            .terminationMessagePolicy(c.getTerminationMessagePolicy()).tty(c.getTty())
+            .volumeDevices(c.getVolumeDevices()).volumeMounts(c.getVolumeMounts()).workingDir(c.getWorkingDir());
   }
 
   private void addIfMissing(V1Volume var) {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
@@ -17,6 +17,7 @@ import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Capabilities;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerBuilder;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
 import io.kubernetes.client.openapi.models.V1NodeAffinity;
@@ -38,12 +39,12 @@ import io.kubernetes.client.openapi.models.V1WeightedPodAffinityTerm;
 import jakarta.validation.Valid;
 import oracle.kubernetes.json.Description;
 import oracle.kubernetes.json.Feature;
-import oracle.kubernetes.operator.helpers.PodHelper;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import static java.util.Collections.emptyList;
+import static oracle.kubernetes.operator.helpers.PodHelper.createCopy;
 
 class ServerPod extends KubernetesResource {
 
@@ -494,14 +495,7 @@ class ServerPod extends KubernetesResource {
   }
 
   private V1Container createWithEnvCopy(V1Container c) {
-    return new V1Container().args(c.getArgs()).command(c.getCommand()).env(PodHelper.createCopy(c.getEnv()))
-            .envFrom(c.getEnvFrom()).image(c.getImage()).imagePullPolicy(c.getImagePullPolicy())
-            .lifecycle(c.getLifecycle()).livenessProbe(c.getLivenessProbe()).name(c.getName()).ports(c.getPorts())
-            .readinessProbe(c.getReadinessProbe()).resources(c.getResources()).securityContext(c.getSecurityContext())
-            .startupProbe(c.getStartupProbe()).stdin(c.getStdin()).stdinOnce(c.getStdinOnce())
-            .terminationMessagePath(c.getTerminationMessagePath())
-            .terminationMessagePolicy(c.getTerminationMessagePolicy()).tty(c.getTty())
-            .volumeDevices(c.getVolumeDevices()).volumeMounts(c.getVolumeMounts()).workingDir(c.getWorkingDir());
+    return new V1ContainerBuilder(c).withEnv(createCopy(c.getEnv())).build();
   }
 
   private void addIfMissing(V1Volume var) {


### PR DESCRIPTION
OFSS domain has 1 domain with multiple clusters each having 2 replicas. There are init containers defined in each cluster. When the introspectVersion is changed with no other changes, the second pod gets rolled. This is caused because the init container env variables point to the same underlying data structures (and not deep copies). However, we set different values for some variables such as SERVER_NAME and SERVICE_NAME. This causes the server name env variable of the init container for the second server to have an incorrect value of the first server name. This change creates a copy of the init container env variables list so they don't get overwritten when value changes for other pods. Integration test results at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5658/