### PR TITLE
add resource request and limit for server pods

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -204,6 +204,8 @@ class ItParameterizedDomain {
   private static String miiDomainNegativeNamespace = null;
   private static String miiImage = null;
   private static String encryptionSecretName = "encryptionsecret";
+  private static Map<String, Quantity> resourceRequest = new HashMap<>();
+  private static Map<String, Quantity> resourceLimit = new HashMap<>();
 
   private String curlCmd = null;
 
@@ -264,6 +266,11 @@ class ItParameterizedDomain {
     nodeportshttp = getServiceNodePort(nginxNamespace, nginxServiceName, "http");
     logger.info("NGINX http node port: {0}", nodeportshttp);
 
+    // set resource request and limit
+    resourceRequest.put("cpu", new Quantity("250m"));
+    resourceRequest.put("memory", new Quantity("768Mi"));
+    resourceLimit.put("cpu", new Quantity("2"));
+    resourceLimit.put("memory", new Quantity("2Gi"));
 
     // create model in image domain with multiple clusters
     miiDomain = createMiiDomainWithMultiClusters(miiDomainUid, miiDomainNamespace);
@@ -926,7 +933,10 @@ class ItParameterizedDomain {
                     .value("-Dweblogic.StdoutDebugEnabled=false"))
                 .addEnvItem(new V1EnvVar()
                     .name("USER_MEM_ARGS")
-                    .value("-Djava.security.egd=file:/dev/./urandom ")))
+                    .value("-Djava.security.egd=file:/dev/./urandom "))
+                .resources(new V1ResourceRequirements()
+                    .requests(resourceRequest)
+                    .limits(resourceLimit)))
             .adminServer(new AdminServer()
                 .serverStartState("RUNNING")
                 .adminService(new AdminService()
@@ -1089,7 +1099,10 @@ class ItParameterizedDomain {
                         .claimName(pvcName)))
                 .addVolumeMountsItem(new V1VolumeMount()
                     .mountPath("/u01/shared")
-                    .name(pvName)))
+                    .name(pvName))
+                .resources(new V1ResourceRequirements()
+                    .limits(resourceLimit)
+                    .requests(resourceRequest)))
             .adminServer(new AdminServer()
                 .serverStartState("RUNNING")
                 .adminService(new AdminService()
@@ -1427,8 +1440,8 @@ class ItParameterizedDomain {
                     .name("USER_MEM_ARGS")
                     .value("-Djava.security.egd=file:/dev/./urandom "))
                 .resources(new V1ResourceRequirements()
-                    .limits(new HashMap<>())
-                    .requests(new HashMap<>())))
+                    .limits(resourceLimit)
+                    .requests(resourceRequest)))
             .adminServer(new AdminServer()
                 .serverStartState("RUNNING")
                 .adminService(new AdminService()


### PR DESCRIPTION
In the nightly parallel runs, ItParameterizedDomain failed intermittently. In the event log, some managed servers got killed. In the kublet.log, it shows:

Jul 15 09:00:15 kind-worker kubelet[312]: W0715 09:00:15.832773     312 empty_dir.go:421] Warning: Failed to clear quota on /var/lib/kubelet/pods/cc48f103-2b9b-49f0-a9a5-b7c11489d9dd/volumes/kubernetes.io~configmap/mii-weblogic-domain-introspect-cm: ClearQuota called, but quotas disabled
Jul 15 09:00:39 kind-worker kubelet[312]: E0715 09:00:39.973754     312 kuberuntime_container.go:476] preStop hook for container "weblogic-server" failed: command '/weblogic-operator/scripts/stopServer.sh' exited with 137:

Adding the resource request and limit for the server pods to prevent the pods get evicted by the k8s cluster. 

Running the Jenkins job now.
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5714/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5715/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5716/