### PR TITLE
OWLS 90628: Update RBAC ClusterRole example in User Guide - Scaling document with rule for services/status

### DIFF
--- a/documentation/staging/content/userguide/managing-domains/domain-lifecycle/scaling.md
+++ b/documentation/staging/content/userguide/managing-domains/domain-lifecycle/scaling.md
@@ -98,7 +98,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: weblogic-domain-cluster-role
 rules:
-- apiGrous: [""]
+- apiGroups: [""]
   resources: ["services/status"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["weblogic.oracle"]
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: weblogic-domain-cluster-role
 rules:
-- apiGrous: [""]
+- apiGroups: [""]
   resources: ["services/status"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["weblogic.oracle"]

--- a/documentation/staging/content/userguide/managing-domains/domain-lifecycle/scaling.md
+++ b/documentation/staging/content/userguide/managing-domains/domain-lifecycle/scaling.md
@@ -98,12 +98,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: weblogic-domain-cluster-role
 rules:
+- apiGrous: [""]
+  resources: ["services/status"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["weblogic.oracle"]
   resources: ["domains"]
   verbs: ["get", "list", "patch", update"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list"]
 ---
 ```
 ##### Operator REST endpoints
@@ -222,12 +222,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: weblogic-domain-cluster-role
 rules:
+- apiGrous: [""]
+  resources: ["services/status"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["weblogic.oracle"]
   resources: ["domains"]
   verbs: ["get", "list", "patch", update"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list"]
 ---
 #
 # creating role-bindings for cluster role


### PR DESCRIPTION
Update example RBAC role, used with scalingAction.sh script, with permissions for 'services/status' resource.  This change:

1. Adds permissions for 'services/status' resource
2. Removes permissions for 'customresourcedefinitions' resource, as not used by scalingAction.sh script

See https://proddev-paas-fmw.slack.com/archives/CATC0G534/p1625561489454000 for discussion