### PR TITLE
OWLS-90971 - Fix for admin server restart when Domain CR patched with incorrect auxiliary image command.

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -63,6 +63,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomRe
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.secretExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResource;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.verifyPodsNotRolled;
 import static oracle.weblogic.kubernetes.utils.CommonPatchTestUtils.patchDomainResource;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkDomainEventContainsExpectedMsg;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodDoesNotExist;
@@ -708,8 +709,6 @@ public class ItMiiAuxiliaryImage {
     checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
 
     // verify the domain is not rolled
-    // TODO: enable this check once https://jira.oraclecorp.com/jira/browse/OWLS-90971 is fixed
-    /*
     logger.info("sleep 2 minutes to make sure the domain is not restarted");
     try {
       Thread.sleep(120000);
@@ -717,7 +716,6 @@ public class ItMiiAuxiliaryImage {
       // ignore
     }
     verifyPodsNotRolled(domainNamespace, pods);
-    */
 
     // restore domain1
     // patch the first auxiliary image to remove the domain.spec.serverPod.auxiliaryImages.command

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -99,7 +99,7 @@ public class JobHelper {
     LOGGER.fine("isModelInImageUpdate: " + isModelInImageUpdate(packet, info));
     return topology == null
           || isBringingUpNewDomain(packet, info)
-          || isIntrospectionRequestedAndRemove(packet)
+          || checkIfIntrospectionRequestedAndReset(packet)
           || isModelInImageUpdate(packet, info)
           || isIntrospectVersionChanged(packet, info);
   }
@@ -108,7 +108,7 @@ public class JobHelper {
     return runningServersCount(info) == 0 && creatingServers(info) && isGenerationChanged(packet, info);
   }
 
-  private static boolean isIntrospectionRequestedAndRemove(Packet packet) {
+  private static boolean checkIfIntrospectionRequestedAndReset(Packet packet) {
     return packet.remove(DOMAIN_INTROSPECT_REQUESTED) != null;
   }
 
@@ -507,6 +507,7 @@ public class JobHelper {
   }
 
   private static class ReadDomainIntrospectorPodLogResponseStep extends ResponseStep<String> {
+    public static final String INTROSPECTION_FAILED = "INTROSPECTION_FAILED";
     private StringBuilder logMessage = new StringBuilder();
     private final List<String> severeStatuses = new ArrayList<>();
 
@@ -553,7 +554,7 @@ public class JobHelper {
                 getJobCreationTime(domainIntrospectorJob).plus(retryIntervalSeconds, SECONDS))) {
           //Introspector job is incomplete and current time is greater than the lazy deletion time for the job,
           //update the domain status and execute the next step
-          packet.put(DOMAIN_INTROSPECT_REQUESTED, "INTROSPECTION_FAILED");
+          packet.put(DOMAIN_INTROSPECT_REQUESTED, INTROSPECTION_FAILED);
           nextStep = getNext();
         }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -57,6 +57,7 @@ import static oracle.kubernetes.operator.DomainStatusUpdater.INSPECTING_DOMAIN_P
 import static oracle.kubernetes.operator.DomainStatusUpdater.createProgressingStartedEventStep;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_DOMAIN_SPEC_GENERATION;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECT_REQUESTED;
 import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_JOB_FAILED;
 import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_JOB_FAILED_DETAIL;
 
@@ -108,7 +109,7 @@ public class JobHelper {
   }
 
   private static boolean isIntrospectionRequestedAndRemove(Packet packet) {
-    return packet.remove(ProcessingConstants.DOMAIN_INTROSPECT_REQUESTED) != null;
+    return packet.remove(DOMAIN_INTROSPECT_REQUESTED) != null;
   }
 
   private static boolean isIntrospectVersionChanged(Packet packet, DomainPresenceInfo info) {
@@ -552,6 +553,7 @@ public class JobHelper {
                 getJobCreationTime(domainIntrospectorJob).plus(retryIntervalSeconds, SECONDS))) {
           //Introspector job is incomplete and current time is greater than the lazy deletion time for the job,
           //update the domain status and execute the next step
+          packet.put(DOMAIN_INTROSPECT_REQUESTED, "INTROSPECTION_FAILED");
           nextStep = getNext();
         }
 


### PR DESCRIPTION
This change will rerun the introspector if the previous introspection run had failed. The recent changes to optimize the detection of when to run the introspection might prevent introspector from re-running in such cases. 

Integration test run URL - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5738/