### PR TITLE
increase the introspection deadline timeout

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -827,7 +827,8 @@ public class ItConfigDistributionStrategy {
             .namespace(domainNamespace))
         .spec(new DomainSpec()
             .configuration(new Configuration()
-                .overrideDistributionStrategy("DYNAMIC"))
+                .overrideDistributionStrategy("DYNAMIC")
+                .introspectorJobActiveDeadlineSeconds(300L))
             .domainUid(domainUid)
             .domainHome("/shared/domains/" + domainUid) // point to domain home in pv
             .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv


### PR DESCRIPTION
Increase the introspection deadline timeout from 120 to 300 seconds to fix nightly failure

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5751/