### PR TITLE
Add call to journalctl

### DIFF
--- a/jenkinsScript.sh
+++ b/jenkinsScript.sh
@@ -51,6 +51,9 @@ function checkJavaVersion {
   fi
 }
 
+# Record start time in a format appropriate for journalctl --since
+start_time=$(date +"%Y-%m-%d %H:%M:%S")
+
 echo "WORKSPACE ${WORKSPACE}"
 
 checkEnvVars  \
@@ -122,5 +125,8 @@ helm repo update
 
 echo "Info: Run tests.."
 sh -x ./kindtest.sh -t "${IT_TEST}" -v ${KUBE_VERSION} -p ${PARALLEL_RUN} -d ${WDT_DOWNLOAD_URL} -i ${WIT_DOWNLOAD_URL} -x ${NUMBER_OF_THREADS} -m ${MAVEN_PROFILE_NAME}
+
+mkdir -m777 -p "${WORKSPACE}/logdir/${BUILD_TAG}/wl_k8s_test_results"
+journalctl --utc --dmesg --system --since "$start_time" > "${WORKSPACE}/logdir/${BUILD_TAG}/wl_k8s_test_results/journalctl.out"
 
 

--- a/jenkinsScript.sh
+++ b/jenkinsScript.sh
@@ -127,6 +127,6 @@ echo "Info: Run tests.."
 sh -x ./kindtest.sh -t "${IT_TEST}" -v ${KUBE_VERSION} -p ${PARALLEL_RUN} -d ${WDT_DOWNLOAD_URL} -i ${WIT_DOWNLOAD_URL} -x ${NUMBER_OF_THREADS} -m ${MAVEN_PROFILE_NAME}
 
 mkdir -m777 -p "${WORKSPACE}/logdir/${BUILD_TAG}/wl_k8s_test_results"
-journalctl --utc --dmesg --system --since "$start_time" > "${WORKSPACE}/logdir/${BUILD_TAG}/wl_k8s_test_results/journalctl.out"
+journalctl --utc --dmesg --system --since "$start_time" > "${WORKSPACE}/logdir/${BUILD_TAG}/wl_k8s_test_results/journalctl-compute.out"
 
 

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -317,4 +317,3 @@ fi
 echo "Collect journalctl logs"
 docker exec kind-worker journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-worker.out"
 docker exec kind-control-plane journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-control-plane.out"
-docker exec kind-registry journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-registry.out"

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -282,7 +282,11 @@ EOF
 echo 'Set up test running ENVVARs...'
 export KIND_REPO="localhost:${reg_port}/"
 export K8S_NODEPORT_HOST=`kubectl get node kind-worker -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}'`
-export JAVA_HOME="${JAVA_HOME:-`type -p java|xargs readlink -f|xargs dirname|xargs dirname`}"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  export JAVA_HOME=$(/usr/libexec/java_home)
+else
+  export JAVA_HOME="${JAVA_HOME:-`type -p java|xargs readlink -f|xargs dirname|xargs dirname`}"
+fi
 
 if [ "$skip_tests" = true ] ; then
   echo 'Cluster created. Skipping tests.'
@@ -309,3 +313,8 @@ else
     time mvn -Dit.test="${test_filter}, !ItOperatorWlsUpgrade, !ItFmwDomainInPVUsingWDT, !ItFmwDynamicDomainInPV, !ItDedicatedMode, !ItT3Channel, !ItOpUpgradeFmwDomainInPV, !ItOCILoadBalancer, !ItIstioCrossClusters*" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
   fi
 fi
+
+echo "Collect journalctl logs"
+docker exec -it kind-worker journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-worker.out"
+docker exec -it kind-control-plane journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-control-plane.out"
+docker exec -it kind-registry journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-registry.out"

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -315,6 +315,6 @@ else
 fi
 
 echo "Collect journalctl logs"
-docker exec -it kind-worker journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-worker.out"
-docker exec -it kind-control-plane journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-control-plane.out"
-docker exec -it kind-registry journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-registry.out"
+docker exec kind-worker journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-worker.out"
+docker exec kind-control-plane journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-control-plane.out"
+docker exec kind-registry journalctl --utc --dmesg --system > "${RESULT_ROOT}/journalctl-kind-registry.out"


### PR DESCRIPTION
The jenkinsScript.sh is shared by the basic "kind-new" and nightly jobs. You can see an example of the data that will be captured here: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5776/artifact/logdir/jenkins-weblogic-kubernetes-operator-kind-new-5776/wl_k8s_test_results/journalctl.out/*view*/