### PR TITLE
Pass credentials to generate OCIR token

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
@@ -771,9 +771,6 @@ class ItPodsRestart {
     // get the pre-built image created by IntegrationTestWatcher
     miiImage = MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;
 
-    // docker login and push image to docker registry if necessary
-    dockerLoginAndPushImageToRegistry(miiImage);
-
     // create docker registry secret to pull the image from registry
     // this secret is used only for non-kind cluster
     logger.info("Creating docker registry secret in namespace {0}", domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -360,7 +360,7 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
 
     // delete images from OCIR, if necessary
     if (DOMAIN_IMAGES_REPO.contains("ocir.io")) {
-      String token = getOcirTokenJava();
+      String token = getOcirTokenShell();
       if (token != null) {
         for (String image : pushedImages) {
           deleteImageOcir(token, image);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -361,6 +361,8 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
     if (DOMAIN_IMAGES_REPO.contains("ocir.io")) {
       String token = getOcirToken();
       if (token != null) {
+        logger.info("Deleting these images from OCIR");
+        logger.info(String.join(", ", pushedImages));
         for (String image : pushedImages) {
           deleteImageOcir(token, image);
         }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -384,7 +384,6 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
         .append(" -e " + OCIR_REGISTRY);
     ExecResult result = null;
     try {
-      logger.info("Running command..\n{0}", cmd.toString());
       result = ExecCommand.exec(cmd.toString(), true);
     } catch (Exception e) {
       logger.info("Got exception while running command: {0}", cmd);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -377,8 +377,11 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
     Path scriptPath = Paths.get(RESOURCE_DIR, "bash-scripts", "ocirtoken.sh");
     String cmd = scriptPath.toFile().getAbsolutePath();
     ExecResult result = null;
+    Map<String,String> credentials = new HashMap<>();
+    credentials.put("-u", OCIR_USERNAME);
+    credentials.put("-p", OCIR_PASSWORD);
     try {
-      result = ExecCommand.exec(cmd, true);
+      result = ExecCommand.exec(cmd, true, credentials);
     } catch (Exception e) {
       logger.info("Got exception while running command: {0}", cmd);
       logger.info(e.toString());


### PR DESCRIPTION
After a test run deleting the images pushed to OCIR needs to be deleted, the current infra impl doesn't pass the credentials for generating the OCIR repo tokens. The fix involves passing the credentials to the ocirtoke.sh script.

https://build.weblogick8s.org:8443/job/wko-oke-nightly-seqential/366/

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5832/