### PR TITLE
Update dependency check and Kotlin dependency

### DIFF
--- a/build-tools/dependency-check/dependency-check-suppression.xml
+++ b/build-tools/dependency-check/dependency-check-suppression.xml
@@ -9,11 +9,19 @@
         <cpe>cpe:/a:kubernetes:kubernetes</cpe>
     </suppress>
     <suppress>
+        <packageUrl regex="true">^pkg:maven/io\.kubernetes/client\-java\-api\-fluent@.*$</packageUrl>
+        <cpe>cpe:/a:kubernetes:kubernetes</cpe>
+    </suppress>
+    <suppress>
         <packageUrl regex="true">^pkg:maven/io\.kubernetes/client\-java\-proto@.*$</packageUrl>
         <cpe>cpe:/a:kubernetes:kubernetes</cpe>
     </suppress>
     <suppress>
         <packageUrl regex="true">^pkg:maven/oracle\.kubernetes/weblogic\-kubernetes\-operator@.*$</packageUrl>
+        <cpe>cpe:/a:kubernetes:kubernetes</cpe>
+    </suppress>
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/oracle\.kubernetes/operator\-swagger@.*$</packageUrl>
         <cpe>cpe:/a:kubernetes:kubernetes</cpe>
     </suppress>
     <suppress>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -109,6 +109,7 @@
               <includeScope>runtime</includeScope>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <excludeGroupIds>io.prometheus,com.google.protobuf</excludeGroupIds>
+              <excludeArtifactIds>kotlin-stdlib-jdk7,kotlin-stdlib-jdk8</excludeArtifactIds>
             </configuration>
           </execution>
         </executions>
@@ -333,6 +334,16 @@
     <dependency>
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java-api-fluent</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,26 @@
         <version>${client-java-version}</version>
       </dependency>
       <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin-stdlib-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>${kotlin-stdlib-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk7</artifactId>
+        <version>${kotlin-stdlib-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin-stdlib-version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-junit</artifactId>
         <version>${hamcrest-junit-version}</version>
@@ -618,6 +638,7 @@
     <commons.io.version>2.11.0</commons.io.version>
     <awaitility-version>4.1.0</awaitility-version>
     <client-java-version>13.0.0</client-java-version>
+    <kotlin-stdlib-version>1.5.21</kotlin-stdlib-version>
     <junit.jupiter.version>5.7.2</junit.jupiter.version>
     <junit.vintage.version>5.7.1</junit.vintage.version>
     <junit.platform.version>1.7.0</junit.platform.version>


### PR DESCRIPTION
Updated the Kotlin dependency (which previously came transitively from the Kubernetes Java Client) and updated the dependency check suppressions list so that the OWASP check is clean.