### PR TITLE
Owls 91266 - Changes to generate CoherenceMemberConfig.UnicastListenAddress for Istio

### DIFF
--- a/integration-tests/src/test/resources/wdt-models/coherence-managed-wdt-config.yaml
+++ b/integration-tests/src/test/resources/wdt-models/coherence-managed-wdt-config.yaml
@@ -49,14 +49,10 @@ topology:
             ListenPort: 8001
             Cluster: 'cluster-1'
             CoherenceClusterSystemResource: CoherenceCluster
-            CoherenceMemberConfig:
-              UnicastListenAddress:  'coherence-managed-domain-cluster-1-managed-server${id}' 
         'cluster-2-template':
             ListenPort: 8001
             Cluster: 'cluster-2'
             CoherenceClusterSystemResource: CoherenceCluster
-            CoherenceMemberConfig:
-              UnicastListenAddress:  'coherence-managed-domain-cluster-2-managed-server${id}' 
 resources:
     CoherenceClusterSystemResource:
         CoherenceCluster:

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1089,6 +1089,8 @@ class SitConfigGenerator(Generator):
     self.writeListenAddress(template.getListenAddress(),listen_address)
     self.customizeNetworkAccessPoints(template,listen_address)
     self.customizeManagedIstioNetworkAccessPoint(listen_address, template)
+    if (self.getCoherenceClusterSystemResourceOrNone(template) is not None):
+      self.customizeCoherenceMemberConfig(listen_address)
     self.undent()
     self.writeln("</d:server-template>")
 
@@ -1162,6 +1164,21 @@ class SitConfigGenerator(Generator):
     self.writeln('<d:enabled %s>true</d:enabled>' % action)
     self.undent()
     self.writeln('</d:network-access-point>')
+
+  def getCoherenceClusterSystemResourceOrNone(self, serverOrTemplate):
+    try:
+      ret = serverOrTemplate.getCoherenceClusterSystemResource()
+    except:
+      trace("Ignoring getCoherenceClusterSystemResource () exception, this is expected.")
+      ret = None
+    return ret
+
+  def customizeCoherenceMemberConfig(self, listen_address):
+   self.writeln('<d:coherence-member-config f:combine-mode="add">')
+   self.indent()
+   self.writeln('<d:unicast-listen-address f:combine-mode="add">%s</d:unicast-listen-address>' % listen_address)
+   self.undent()
+   self.writeln('</d:coherence-member-config>')
 
   def customizeServerIstioNetworkAccessPoint(self, listen_address, server):
     istio_enabled = self.env.getEnvOrDef("ISTIO_ENABLED", "false")

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1169,24 +1169,28 @@ class SitConfigGenerator(Generator):
 
   def getCoherenceClusterSystemResourceOrNone(self, serverOrTemplate):
     try:
-      ret = serverOrTemplate.getCoherenceClusterSystemResource()
+      cluster=serverOrTemplate.getCluster()
+      if (cluster is not None):
+        ret=cluster.getCoherenceClusterSystemResource()
+      else:
+        ret=serverOrTemplate.getCoherenceClusterSystemResource()
     except:
       trace("Ignoring getCoherenceClusterSystemResource () exception, this is expected.")
       ret = None
     return ret
 
-  def customizeCoherenceMemberConfig(self, originalValue, listen_address):
-    if (originalValue is None):
-      self.writeln('<d:coherence-member-config f:combine-mode="add">')
+  def customizeCoherenceMemberConfig(self, coherence_member_config, listen_address):
+    repVerb='"add"'
+    if (coherence_member_config is None):
+      self.writeln('<d:coherence-member-config f:combine-mode=' + repVerb + '>')
       self.indent()
-      self.writeln('<d:unicast-listen-address f:combine-mode="add">%s</d:unicast-listen-address>' % listen_address)
+      self.writeln('<d:unicast-listen-address f:combine-mode=' + repVerb + '>%s</d:unicast-listen-address>' % listen_address)
       self.undent()
       self.writeln('</d:coherence-member-config>')
     else:
-      unicastAddress=originalValue.getUnicastListenAddress()
-      repVerb='"replace"'
-      if unicastAddress is None or len(unicastAddress)==0:
-        repVerb='"add"'
+      unicastAddress=coherence_member_config.getUnicastListenAddress()
+      if unicastAddress is not None:
+        repVerb='"replace"'
 
       self.writeln('<d:coherence-member-config>')
       self.indent()

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -617,8 +617,11 @@ def getCoherenceClusterSystemResourceOrNone(topology, serverOrTemplate):
     else:
       if 'CoherenceClusterSystemResource' not in serverOrTemplate:
         return None
+  else:
+    if 'CoherenceClusterSystemResource' not in serverOrTemplate:
+      return None
+    return serverOrTemplate['CoherenceClusterSystemResource']
 
-  return serverOrTemplate['CoherenceClusterSystemResource']
 
 def getDynamicServerOrNone(cluster):
   if 'DynamicServers' not in cluster:

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -217,7 +217,7 @@ def customizeServerTemplate(topology, template):
   setServerListenAddress(template, listen_address)
   customizeNetworkAccessPoints(template, listen_address)
   customizeManagedIstioNetworkAccessPoint(template, listen_address)
-  if (getCoherenceClusterSystemResourceOrNone(template) is not None):
+  if (getCoherenceClusterSystemResourceOrNone(topology, template) is not None):
     customizeCoherenceMemberConfig(template, listen_address)
 
 
@@ -297,10 +297,10 @@ def customizeServers(model):
   names = servers.keys()
   for name in names:
     server = servers[name]
-    customizeServer(server, name)
+    customizeServer(model, server, name)
 
 
-def customizeServer(server, name):
+def customizeServer(model, server, name):
   listen_address=env.toDNS1123Legal(env.getDomainUID() + "-" + name)
   customizeLog(name, server)
   customizeAccessLog(name, server)
@@ -308,7 +308,7 @@ def customizeServer(server, name):
   setServerListenAddress(server, listen_address)
   customizeNetworkAccessPoints(server,listen_address)
   customizeServerIstioNetworkAccessPoint(server, listen_address)
-  if (getCoherenceClusterSystemResourceOrNone(server) is not None):
+  if (getCoherenceClusterSystemResourceOrNone(model['topology'], server) is not None):
     customizeCoherenceMemberConfig(server, listen_address)
 
 
@@ -605,10 +605,18 @@ def getClusterOrNone(topology, name):
 
   return None
 
+def getCoherenceClusterSystemResourceOrNone(topology, serverOrTemplate):
 
-def getCoherenceClusterSystemResourceOrNone(serverOrTemplate):
-  if 'CoherenceClusterSystemResource' not in serverOrTemplate:
-    return None
+  cluster_name = getClusterNameOrNone(serverOrTemplate)
+  if cluster_name is not None:
+    cluster = getClusterOrNone(topology, cluster_name)
+    if cluster is not None:
+      if 'CoherenceClusterSystemResource' not in cluster:
+        return None
+      return cluster['CoherenceClusterSystemResource']
+    else:
+      if 'CoherenceClusterSystemResource' not in serverOrTemplate:
+        return None
 
   return serverOrTemplate['CoherenceClusterSystemResource']
 

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -309,6 +309,7 @@ def customizeServer(server, name):
   customizeNetworkAccessPoints(server,listen_address)
   customizeServerIstioNetworkAccessPoint(server, listen_address)
 
+
 def customizeCoherenceMemberConfig(server, listen_address):
   if 'CoherenceMemberConfig ' not in server:
     server['CoherenceMemberConfig'] = {}
@@ -385,6 +386,7 @@ def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_ena
   nap['TunnelingEnabled'] = 'false'
   nap['OutboundEnabled'] = 'true'
   nap['Enabled'] = 'true'
+
 
 def customizeServerIstioNetworkAccessPoint(server, listen_address):
   istio_enabled = env.getEnvOrDef("ISTIO_ENABLED", "false")
@@ -600,6 +602,7 @@ def getClusterOrNone(topology, name):
     return clusters[name]
 
   return None
+
 
 def getCoherenceClusterSystemResourceOrNone(serverOrTemplate):
   if 'CoherenceClusterSystemResource' not in serverOrTemplate:

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -308,6 +308,8 @@ def customizeServer(server, name):
   setServerListenAddress(server, listen_address)
   customizeNetworkAccessPoints(server,listen_address)
   customizeServerIstioNetworkAccessPoint(server, listen_address)
+  if (getCoherenceClusterSystemResourceOrNone(server) is not None):
+    customizeCoherenceMemberConfig(server, listen_address)
 
 
 def customizeCoherenceMemberConfig(server, listen_address):

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -309,6 +309,13 @@ def customizeServer(server, name):
   customizeNetworkAccessPoints(server,listen_address)
   customizeServerIstioNetworkAccessPoint(server, listen_address)
 
+def customizeCoherenceMemberConfig(server, listen_address):
+  if 'CoherenceMemberConfig ' not in server:
+    server['CoherenceMemberConfig'] = {}
+
+  cmc = server['CoherenceMemberConfig']
+  cmc['UnicastListenAddress'] = listen_address
+
 
 def getAdministrationPort(server, topology):
   port = 0
@@ -378,15 +385,6 @@ def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_ena
   nap['TunnelingEnabled'] = 'false'
   nap['OutboundEnabled'] = 'true'
   nap['Enabled'] = 'true'
-
-def customizeCoherenceMemberConfig(server, listen_address):
-  if 'CoherenceMemberConfig ' not in server:
-    server['CoherenceMemberConfig'] = {}
-
-  cmc = server['CoherenceMemberConfig']
-  cmc['UnicastListenAddress'] = listen_address
-
-
 
 def customizeServerIstioNetworkAccessPoint(server, listen_address):
   istio_enabled = env.getEnvOrDef("ISTIO_ENABLED", "false")

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -206,6 +206,7 @@ def customizeServerTemplates(model):
         customizeServerTemplate(topology, template)
 
 
+
 def customizeServerTemplate(topology, template):
   server_name_prefix = getServerNamePrefix(topology, template)
   domain_uid = env.getDomainUID()
@@ -216,6 +217,8 @@ def customizeServerTemplate(topology, template):
   setServerListenAddress(template, listen_address)
   customizeNetworkAccessPoints(template, listen_address)
   customizeManagedIstioNetworkAccessPoint(template, listen_address)
+  if (getCoherenceClusterSystemResourceOrNone(template) is not None):
+    customizeCoherenceMemberConfig(template, listen_address)
 
 
 def getServerNamePrefix(topology, template):
@@ -375,6 +378,14 @@ def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_ena
   nap['TunnelingEnabled'] = 'false'
   nap['OutboundEnabled'] = 'true'
   nap['Enabled'] = 'true'
+
+def customizeCoherenceMemberConfig(server, listen_address):
+  if 'CoherenceMemberConfig ' not in server:
+    server['CoherenceMemberConfig'] = {}
+
+  cmc = server['CoherenceMemberConfig']
+  cmc['UnicastListenAddress'] = listen_address
+
 
 
 def customizeServerIstioNetworkAccessPoint(server, listen_address):
@@ -592,6 +603,11 @@ def getClusterOrNone(topology, name):
 
   return None
 
+def getCoherenceClusterSystemResourceOrNone(serverOrTemplate):
+  if 'CoherenceClusterSystemResource' not in serverOrTemplate:
+    return None
+
+  return serverOrTemplate['CoherenceClusterSystemResource']
 
 def getDynamicServerOrNone(cluster):
   if 'DynamicServers' not in cluster:

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -101,7 +101,7 @@ class WdtUpdateFilterCase(unittest.TestCase):
 
     server_name = 'admin-server'
     server = model['topology']['Server'][server_name]
-    model_wdt_mii_filter.customizeServer(server, server_name)
+    model_wdt_mii_filter.customizeServer(model, server, server_name)
     listen_address = server['ListenAddress']
     self.assertEqual('sample-domain1-admin-server', listen_address, "Expected listen address to be \'sample-domain1-admin-server\'")
 


### PR DESCRIPTION
Changes to generate CoherenceMemberConfig.UnicastListenAddress for Istio. These include changes to the model WDT filter file for the MII domain and situational config generator for DII and domain-on-pv domains. 

Jenkins results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/5908/