### PR TITLE
get stored secrets and configmaps from packet without dependency on c…

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -17,7 +17,6 @@ import io.kubernetes.client.openapi.models.V1SecretList;
 import oracle.kubernetes.operator.DomainStatusUpdater;
 import oracle.kubernetes.operator.MakeRightDomainOperation;
 import oracle.kubernetes.operator.ProcessingConstants;
-import oracle.kubernetes.operator.calls.AsyncRequestStep;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.EventHelper.EventData;
 import oracle.kubernetes.operator.helpers.EventHelper.EventItem;
@@ -80,12 +79,12 @@ public class DomainValidationSteps {
     }
 
     static List<V1Secret> getSecrets(Packet packet) {
-      return Optional.ofNullable(getSecretsIfContinue(packet)).orElse(new ArrayList<>());
+      return Optional.ofNullable(getSecretsFromPacket(packet)).orElse(new ArrayList<>());
     }
 
     @SuppressWarnings("unchecked")
-    private static List<V1Secret> getSecretsIfContinue(Packet packet) {
-      return packet.get(AsyncRequestStep.CONTINUE) != null ? (List<V1Secret>) packet.get(SECRETS) : null;
+    private static List<V1Secret> getSecretsFromPacket(Packet packet) {
+      return packet.get(SECRETS) != null ? (List<V1Secret>) packet.get(SECRETS) : null;
     }
   }
 
@@ -105,12 +104,12 @@ public class DomainValidationSteps {
     }
 
     static List<V1ConfigMap> getConfigMaps(Packet packet) {
-      return Optional.ofNullable(getConfigMapsIfContinue(packet)).orElse(new ArrayList<>());
+      return Optional.ofNullable(getConfigMapsFromPacket(packet)).orElse(new ArrayList<>());
     }
 
     @SuppressWarnings("unchecked")
-    private static List<V1ConfigMap> getConfigMapsIfContinue(Packet packet) {
-      return packet.get(AsyncRequestStep.CONTINUE) != null ? (List<V1ConfigMap>) packet.get(CONFIGMAPS) : null;
+    private static List<V1ConfigMap> getConfigMapsFromPacket(Packet packet) {
+      return packet.get(CONFIGMAPS) != null ? (List<V1ConfigMap>) packet.get(CONFIGMAPS) : null;
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -79,12 +79,7 @@ public class DomainValidationSteps {
     }
 
     static List<V1Secret> getSecrets(Packet packet) {
-      return Optional.ofNullable(getSecretsFromPacket(packet)).orElse(new ArrayList<>());
-    }
-
-    @SuppressWarnings("unchecked")
-    private static List<V1Secret> getSecretsFromPacket(Packet packet) {
-      return packet.get(SECRETS) != null ? (List<V1Secret>) packet.get(SECRETS) : null;
+      return (List<V1Secret>) Optional.ofNullable(packet.get(SECRETS)).orElse(new ArrayList<>());
     }
   }
 
@@ -104,12 +99,7 @@ public class DomainValidationSteps {
     }
 
     static List<V1ConfigMap> getConfigMaps(Packet packet) {
-      return Optional.ofNullable(getConfigMapsFromPacket(packet)).orElse(new ArrayList<>());
-    }
-
-    @SuppressWarnings("unchecked")
-    private static List<V1ConfigMap> getConfigMapsFromPacket(Packet packet) {
-      return packet.get(CONFIGMAPS) != null ? (List<V1ConfigMap>) packet.get(CONFIGMAPS) : null;
+      return (List<V1ConfigMap>) Optional.ofNullable(packet.get(CONFIGMAPS)).orElse(new ArrayList<>());
     }
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -86,6 +86,7 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static oracle.kubernetes.operator.calls.AsyncRequestStep.CONTINUE;
 import static oracle.kubernetes.operator.calls.AsyncRequestStep.RESPONSE_COMPONENT_NAME;
 
 @SuppressWarnings("WeakerAccess")
@@ -1205,6 +1206,8 @@ public class KubernetesTestSupport extends FiberTestSupport {
         Object callResult = callContext.execute();
         CallResponse<Object> callResponse = createResponse(callResult);
         packet.getComponents().put(RESPONSE_COMPONENT_NAME, Component.createFor(callResponse));
+        // clear out earlier results.  Replicating the behavior as in AsyncRequestStep.apply()
+        packet.remove(CONTINUE);
       } catch (NotFoundException e) {
         packet.getComponents().put(RESPONSE_COMPONENT_NAME, Component.createFor(createResponse(e)));
       } catch (HttpErrorException e) {


### PR DESCRIPTION
When listing secrets and configmaps, greater than the configured callRequestLimit (default 50), the previous list in the packet is overridden with the last set of results causing DomainValidation to fail.  When reading multiple results, a 'continue' flag is placed in the packet but is cleared at the beginning of the next async request which results in an empty list returned instead of the aggregated list in the packet.  It is unnecessary to rely on the 'continue' flag to return the results in the packet and hence this fix is to just return the secrets/configmaps list if it exists in the packet.

Unit tests already exist for handling listing of secrets and configmaps greater than the configured callRequestLimit.