### PR TITLE
remove CoherenceMemberConfig in model file 

### DIFF
--- a/integration-tests/src/test/resources/wdt-models/coherence-managed-wdt-config-mii.yaml
+++ b/integration-tests/src/test/resources/wdt-models/coherence-managed-wdt-config-mii.yaml
@@ -43,14 +43,10 @@ topology:
             ListenPort: 8001
             Cluster: 'cluster-1'
             CoherenceClusterSystemResource: CoherenceCluster
-            CoherenceMemberConfig:
-              UnicastListenAddress:  'miidomain-cluster-1-managed-server${id}'
         'cluster-2-template':
             ListenPort: 8001
             Cluster: 'cluster-2'
             CoherenceClusterSystemResource: CoherenceCluster
-            CoherenceMemberConfig:
-              UnicastListenAddress:  'miidomain-cluster-2-managed-server${id}'
 resources:
     CoherenceClusterSystemResource:
         CoherenceCluster:


### PR DESCRIPTION
After PR #2499 is merged, the CoherenceMemberConfig is not needed in the model file. Remove it now.

Jenkins result:
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/6021/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/6024/