### PR TITLE
On branch main: update TwoWaySslEnabled with TwoWaySSLEnabled in faq/external-client/model-sample

### DIFF
--- a/documentation/staging/content/faq/external-clients.md
+++ b/documentation/staging/content/faq/external-clients.md
@@ -320,7 +320,7 @@ topology:
                 TunnelingEnabled: true
                 OutboundEnabled: false
                 Enabled: true
-                TwoWaySslEnabled: false
+                TwoWaySSLEnabled: false
                 ClientCertificateEnforced: false
 ```
 


### PR DESCRIPTION
Hello team, 

When I worked on T3s set up with the WDT model YAML sample provided in faq/external-client, I got an error when building the image:

```
1. WLSDPLY-05029: TwoWaySslEnabled is not one of the attribute names allowed in model location topology:/Server/admin-server/NetworkAccessPoint/MyT3Channel
2. WLSDPLY-05029: TwoWaySslEnabled is not one of the attribute names allowed in model location topology:/ServerTemplate/cluster-1-template/NetworkAccessPoint/MyT3Channel
```

Should use `TwoWaySSLEnabled`.

I haven't tried the provided snippet of offline WLST code and `config.xml`, please have a check.

