### PR TITLE
Support for network changes starting with Istio v1.10 and greater

### DIFF
--- a/documentation/staging/content/userguide/istio/istio.md
+++ b/documentation/staging/content/userguide/istio/istio.md
@@ -146,9 +146,9 @@ ensures that the Istio sidecar is not injected into the introspector job's pods.
  
 Starting with Istio 1.10, the networking behavior was changed in that the proxy no longer redirects 
 the traffic to the localhost interface, but instead forwards it to the network interface associated
-to the pod's IP.  
+with the pod's IP.  
 
-To learn more about changes to Istio networking beginning with Istio 1.10, see [Upcoming networking changes in Istio 1.10](https://istio.io/latest/blog/2021/upcoming-networking-changes//).
+To learn more about changes to Istio networking beginning with Istio 1.10, see [Upcoming networking changes in Istio 1.10](https://istio.io/latest/blog/2021/upcoming-networking-changes/).
 
 In order to support Istio v1.10 and later, as well as previous releases, the
 operator will:

--- a/documentation/staging/content/userguide/istio/istio.md
+++ b/documentation/staging/content/userguide/istio/istio.md
@@ -143,13 +143,14 @@ Additionally, when Istio support is enabled for a domain, the operator
 ensures that the Istio sidecar is not injected into the introspector job's pods.
 
 #### Support for network changes in Istio v1.10 and later
-
-Prior to Istio release 1.10, the Istio Envoy proxy redirected all inbound traffic to the localhost
-network interface.  The network channels listed above, which the operator automatically added, 
-were bound to the localhost interface in order for WebLogic to receive the inbound traffic.  
+ 
 Starting with Istio 1.10, the networking behavior was changed in that the proxy no longer redirects 
 the traffic to the localhost interface, but instead forwards it to the network interface associated
-to the pod's IP.  In order to support Istio v1.10 and later, as well as pre-1.10 releases, the
+to the pod's IP.  
+
+To learn more about changes to Istio networking beginning with Istio 1.10, see [Upcoming networking changes in Istio 1.10](https://istio.io/latest/blog/2021/upcoming-networking-changes//).
+
+In order to support Istio v1.10 and later, as well as previous releases, the
 operator will:
     
 * Add an additional WebLogic HTTP protocol network channel for the readiness probe that is bound to the localhost network interface.
@@ -173,8 +174,6 @@ and protocol `t3`, the additional channel would be defined as follows:
 |Name|Port|Listening address|Protocol|Exposed as a container port|
 |----|----|----|--------|-----|
 |`T3Channel-lh01`| `5556` | `127.0.0.1` | `t3`| Yes |
-
-To learn more about changes to Istio networking beginning with Istio 1.10, see [Upcoming networking changes in Istio 1.10](https://istio.io/latest/blog/2021/upcoming-networking-changes//).
 
 ### Apply the Domain YAML file
 

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1217,6 +1217,9 @@ class SitConfigGenerator(Generator):
     self._writeIstioNAP(name='http-probe', server=server, listen_address=listen_address,
                         listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
+    self._writeIstioNAP(name='http-local-probe', server=server, listen_address=listen_address,
+                        listen_port=istio_readiness_port, protocol='http', http_enabled="true")
+
     # Generate NAP for each protocols
     self._writeIstioNAP(name='tcp-ldap', server=server, listen_address=listen_address,
                         listen_port=admin_server_port, protocol='ldap')
@@ -1269,6 +1272,9 @@ class SitConfigGenerator(Generator):
 
     listen_port = getRealListenPort(template)
     self._writeIstioNAP(name='http-probe', server=template, listen_address=listen_address,
+                        listen_port=istio_readiness_port, protocol='http')
+
+    self._writeIstioNAP(name='http-local-probe', server=template, listen_address=listen_address,
                         listen_port=istio_readiness_port, protocol='http')
 
     self._writeIstioNAP(name='tcp-default', server=template, listen_address=listen_address,

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1071,7 +1071,8 @@ class SitConfigGenerator(Generator):
       self.writeln("<d:listen-port f:combine-mode=\"add\">" + str(listen_port) + "</d:listen-port>")
 
   def writePublicAddress(self, public_address):
-    self.writeln("<d:public-address f:combine-mode=\"add\">" + public_address + "</d:public-address>")
+    if public_address is not None and len(public_address) > 0:
+      self.writeln("<d:public-address f:combine-mode=\"add\">" + public_address + "</d:public-address>")
 
   def writePublicPort(self, public_port):
     # offline WLST initializes int values to 0

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -99,6 +99,8 @@ sys.path.append(tmp_scriptdir)
 from utils import *
 from weblogic.management.configuration import LegalHelper
 
+ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-default', 'tcp-default', 'https-secure', 'tls-ldaps', 'tls-default', 'tls-cbts', 'tls-iiops', 'https-admin']
+WLS_LOCALHOST_IDENTIFIER = '-lh'
 
 class OfflineWlstEnv(object):
 
@@ -751,7 +753,8 @@ class TopologyGenerator(Generator):
 
     if istio_enabled == 'true':
       name = nap.getName()
-      if name.startswith('http-') or name.startswith('tcp-') or name.startswith('tls-') or name.startswith('https-'):
+      if name.startswith('http-') or name.startswith('tcp-') or name.startswith('tls-') \
+          or name.startswith('https-') or nameContainsLocalHostIdentifier(name):
         # skip istio ports already defined by WDT filtering for MII
         return
       http_protocol = [ 'http' ]
@@ -1056,6 +1059,221 @@ class SitConfigGenerator(Generator):
       repVerb="\"add\""
     self.writeln("<d:listen-address f:combine-mode=" + repVerb + ">" + newValue + "</d:listen-address>")
 
+  def writeName(self, name):
+    self.writeln("<d:name>" + name + "</d:name>")
+
+  def writeProtocol(self, protocol):
+    self.writeln("<d:protocol f:combine-mode=\"add\">" + protocol + "</d:protocol>")
+
+  def writeListenPort(self, listen_port):
+    # offline WLST initializes int values to 0
+    if listen_port > 0:
+      self.writeln("<d:listen-port f:combine-mode=\"add\">" + str(listen_port) + "</d:listen-port>")
+
+  def writePublicAddress(self, public_address):
+    self.writeln("<d:public-address f:combine-mode=\"add\">" + public_address + "</d:public-address>")
+
+  def writePublicPort(self, public_port):
+    # offline WLST initializes int values to 0
+    if public_port > 0:
+      self.writeln("<d:public-port f:combine-mode=\"add\">" + str(public_port) + "</d:public-port>")
+
+  def writeAcceptBacklog(self, accept_backlog):
+    # offline WLST initializes int values to 0
+    if accept_backlog > 0:
+      self.writeln("<d:accept-backlog f:combine-mode=\"add\">" + str(accept_backlog) + "</d:accept-backlog>")
+
+  def writeMaxBackoffBetweenFailures(self, maxBackoffBetweenFailures):
+    if maxBackoffBetweenFailures > 0:
+      self.writeln("<d:max-backoff-between-failures f:combine-mode=\"add\">" + str(maxBackoffBetweenFailures) + "</d:max-backoff-between-failures>")
+
+  def writeLoginTimeoutMillis(self, loginTimeoutMillis):
+    # offline WLST initializes int values to 0
+    if loginTimeoutMillis > 0:
+      self.writeln("<d:login-timeout-millis f:combine-mode=\"add\">" + str(loginTimeoutMillis) + "</d:login-timeout-millis>")
+
+  def writeCompleteMessageTimeout(self, completeMessageTimeout):
+    # offline WLST initializes int values to 0
+    if completeMessageTimeout > 0:
+      self.writeln("<d:complete-message-timeout f:combine-mode=\"add\">" + str(completeMessageTimeout) + "</d:complete-message-timeout>")
+
+  def writeIdleConnectionTimeout(self, idleConnectionTimeout):
+    # offline WLST initializes int values to 0
+    if idleConnectionTimeout > 0:
+      self.writeln("<d:idle-connection-timeout f:combine-mode=\"add\">" + str(idleConnectionTimeout) + "</d:idle-connection-timeout>")
+
+  def writeConnectTimeout(self, connectTimeout):
+    # offline WLST initializes int values to 0
+    if connectTimeout > 0:
+      self.writeln("<d:connect-timeout f:combine-mode=\"add\">" + str(connectTimeout) + "</d:connect-timeout>")
+
+  def writeTunnelingClientPingSecs(self, tunnelingClientPingSecs):
+    # offline WLST initializes int values to 0
+    if tunnelingClientPingSecs > 0:
+      self.writeln("<d:tunneling-client-ping-secs f:combine-mode=\"add\">" + str(tunnelingClientPingSecs) + "</d:tunneling-client-ping-secs>")
+
+  def writeTunnelingClientTimeoutSecs(self, tunnelingClientTimeoutSecs):
+    # offline WLST initializes int values to 0
+    if tunnelingClientTimeoutSecs > 0:
+      self.writeln("<d:tunneling-client-timeout-secs f:combine-mode=\"add\">" + str(tunnelingClientTimeoutSecs) + "</d:tunneling-client-timeout-secs>")
+
+  def writeMaxMessageSize(self, maxMessageSize):
+    # offline WLST initializes int values to 0
+    # Legal minimum max message size is 4096
+    # Allow WLS to check legal range
+    if maxMessageSize > 0:
+      self.writeln("<d:max-message-size f:combine-mode=\"add\">" + str(maxMessageSize) + "</d:max-message-size>")
+
+  def writeChannelWeight(self, channelWeight):
+    # default is 50
+    if channelWeight != 50:
+      self.writeln("<d:channel-weight f:combine-mode=\"add\">" + str(channelWeight) + "</d:channel-weight>")
+
+  def writeMaxConnectedClients(self, maxConnectedClients):
+    # default = java.lang.Integer.MAX_VALUE
+    if maxConnectedClients != 2147483647:
+      self.writeln("<d:max-connected-clients f:combine-mode=\"add\">" + str(maxConnectedClients) + "</d:max-connected-clients>")
+
+  def writeEnabled(self, nap):
+    # default enabled = 'true'
+    if nap.isEnabled() == false:
+      enabled = 'false'
+      self.writeln("<d:enabled f:combine-mode=\"add\">" + enabled + "</d:enabled>")
+
+  def writeTunnelingEnabled(self, nap):
+    # default tunnelingEnabled = 'false'
+    if nap.isTunnelingEnabled() == true:
+      tunnelingEnabled = 'true'
+      self.writeln("<d:tunneling-enabled f:combine-mode=\"add\">" + tunnelingEnabled + "</d:tunneling-enabled>")
+
+  def writeOutboundEnabled(self, nap):
+    # default outboundEnabled = 'false'
+    if nap.isOutboundEnabled() == true:
+      outboundEnabled = 'true'
+      self.writeln("<d:outbound-enabled f:combine-mode=\"add\">" + outboundEnabled + "</d:outbound-enabled>")
+
+  def writeUseFastSerialization(self, nap):
+    # default useFastSerialization = 'false'
+    if nap.getUseFastSerialization() == true:
+      useFastSerialization = 'true'
+      self.writeln("<d:use-fast-serialization f:combine-mode=\"add\">" + useFastSerialization + "</d:use-fast-serialization>")
+
+  def writeHttpEnabledForThisProtocol(self, nap):
+    # default httpEnabledForThisProtocol = 'true'
+    if nap.isHttpEnabledForThisProtocol() == false:
+      httpEnabledForThisProtocol = 'false'
+      self.writeln("<d:http-enabled-for-this-protocol f:combine-mode=\"add\">" + httpEnabledForThisProtocol + "</d:http-enabled-for-this-protocol>")
+
+  def writeTimeoutConnectionWithPendingResponses(self, nap):
+    # default timeoutConnectionWithPendingResponses = 'false'
+    if nap.getTimeoutConnectionWithPendingResponses() == true:
+      timeoutConnectionWithPendingResponses = 'true'
+      self.writeln("<d:timeout-connection-with-pending-responses f:combine-mode=\"add\">" + timeoutConnectionWithPendingResponses + "</d:timeout-connection-with-pending-responses>")
+
+  def writeSDPEnabled(self, nap):
+    # default sdpEnabled = 'false'
+    if nap.isSDPEnabled() == true:
+      sdpEnabled = 'true'
+      self.writeln("<d:sdp-enabled f:combine-mode=\"add\">" + sdpEnabled + "</d:sdp-enabled>")
+
+  def writeTwoWaySSLEnabled(self, nap):
+    # default twoWaySSLEnabled = 'false'
+    if nap.isTwoWaySSLEnabled() == true:
+      twoWaySSLEnabled = 'true'
+      self.writeln("<d:two-way-ssl-enabled f:combine-mode=\"add\">" + twoWaySSLEnabled + "</d:two-way-ssl-enabled>")
+
+  def writeClientCertificateEnforced(self, nap):
+    # default clientCertificateEnforced = 'false'
+    if nap.isClientCertificateEnforced() == true:
+      clientCertificateEnforced = 'true'
+      self.writeln("<d:client-certificate-enforced f:combine-mode=\"add\">" + clientCertificateEnforced + "</d:client-certificate-enforced>")
+
+  def writeChannelIdentityCustomized(self, nap):
+    # default channelIdentityCustomized = 'false'
+    if nap.isChannelIdentityCustomized() == true:
+      channelIdentityCustomized = 'true'
+      self.writeln("<d:channel-identity-customized f:combine-mode=\"add\">" + channelIdentityCustomized + "</d:channel-identity-customized>")
+
+  def writeCustomPrivateKeyAlias(self, nap):
+    customPrivateKeyAlias = nap.getCustomPrivateKeyAlias()
+    if customPrivateKeyAlias is not None:
+      self.writeln("<d:custom-private-key-alias f:combine-mode=\"add\">" + customPrivateKeyAlias + "</d:custom-private-key-alias>")
+
+  def writeCustomPrivateKeyPassPhraseEncrypted(self, nap):
+    customPriveKeyPassPhraseEncrypted = nap.getCustomPrivateKeyPassPhraseEncrypted()
+    if customPriveKeyPassPhraseEncrypted is not None and len(customPriveKeyPassPhraseEncrypted) > 0:
+      self.writeln("<d:custom-private-key-pass-phrase-encrypted f:combine-mode=\"add\">" + customPriveKeyPassPhraseEncrypted + "</d:custom-private-key-pass-phrase-encrypted>")
+
+  def writeCustomIdentityKeyStoreType(self, nap):
+    customIdentityKeyStoreType = nap.getCustomIdentityKeyStoreType()
+    if customIdentityKeyStoreType is not None and len(customIdentityKeyStoreType) > 0:
+      self.writeln("<d:custom-identity-key-store-type f:combine-mode=\"add\">" + customIdentityKeyStoreType + "</d:custom-identity-key-store-type>")
+
+  def writeCustomIdentityKeyStorePassPhraseEncrypted(self, nap):
+    customIdentityKeyStorePassPhraseEncrypted = nap.getCustomIdentityKeyStorePassPhraseEncrypted()
+    if customIdentityKeyStorePassPhraseEncrypted is not None and len(customIdentityKeyStorePassPhraseEncrypted) > 0:
+      self.writeln("<d:custom-identity-key-store-pass-phrase-encrypted f:combine-mode=\"add\">" + customIdentityKeyStorePassPhraseEncrypted + "</d:custom-identity-key-store-pass-phrase-encrypted>")
+
+  def writeHostnameVerificationIgnored(self, nap):
+    # default hostnameVerificationIgnored = 'false'
+    if nap.isHostnameVerificationIgnored() == true:
+      hostnameVerificationIgnored = 'true'
+      self.writeln("<d:hostname-verification-ignored f:combine-mode=\"add\">" + hostnameVerificationIgnored + "</d:hostname-verification-ignored>")
+
+  def writeHostnameVerifier(self, nap):
+    hostnameVerifier = nap.getHostnameVerifier()
+    if hostnameVerifier is not None and len(hostnameVerifier) > 0:
+      self.writeln("<d:hostname-verifier f:combine-mode=\"add\">" + hostnameVerifier + "</d:hostname-verifier>")
+
+  def writeCiphersuites(self, nap):
+    ciphersuites = nap.getCiphersuites()
+    if ciphersuites is not None:
+      for cipher in ciphersuites:
+        self.writeln("<d:ciphersuite f:combine-mode=\"add\">" + cipher + "</d:ciphersuite>")
+
+  def writeAllowUnencryptedNullCipher(self, nap):
+    # default allowUnencryptedNullCipher = 'false'
+    if nap.isAllowUnencryptedNullCipher() == true:
+      allowUnencryptedNullCipher = 'true'
+      self.writeln("<d:allow-unencrypted-null-cipher f:combine-mode=\"add\">" + allowUnencryptedNullCipher + "</d:allow-unencrypted-null-cipher>")
+
+  def writeInboundCertificateValidation(self, nap):
+    inboundCertificateValidation = nap.getInboundCertificateValidation()
+    if inboundCertificateValidation is not None and len(inboundCertificateValidation) > 0:
+      self.writeln("<d:inbound-certificate-validation f:combine-mode=\"add\">" + inboundCertificateValidation + "</d:inbound-certificate-validation>")
+
+  def writeOutboundCertificateValidation(self, nap):
+    outboundCertificateValidation = nap.getOutboundCertificateValidation()
+    if outboundCertificateValidation is not None and len(outboundCertificateValidation) > 0:
+      self.writeln("<d:outbound-certificate-validation f:combine-mode=\"add\">" + outboundCertificateValidation + "</d:outbound-certificate-validation>")
+
+  def createNameForLocalHostNetworkAccessPoint(self, nap_name, nap_name_dict):
+    # NAP names can be a maximum of 15 characters in length
+    key = nap_name
+    idx = 1
+    if len(nap_name) >= 10:
+      # Slice out the first 10 characters to use since there is a 15 character
+      # limit to NAP names
+      key = nap_name[:10]
+      if key not in nap_name_dict:
+        # Add the first nap name with index=1 into the Dictionary
+        nap_name_dict[key] = idx
+      else:
+        # Found a nap with the same first 10 characters so increment and
+        # save the index
+        idx = nap_name_dict[key] + 1
+        nap_name_dict[key] = idx
+
+    # zero fill to the left for single digit index (e.g. 01)
+    idx_str = str(idx)
+    if idx < 10:
+      idx_str = '0' + idx_str
+
+    # NAP name of for localhost binding will be of the form 'xxxxxxxxxx-lh01'
+    return key + WLS_LOCALHOST_IDENTIFIER + idx_str
+
+
+
   def customizeServer(self, server):
     name=server.getName()
     listen_address=self.env.toDNS1123Legal(self.env.getDomainUID() + "-" + name)
@@ -1097,8 +1315,10 @@ class SitConfigGenerator(Generator):
     self.writeln("</d:server-template>")
 
   def customizeNetworkAccessPoints(self, server, listen_address):
+    nap_name_dict = {}
     for nap in server.getNetworkAccessPoints():
       self.customizeNetworkAccessPoint(nap,listen_address)
+      self.createLocalHostNetworkAccessPoint(nap, '127.0.0.1', listen_address, nap_name_dict)
 
   def customizeNetworkAccessPoint(self, nap, listen_address):
     # Don't bother 'add' a nap listen-address, only do a 'replace'.
@@ -1110,20 +1330,85 @@ class SitConfigGenerator(Generator):
     istio_enabled = self.env.getEnvOrDef("ISTIO_ENABLED", "false")
 
     nap_name=nap.getName()
+    if nap_name in ISTIO_NAP_NAMES or nameContainsLocalHostIdentifier(nap_name):
+      # skip customizing internal channels that were generated
+      return
+
+    # replace listen address to bind to server pod IP
     if not (nap.getListenAddress() is None) and len(nap.getListenAddress()) > 0:
         self.writeln("<d:network-access-point>")
         self.indent()
         self.writeln("<d:name>" + nap_name + "</d:name>")
-        if istio_enabled == 'true':
-          if nap_name == 'http-probe':
-            self.writeListenAddress("force a replace", listen_address)
-          else:
-            self.writeListenAddress("force a replace", '127.0.0.1')
-        else:
-          self.writeListenAddress("force a replace",listen_address)
-
+        self.writeListenAddress("force a replace",listen_address)
         self.undent()
         self.writeln("</d:network-access-point>")
+
+  # Create copy of custom NAP for binding to localhost for handling k8s 'port-forward'
+  # feature and Istio versions < 1.10.x
+  def createLocalHostNetworkAccessPoint(self, nap, listen_address, public_listen_address, nap_name_dict):
+    # Don't bother 'add' a nap listen-address, only do a 'replace'.
+    # If we try 'add' this appears to mess up an attempt to
+    #   'add' PublicAddress/Port via custom sit-cfg.
+    # FWIW there's theoretically no need to 'add' or 'replace' when empty
+    #   since the runtime default is the server listen-address.
+
+    istio_enabled = self.env.getEnvOrDef("ISTIO_ENABLED", "false")
+    if istio_enabled == 'true':
+      nap_name=nap.getName()
+      if nap_name in ISTIO_NAP_NAMES or nameContainsLocalHostIdentifier(nap_name):
+        # skip creating ISTIO channels
+        return
+
+      self.writeln('<d:network-access-point f:combine-mode="add">')
+      self.indent()
+      self.writeName(self.createNameForLocalHostNetworkAccessPoint(nap_name, nap_name_dict))
+      self.writeGeneralNetworkAccessPointConfiguration(nap, listen_address, public_listen_address)
+      self.writeSecureNetworkAccessPointConfiguration(nap)
+      self.undent()
+      self.writeln("</d:network-access-point>")
+
+  def writeGeneralNetworkAccessPointConfiguration(self, nap, listen_address, public_listen_address):
+    self.writeProtocol(nap.getProtocol())
+    self.writeListenAddress("", listen_address)
+    self.writeListenPort(nap.getListenPort())
+    self.writePublicAddress(public_listen_address)
+    self.writePublicPort(nap.getPublicPort())
+    self.writeEnabled(nap)
+    self.writeOutboundEnabled(nap)
+    self.writeAcceptBacklog(nap.getAcceptBacklog())
+    self.writeMaxBackoffBetweenFailures(nap.getMaxBackoffBetweenFailures())
+    self.writeHttpEnabledForThisProtocol(nap)
+    self.writeLoginTimeoutMillis(nap.getLoginTimeoutMillis())
+    self.writeCompleteMessageTimeout(nap.getCompleteMessageTimeout())
+    self.writeIdleConnectionTimeout(nap.getIdleConnectionTimeout())
+    self.writeConnectTimeout(nap.getConnectTimeout())
+    self.writeTimeoutConnectionWithPendingResponses(nap)
+    self.writeTunnelingEnabled(nap)
+    self.writeTunnelingClientPingSecs(nap.getTunnelingClientPingSecs())
+    self.writeTunnelingClientTimeoutSecs(nap.getTunnelingClientTimeoutSecs())
+    self.writeMaxMessageSize(nap.getMaxMessageSize())
+    self.writeChannelWeight(nap.getChannelWeight())
+    self.writeMaxConnectedClients(nap.getMaxConnectedClients())
+    self.writeUseFastSerialization(nap)
+    self.writeSDPEnabled(nap)
+
+  def writeSecureNetworkAccessPointConfiguration(self, nap):
+    protocol = nap.getProtocol()
+    if protocol.endswith('s') or protocol == 'admin':
+      self.writeTwoWaySSLEnabled(nap)
+      self.writeClientCertificateEnforced(nap)
+      self.writeChannelIdentityCustomized(nap)
+      self.writeCustomPrivateKeyAlias(nap)
+      self.writeCustomPrivateKeyPassPhraseEncrypted(nap)
+      self.writeCustomIdentityKeyStoreType(nap)
+      self.writeCustomIdentityKeyStorePassPhraseEncrypted(nap)
+      self.writeHostnameVerificationIgnored(nap)
+      self.writeHostnameVerifier(nap)
+      self.writeCiphersuites(nap)
+      self.writeAllowUnencryptedNullCipher(nap)
+      self.writeInboundCertificateValidation(nap)
+      self.writeOutboundCertificateValidation(nap)
+
 
   def _getNapConfigOverrideAction(self, svr, testname):
     replace_action = 'f:combine-mode="replace"'
@@ -1217,7 +1502,7 @@ class SitConfigGenerator(Generator):
     self._writeIstioNAP(name='http-probe', server=server, listen_address=listen_address,
                         listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
-    self._writeIstioNAP(name='http-local-probe', server=server, listen_address=listen_address,
+    self._writeIstioNAP(name=self.createNameForLocalHostNetworkAccessPoint('http-probe', {}), server=server, listen_address=listen_address,
                         listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
     # Generate NAP for each protocols
@@ -1274,7 +1559,7 @@ class SitConfigGenerator(Generator):
     self._writeIstioNAP(name='http-probe', server=template, listen_address=listen_address,
                         listen_port=istio_readiness_port, protocol='http')
 
-    self._writeIstioNAP(name='http-local-probe', server=template, listen_address=listen_address,
+    self._writeIstioNAP(name=self.createNameForLocalHostNetworkAccessPoint('http-probe', {}), server=template, listen_address=listen_address,
                         listen_port=istio_readiness_port, protocol='http')
 
     self._writeIstioNAP(name='tcp-default', server=template, listen_address=listen_address,
@@ -1888,6 +2173,9 @@ def get_server_template_listening_ports_from_configxml(config_xml):
     server_template_ssls[template_name] = sslport
 
   return server_template_ssls, server_template_ports
+
+def nameContainsLocalHostIdentifier(name):
+  return name.find(WLS_LOCALHOST_IDENTIFIER) > -1
 
 def main(env):
   try:

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1115,7 +1115,10 @@ class SitConfigGenerator(Generator):
         self.indent()
         self.writeln("<d:name>" + nap_name + "</d:name>")
         if istio_enabled == 'true':
-          self.writeListenAddress("force a replace", '127.0.0.1')
+          if nap_name == 'http-probe':
+            self.writeListenAddress("force a replace", listen_address)
+          else:
+            self.writeListenAddress("force a replace", '127.0.0.1')
         else:
           self.writeListenAddress("force a replace",listen_address)
 
@@ -1155,7 +1158,11 @@ class SitConfigGenerator(Generator):
       self.writeln('<d:name>%s</d:name>' % name)
 
     self.writeln('<d:protocol %s>%s</d:protocol>' % (action, protocol))
-    self.writeln('<d:listen-address %s>127.0.0.1</d:listen-address>' % action)
+    if name == 'http-probe':
+      self.writeln('<d:listen-address %s>%s.%s</d:listen-address>' % (action, listen_address,
+                                                          self.env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default")))
+    else:
+      self.writeln('<d:listen-address %s>127.0.0.1</d:listen-address>' % action)
     self.writeln('<d:public-address %s>%s.%s</d:public-address>' % (action, listen_address,
                                                           self.env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default")))
     self.writeln('<d:listen-port %s>%s</d:listen-port>' % (action, listen_port))

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -621,7 +621,6 @@ def nameContainsLocalHostIdentifier(name):
     endIdentifierIdx = identifierIdx + len(WLS_LOCALHOST_IDENTIFIER)
     # get substring from localhost identifier to end
     subStr = name[endIdentifierIdx:]
-    print subStr
     # should be only 2 digits 'NN' from '-lhNN' format
     if len(subStr) == 2:
       # verify the last two chars are digits

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -44,7 +44,7 @@
 #   configuration.
 #
 
-
+import copy
 import inspect
 import os
 import sys
@@ -55,12 +55,20 @@ tmp_scriptdir=os.path.dirname(tmp_info[0])
 sys.path.append(tmp_scriptdir)
 
 env = None
+ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-default', 'tcp-default', 'https-secure', 'tls-ldaps', 'tls-default', 'tls-cbts', 'tls-iiops', 'https-admin']
+WLS_LOCALHOST_IDENTIFIER = '-lh'
+
 
 class OfflineWlstEnv(object):
 
   def open(self, model):
 
     self.model = model
+
+    # Dictionary to track the count of naps that have names > 15 characters
+    # key = 10 char name, value = index count
+    #self.nap_name_dict = {}
+
     # before doing anything, get each env var and verify it exists
 
     self.DOMAIN_UID               = self.getEnv('DOMAIN_UID')
@@ -370,7 +378,7 @@ def getSSLOrNone(server):
   return server['SSL']
 
 
-def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_enabled="true"):
+def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_enabled="true", bind_to_localhost="true"):
 
   if 'NetworkAccessPoint' not in server:
     server['NetworkAccessPoint'] = {}
@@ -381,10 +389,10 @@ def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_ena
 
   nap = naps[name]
   nap['Protocol'] = protocol
-  if name == 'http-probe':
-    nap['ListenAddress'] = '%s.%s' % (listen_address, env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default"))
-  else:
+  if bind_to_localhost == 'true':
     nap['ListenAddress'] = '127.0.0.1'
+  else:
+    nap['ListenAddress'] = '%s.%s' % (listen_address, env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default"))
   nap['PublicAddress'] = '%s.%s' % (listen_address, env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default"))
   nap['ListenPort'] = listen_port
   nap['HttpEnabledForThisProtocol'] = http_enabled
@@ -408,9 +416,11 @@ def customizeServerIstioNetworkAccessPoint(server, listen_address):
 
   # readiness probe
   _writeIstioNAP(name='http-probe', server=server, listen_address=listen_address,
-                      listen_port=istio_readiness_port, protocol='http', http_enabled="true")
+                      listen_port=istio_readiness_port, protocol='http', http_enabled="true",
+                      bind_to_localhost="false")
 
-  _writeIstioNAP(name='http-local-probe', server=server, listen_address=listen_address,
+  # readiness probe NAP binding to localhost
+  _writeIstioNAP(name=createNameForLocalHostNetworkAccessPoint('http-probe', {}), server=server, listen_address=listen_address,
                  listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
   # Generate NAP for each protocols
@@ -477,9 +487,11 @@ def customizeManagedIstioNetworkAccessPoint(template, listen_address):
     listen_port = 7001
   # readiness probe
   _writeIstioNAP(name='http-probe', server=template, listen_address=listen_address,
-                 listen_port=istio_readiness_port, protocol='http', http_enabled="true")
+                 listen_port=istio_readiness_port, protocol='http', http_enabled="true",
+                 bind_to_localhost="false")
 
-  _writeIstioNAP(name='http-local-probe', server=template, listen_address=listen_address,
+  # readiness probe NAP binding to localhost address for Istio versions < 1.10.x
+  _writeIstioNAP(name=createNameForLocalHostNetworkAccessPoint('http-probe', {}), server=template, listen_address=listen_address,
                  listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
   # Generate NAP for each protocols
@@ -534,25 +546,67 @@ def customizeNetworkAccessPoints(server, listen_address):
 
   naps = server['NetworkAccessPoint']
   nap_names = naps.keys()
+  # Dictionary to track the count of naps that have names > 15 characters
+  # key = 10 char name, value = index count
+  nap_name_dict = {}
   for nap_name in nap_names:
     nap = naps[nap_name]
     customizeNetworkAccessPoint(nap_name, nap, listen_address)
+    createLocalHostNetworkAccessPoint(nap_name, nap, server, nap_name_dict)
 
 
 def customizeNetworkAccessPoint(nap_name, nap, listen_address):
-  istio_enabled = env.getEnvOrDef("ISTIO_ENABLED", "false")
+  if nap_name in ISTIO_NAP_NAMES or nameContainsLocalHostIdentifier(nap_name):
+    # skip creating ISTIO channels
+    return
 
+  # fix NAP listen address
   if 'ListenAddress' in nap:
     original_listen_address = nap['ListenAddress']
     if len(original_listen_address) > 0:
-      if istio_enabled == 'true':
-        if nap_name == 'http-probe':
-          nap['ListenAddress'] = listen_address
-        else:
-          nap['ListenAddress'] = '127.0.0.1'
-      else:
         nap['ListenAddress'] = listen_address
 
+# Create copy of custom NAP for binding to localhost for handling k8s 'port-forward'
+# feature and Istio versions < 1.10.x
+def createLocalHostNetworkAccessPoint(nap_name, nap, server, nap_name_dict):
+  istio_enabled = env.getEnvOrDef("ISTIO_ENABLED", "false")
+  if istio_enabled == 'true':
+    if nap_name in ISTIO_NAP_NAMES or nameContainsLocalHostIdentifier(nap_name):
+      # skip creating ISTIO channels
+      return
+
+    wls_local_nap = copy.deepcopy(nap)
+    wls_local_nap['ListenAddress'] = '127.0.0.1'
+    local_nap_name = createNameForLocalHostNetworkAccessPoint(nap_name, nap_name_dict)
+    server['NetworkAccessPoint'][local_nap_name] = wls_local_nap
+
+def createNameForLocalHostNetworkAccessPoint(nap_name, nap_name_dict):
+  # NAP names can be a maximum of 15 characters in length
+  key = nap_name
+  idx = 1
+  if len(nap_name) >= 10:
+    # Slice out the first 10 characters to use since there is a 15 character
+    # limit to NAP names
+    key = nap_name[:10]
+    if key not in nap_name_dict:
+      # Add the first nap name with index=1 into the Dictionary
+      nap_name_dict[key] = idx
+    else:
+      # Found a nap with the same first 10 characters so increment and
+      # save the index
+      idx = nap_name_dict[key] + 1
+      nap_name_dict[key] = idx
+
+  # zero fill to the left for single digit index (e.g. 01)
+  idx_str = str(idx)
+  if idx < 10:
+    idx_str = '0' + idx_str
+
+  # NAP name of for localhost binding will be of the form 'xxxxxxxxxx-lh01'
+  return key + WLS_LOCALHOST_IDENTIFIER + idx_str
+
+def nameContainsLocalHostIdentifier(name):
+  return name.find(WLS_LOCALHOST_IDENTIFIER) > -1
 
 def setServerListenAddress(serverOrTemplate, listen_address):
   serverOrTemplate['ListenAddress'] = listen_address

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -381,7 +381,10 @@ def _writeIstioNAP(name, server, listen_address, listen_port, protocol, http_ena
 
   nap = naps[name]
   nap['Protocol'] = protocol
-  nap['ListenAddress'] = '127.0.0.1'
+  if name == 'http-probe':
+    nap['ListenAddress'] = '%s.%s' % (listen_address, env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default"))
+  else:
+    nap['ListenAddress'] = '127.0.0.1'
   nap['PublicAddress'] = '%s.%s' % (listen_address, env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default"))
   nap['ListenPort'] = listen_port
   nap['HttpEnabledForThisProtocol'] = http_enabled
@@ -527,17 +530,20 @@ def customizeNetworkAccessPoints(server, listen_address):
   nap_names = naps.keys()
   for nap_name in nap_names:
     nap = naps[nap_name]
-    customizeNetworkAccessPoint(nap, listen_address)
+    customizeNetworkAccessPoint(nap_name, nap, listen_address)
 
 
-def customizeNetworkAccessPoint(nap, listen_address):
+def customizeNetworkAccessPoint(nap_name, nap, listen_address):
   istio_enabled = env.getEnvOrDef("ISTIO_ENABLED", "false")
 
   if 'ListenAddress' in nap:
     original_listen_address = nap['ListenAddress']
     if len(original_listen_address) > 0:
       if istio_enabled == 'true':
-        nap['ListenAddress'] = '127.0.0.1'
+        if nap_name == 'http-probe':
+          nap['ListenAddress'] = listen_address
+        else:
+          nap['ListenAddress'] = '127.0.0.1'
       else:
         nap['ListenAddress'] = listen_address
 

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -410,6 +410,9 @@ def customizeServerIstioNetworkAccessPoint(server, listen_address):
   _writeIstioNAP(name='http-probe', server=server, listen_address=listen_address,
                       listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
+  _writeIstioNAP(name='http-local-probe', server=server, listen_address=listen_address,
+                 listen_port=istio_readiness_port, protocol='http', http_enabled="true")
+
   # Generate NAP for each protocols
   _writeIstioNAP(name='tcp-ldap', server=server, listen_address=listen_address,
                       listen_port=admin_server_port, protocol='ldap')
@@ -474,6 +477,9 @@ def customizeManagedIstioNetworkAccessPoint(template, listen_address):
     listen_port = 7001
   # readiness probe
   _writeIstioNAP(name='http-probe', server=template, listen_address=listen_address,
+                 listen_port=istio_readiness_port, protocol='http', http_enabled="true")
+
+  _writeIstioNAP(name='http-local-probe', server=template, listen_address=listen_address,
                  listen_port=istio_readiness_port, protocol='http', http_enabled="true")
 
   # Generate NAP for each protocols

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -549,10 +549,18 @@ def customizeNetworkAccessPoints(server, listen_address):
   # Dictionary to track the count of naps that have names > 15 characters
   # key = 10 char name, value = index count
   nap_name_dict = {}
+  # Dictionary of LocalHost NAP's created
+  local_nap_dict = {}
   for nap_name in nap_names:
     nap = naps[nap_name]
     customizeNetworkAccessPoint(nap_name, nap, listen_address)
-    createLocalHostNetworkAccessPoint(nap_name, nap, server, nap_name_dict)
+    createLocalHostNetworkAccessPoint(nap_name, nap, nap_name_dict, local_nap_dict)
+
+  # Iterate through the Dictionary of cloned local NAP's and add to the NetworkAccesPoint
+  # list of the model
+  local_nap_names = local_nap_dict.keys()
+  for local_nap_name in local_nap_names:
+    server['NetworkAccessPoint'][local_nap_name] = local_nap_dict[local_nap_name]
 
 
 def customizeNetworkAccessPoint(nap_name, nap, listen_address):
@@ -568,7 +576,7 @@ def customizeNetworkAccessPoint(nap_name, nap, listen_address):
 
 # Create copy of custom NAP for binding to localhost for handling k8s 'port-forward'
 # feature and Istio versions < 1.10.x
-def createLocalHostNetworkAccessPoint(nap_name, nap, server, nap_name_dict):
+def createLocalHostNetworkAccessPoint(nap_name, nap, nap_name_dict, local_nap_dict):
   istio_enabled = env.getEnvOrDef("ISTIO_ENABLED", "false")
   if istio_enabled == 'true':
     if nap_name in ISTIO_NAP_NAMES or nameContainsLocalHostIdentifier(nap_name):
@@ -578,7 +586,7 @@ def createLocalHostNetworkAccessPoint(nap_name, nap, server, nap_name_dict):
     wls_local_nap = copy.deepcopy(nap)
     wls_local_nap['ListenAddress'] = '127.0.0.1'
     local_nap_name = createNameForLocalHostNetworkAccessPoint(nap_name, nap_name_dict)
-    server['NetworkAccessPoint'][local_nap_name] = wls_local_nap
+    local_nap_dict[local_nap_name] = wls_local_nap
 
 def createNameForLocalHostNetworkAccessPoint(nap_name, nap_name_dict):
   # NAP names can be a maximum of 15 characters in length
@@ -606,7 +614,21 @@ def createNameForLocalHostNetworkAccessPoint(nap_name, nap_name_dict):
   return key + WLS_LOCALHOST_IDENTIFIER + idx_str
 
 def nameContainsLocalHostIdentifier(name):
-  return name.find(WLS_LOCALHOST_IDENTIFIER) > -1
+  # look for '-lh'
+  identifierIdx = name.find(WLS_LOCALHOST_IDENTIFIER)
+  # check if there is a localhost identifier
+  if identifierIdx > -1:
+    endIdentifierIdx = identifierIdx + len(WLS_LOCALHOST_IDENTIFIER)
+    # get substring from localhost identifier to end
+    subStr = name[endIdentifierIdx:]
+    print subStr
+    # should be only 2 digits 'NN' from '-lhNN' format
+    if len(subStr) == 2:
+      # verify the last two chars are digits
+      if subStr.isdigit():
+        return True
+
+  return False
 
 def setServerListenAddress(serverOrTemplate, listen_address):
   serverOrTemplate['ListenAddress'] = listen_address

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -8,7 +8,7 @@ import model_wdt_mii_filter
 
 class WdtUpdateFilterCase(unittest.TestCase):
 
-  ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-probe', 'http-default', 'tcp-default']
+  ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-probe', 'http-local-probe', 'http-default', 'tcp-default']
 
   def setUp(self):
     self.initialize_environment_variables()

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -8,7 +8,7 @@ import model_wdt_mii_filter
 
 class WdtUpdateFilterCase(unittest.TestCase):
 
-  ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-probe', 'http-local-probe', 'http-default', 'tcp-default']
+  ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-probe', 'http-probe' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', 'http-default', 'tcp-default']
 
   def setUp(self):
     self.initialize_environment_variables()
@@ -147,7 +147,17 @@ class WdtUpdateFilterCase(unittest.TestCase):
       server_template = self.getServerTemplate(model)
       model_wdt_mii_filter.customizeNetworkAccessPoints(server_template, 'sample-domain1-managed-server${id}')
       nap_listen_address = model['topology']['ServerTemplate']['cluster-1-template']['NetworkAccessPoint']['T3Channel']['ListenAddress']
-      self.assertEqual('127.0.0.1', nap_listen_address, "Expected nap listen address to be \'127.0.0.1\'")
+      self.assertEqual('sample-domain1-managed-server${id}', nap_listen_address, "Expected nap listen address to be \'sample-domain1-managed-server${id}\'")
+
+      # Assert LocalHost channel listen address is '127.0.0.1'
+      nap_local_host = model['topology']['ServerTemplate']['cluster-1-template']['NetworkAccessPoint']['T3Channel' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01']['ListenAddress']
+      self.assertEqual('127.0.0.1', nap_local_host, "Expected nap listen address to be \'127.0.0.1\'")
+
+      # Verify we don't duplicate channels more than once
+      model_wdt_mii_filter.customizeNetworkAccessPoints(server_template, 'sample-domain1-managed-server${id}')
+      naps = server_template['NetworkAccessPoint']
+      nap_names = naps.keys()
+      self.assertEqual(2, len(nap_names), "Expected only two NAPS")
     finally:
       del os.environ['ISTIO_ENABLED']
 
@@ -235,6 +245,51 @@ class WdtUpdateFilterCase(unittest.TestCase):
     model_wdt_mii_filter.env.readDomainNameFromTopologyYaml('../resources/topology.yaml')
     domain_name = model_wdt_mii_filter.env.getDomainName()
     self.assertEqual('wls-domain1', domain_name, "Expected domain name to be \'wls-domain1\'")
+
+  def test_createNameForLocalHostNetworkAccessPoint(self):
+    model = self.getModel()
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint('http-probe', {})
+    self.assertEquals('http-probe' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be http-probe" + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+
+  def test_createNameForLocalHostNetworkAccessPoint_with_long_name(self):
+    nap_name_10_chars = 'abcdefghij'
+    nap_name_15_chars = nap_name_10_chars + 'klmno'
+    nap_name_20_chars = nap_name_15_chars + 'pqrst'
+
+    model = self.getModel()
+    nap_name_dict = {}
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_10_chars, nap_name_dict)
+    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_15_chars, nap_name_dict)
+    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02', nap_name_copy, "Expected 15 character name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02')
+
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '03', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '03')
+
+  def test_createNameForLocalHostNetworkAccessPoint_with_double_digit_idx(self):
+    nap_name_10_chars = 'abcdefghij'
+    nap_name_20_chars = nap_name_10_chars + 'klmnopqrst'
+    nap_name_dict = {}
+
+    # 01
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+
+    # 02
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    # 10
+    nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
+    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '10', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '10')
 
 class MockOfflineWlstEnv(model_wdt_mii_filter.OfflineWlstEnv):
 

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -304,8 +304,6 @@ class WdtUpdateFilterCase(unittest.TestCase):
       model_wdt_mii_filter.createLocalHostNetworkAccessPoint('T3Channel',
                         nap, nap_name_dict, local_nap_dict)
       self.assertEqual(1, len(local_nap_dict), "Expected only one dictionary entry")
-      self.assertTrue(local_nap_dict.has_key('T3Channel' +
-                        model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01'))
       nap = local_nap_dict['T3Channel' +
                            model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01']
       self.assertEqual('127.0.0.1', nap['ListenAddress'],

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -249,7 +249,7 @@ class WdtUpdateFilterCase(unittest.TestCase):
   def test_createNameForLocalHostNetworkAccessPoint(self):
     model = self.getModel()
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint('http-probe', {})
-    self.assertEquals('http-probe' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be http-probe" + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+    self.assertEqual('http-probe' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be http-probe" + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
 
   def test_createNameForLocalHostNetworkAccessPoint_with_long_name(self):
     nap_name_10_chars = 'abcdefghij'
@@ -259,13 +259,13 @@ class WdtUpdateFilterCase(unittest.TestCase):
     model = self.getModel()
     nap_name_dict = {}
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_10_chars, nap_name_dict)
-    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+    self.assertEqual(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
 
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_15_chars, nap_name_dict)
-    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02', nap_name_copy, "Expected 15 character name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02')
+    self.assertEqual(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02', nap_name_copy, "Expected 15 character name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02')
 
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
-    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '03', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '03')
+    self.assertEqual(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '03', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '03')
 
   def test_createNameForLocalHostNetworkAccessPoint_with_double_digit_idx(self):
     nap_name_10_chars = 'abcdefghij'
@@ -274,11 +274,11 @@ class WdtUpdateFilterCase(unittest.TestCase):
 
     # 01
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
-    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+    self.assertEqual(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
 
     # 02
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
-    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
+    self.assertEqual(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '02', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01')
 
     model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
     model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
@@ -289,7 +289,44 @@ class WdtUpdateFilterCase(unittest.TestCase):
     model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
     # 10
     nap_name_copy = model_wdt_mii_filter.createNameForLocalHostNetworkAccessPoint(nap_name_20_chars, nap_name_dict)
-    self.assertEquals(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '10', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '10')
+    self.assertEqual(nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '10', nap_name_copy, "Expected name to be " + nap_name_10_chars + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '10')
+
+  def test_createLocalHostNetworkAccessPoint(self):
+    try:
+      os.environ['ISTIO_ENABLED'] = 'true'
+      model = self.getModel()
+      server_template = self.getServerTemplate(model)
+      naps = server_template['NetworkAccessPoint']
+
+      nap_name_dict = {}
+      local_nap_dict = {}
+      nap = naps['T3Channel']
+      model_wdt_mii_filter.createLocalHostNetworkAccessPoint('T3Channel',
+                        nap, nap_name_dict, local_nap_dict)
+      self.assertEqual(1, len(local_nap_dict), "Expected only one dictionary entry")
+      self.assertTrue(local_nap_dict.has_key('T3Channel' +
+                        model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01'))
+      nap = local_nap_dict['T3Channel' +
+                           model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01']
+      self.assertEqual('127.0.0.1', nap['ListenAddress'],
+                       "Expected ListenAddress to be '\127.0.0.1\'")
+    finally:
+      del os.environ['ISTIO_ENABLED']
+
+  def test_nameContainsLocalHostIdentifier(self):
+    channelName = 'abced' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + '01'
+    self.assertTrue(model_wdt_mii_filter.nameContainsLocalHostIdentifier(channelName),
+                "Expected name to contain " + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER)
+
+  def test_nameDoesNotContainsLocalHostIdentifier(self):
+    channelName = 'abcedefg-l01'
+    self.assertFalse(model_wdt_mii_filter.nameContainsLocalHostIdentifier(channelName),
+                    "Expected name to not contain " + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER)
+
+  def test_localHostIdentifierDoesNotContainDigits(self):
+    channelName = 'abced' + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER + 'o1'
+    self.assertFalse(model_wdt_mii_filter.nameContainsLocalHostIdentifier(channelName),
+                     "Expected name to not contain " + model_wdt_mii_filter.WLS_LOCALHOST_IDENTIFIER)
 
 class MockOfflineWlstEnv(model_wdt_mii_filter.OfflineWlstEnv):
 


### PR DESCRIPTION
Beginning with Istio v1.10, network changes were made by Istio where the proxy no longer redirects the traffic to the localhost interface, but instead forwards it to the network interface associated with the pod IP (e.g. eth0).  Since the operator has to support all versions of Istio, we are adding additional WebLogic network channels for binding to the localhost and pod IP network interfaces.  This will allow the WebLogic managed servers to continue to receive application traffic through either network interfaces.  During introspection, copies of the readiness probe and any custom WebLogic NAP's are created and listening addresses set to '127.0.0.1' so that the NAP's are bound to the localhost interface.  We continue to customize any existing defined NAPs and override the listening address by setting it to the defined service name (e.g. sample-domain1-managed-server${id}).

For DII and DomainOnPV domains, we generate additional NAP's in situational config files.  For example:

<d:network-access-point f:combine-mode="add">
      <d:name f:combine-mode="add">http-probe</d:name>
      <d:protocol f:combine-mode="add">http</d:protocol>
      <d:listen-address f:combine-mode="add">sample-domain1-admin-server.sample-domain1-ns</d:listen-address>
      <d:public-address f:combine-mode="add">sample-domain1-admin-server.sample-domain1-ns</d:public-address>
      <d:listen-port f:combine-mode="add">8888</d:listen-port>
      <d:http-enabled-for-this-protocol f:combine-mode="add">true</d:http-enabled-for-this-protocol>
      <d:outbound-enabled f:combine-mode="add">true</d:outbound-enabled>
      <d:enabled f:combine-mode="add">true</d:enabled>
    </d:network-access-point>
    <d:network-access-point f:combine-mode="add">
      <d:name f:combine-mode="add">http-probe-lh01</d:name>
      <d:protocol f:combine-mode="add">http</d:protocol>
      <d:listen-address f:combine-mode="add">127.0.0.1</d:listen-address>
      <d:public-address f:combine-mode="add">sample-domain1-admin-server.sample-domain1-ns</d:public-address>
      <d:listen-port f:combine-mode="add">8888</d:listen-port>
      <d:http-enabled-for-this-protocol f:combine-mode="add">true</d:http-enabled-for-this-protocol>
      <d:outbound-enabled f:combine-mode="add">true</d:outbound-enabled>
      <d:enabled f:combine-mode="add">true</d:enabled>
    </d:network-access-point>

Since container port names are limited to a maximum  of 15 characters, we truncate the names of any cloned network channel  to the first 10 characters and append the identifier '-lhNN'  (e.g 'http-probe-lh01')

Have successfully run all Istio integration tests on Kind cluster using Istio v1.7.3, v1.10.4, and v1.11.2