### PR TITLE
Owls 91563 - Changes to validate the container port names and truncate automatically generated long names

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -55,7 +55,7 @@ public class LegalNames {
   public static final int LEGAL_DNS_LABEL_NAME_MAX_LENGTH = 63;
 
   // The maximum length of a container port name
-  public static final int LEGAL_CONTAINER_PORT_MAX_LENGTH = 15;
+  public static final int LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH = 15;
 
   private static final String DNS_NAME_REGEXP = "[a-z0-9]([-a-z0-9]*[a-z0-9])?";
   private static final Pattern DNS_NAME_PATTERN = Pattern.compile(DNS_NAME_REGEXP);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/LegalNames.java
@@ -54,6 +54,9 @@ public class LegalNames {
   // The maximum length of a legal DNS label name
   public static final int LEGAL_DNS_LABEL_NAME_MAX_LENGTH = 63;
 
+  // The maximum length of a container port name
+  public static final int LEGAL_CONTAINER_PORT_MAX_LENGTH = 15;
+
   private static final String DNS_NAME_REGEXP = "[a-z0-9]([-a-z0-9]*[a-z0-9])?";
   private static final Pattern DNS_NAME_PATTERN = Pattern.compile(DNS_NAME_REGEXP);
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -325,7 +325,7 @@ public abstract class PodStepContext extends BasePodStepContext {
       if (index < 10) {
         indexStr = "0" + index;
       }
-      name = getPortNamePrefix(name) + "-" + indexStr;
+      name = portNamePrefix + "-" + indexStr;
     }
     return  name;
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -73,6 +73,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.EventConstants.ROLL_REASON_DOMAIN_RESOURCE_CHANGED;
 import static oracle.kubernetes.operator.EventConstants.ROLL_REASON_WEBLOGIC_CONFIGURATION_CHANGED;
@@ -313,21 +314,26 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   private String createContainerPortName(List<V1ContainerPort> ports, String name) {
     //Container port names can be a maximum of 15 characters in length
-    if (name.length() > LegalNames.LEGAL_CONTAINER_PORT_MAX_LENGTH) {
-      // Extract the first 12 characters to use since there is a 15 character
-      // limit to the container port name
-      String cpName = name.substring(0, 12);
+    if (name.length() > LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH) {
+      String portNamePrefix = getPortNamePrefix(name);
       // Find ports with the name having the same first 12 characters
       List<V1ContainerPort> containerPortsWithSamePrefix = ports.stream().filter(port ->
-              port.getName().substring(0, 12).equals(cpName)).collect(Collectors.toList());
+              portNamePrefix.equals(getPortNamePrefix(port.getName()))).collect(Collectors.toList());
       int index = containerPortsWithSamePrefix.size() + 1;
       String indexStr = String.valueOf(index);
+      // zero fill to the left for single digit index (e.g. 01)
       if (index < 10) {
         indexStr = "0" + index;
       }
-      name = cpName + "-" + indexStr;
+      name = getPortNamePrefix(name) + "-" + indexStr;
     }
     return  name;
+  }
+
+  @NotNull
+  private String getPortNamePrefix(String name) {
+    // Use first 12 characters of port name as prefix due to 15 character port name limit
+    return name.substring(0, 12);
   }
 
   Integer getListenPort() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -92,6 +92,7 @@ import static oracle.kubernetes.operator.helpers.CompatibilityCheck.Compatibilit
 import static oracle.kubernetes.operator.helpers.CompatibilityCheck.CompatibilityScope.UNKNOWN;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_ROLL_STARTING;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.POD_CYCLE_STARTING;
+import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
 
 public abstract class PodStepContext extends BasePodStepContext {
 
@@ -314,7 +315,7 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   private String createContainerPortName(List<V1ContainerPort> ports, String name) {
     //Container port names can be a maximum of 15 characters in length
-    if (name.length() > LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH) {
+    if (name.length() > LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH) {
       String portNamePrefix = getPortNamePrefix(name);
       // Find ports with the name having the same first 12 characters
       List<V1ContainerPort> containerPortsWithSamePrefix = ports.stream().filter(port ->
@@ -324,6 +325,10 @@ public abstract class PodStepContext extends BasePodStepContext {
       // zero fill to the left for single digit index (e.g. 01)
       if (index < 10) {
         indexStr = "0" + index;
+      } else if (index >= 100) {
+        LOGGER.severe(MessageKeys.ILLEGAL_NETWORK_CHANNEL_NAME_LENGTH, getDomainUid(), getServerName(),
+                name, LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH);
+        return name;
       }
       name = portNamePrefix + "-" + indexStr;
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -144,7 +144,6 @@ public class MessageKeys {
   public static final String LOG_WAITING_COUNT = "WLSKO-0193";
   public static final String INTERNAL_IDENTITY_INITIALIZATION_FAILED = "WLSKO-0194";
 
-
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";
   public static final String DUPLICATE_CLUSTER_NAME_FOUND = "WLSDO-0002";
@@ -177,6 +176,7 @@ public class MessageKeys {
   public static final String INVALID_LIVENESS_PROBE_SUCCESS_THRESHOLD_VALUE = "WLSDO-0029";
   public static final String RESERVED_CONTAINER_NAME = "WLSDO-0030";
   public static final String ILLEGAL_CONTAINER_PORT_NAME_LENGTH = "WLSDO-0031";
+  public static final String ILLEGAL_NETWORK_CHANNEL_NAME_LENGTH = "WLSDO-0032";
 
   private MessageKeys() {
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -176,6 +176,7 @@ public class MessageKeys {
   public static final String MONITORING_EXPORTER_CONFLICT_DYNAMIC_CLUSTER = "WLSDO-0028";
   public static final String INVALID_LIVENESS_PROBE_SUCCESS_THRESHOLD_VALUE = "WLSDO-0029";
   public static final String RESERVED_CONTAINER_NAME = "WLSDO-0030";
+  public static final String ILLEGAL_CONTAINER_PORT_NAME_LENGTH = "WLSDO-0031";
 
   private MessageKeys() {
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfig.java
@@ -407,6 +407,20 @@ public class WlsDomainConfig implements WlsDomain {
     return this;
   }
 
+  /**
+   * Build the domain config with a WLS server.
+   * @param server WLS server configuration
+   * @param isAdmin Specifies if the server is Admin or managed server.
+   * @return domain config
+   */
+  public WlsDomainConfig withServer(WlsServerConfig server, boolean isAdmin) {
+    if (isAdmin) {
+      setAdminServerName(server.getName());
+    }
+    getServers().add(server);
+    return this;
+  }
+
   public WlsDomainConfig addWlsServer(String name, String listenAddress, int port) {
     getServers().add(new WlsServerConfig(name, listenAddress, port));
     return this;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -1139,13 +1139,11 @@ public class Domain implements KubernetesObject {
     }
 
     private void checkPortNameLength(V1ContainerPort port, String name, String prefix) {
-      int limit = LegalNames.LEGAL_CONTAINER_PORT_MAX_LENGTH;
-      if (port.getName().length() > limit) {
+      if (port.getName().length() > LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH) {
         failures.add(DomainValidationMessages.exceedMaxContainerPortName(
                 getDomainUid(),
                 prefix + "." + name,
-                port.getName(),
-                limit));
+                port.getName()));
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -21,6 +21,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -833,6 +834,7 @@ public class Domain implements KubernetesObject {
       addDuplicateAuxiliaryImageVolumeNames();
       verifyLivenessProbeSuccessThreshold();
       verifyContainerNameValidInPodSpec();
+      verifyContainerPortNameValidInPodSpec();
 
       return failures;
     }
@@ -1115,6 +1117,35 @@ public class Domain implements KubernetesObject {
     private void isContainerNameReserved(V1Container container, String prefix) {
       if (container.getName().equals(WLS_CONTAINER_NAME)) {
         failures.add(DomainValidationMessages.reservedContainerName(container.getName(), prefix));
+      }
+    }
+
+    private void verifyContainerPortNameValidInPodSpec() {
+      getAdminServerSpec().getContainers().forEach(container ->
+              areContainerPortNamesValid(container, ADMIN_SERVER_POD_SPEC_PREFIX + ".containers"));
+      getSpec().getClusters().forEach(cluster ->
+              cluster.getContainers().forEach(container ->
+                      areContainerPortNamesValid(container, CLUSTER_SPEC_PREFIX + "[" + cluster.getClusterName()
+                              + "].serverPod.containers")));
+      getSpec().getManagedServers().forEach(managedServer ->
+              managedServer.getContainers().forEach(container ->
+                      areContainerPortNamesValid(container, MS_SPEC_PREFIX + "[" + managedServer.getServerName()
+                              + "].serverPod.containers")));
+    }
+
+    private void areContainerPortNamesValid(V1Container container, String prefix) {
+      Optional.ofNullable(container.getPorts()).ifPresent(portList ->
+              portList.forEach(port -> checkPortNameLength(port, container.getName(), prefix)));
+    }
+
+    private void checkPortNameLength(V1ContainerPort port, String name, String prefix) {
+      int limit = LegalNames.LEGAL_CONTAINER_PORT_MAX_LENGTH;
+      if (port.getName().length() > limit) {
+        failures.add(DomainValidationMessages.exceedMaxContainerPortName(
+                getDomainUid(),
+                prefix + "." + name,
+                port.getName(),
+                limit));
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
@@ -15,6 +15,8 @@ import oracle.kubernetes.operator.helpers.SecretType;
 import oracle.kubernetes.operator.logging.MessageKeys;
 import oracle.kubernetes.utils.OperatorUtils;
 
+import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
+
 class DomainValidationMessages {
 
   /**
@@ -175,8 +177,9 @@ class DomainValidationMessages {
     return getMessage(MessageKeys.RESERVED_CONTAINER_NAME, name, prefix);
   }
 
-  public static String exceedMaxContainerPortName(String domainUid, String containerName, String portName, int limit) {
-    return getMessage(MessageKeys.ILLEGAL_CONTAINER_PORT_NAME_LENGTH, domainUid, containerName, portName, limit);
+  public static String exceedMaxContainerPortName(String domainUid, String containerName, String portName) {
+    return getMessage(MessageKeys.ILLEGAL_CONTAINER_PORT_NAME_LENGTH, domainUid, containerName, portName,
+            LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH);
   }
 
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
@@ -174,4 +174,9 @@ class DomainValidationMessages {
   public static String reservedContainerName(String name, String prefix) {
     return getMessage(MessageKeys.RESERVED_CONTAINER_NAME, name, prefix);
   }
+
+  public static String exceedMaxContainerPortName(String domainUid, String containerName, String portName, int limit) {
+    return getMessage(MessageKeys.ILLEGAL_CONTAINER_PORT_NAME_LENGTH, domainUid, containerName, portName, limit);
+  }
+
 }

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -185,6 +185,8 @@ WLSDO-0028=The Monitoring Exporter port ''{0}'' specified by ''spec.monitoringEx
 WLSDO-0029=Invalid value ''{0}'' for the liveness probe success threshold under ''{1}''. The liveness probe successThreshold value must be 1.
 WLSDO-0030=The container name ''{0}'' specified under ''{1}'' is reserved for use by the operator.
 WLSDO-0031=Container port name ''{2}'' for domain with domainUID ''{0}'' and container name ''{1}'' exceeds maximum allowed length ''{3}''.
+WLSDO-0032=Network channel name ''{2}'' for domain with domainUID ''{0}'' and server with \
+  name ''{1}'' exceeds maximum allowed length ''{3}''. Please specify a shorter channel name.
 
 oneEnvVar=variable
 multipleEnvVars=variables

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -184,6 +184,7 @@ WLSDO-0027=The Monitoring Exporter port ''{0}'' specified by ''spec.monitoringEx
 WLSDO-0028=The Monitoring Exporter port ''{0}'' specified by ''spec.monitoringExporter.port'' conflicts with Cluster ''{1}'' dynamic server template port ''{2}''
 WLSDO-0029=Invalid value ''{0}'' for the liveness probe success threshold under ''{1}''. The liveness probe successThreshold value must be 1.
 WLSDO-0030=The container name ''{0}'' specified under ''{1}'' is reserved for use by the operator.
+WLSDO-0031=Container port name ''{2}'' for domain with domainUID ''{0}'' and container name ''{1}'' exceeds maximum allowed length ''{3}''.
 
 oneEnvVar=variable
 multipleEnvVars=variables

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -201,6 +201,8 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   private static final int READ_AND_EXECUTE_MODE = 0555;
   private static final String TEST_PRODUCT_VERSION = "unit-test";
   private static final String NOOP_EXPORTER_CONFIG = "queries:\n";
+  public static final String LONG_CHANNEL_NAME = "Very_Long_Channel_Name";
+  public static final String TRUNCATED_PORT_NAME_PREFIX = "very-long-ch";
 
   final TerminalStep terminalStep = new TerminalStep();
   private final Domain domain = createDomain();
@@ -376,6 +378,49 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
             hasEntry("prometheus.io/port", "7001"),
             hasEntry("prometheus.io/path", "/wls-exporter/metrics"),
             hasEntry("prometheus.io/scrape", "true")));
+  }
+
+  @Test
+  void whenPodCreatedWithAdminNapNameExceedingMaxPortNameLength_podContainerCreatedWithTruncatedPortName() {
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME, "admin", 8001, 8001));
+    assertThat(
+            getContainerPorts(),
+            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01")));
+  }
+
+  private List<V1ContainerPort> getContainerPorts() {
+    return getCreatedPod().getSpec().getContainers().stream()
+            .filter(c -> c.getName().equals(WLS_CONTAINER_NAME)).findFirst().map(c -> c.getPorts()).orElse(null);
+  }
+
+  private V1ContainerPort createContainerPort(String portName) {
+    return new V1ContainerPort().name(portName).containerPort(8001).protocol("TCP");
+  }
+
+  @Test
+  void whenPodCreatedWithMultipleNapsWithNamesExceedingMaxPortNameLength_podContainerCreatedWithTruncatedPortNames() {
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME + "1", "admin", 8001, 8001));
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME + "11", "admin", 8001, 8001));
+    assertThat(
+            getContainerPorts(),
+            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01")));
+
+    assertThat(
+            getContainerPorts(),
+            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-02")));
+  }
+
+  @Test
+  void whenPodCreatedWithMultipleNapsSomeWithNamesExceedingMaxPortNameLength_podContainerCreatedWithMixedPortNames() {
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME, "admin", 8001, 8001));
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint("My_Channel_Name", "admin", 8001, 8001));
+    assertThat(
+            getContainerPorts(),
+            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01")));
+
+    assertThat(
+            getContainerPorts(),
+            hasItem(createContainerPort("my-channel-name")));
   }
 
   protected DomainConfigurator defineExporterConfiguration() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -161,6 +161,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -403,11 +404,8 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME + "11", "admin", 8001, 8001));
     assertThat(
             getContainerPorts(),
-            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01")));
-
-    assertThat(
-            getContainerPorts(),
-            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-02")));
+            hasItems(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01"),
+                     createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-02")));
   }
 
   @Test
@@ -416,11 +414,8 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint("My_Channel_Name", "admin", 8001, 8001));
     assertThat(
             getContainerPorts(),
-            hasItem(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01")));
-
-    assertThat(
-            getContainerPorts(),
-            hasItem(createContainerPort("my-channel-name")));
+            hasItems(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01"),
+                     createContainerPort("my-channel-name")));
   }
 
   protected DomainConfigurator defineExporterConfiguration() {


### PR DESCRIPTION
- Validate the container port name lengths for containers provided by the customers. 
- Truncate the automatically generated port names (based on NAP names) for WebLogic Server containers.
- Added unit tests for the customer-provided container port validation and truncation of generated port names for WLS containers.
- External Jenkins test run is in progress at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/6511/