### PR TITLE
Remove extra permissions for server.pid file created by the operator to avoid umask warning.

### DIFF
--- a/operator/src/main/resources/scripts/tailLog.sh
+++ b/operator/src/main/resources/scripts/tailLog.sh
@@ -10,6 +10,7 @@
 #
 
 echo $$ > $2
+chmod g-wx,o-rwx $2
 
 while true ; do
   if [ -f $1 ]; then


### PR DESCRIPTION
Fix for the security warning issue reported by Pani when `logHome` is disabled.