### PR TITLE
Fix NPE in WlsClusterConfig when max dynamic cluster size is 0

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import oracle.kubernetes.utils.OperatorUtils;
@@ -226,9 +227,8 @@ public class WlsClusterConfig {
   public synchronized List<WlsServerConfig> getServerConfigs() {
     int dcsize = dynamicServersConfig == null ? 0 : dynamicServersConfig.getDynamicClusterSize();
     List<WlsServerConfig> result = new ArrayList<>(dcsize + servers.size());
-    if (dynamicServersConfig != null) {
-      result.addAll(dynamicServersConfig.getServerConfigs());
-    }
+    Optional.ofNullable(dynamicServersConfig).map(WlsDynamicServersConfig::getServerConfigs)
+        .ifPresent(dynamicServers -> dynamicServers.forEach(item -> result.add(item)));
     result.addAll(servers);
     result.sort(Comparator.comparing((WlsServerConfig sc) -> OperatorUtils.getSortingString(sc.getName())));
     return result;

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfigTest.java
@@ -196,6 +196,14 @@ class WlsClusterConfigTest {
   }
 
   @Test
+  void verifyGetServerConfigsReturnEmptyServerListForDynamicServersWithClusterSizeOf0() {
+    WlsClusterConfig wlsClusterConfig =
+        new WlsClusterConfig("cluster1", createDynamicServersConfig(0, 0, 0, "ms-", "cluster1"));
+
+    assertTrue(wlsClusterConfig.getServerConfigs().isEmpty());
+  }
+
+  @Test
   void verifyGetServerConfigsReturnListOfAllServerConfigsWithDynamicServers() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(3, 5, 1, "ms-", "cluster1"));


### PR DESCRIPTION
Fixes an NullPointerException in WlsClusterConfig.getServerConfigs() that prevents server pods from starting up, when max dynamic cluster size of a cluster in the domain is configured with a value of 0.

Jenkins (in progress): https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/6523/

Example <cluster> configuration in config.xml that causes the NPE:

```
  <cluster>
    <name>DockerCluster</name>
    <cluster-messaging-mode>unicast</cluster-messaging-mode>
    <dynamic-servers>
      <name>DockerCluster</name>
      <server-template>DockerCluster-template</server-template>
      <maximum-dynamic-server-count>0</maximum-dynamic-server-count>
      <calculated-listen-ports>false</calculated-listen-ports>
      <server-name-prefix>managed-server</server-name-prefix>
      <max-dynamic-cluster-size>0</max-dynamic-cluster-size>
    </dynamic-servers>
  </cluster>
```
NPE in operator log:
```
java.lang.NullPointerException: Cannot invoke \"java.util.Collection.toArray()\" because \"c\" is null
  at java.base/java.util.ArrayList.addAll(ArrayList.java:670)
  at oracle.kubernetes.operator.wlsconfig.WlsClusterConfig.getServerConfigs(WlsClusterConfig.java:230)
  at oracle.kubernetes.weblogic.domain.model.Domain$Validator.lambda$verifyGeneratedResourceNames$3(Domain.java:891)
  at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
  at oracle.kubernetes.weblogic.domain.model.Domain$Validator.verifyGeneratedResourceNames(Domain.java:889)
  at oracle.kubernetes.weblogic.domain.model.Domain$Validator.getAfterIntrospectValidationFailures(Domain.java:1199)
  at oracle.kubernetes.weblogic.domain.model.Domain.getAfterIntrospectValidationFailures(Domain.java:808)
```

