### PR TITLE
Document WIT change regarding Security validation

### DIFF
--- a/documentation/staging/content/faq/security-validation.md
+++ b/documentation/staging/content/faq/security-validation.md
@@ -22,7 +22,19 @@ Warnings may be at the level of the JDK, or that SSL is not enabled. Some warnin
 
 - For Model in Image, supply model files with the recommended changes in its image's `modelHome` directory or use [runtime updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}).
 
+
+> Msg ID: 090985
+>
+> Description: Production Mode is enabled but the the file or directory /u01/oracle/user_projects/domains/domain/bin/setDomainEnv.sh is insecure since its permission is not a minimum of umask 027.
+>
+> SOLUTION: Change the file or directory permission to at most allow only write by owner, read by group.
+>
+> Description:  The file or directory SerializedSystemIni.dat is insecure since its permission is not a minimum of umask 027.
+>
+> SOLUTION: Change the file or directory permission to at most allow only write by owner, read by group.
+
+When the [WebLogic Image Tool](https://oracle.github.io/weblogic-image-tool/) (WIT) creates a [Domain Home in Image](https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/choosing-a-model/), you can specify the `--target OpenShift` option so that when WIT creates the domain, it sets the correct permissions in the domain home. When no `--target` option is specified, then the domain home directory has a umask of 027.
+
 {{% notice note %}}
 For information about handling file permission warnings on the OpenShift Kubernetes Platform, see the [OpenShift chapter]({{<relref "/security/openshift.md">}}) in the Security section.
 {{% /notice %}}
-

--- a/documentation/staging/content/security/openshift.md
+++ b/documentation/staging/content/security/openshift.md
@@ -113,9 +113,12 @@ For additional information about OpenShift requirements and the operator,
 see [OpenShift]({{<relref  "/userguide/platforms/environments#openshift">}}).
 {{% /notice %}}
 
-#### Using a dedicated namespace
+#### Use a dedicated namespace
 
 When the user that installs an individual instance of the operator does not have the required privileges to create resources at the Kubernetes cluster level, a dedicated namespace can be used for the operator instance and all the WebLogic domains that it manages. For more details about the `dedicated` setting, please refer to [Operator Helm configuration values]({{< relref "/userguide/managing-operators/using-helm#operator-helm-configuration-values" >}}).
 
 #### Set the Helm chart property `kubernetesPlatorm` to `OpenShift`
 Beginning with operator version 3.3.2, set the operator `kubernetesPlatform` Helm chart property to `OpenShift`. This property accommodates OpenShift security requirements. For more information, see [Operator Helm configuration values]({{<relref "/userguide/managing-operators/using-helm#operator-helm-configuration-values">}}).
+
+#### With WIT, set the `target` parameter to `OpenShift`
+When using the [WebLogic Image Tool](https://oracle.github.io/weblogic-image-tool/) (WIT), `create`, `rebase`, or `update` command, to create a [Domain in Image](https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/choosing-a-model/) domain home, you can specify the `--target` parameter for the target Kubernetes environment. Its value can be either `Default` or `OpenShift`. The `OpenShift` option changes the domain directory files such that the group permissions for those files will be the same as the user permissions (group writable, in most cases). If you do not supply the OS group and user setting with `--chown`, then the `Default` setting for this option is changed from `oracle:oracle` to `oracle:root` to be in line with the expectations of an OpenShift environment.


### PR DESCRIPTION
As per OWLS-92546: WKO- Document WIT change regarding Security validation in WLS complains when the domain filesystem does not have umask 027