### PR TITLE
fix secret validation messages

### DIFF
--- a/kubernetes/samples/scripts/common/validate.sh
+++ b/kubernetes/samples/scripts/common/validate.sh
@@ -339,13 +339,13 @@ function validateDomainSecret {
   # Verify the secret contains a username
   SECRET=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}' | tr -d '"' | grep username: | wc | awk ' { print $1; }'`
   if [ "${SECRET}" != "1" ]; then
-    validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does contain a username"
+    validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does not contain a username"
   fi
 
   # Verify the secret contains a password
   SECRET=`kubectl get secret ${weblogicCredentialsSecretName} -n ${namespace} -o jsonpath='{.data}' | tr -d '"'| grep password: | wc | awk ' { print $1; }'`
   if [ "${SECRET}" != "1" ]; then
-    validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does contain a password"
+    validationError "The domain secret ${weblogicCredentialsSecretName} in namespace ${namespace} does not contain a password"
   fi
   failIfValidationErrors
 }


### PR DESCRIPTION
Signed-off-by: Rishi Agarwal <rishi.agarwal@oracle.com>

fix secret validation messages. the messages were giving the wrong info to the consumers while validating the presence of username and password. 