### PR TITLE
larger logo

### DIFF
--- a/documentation/staging/themes/hugo-theme-learn/layouts/partials/logo.html
+++ b/documentation/staging/themes/hugo-theme-learn/layouts/partials/logo.html
@@ -1,4 +1,4 @@
 <a id="logo" href="{{ .Site.BaseURL }}">
-  <img src="{{ .Site.BaseURL }}/images/logo.png" height="60"><br/>
+  <img src="{{ .Site.BaseURL }}/images/logo.png" height="90"><br/>
   WebLogic Kubernetes Operator
 </a>


### PR DESCRIPTION
Increased the height attribute of the image tag to 90. Same as WKT UI (larger than Remote Console).