### PR TITLE
Rename the env varaiable  SKIP_BASIC_IMAGE_BUILD to SKIP_BUILD_IMAGES_IF_EXISTS to skip local domain image build

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -221,7 +221,7 @@ public interface TestConstants {
 
   // Skip the mii/wdt basic image build locally if needed
   public static final String MII_BASIC_IMAGE_TAG =
-      SKIP_BUILD_IMAGES_IF_EXISTS.contains("true") ? "local" : getDateAndTimeStamp();
+      Boolean.valueOf(SKIP_BUILD_IMAGES_IF_EXISTS) ? "local" : getDateAndTimeStamp();
   public static final String MII_BASIC_IMAGE_DOMAINTYPE = "mii";
   public static final String MII_BASIC_APP_NAME = "sample-app";
   public static final String MII_BASIC_APP_DEPLOYMENT_NAME = "myear";
@@ -240,7 +240,7 @@ public interface TestConstants {
   public static final String WDT_BASIC_IMAGE_NAME = DOMAIN_IMAGES_REPO + "wdt-basic-image";
   // Skip the mii/wdt basic image build locally if needed
   public static final String WDT_BASIC_IMAGE_TAG = 
-      SKIP_BUILD_IMAGES_IF_EXISTS.contains("true") ? "local" : getDateAndTimeStamp();
+      Boolean.valueOf(SKIP_BUILD_IMAGES_IF_EXISTS) ? "local" : getDateAndTimeStamp();
   public static final String WDT_BASIC_IMAGE_DOMAINHOME = "/u01/oracle/user_projects/domains/domain1";
   public static final String WDT_IMAGE_DOMAINHOME_BASE_DIR = "/u01/oracle/user_projects/domains";
   public static final String WDT_BASIC_IMAGE_DOMAINTYPE = "wdt";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -56,7 +56,6 @@ import static oracle.weblogic.kubernetes.TestConstants.OCR_USERNAME;
 import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.REPO_DUMMY_VALUE;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
-import static oracle.weblogic.kubernetes.TestConstants.SKIP_BUILD_IMAGES_IF_EXISTS;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_IMAGE_DOMAINHOME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_IMAGE_DOMAINTYPE;
@@ -189,81 +188,48 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
           }
         }
 
-        if (SKIP_BUILD_IMAGES_IF_EXISTS.equals("false")) {
-          // build MII basic image
-          miiBasicImage = MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;
+        miiBasicImage = MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;
+        wdtBasicImage = WDT_BASIC_IMAGE_NAME + ":" + WDT_BASIC_IMAGE_TAG;
+
+        // build MII basic image if does not exits
+        logger.info("Build/Check mii-basic image with tag {0}", MII_BASIC_IMAGE_TAG);
+        if (! dockerImageExists(MII_BASIC_IMAGE_NAME, MII_BASIC_IMAGE_TAG)) { 
+          logger.info("Building mii-basic image {0}", miiBasicImage);
           testUntil(
-              withVeryLongRetryPolicy,
-              createBasicImage(MII_BASIC_IMAGE_NAME, MII_BASIC_IMAGE_TAG, MII_BASIC_WDT_MODEL_FILE,
-                null, MII_BASIC_APP_NAME, MII_BASIC_IMAGE_DOMAINTYPE),
-              logger,
-              "createBasicImage to be successful");
-
-          // build WDT basic domain in image
-          wdtBasicImage = WDT_BASIC_IMAGE_NAME + ":" + WDT_BASIC_IMAGE_TAG;
-          testUntil(
-              withVeryLongRetryPolicy,
-              createBasicImage(WDT_BASIC_IMAGE_NAME, WDT_BASIC_IMAGE_TAG, WDT_BASIC_MODEL_FILE,
-                WDT_BASIC_MODEL_PROPERTIES_FILE, WDT_BASIC_APP_NAME, WDT_BASIC_IMAGE_DOMAINTYPE),
-              logger,
-              "createBasicImage to be successful");
-
-          /* Check image exists using docker images | grep image tag.
-           * Tag name is unique as it contains date and timestamp.
-           * This is a workaround for the issue on Jenkins machine
-           * as docker images imagename:imagetag is not working and
-           * the test fails even though the image exists.
-           */
-          assertTrue(doesImageExist(MII_BASIC_IMAGE_TAG),
-              String.format("Image %s doesn't exist", miiBasicImage));
-
-          assertTrue(doesImageExist(WDT_BASIC_IMAGE_TAG),
-              String.format("Image %s doesn't exist", wdtBasicImage));
-        }
-
-        if (SKIP_BUILD_IMAGES_IF_EXISTS.equals("true")) {
-          miiBasicImage = MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG;
-          logger.info("Build/Check mii-basic image with tag {0}", MII_BASIC_IMAGE_TAG);
-          // build MII basic image if does not exits
-          if (! dockerImageExists(MII_BASIC_IMAGE_NAME, MII_BASIC_IMAGE_TAG)) { 
-            logger.info("Building mii-basic image {0}", miiBasicImage);
-            testUntil(
                 withVeryLongRetryPolicy,
                 createBasicImage(MII_BASIC_IMAGE_NAME, MII_BASIC_IMAGE_TAG, MII_BASIC_WDT_MODEL_FILE,
                 null, MII_BASIC_APP_NAME, MII_BASIC_IMAGE_DOMAINTYPE),
                 logger,
                 "createBasicImage to be successful");
-          } else {
-            logger.info("SKIP building mii-basic image {0}", miiBasicImage);
-          }
+        } else {
+          logger.info("!!!! domain image {0} exists !!!!", miiBasicImage);
+        }
 
-          wdtBasicImage = WDT_BASIC_IMAGE_NAME + ":" + WDT_BASIC_IMAGE_TAG;
-          logger.info("Build/Check wdt-basic image with tag {0}", WDT_BASIC_IMAGE_TAG);
-          // build WDT basic image if does not exits
-          if (! dockerImageExists(WDT_BASIC_IMAGE_NAME, WDT_BASIC_IMAGE_TAG)) {
-            logger.info("Building wdt-basic image {0}", wdtBasicImage);
-            testUntil(
+        logger.info("Build/Check wdt-basic image with tag {0}", WDT_BASIC_IMAGE_TAG);
+        // build WDT basic image if does not exits
+        if (! dockerImageExists(WDT_BASIC_IMAGE_NAME, WDT_BASIC_IMAGE_TAG)) {
+          logger.info("Building wdt-basic image {0}", wdtBasicImage);
+          testUntil(
                 withVeryLongRetryPolicy,
                 createBasicImage(WDT_BASIC_IMAGE_NAME, WDT_BASIC_IMAGE_TAG, WDT_BASIC_MODEL_FILE,
                 WDT_BASIC_MODEL_PROPERTIES_FILE, WDT_BASIC_APP_NAME, WDT_BASIC_IMAGE_DOMAINTYPE),
                 logger,
                 "createBasicImage to be successful");
-          } else {
-            logger.info("SKIP building wdt-basic image {0}", miiBasicImage);
-          }
+        } else {
+          logger.info("!!!! domain image {0} exists !!!!", wdtBasicImage);
+        }
 
-          /* Check image exists using docker images | grep image tag.
-           * Tag name is unique as it contains date and timestamp.
-           * This is a workaround for the issue on Jenkins machine
-           * as docker images imagename:imagetag is not working and
-           * the test fails even though the image exists.
-           */
-          assertTrue(doesImageExist(MII_BASIC_IMAGE_TAG),
+        /* Check image exists using docker images | grep image tag.
+         * Tag name is unique as it contains date and timestamp.
+         * This is a workaround for the issue on Jenkins machine
+         * as docker images imagename:imagetag is not working and
+         * the test fails even though the image exists.
+         */
+        assertTrue(doesImageExist(MII_BASIC_IMAGE_TAG),
               String.format("Image %s doesn't exist", miiBasicImage));
 
-          assertTrue(doesImageExist(WDT_BASIC_IMAGE_TAG),
+        assertTrue(doesImageExist(WDT_BASIC_IMAGE_TAG),
               String.format("Image %s doesn't exist", wdtBasicImage));
-        }
 
         if (!OCIR_USERNAME.equals(REPO_DUMMY_VALUE)) {
           logger.info("docker login");

--- a/kubernetes/samples/charts/util/setupLoadBalancer.sh
+++ b/kubernetes/samples/charts/util/setupLoadBalancer.sh
@@ -281,6 +281,7 @@ function createNginx() {
   if [ "$(helm list --namespace ${ns} | grep $chart |  wc -l)" = 0 ]; then
     purgeDefaultResources || true
     helm install $chart ingress-nginx/ingress-nginx \
+         --set "controller.admissionWebhooks.enabled=false" \
          --namespace ${ns} --version ${release}
     if [ $? != 0 ]; then
      printError "Helm istallation of the Nginx ingress controller failed."


### PR DESCRIPTION
In a repeated local run,  we need not re-build the basic mii/wdt domain image repeatedly, if the content of the domain image is not modified e.g.  you are only modifying the logic of the test or some utility class. 

The existing env variable SKIP_BASIC_IMAGE_BUILD does not work, as it create the domain image with timestamp. So even if the SKIP_BASIC_IMAGE_BUILD  is set to true, the infra build the domain images as it does not find a (local) domain image with latest timestamp.

Now using the new SKIP_BUILD_IMAGES_IF_EXISTS, the infra will create the basic mii/wdt domain image with tag "local" instead of timestamp e.g. mii-basic-image:local  and wdt-basic-image:local  
So it will skip the domain image build if you re-run the test locally. 

The default value for this variable is false 

This variable is applicable to local run only.  Note if the basic domain image content is being modified on the re-run, remove  the images mii-basic-image:local  and wdt-basic-image:local   before running the tests

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/6967/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/69788