### PR TITLE
Modify the DomainProcessingAborted event test to use DOMAIN_HOME instead of credentials

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -80,6 +80,7 @@ import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_CREATED;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_DELETED;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_PROCESSING_ABORTED;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_PROCESSING_FAILED;
+import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_PROCESSING_RETRYING;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_ROLL_COMPLETED;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_ROLL_STARTING;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_VALIDATION_ERROR;
@@ -291,13 +292,13 @@ class ItKubernetesEvents {
   }
 
   /**
-   * Test the following domain events are logged when domain resource goes through various life cycle stages.
-   * Patch the domain resource to remove the webLogicCredentialsSecret and verify DomainChanged is
-   * logged when operator processes the domain resource changes.
-   * Verifies DomainProcessingRetrying is logged when operator retries the failed domain resource
-   * changes since webLogicCredentialsSecret is still missing.
+   * Test the following domain events are logged when domain resource goes through introspector failure.
+   * Patch the domain resource to shutdown servers.
+   * Patch the domain resource to point to a bad DOMAIN_HOME and update serverStartPolicy to IF_NEEDED.
+   * Verifies DomainProcessingFailed event is logged.
    * Verifies DomainProcessingAborted is logged when operator exceeds the maximum retries and gives
    * up processing the domain resource.
+   * Cleanup by patching the domain resource to a valid location and introspectVersion to bring up all servers again.
    */
   @Order(4)
   @Test
@@ -310,19 +311,23 @@ class ItKubernetesEvents {
 
     OffsetDateTime timestamp = now();
     try {
+      logger.info("Shutting down all servers in domain with serverStartPolicy : NEVER");
       patchStr = "[{\"op\": \"replace\", \"path\": \"/spec/serverStartPolicy\", \"value\": \"NEVER\"}]";
       patch = new V1Patch(patchStr);
       assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
           "patchDomainCustomResource failed");
 
+      logger.info("Checking if the admin server {0} is shutdown in namespace {1}",
+          adminServerPodName, domainNamespace1);
       checkPodDoesNotExist(adminServerPodName, domainUid, domainNamespace1);
+
       for (int i = 1; i <= replicaCount; i++) {
-        logger.info("Checking managed server service/pod {0} is created in namespace {1}",
+        logger.info("Checking if the managed server {0} is shutdown in namespace {1}",
             managedServerPodNamePrefix + i, domainNamespace1);
         checkPodDoesNotExist(managedServerPodNamePrefix + i, domainUid, domainNamespace1);
       }
 
-      logger.info("Replace the domainHome to a invalid value to verify the following events"
+      logger.info("Replace the domainHome to a nonexisting location to verify the following events"
           + " DomainChanged, DomainProcessingRetrying and DomainProcessingAborted are logged");
       patchStr = "[{\"op\": \"replace\", "
           + "\"path\": \"/spec/domainHome\", \"value\": \"" + originalDomainHome + "bad\"},"
@@ -335,17 +340,12 @@ class ItKubernetesEvents {
 
       logger.info("verify domain changed event is logged");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_CHANGED, "Normal", timestamp);
-
-      // logger.info("verify domain processing retrying event");
-      // checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_RETRYING, "Normal", timestamp);
+      logger.info("verify domain processing retrying event");
+      checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_RETRYING, "Normal", timestamp);
       logger.info("verify domain processing aborted event");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_ABORTED, "Warning", timestamp);
     } finally {
-      try {
-        Thread.sleep(1000 * 60 * 60);
-      } catch (Exception e) {
-        ;
-      }
+      logger.info("Restoring the domain with valid location and bringing up all servers");
       timestamp = now();
       String introspectVersion = assertDoesNotThrow(() -> getNextIntrospectVersion(domainUid, domainNamespace1));
       // add back the original domain home
@@ -361,7 +361,7 @@ class ItKubernetesEvents {
 
       logger.info("verify domain changed event is logged");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_CHANGED, "Normal", timestamp);
-      // verify the admin server service created
+      logger.info("verifying the admin server is created and started");
       checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace1);
 
       // verify managed server services created

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
@@ -407,6 +407,7 @@ public class K8sEvents {
   public static final String DOMAIN_CHANGED = "DomainChanged";
   public static final String DOMAIN_COMPLETED = "DomainCompleted";
   public static final String DOMAIN_PROCESSING_FAILED = "DomainProcessingFailed";
+  public static final String DOMAIN_PROCESSING_RETRYING = "DomainProcessingRetrying";
   public static final String DOMAIN_PROCESSING_ABORTED = "DomainProcessingAborted";
   public static final String DOMAIN_ROLL_STARTING = "DomainRollStarting";
   public static final String DOMAIN_ROLL_COMPLETED = "DomainRollCompleted";


### PR DESCRIPTION
The existing test deletes the weblogic credentials to simulate the  DomainProcessingAborted due to a NPE thrown by the operator while trying to retrieve the credentials. Since the NPE is fixed we have to change the test to use some other means to simulate introspector failure and cause DomainProcessingAborted event.

This approach uses the following steps to verify the DomainProcessingAborted event.

  * Test the following domain events are logged when domain resource goes through introspector failure.
   * Patch the domain resource to shutdown servers.
   * Patch the domain resource to point to a bad DOMAIN_HOME and update serverStartPolicy to IF_NEEDED.
   * Verifies DomainProcessingFailed event is logged.
   * Verifies DomainProcessingAborted is logged when operator exceeds the maximum retries and gives
   * up processing the domain resource.
   * Cleanup by patching the domain resource to a valid location and introspectVersion to bring up all servers again.