### PR TITLE
Intermittent Integration test failure  with image tool/application build in parallel run

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
@@ -233,10 +233,9 @@ class ItCrossDomainTransaction {
   private static void buildApplicationsAndDomains() {
 
     //build application archive
-    // Path targetDir = Paths.get(WORK_DIR, this.getClass().getSimpleName());
-    // non-static variable this cannot be referenced from a static context
 
-    Path targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/txforward");
+    Path targetDir = Paths.get(WORK_DIR, 
+         ItCrossDomainTransaction.class.getName() + "/txforward");
     Path distDir = buildApplication(Paths.get(APP_DIR, "txforward"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
@@ -247,7 +246,8 @@ class ItCrossDomainTransaction {
     logger.info("Application is in {0}", appSource);
 
     //build application archive
-    targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/cdtservlet");
+    targetDir = Paths.get(WORK_DIR, 
+        ItCrossDomainTransaction.class.getName() + "/cdtservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "cdtservlet"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
@@ -258,7 +258,8 @@ class ItCrossDomainTransaction {
     logger.info("Application is in {0}", appSource1);
 
     //build application archive for JMS Send/Receive
-    targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/jmsservlet");
+    targetDir = Paths.get(WORK_DIR, 
+        ItCrossDomainTransaction.class.getName() + "/jmsservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "jmsservlet"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
@@ -285,7 +286,8 @@ class ItCrossDomainTransaction {
         "Could not modify the domain2Namespace in MDB Template file");
 
     //build application archive for MDB
-    targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/mdbtopic");
+    targetDir = Paths.get(WORK_DIR, 
+         ItCrossDomainTransaction.class.getName() + "/mdbtopic");
     distDir = buildApplication(Paths.get(PROPS_TEMP_DIR, "mdbtopic"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItCrossDomainTransaction.java
@@ -49,6 +49,7 @@ import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
@@ -217,8 +218,12 @@ class ItCrossDomainTransaction {
   private static void buildApplicationsAndDomains() {
 
     //build application archive
+    // Path targetDir = Paths.get(WORK_DIR, this.getClass().getSimpleName());
+    // non-static variable this cannot be referenced from a static context
+
+    Path targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/txforward");
     Path distDir = buildApplication(Paths.get(APP_DIR, "txforward"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "txforward.ear").toFile().exists(),
@@ -227,8 +232,9 @@ class ItCrossDomainTransaction {
     logger.info("Application is in {0}", appSource);
 
     //build application archive
+    targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/cdtservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "cdtservlet"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "cdttxservlet.war").toFile().exists(),
@@ -237,8 +243,9 @@ class ItCrossDomainTransaction {
     logger.info("Application is in {0}", appSource1);
 
     //build application archive for JMS Send/Receive
+    targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/jmsservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "jmsservlet"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "jmsservlet.war").toFile().exists(),
@@ -263,8 +270,9 @@ class ItCrossDomainTransaction {
         "Could not modify the domain2Namespace in MDB Template file");
 
     //build application archive for MDB
+    targetDir = Paths.get(WORK_DIR, "ItCrossDomainTransaction/mdbtopic");
     distDir = buildApplication(Paths.get(PROPS_TEMP_DIR, "mdbtopic"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "mdbtopic.jar").toFile().exists(),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
@@ -50,6 +50,7 @@ import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.APP_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.addLabelsToNamespace;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
@@ -229,8 +230,11 @@ class ItIstioCrossDomainTransaction {
   private static void buildApplicationsAndDomains() {
 
     //build application archive
+    // Path targetDir = Paths.get(WORK_DIR, this.getClass().getSimpleName());
+    // non-static variable this cannot be referenced from a static context
+    Path targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/txforward");
     Path distDir = buildApplication(Paths.get(APP_DIR, "txforward"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "txforward.ear").toFile().exists(),
@@ -239,8 +243,9 @@ class ItIstioCrossDomainTransaction {
     logger.info("Application is in {0}", appSource);
 
     //build application archive
+    targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/cdtservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "cdtservlet"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "cdttxservlet.war").toFile().exists(),
@@ -249,8 +254,9 @@ class ItIstioCrossDomainTransaction {
     logger.info("Application is in {0}", appSource1);
 
     //build application archive for JMS Send/Receive
+    targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/jmsservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "jmsservlet"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "jmsservlet.war").toFile().exists(),
@@ -275,8 +281,9 @@ class ItIstioCrossDomainTransaction {
         "Could not modify the domain2Namespace in MDB Template file");
 
     //build application archive for MDB
+    targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/mdbtopic");
     distDir = buildApplication(Paths.get(PROPS_TEMP_DIR, "mdbtopic"), null, null,
-        "build", domain1Namespace);
+        "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
     assertTrue(Paths.get(distDir.toString(),
         "mdbtopic.jar").toFile().exists(),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioCrossDomainTransaction.java
@@ -230,9 +230,8 @@ class ItIstioCrossDomainTransaction {
   private static void buildApplicationsAndDomains() {
 
     //build application archive
-    // Path targetDir = Paths.get(WORK_DIR, this.getClass().getSimpleName());
-    // non-static variable this cannot be referenced from a static context
-    Path targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/txforward");
+    Path targetDir = Paths.get(WORK_DIR, 
+        ItIstioCrossDomainTransaction.class.getName() + "/txforward");
     Path distDir = buildApplication(Paths.get(APP_DIR, "txforward"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
@@ -243,7 +242,8 @@ class ItIstioCrossDomainTransaction {
     logger.info("Application is in {0}", appSource);
 
     //build application archive
-    targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/cdtservlet");
+    targetDir = Paths.get(WORK_DIR, 
+        ItIstioCrossDomainTransaction.class.getName() + "/cdtservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "cdtservlet"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
@@ -254,7 +254,8 @@ class ItIstioCrossDomainTransaction {
     logger.info("Application is in {0}", appSource1);
 
     //build application archive for JMS Send/Receive
-    targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/jmsservlet");
+    targetDir = Paths.get(WORK_DIR, 
+        ItIstioCrossDomainTransaction.class.getName() + "/jmsservlet");
     distDir = buildApplication(Paths.get(APP_DIR, "jmsservlet"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());
@@ -281,7 +282,8 @@ class ItIstioCrossDomainTransaction {
         "Could not modify the domain2Namespace in MDB Template file");
 
     //build application archive for MDB
-    targetDir = Paths.get(WORK_DIR, "ItIstioCrossDomainTransaction/mdbtopic");
+    targetDir = Paths.get(WORK_DIR, 
+         ItIstioCrossDomainTransaction.class.getName()  + "/mdbtopic");
     distDir = buildApplication(Paths.get(PROPS_TEMP_DIR, "mdbtopic"), null, null,
         "build", domain1Namespace, targetDir);
     logger.info("distDir is {0}", distDir.toString());

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/BuildApplication.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/BuildApplication.java
@@ -61,7 +61,7 @@ public class BuildApplication {
    *     antParams.put("key","value");
    *
    *     Path archivesDir = BuildApplication.buildApplication(
-   *         "/scratch/speriyat/weblogic-kubernetes-operator/new-integration-tests/src/test/resources/apps/clusterview",
+   *         "/scratch/uid/weblogic-kubernetes-operator/integration-tests/src/test/resources/apps/clusterview",
    *         antParams,
    *         "clean build all" // these targets must be supported by your build file
    *         "build" // the directory your build system creates
@@ -82,8 +82,28 @@ public class BuildApplication {
    * @param namespace name of the namespace to create the pod in
    * @return Path path of the archive built
    */
-  public static Path buildApplication(Path appSrcPath, Map<String, String> antParams,
-                                      String antTargets, String archiveDistDir, String namespace) {
+  public static Path buildApplication(
+          Path appSrcPath, 
+          Map<String, String> antParams,
+          String antTargets, String archiveDistDir, String namespace) {
+    return buildApplication(appSrcPath, antParams, antTargets, archiveDistDir, namespace, null);
+  }
+
+  /**
+   * Build application.
+   * @param appSrcPath path of the application source folder
+   * @param antParams ant parameters
+   * @param antTargets ant targets to call
+   * @param archiveDistDir location of the archive built inside source directory
+   * @param namespace name of the namespace to create the pod in
+   * @param targetPath name of the namespace to create the pod in
+   * @return Path path of the archive built
+   */
+  public static Path buildApplication(
+        Path appSrcPath, Map<String, String> antParams,
+        String antTargets, String archiveDistDir, 
+        String namespace, Path targetPath) {
+
     final LoggingFacade logger = getLogger();
 
     // this secret is used only for non-kind cluster
@@ -92,7 +112,9 @@ public class BuildApplication {
     // Path of temp location for application source directory
     Path tempAppPath = Paths.get(WORK_DIR, "j2eeapplications", appSrcPath.getFileName().toString());
     // directory to copy archives built
-    Path destArchiveBaseDir = Paths.get(WORK_DIR, appSrcPath.getFileName().toString());
+    Path destArchiveBaseDir = 
+         targetPath == null  ? Paths.get(WORK_DIR, appSrcPath.getFileName().toString()) : targetPath;
+    logger.info("DestArchiveBaseDir set to {0}", destArchiveBaseDir.toString());
     Path destDir = null;
 
     assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/BuildApplication.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/BuildApplication.java
@@ -96,7 +96,7 @@ public class BuildApplication {
    * @param antTargets ant targets to call
    * @param archiveDistDir location of the archive built inside source directory
    * @param namespace name of the namespace to create the pod in
-   * @param targetPath name of the namespace to create the pod in
+   * @param targetPath the target path where the application will be archived
    * @return Path path of the archive built
    */
   public static Path buildApplication(

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ImageUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ImageUtils.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import com.google.gson.JsonObject;
 import io.kubernetes.client.openapi.ApiException;
@@ -350,9 +351,23 @@ public class ImageUtils {
     }
 
     // Set additional environment variables for WIT
+
+    // Generates a "unique" name by choosing a random name from
+    // 26^4 possible combinations.
+    Random random = new Random(System.currentTimeMillis());
+    char[] cacheSfx = new char[4];
+    for (int i = 0; i < cacheSfx.length; i++) {
+      cacheSfx[i] = (char) (random.nextInt(25) + (int) 'a');
+    }
+    String cacheDir = WIT_BUILD_DIR + "/cache-" + new String(cacheSfx);
+    logger.info("WLSIMG_CACHEDIR is set to {0}", cacheDir);
+    logger.info("WLSIMG_BLDDIR is set to {0}", WIT_BUILD_DIR);
+
     checkDirectory(WIT_BUILD_DIR);
+    checkDirectory(cacheDir);
     Map<String, String> env = new HashMap<>();
     env.put("WLSIMG_BLDDIR", WIT_BUILD_DIR);
+    env.put("WLSIMG_CACHEDIR", cacheDir);
 
     // For k8s 1.16 support and as of May 6, 2020, we presently need a different JDK for these
     // tests and for image tool. This is expected to no longer be necessary once JDK 11.0.8 or


### PR DESCRIPTION
Recently we are having intermittent issues in ItCohereance/ItCrossDomain tests in parallel run.  Looks like when run in parallel, those step each other with common Image Cache and Target Application directory. 

We had two JIRA(s) to address the issues.

    (a) OWLS-93332  - Added a environment variable  WLSIMG_CACHEDIR  
    (b) OWLS-93590  - Introduced a custom target directory for application build.

External Jenkins runs (s)

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7034
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7035/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7037/
 