### PR TITLE
Resolution to Nightly Failure and  Upgrade Usecases 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/domain/AdminServer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/AdminServer.java
@@ -47,7 +47,7 @@ public class AdminServer {
           + " NetworkAccessPoint with a 'localhost' address for each existing admin\n"
           + " protocol capable port. This allows external Administration Console and WLST\n"
           + " 'T3' access when using the 'kubectl port-forward' pattern. Defaults to true.")
-  private boolean adminChannelPortForwardingEnabled;
+  private boolean adminChannelPortForwardingEnabled = true;
 
   public AdminServer adminService(AdminService adminService) {
     this.adminService = adminService;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorFmwUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorFmwUpgrade.java
@@ -229,12 +229,12 @@ class ItOperatorFmwUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.3.1 to latest with a FMW Domain.
+   * Operator upgrade from 3.3.3 to latest with a FMW Domain.
    */
   @Test
-  @DisplayName("Upgrade Operator from 3.3.1 to main")
-  void testOperatorFmwUpgradeFrom331ToMain() {
-    installAndUpgradeOperator("3.3.1", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+  @DisplayName("Upgrade Operator from 3.3.3 to main")
+  void testOperatorFmwUpgradeFrom333ToMain() {
+    installAndUpgradeOperator("3.3.3", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   private void installAndUpgradeOperator(String operatorVersion,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -166,14 +166,14 @@ class ItOperatorWlsUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.3.1 to latest.
+   * Operator upgrade from 3.3.3 to latest.
    */
   @ParameterizedTest
-  @DisplayName("Upgrade Operator from 3.3.1 to main")
+  @DisplayName("Upgrade Operator from 3.3.3 to main")
   @ValueSource(strings = { "domain-in-image", "model-in-image" })
-  void testOperatorWlsUpgradeFrom331ToMain(String domainType) {
+  void testOperatorWlsUpgradeFrom333ToMain(String domainType) {
     logger.info("Starting test testOperatorWlsUpgradeFrom331ToMain with domain type {0}", domainType);
-    upgradeOperator(domainType, "3.3.1", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
+    upgradeOperator(domainType, "3.3.3", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX, true);
   }
 
   /**


### PR DESCRIPTION

Ref: https://jira.oraclecorp.com/jira/browse/OWLS-93556
(wko-nightly: kubectl port-forward fails in SecureMode Domain)

Add WLS/FMW upgrade tests from release 3.3.3 to main 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7037/  (parallel) 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7088/  (sequential) 