### PR TITLE
Enhance fiber breadcrumbs

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -487,13 +487,18 @@ public class Kubernetes {
             null, // Timeout for the list/watch call.
             Boolean.FALSE // Watch for changes to the described resources.
         );
+    getLogger().info("REG-> found {0} pods in namespace {1}", v1PodList.getItems().size(), namespace);
     for (V1Pod item : v1PodList.getItems()) {
+      getLogger().info("REG-> comparing actual name {0} against specified pod name {1}",
+            item.getMetadata().getName(), podName);
       if (item.getMetadata().getName().contains(podName.trim())) {
         getLogger().info("Name: {0}, Namespace: {1}, Phase: {2}",
             item.getMetadata().getName(), namespace, item.getStatus().getPhase());
+        getLogger().info("REG-> found a match");
         return item;
       }
     }
+    getLogger().info("REG-> did not find a match");
     return null;
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -487,18 +487,13 @@ public class Kubernetes {
             null, // Timeout for the list/watch call.
             Boolean.FALSE // Watch for changes to the described resources.
         );
-    getLogger().info("REG-> found {0} pods in namespace {1}", v1PodList.getItems().size(), namespace);
     for (V1Pod item : v1PodList.getItems()) {
-      getLogger().info("REG-> comparing actual name {0} against specified pod name {1}",
-            item.getMetadata().getName(), podName);
       if (item.getMetadata().getName().contains(podName.trim())) {
         getLogger().info("Name: {0}, Namespace: {1}, Phase: {2}",
             item.getMetadata().getName(), namespace, item.getStatus().getPhase());
-        getLogger().info("REG-> found a match");
         return item;
       }
     }
-    getLogger().info("REG-> did not find a match");
     return null;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/Main.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Main.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.CoreV1EventList;
@@ -85,8 +84,7 @@ public class Main {
   private NamespaceWatcher namespaceWatcher;
   protected OperatorEventWatcher operatorNamespaceEventWatcher;
   private boolean warnedOfCrdAbsence;
-  private static NextStepFactory NEXT_STEP_FACTORY =
-          (next) -> createInitializeInternalIdentityStep(next);
+  private static final NextStepFactory NEXT_STEP_FACTORY = Main::createInitializeInternalIdentityStep;
 
   private static String getConfiguredServiceAccount() {
     return TuningParameters.getInstance().get("serviceaccount");
@@ -176,19 +174,18 @@ public class Main {
       return Optional.ofNullable(buildProps.getProperty(key)).orElse("unknown");
     }
 
-    private void logStartup(LoggingFacade loggingFacade) {
-      loggingFacade.info(MessageKeys.OPERATOR_STARTED, buildVersion, operatorImpl, operatorBuildTime);
+    private void logStartup() {
+      Main.LOGGER.info(MessageKeys.OPERATOR_STARTED, buildVersion, operatorImpl, operatorBuildTime);
       Optional.ofNullable(TuningParameters.getInstance().getFeatureGates().getEnabledFeatures())
-          .ifPresent(ef -> loggingFacade.info(MessageKeys.ENABLED_FEATURES, ef));
-      loggingFacade.info(MessageKeys.OP_CONFIG_NAMESPACE, getOperatorNamespace());
-      loggingFacade.info(MessageKeys.OP_CONFIG_SERVICE_ACCOUNT, serviceAccountName);
-      Optional.ofNullable(Namespaces.getConfiguredDomainNamespaces())
-            .ifPresent(strings -> logConfiguredNamespaces(loggingFacade, strings));
+          .ifPresent(ef -> Main.LOGGER.info(MessageKeys.ENABLED_FEATURES, ef));
+      Main.LOGGER.info(MessageKeys.OP_CONFIG_NAMESPACE, getOperatorNamespace());
+      Main.LOGGER.info(MessageKeys.OP_CONFIG_SERVICE_ACCOUNT, serviceAccountName);
+      Optional.ofNullable(Namespaces.getConfiguredDomainNamespaces()).ifPresent(this::logConfiguredNamespaces);
     }
 
-    private void logConfiguredNamespaces(LoggingFacade loggingFacade, Collection<String> configuredDomainNamespaces) {
-      loggingFacade.info(MessageKeys.OP_CONFIG_DOMAIN_NAMESPACES,
-          configuredDomainNamespaces.stream().collect(Collectors.joining(", ")));
+    private void logConfiguredNamespaces(Collection<String> configuredDomainNamespaces) {
+      Main.LOGGER.info(MessageKeys.OP_CONFIG_DOMAIN_NAMESPACES,
+            String.join(", ", configuredDomainNamespaces));
     }
 
     @Override
@@ -296,7 +293,7 @@ public class Main {
   static @Nonnull Main createMain(Properties buildProps) {
     final MainDelegateImpl delegate = new MainDelegateImpl(buildProps, wrappedExecutorService);
 
-    delegate.logStartup(LOGGER);
+    delegate.logStartup();
     return new Main(delegate);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -28,6 +28,8 @@ public interface MakeRightDomainOperation {
 
   MakeRightDomainOperation withEventData(EventItem eventItem, String message);
 
+  MakeRightDomainOperation withDeleting(boolean deleting);
+
   MakeRightDomainOperation interrupt();
 
   void execute();

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -574,11 +574,12 @@ public class DomainPresenceInfo implements PacketComponent {
     retryCount.set(0);
   }
 
-  public int incrementAndGetFailureCount() {
-    return retryCount.incrementAndGet();
+  public void indicateFailure() {
+    retryCount.incrementAndGet();
+    isPopulated.set(false);
   }
 
-  int getRetryCount() {
+  public int getRetryCount() {
     return retryCount.get();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -99,7 +99,7 @@ public class DomainValidationSteps {
     }
 
     static List<V1ConfigMap> getConfigMaps(Packet packet) {
-      return (List<V1ConfigMap>) Optional.ofNullable(packet.get(CONFIGMAPS)).orElse(new ArrayList<>());
+      return Optional.ofNullable(packet.<List<V1ConfigMap>>getValue(CONFIGMAPS)).orElse(new ArrayList<>());
     }
   }
 
@@ -116,7 +116,7 @@ public class DomainValidationSteps {
       List<String> validationFailures = domain.getValidationFailures(new KubernetesResourceLookupImpl(packet));
 
       if (validationFailures.isEmpty()) {
-        return doNext(packet);
+        return doNext(packet).withDebugComment(packet, this::domainValidated);
       }
 
       LOGGER.severe(DOMAIN_VALIDATION_FAILED, domain.getDomainUid(), perLine(validationFailures));
@@ -126,6 +126,10 @@ public class DomainValidationSteps {
 
     private String perLine(List<String> validationFailures) {
       return String.join(lineSeparator(), validationFailures);
+    }
+
+    private String domainValidated(Packet packet) {
+      return "Validated " + DomainPresenceInfo.fromPacket(packet).orElse(null);
     }
     
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.helpers;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -217,12 +218,18 @@ public class JobHelper {
         if (isKnownFailedJob(job)) {
           return doNext(cleanUpAndReintrospect(), packet);
         } else if (job != null) {
-          return doNext(processIntrospectionResults(), packet);
+          return doNext(processIntrospectionResults(), packet).withDebugComment(job, this::foundJobDescription);
         } else if (isIntrospectionNeeded(packet)) {
-          return doNext(createIntrospectionSteps(), packet);
+          return doNext(createIntrospectionSteps(), packet).withDebugComment(packet, this::introspectionNeededReason);
         } else {
-          return doNext(packet);
+          return doNext(packet).withDebugComment(packet, this::introspectionNotNeededReason);
         }
+      }
+
+      @Nonnull
+      private String foundJobDescription(@Nonnull V1Job job) {
+        return "found introspection job " + job.getMetadata().getName()
+                         + ", started at " + job.getMetadata().getCreationTimestamp();
       }
 
       private boolean isKnownFailedJob(V1Job job) {
@@ -260,6 +267,36 @@ public class JobHelper {
               || isIntrospectionRequested(packet)
               || isModelInImageUpdate(packet)
               || isIntrospectVersionChanged(packet);
+      }
+
+      private String introspectionNeededReason(Packet packet) {
+        StringBuilder sb = new StringBuilder("introspection needed because ");
+        if (getDomainTopology() == null) {
+          sb.append("domain topology is null");
+        } else if (isBringingUpNewDomain(packet)) {
+          sb.append("bringing up new domain");
+        } else {
+          sb.append("something else");
+        }
+        return sb.toString();
+      }
+
+      private String introspectionNotNeededReason(Packet packet) {
+        StringBuilder sb = new StringBuilder("introspection not needed because ");
+        if (getNumRunningServers() != 0) {
+          sb.append("have running servers: ").append(String.join(", ", getRunningServerNames()));
+        } else if (!creatingServers(info)) {
+          sb.append("should not be creating servers");
+        } else {
+          sb.append("domain generation = ").append(getDomainGeneration())
+                .append(" and packet last generation is ").append(packet.get(INTROSPECTION_DOMAIN_SPEC_GENERATION));
+        }
+        return sb.toString();
+      }
+
+      @Nonnull
+      private Collection<String> getRunningServerNames() {
+        return Optional.ofNullable(info).map(DomainPresenceInfo::getServerNames).orElse(Collections.emptyList());
       }
 
       private boolean isBringingUpNewDomain(Packet packet) {
@@ -317,17 +354,16 @@ public class JobHelper {
 
     // Returns a chain of steps which attempt to read the introspection result into a config map.
     private Step processIntrospectionResults() {
+      return new WatchDomainIntrospectorJobReadyStep(readIntrospectionResults());
+    }
+
+    private Step readIntrospectionResults() {
       return Step.chain(
-            waitForIntrospectionToComplete(),
             findIntrospectorPodName(),
             readNamedPodLog(),
             deleteIntrospectorJob(),
             createIntrospectorConfigMap()
             );
-    }
-
-    private Step waitForIntrospectionToComplete() {
-      return new WatchDomainIntrospectorJobReadyStep();
     }
 
     private Step findIntrospectorPodName() {

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -143,6 +143,7 @@ public class MessageKeys {
   public static final String EXECUTE_MAKE_RIGHT_DOMAIN = "WLSKO-0192";
   public static final String LOG_WAITING_COUNT = "WLSKO-0193";
   public static final String INTERNAL_IDENTITY_INITIALIZATION_FAILED = "WLSKO-0194";
+  public static final String DUMP_BREADCRUMBS = "WLSKO-0195";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/WatchDomainIntrospectorJobReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/WatchDomainIntrospectorJobReadyStep.java
@@ -7,11 +7,18 @@ import io.kubernetes.client.openapi.models.V1Job;
 import oracle.kubernetes.operator.JobAwaiterStepFactory;
 import oracle.kubernetes.operator.JobWatcher;
 import oracle.kubernetes.operator.ProcessingConstants;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
 public class WatchDomainIntrospectorJobReadyStep extends Step {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  public WatchDomainIntrospectorJobReadyStep(Step next) {
+    super(next);
+  }
 
   @Override
   public NextAction apply(Packet packet) {
@@ -19,7 +26,8 @@ public class WatchDomainIntrospectorJobReadyStep extends Step {
 
     if (hasNotCompleted(domainIntrospectorJob)) {
       JobAwaiterStepFactory jw = packet.getSpi(JobAwaiterStepFactory.class);
-      return doNext(jw.waitForReady(domainIntrospectorJob, getNext()), packet);
+      final Step step = jw.waitForReady(domainIntrospectorJob, getNext());
+      return doNext(step, packet);
     } else {
       return doNext(packet);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/work/FiberGate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/FiberGate.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator.work;
 
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,6 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.work.Fiber.CompletionCallback;
+import oracle.kubernetes.utils.SystemClock;
 
 /**
  * Allows at most one running Fiber per key value. However, rather than queue later arriving Fibers
@@ -137,7 +139,7 @@ public class FiberGate {
       WaitForOldFiberStep c = current.get();
       Fiber o = c != null ? c.old.getAndSet(null) : null;
       if (o == null) {
-        return doNext(packet);
+        return doNext(packet).withDebugComment(this::getProceedTime);
       }
 
       return doSuspend(
@@ -156,6 +158,10 @@ public class FiberGate {
               fiber.resume(packet);
             }
           });
+    }
+
+    private String getProceedTime() {
+      return "starting fiber at " + SystemClock.now().format(DateTimeFormatter.ISO_LOCAL_TIME);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/work/NextAction.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/NextAction.java
@@ -3,9 +3,14 @@
 
 package oracle.kubernetes.operator.work;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static oracle.kubernetes.operator.work.Fiber.DEBUG_FIBER;
 
 /**
  * Indicates what shall happen after {@link Step#apply(Packet)} returns.
@@ -13,11 +18,18 @@ import java.util.function.Consumer;
  * <p>To allow reuse of this object, this class is mutable.
  */
 public final class NextAction implements BreadCrumbFactory {
+
+  /** To enable explanatory comments in breadcrumbs, set this to a non-null value.
+   * It will be printed with each breadcrumb comment. */
+  @SuppressWarnings("unused")
+  private static String commentPrefix;
+
   Kind kind;
   Step next;
   Packet packet;
   Consumer<AsyncFiber> onExit;
   Throwable throwable;
+  private String comment;
 
   private void set(Kind k, Step v, Packet p) {
     this.kind = k;
@@ -102,6 +114,33 @@ public final class NextAction implements BreadCrumbFactory {
         + ']';
   }
 
+  /**
+   * Defines a comment for an action that gives more information. The comment supplier will only be invoked
+   * if the comment prefix has been defined.
+   *
+   * @param commentSupplier a no-argument function that generates a debug comment
+   */
+  public NextAction withDebugComment(Supplier<String> commentSupplier) {
+    Optional.ofNullable(packet).map(p -> p.get(DEBUG_FIBER)).ifPresent(prefix -> annotate(commentSupplier.get()));
+    return this;
+  }
+
+  /**
+   * Defines a comment for an action that gives more information. The comment supplier will only be invoked
+   * if the comment prefix has been defined.
+   *
+   * @param data a value uses to create the comment
+   * @param commentFunction a function that creates a comment from the data value
+   */
+  public <T> NextAction withDebugComment(T data, Function<T, String> commentFunction) {
+    Optional.ofNullable(packet).map(p -> p.get(DEBUG_FIBER)).ifPresent(prefix -> annotate(commentFunction.apply(data)));
+    return this;
+  }
+
+  private void annotate(String comment) {
+    this.comment = " ((" + comment + "))";
+  }
+
   public enum Kind {
     INVOKE,
     SUSPEND,
@@ -124,8 +163,9 @@ public final class NextAction implements BreadCrumbFactory {
       switch (na.kind) {
         case INVOKE:
           if (na.next != null) {
-            if (previousKind == Kind.INVOKE) {
-              sb.append(",");
+            Optional.ofNullable(na.comment).ifPresent(sb::append);
+            if (previousKind != null) {
+              sb.append(", ");
             }
             sb.append(na.next.getName());
             dumper.dump(sb, na.packet);
@@ -133,7 +173,7 @@ public final class NextAction implements BreadCrumbFactory {
           break;
         case SUSPEND:
           if (previousKind != Kind.SUSPEND) {
-            sb.append("][");
+            sb.append("...");
           }
           break;
         case THROW:

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
@@ -202,6 +202,7 @@ public abstract class Step {
    * @param unit Delay time unit
    * @return The next action
    */
+  @SuppressWarnings("SameParameterValue")
   protected NextAction doRetry(Packet packet, long delay, TimeUnit unit) {
     NextAction na = new NextAction();
     na.delay(this, packet, delay, unit);
@@ -296,7 +297,6 @@ public abstract class Step {
   }
 
   /** Multi-exception. */
-  @SuppressWarnings("serial")
   public static class MultiThrowable extends RuntimeException {
     private final List<Throwable> throwables;
 

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -142,6 +142,7 @@ WLSKO-0191=Rolling restart of domain {0} completed
 WLSKO-0192=Executing make right domain operation, recheck count for server {0} is {1}.
 WLSKO-0193=Waiting for server {0} to start, recheck count is {1}.
 WLSKO-0194=Internal identity initialization step failed with exception {0}.
+WLSKO-0195={0} Fiber {1}
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -648,7 +648,7 @@ class DomainIntrospectorJobTest {
   }
 
   @Test
-  void whenIntrospectorJobNotNeeded_doesNotValidatesDomainTopology() throws JsonProcessingException {
+  void whenIntrospectorJobNotNeeded_doesNotValidateDomainTopology() throws JsonProcessingException {
     // create WlsDomainConfig with "cluster-2" whereas domain spec contains "cluster-1"
     WlsDomainConfig wlsDomainConfig = createDomainConfig("cluster-2");
     IntrospectionTestUtils.defineResources(testSupport, wlsDomainConfig);

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -677,7 +677,8 @@ class JobHelperTest extends DomainValidationBaseTest {
 
   @Test
   void verify_introspectorPodSpec_activeDeadlineSeconds_retry_values() {
-    int failureCount = domainPresenceInfo.incrementAndGetFailureCount();
+    domainPresenceInfo.indicateFailure();
+    final int failureCount = domainPresenceInfo.getRetryCount();
 
     V1JobSpec jobSpec = createJobSpec();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/work/FiberTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/FiberTest.java
@@ -9,13 +9,24 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import oracle.kubernetes.utils.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static oracle.kubernetes.operator.logging.MessageKeys.DUMP_BREADCRUMBS;
+import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -37,7 +48,7 @@ class FiberTest {
   private final Fiber fiber = testSupport.getEngine().createFiber();
 
   private final List<Step> stepList = new ArrayList<>();
-  private final List<Throwable> throwablesList = new ArrayList<>();
+  private final List<Throwable> throwableList = new ArrayList<>();
   private final List<AsyncFiber> fiberList = new ArrayList<>();
 
   private final Step step1 = new BasicStep(1);
@@ -47,11 +58,22 @@ class FiberTest {
   private final Step retry = new RetryStep();
   private final Step error = new ThrowableStep();
   private final Step suspend = new SuspendingStep(this::recordFiber);
+  private final List<Memento> mementos = new ArrayList<>();
+  private final List<LogRecord> logRecords = new ArrayList<>();
 
   @BeforeEach
   public void setUp() {
+    mementos.add(TestUtils.silenceOperatorLogger()
+          .collectLogMessages(logRecords, DUMP_BREADCRUMBS)
+          .withLogLevel(Level.INFO));
+    
     packet.put(STEPS, stepList);
     packet.put(FIBERS, fiberList);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mementos.forEach(Memento::revert);
   }
 
   @Test
@@ -91,7 +113,7 @@ class FiberTest {
   void whenStepThrowsException_captureThrowable() {
     runSteps(step1, error, step3);
 
-    assertThat(throwablesList, contains(instanceOf(RuntimeException.class)));
+    assertThat(throwableList, contains(instanceOf(RuntimeException.class)));
   }
 
   @Test
@@ -174,7 +196,7 @@ class FiberTest {
     runSteps(step1, suspend, step3);
     fiber.resume(packet);
 
-    assertThat(fiber.getBreadCrumbString(), allOf(containsString("Suspending]["), containsString("Basic (3)")));
+    assertThat(fiber.getBreadCrumbString(), allOf(containsString("Suspending..."), containsString("Basic (3)")));
   }
 
   @Test
@@ -189,6 +211,44 @@ class FiberTest {
     runSteps(childFiberStep);
 
     assertThat(fiber.getBreadCrumbString(), containsString("child-1: [FiberTest$Basic (1)"));
+  }
+
+  @Test
+  void whenDebugNotEnabled_doNotInvokeDebugCommentGenerator() {
+    runSteps(
+          new SimpleAnnotationStep(this::failOnInvoke),
+          new ComputedAnnotationStep(this::failOnInvoke));
+  }
+
+  private String failOnInvoke() {
+    throw new RuntimeException();
+  }
+
+  private String failOnInvoke(Integer i) {
+    throw new RuntimeException();
+  }
+
+  @Test
+  void whenDebugEnable_breadCrumbsIncludeComments() throws NoSuchFieldException {
+    mementos.add(StaticStubSupport.install(NextAction.class, "commentPrefix", "PREFIX: "));
+    packet.put(Fiber.DEBUG_FIBER, "PREFIX");
+
+    runSteps(
+          new SimpleAnnotationStep(this::simpleComment),
+          new ComputedAnnotationStep(this::computedComment),
+          step1);
+
+    final String breadCrumbString = fiber.getBreadCrumbString();
+    assertThat(logRecords, containsInfo(DUMP_BREADCRUMBS, "PREFIX", breadCrumbString));
+    assertThat(breadCrumbString, both(containsString("something")).and(containsString("comment(0)")));
+  }
+
+  private String simpleComment() {
+    return "something";
+  }
+
+  private String computedComment(Integer i) {
+    return "comment(" + i + ")";
   }
 
   static class BasicStep extends Step {
@@ -217,6 +277,44 @@ class FiberTest {
     @Override
     protected String getDetail() {
       return Optional.ofNullable(stepNum).map(Integer::toHexString).orElse(null);
+    }
+  }
+
+  static class SimpleAnnotationStep extends Step {
+    private final Supplier<String> annotationGenerator;
+
+    SimpleAnnotationStep(Supplier<String> annotationGenerator) {
+      this.annotationGenerator = annotationGenerator;
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      recordStep(packet);
+      return doNext(packet).withDebugComment(annotationGenerator);
+    }
+
+    @SuppressWarnings("unchecked")
+    final void recordStep(Packet packet) {
+      ((List<Step>) packet.get(STEPS)).add(this);
+    }
+  }
+
+  static class ComputedAnnotationStep extends Step {
+    private final Function<Integer,String> annotationGenerator;
+
+    ComputedAnnotationStep(Function<Integer,String> annotationGenerator) {
+      this.annotationGenerator = annotationGenerator;
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      recordStep(packet);
+      return doNext(packet).withDebugComment(0, annotationGenerator);
+    }
+
+    @SuppressWarnings("unchecked")
+    final void recordStep(Packet packet) {
+      ((List<Step>) packet.get(STEPS)).add(this);
     }
   }
 
@@ -287,7 +385,7 @@ class FiberTest {
 
     @Override
     public void onThrowable(Packet packet, Throwable throwable) {
-      throwablesList.add(throwable);
+      throwableList.add(throwable);
     }
   }
 }


### PR DESCRIPTION
This adds some additional debugging capabilities for fibers:

1. When returning a `NextAction` it is now possible to add some static or computed information:

```
return doNext(getNext(), packet).withDebugComment(() -> "assume presence up-to-date");
```

indicates that the fiber has chosen a path in which the domain presence is considered to be up-to-date

```
return doNext(createIntrospectionSteps(), packet)
                    .withDebugComment(packet, this::introspectionNeededReason);
```
indicates that the fiber has decided that it needs to run an introspection, along with its reasoning, derived from the packet.

2. In each case, the comment is actually derived from a method, which is not invoked unless the feature is enabled for the current fiber (intended to avoid excess computation). That means that it may safely be left in the code.

3. To enable the feature, the code must add a string to the packet, using the key Fiber.DEBUG_FIBER

4. When the fiber terminates, it will be logged, along with the value of the Fiber.DEBUG_FIBER entry as a prefix.


Note that, at present, the feature is disabled unless specifically enabled in the code.