### PR TITLE
Owls 91212 - Merge fixes for the introspector retry behavior after the job times out and to capture WDT logs. 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -292,13 +292,13 @@ class ItKubernetesEvents {
   }
 
   /**
-   * Test the following domain events are logged when domain resource goes through various life cycle stages.
-   * Patch the domain resource to remove the webLogicCredentialsSecret and verify DomainChanged is
-   * logged when operator processes the domain resource changes.
-   * Verifies DomainProcessingRetrying is logged when operator retries the failed domain resource
-   * changes since webLogicCredentialsSecret is still missing.
+   * Test the following domain events are logged when domain resource goes through introspector failure.
+   * Patch the domain resource to shutdown servers.
+   * Patch the domain resource to point to a bad DOMAIN_HOME and update serverStartPolicy to IF_NEEDED.
+   * Verifies DomainProcessingFailed event is logged.
    * Verifies DomainProcessingAborted is logged when operator exceeds the maximum retries and gives
    * up processing the domain resource.
+   * Cleanup by patching the domain resource to a valid location and introspectVersion to bring up all servers again.
    */
   @Order(4)
   @Test
@@ -306,40 +306,68 @@ class ItKubernetesEvents {
   void testDomainK8SEventsFailed() {
     V1Patch patch;
     String patchStr;
+    Domain domain = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace1));
+    String originalDomainHome = domain.getSpec().getDomainHome();
 
     OffsetDateTime timestamp = now();
     try {
-      logger.info("remove the webLogicCredentialsSecret to verify the following events"
-          + " DomainChanged, DomainProcessingRetrying and DomainProcessingAborted are logged");
-      patchStr = "[{\"op\": \"remove\", \"path\": \"/spec/webLogicCredentialsSecret\"}]";
-      logger.info("PatchStr for webLogicCredentialsSecret: {0}", patchStr);
+      logger.info("Shutting down all servers in domain with serverStartPolicy : NEVER");
+      patchStr = "[{\"op\": \"replace\", \"path\": \"/spec/serverStartPolicy\", \"value\": \"NEVER\"}]";
+      patch = new V1Patch(patchStr);
+      assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
+              "patchDomainCustomResource failed");
+
+      logger.info("Checking if the admin server {0} is shutdown in namespace {1}",
+              adminServerPodName, domainNamespace1);
+      checkPodDoesNotExist(adminServerPodName, domainUid, domainNamespace1);
+
+      for (int i = 1; i <= replicaCount; i++) {
+        logger.info("Checking if the managed server {0} is shutdown in namespace {1}",
+                managedServerPodNamePrefix + i, domainNamespace1);
+        checkPodDoesNotExist(managedServerPodNamePrefix + i, domainUid, domainNamespace1);
+      }
+
+      logger.info("Replace the domainHome to a nonexisting location to verify the following events"
+              + " DomainChanged, DomainProcessingRetrying and DomainProcessingAborted are logged");
+      patchStr = "[{\"op\": \"replace\", "
+              + "\"path\": \"/spec/domainHome\", \"value\": \"" + originalDomainHome + "bad\"},"
+              + "{\"op\": \"replace\", \"path\": \"/spec/serverStartPolicy\", \"value\": \"IF_NEEDED\"}]";
+      logger.info("PatchStr for domainHome: {0}", patchStr);
 
       patch = new V1Patch(patchStr);
       assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
-          "patchDomainCustomResource failed");
+              "patchDomainCustomResource failed");
 
       logger.info("verify domain changed event is logged");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_CHANGED, "Normal", timestamp);
-
-      //      logger.info("verify domain processing retrying event");
-      //      checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_RETRYING, "Normal", timestamp);
-
       logger.info("verify domain processing aborted event");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_PROCESSING_ABORTED, "Warning", timestamp);
     } finally {
+      logger.info("Restoring the domain with valid location and bringing up all servers");
       timestamp = now();
-      // add back the webLogicCredentialsSecret
-      patchStr = "[{\"op\": \"add\", \"path\": \"/spec/webLogicCredentialsSecret\", "
-          + "\"value\" : {\"name\":\"" + wlSecretName + "\" , \"namespace\":\"" + domainNamespace1 + "\"}"
-          + "}]";
-      logger.info("PatchStr for webLogicCredentialsSecret: {0}", patchStr);
+      String introspectVersion = assertDoesNotThrow(() -> getNextIntrospectVersion(domainUid, domainNamespace1));
+      // add back the original domain home
+      patchStr = "["
+              + "{\"op\": \"replace\", \"path\": \"/spec/domainHome\", \"value\": \"" + originalDomainHome + "\"},"
+              + "{\"op\": \"add\", \"path\": \"/spec/introspectVersion\", \"value\": \"" + introspectVersion + "\"}"
+              + "]";
+      logger.info("PatchStr for domainHome: {0}", patchStr);
 
       patch = new V1Patch(patchStr);
       assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
-          "patchDomainCustomResource failed");
+              "patchDomainCustomResource failed");
 
       logger.info("verify domain changed event is logged");
       checkEvent(opNamespace, domainNamespace1, domainUid, DOMAIN_CHANGED, "Normal", timestamp);
+      logger.info("verifying the admin server is created and started");
+      checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace1);
+
+      // verify managed server services created
+      for (int i = 1; i <= replicaCount; i++) {
+        logger.info("Checking managed server service/pod {0} is created in namespace {1}",
+                managedServerPodNamePrefix + i, domainNamespace1);
+        checkPodReadyAndServiceExists(managedServerPodNamePrefix + i, domainUid, domainNamespace1);
+      }
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -164,36 +164,33 @@ public class DomainStatusUpdater {
   static class FailureCountStep extends DomainStatusUpdaterStep {
 
     private final V1Job domainIntrospectorJob;
-    private final boolean resetFailureCount;
 
     public FailureCountStep(V1Job domainIntrospectorJob) {
-      this(domainIntrospectorJob, false);
-    }
-
-    public FailureCountStep(V1Job domainIntrospectorJob, boolean resetFailureCount) {
       super(null);
       this.domainIntrospectorJob = domainIntrospectorJob;
-      this.resetFailureCount = resetFailureCount;
     }
 
     @Override
     void modifyStatus(DomainStatus domainStatus) {
-      if (resetFailureCount) {
-        domainStatus.resetIntrospectJobFailureCount();
-      } else {
-        domainStatus.incrementIntrospectJobFailureCount(getJobUid());
-      }
+      domainStatus.incrementIntrospectJobFailureCount(getJobUid());
     }
 
     @Nullable
     private String getJobUid() {
-      return Optional.ofNullable(domainIntrospectorJob).map(V1Job::getMetadata)
-              .map(V1ObjectMeta::getUid).orElse(null);
+      return Optional.ofNullable(domainIntrospectorJob).map(V1Job::getMetadata).map(V1ObjectMeta::getUid).orElse(null);
+    }
+  }
+
+  static class ResetFailureCountStep extends DomainStatusUpdaterStep {
+
+    @Override
+    void modifyStatus(DomainStatus domainStatus) {
+      domainStatus.resetIntrospectJobFailureCount();
     }
   }
 
   public static Step createResetFailureCountStep() {
-    return new FailureCountStep(null, true);
+    return new ResetFailureCountStep();
   }
 
   private static String getEventMessage(@Nonnull DomainFailureReason reason, String message) {

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -137,7 +137,12 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
     return false;
   }
 
-  static boolean isFailed(V1Job job) {
+  /**
+   * Test if job is failed.
+   * @param job job
+   * @return true, if failed
+   */
+  public static boolean isFailed(V1Job job) {
     if (job == null) {
       return false;
     }
@@ -173,8 +178,12 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
     return Optional.ofNullable(jobCondition).map(V1JobCondition::getStatus).orElse("");
   }
 
-
-  static String getFailedReason(V1Job job) {
+  /**
+   * Get the reason for job failure.
+   * @param job job
+   * @return Job failure reason.
+   */
+  public static String getFailedReason(V1Job job) {
     V1JobStatus status = job.getStatus();
     if (status != null && status.getConditions() != null) {
       for (V1JobCondition cond : status.getConditions()) {

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -306,7 +306,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
     // be available for reading
     @Override
     boolean shouldTerminateFiber(V1Job job) {
-      return isFailed(job) && ("DeadlineExceeded".equals(getFailedReason(job)));
+      return isJobTimedOut(job);
     }
 
     // create an exception to terminate the fiber
@@ -334,6 +334,10 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
         }
       };
     }
+  }
+
+  public static boolean isJobTimedOut(V1Job job) {
+    return isFailed(job) && ("DeadlineExceeded".equals(getFailedReason(job)));
   }
 
   static class DeadlineExceededException extends Exception {

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -138,9 +138,8 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
   }
 
   /**
-   * Test if job is failed.
-   * @param job job
-   * @return true, if failed
+   * Returns true if the specified job has a failed status or condition.
+   * @param job job to be tested
    */
   public static boolean isFailed(V1Job job) {
     if (job == null) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -62,7 +61,6 @@ public class DomainPresenceInfo implements PacketComponent {
   private final AtomicReference<Domain> domain;
   private final AtomicBoolean isDeleting = new AtomicBoolean(false);
   private final AtomicBoolean isPopulated = new AtomicBoolean(false);
-  private final AtomicInteger retryCount = new AtomicInteger(0);
   private final AtomicReference<Collection<ServerStartupInfo>> serverStartupInfo;
   private final AtomicReference<Collection<ServerShutdownInfo>> serverShutdownInfo;
 
@@ -568,23 +566,6 @@ public class DomainPresenceInfo implements PacketComponent {
 
   public void setPopulated(boolean populated) {
     isPopulated.set(populated);
-  }
-
-  private void resetFailureCount() {
-    retryCount.set(0);
-  }
-
-  public int incrementAndGetFailureCount() {
-    return retryCount.incrementAndGet();
-  }
-
-  int getRetryCount() {
-    return retryCount.get();
-  }
-
-  /** Sets the last completion time to now. */
-  public void complete() {
-    resetFailureCount();
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -51,10 +51,9 @@ import static oracle.kubernetes.operator.DomainFailureReason.Introspection;
 import static oracle.kubernetes.operator.DomainSourceType.FromModel;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createFailureCountStep;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createFailureRelatedSteps;
-import static oracle.kubernetes.operator.JobWatcher.getFailedReason;
-import static oracle.kubernetes.operator.JobWatcher.isFailed;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_DOMAIN_SPEC_GENERATION;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR_JOB;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECT_REQUESTED;
 import static oracle.kubernetes.operator.helpers.ConfigMapHelper.readExistingIntrospectorConfigMap;
 import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_JOB_FAILED;
@@ -216,92 +215,23 @@ public class JobHelper {
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
         V1Job job = (V1Job) callResponse.getResult();
-        if ((job != null) && (packet.get(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB) == null)) {
-          packet.put(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB, job);
+        if ((job != null) && (packet.get(DOMAIN_INTROSPECTOR_JOB) == null)) {
+          packet.put(DOMAIN_INTROSPECTOR_JOB, job);
         }
 
-        return doNext(verifyIntrospectorJobPod(info.getNamespace(), getNext()), packet);
-      }
-
-      private Step verifyIntrospectorJobPod(String namespace, Step next) {
-        return new CallBuilder()
-                .withLabelSelectors(LabelConstants.JOBNAME_LABEL)
-                .listPodAsync(namespace, createReadJobPodResponse(next));
-      }
-
-      @Nonnull
-      private VerifyIntrospectorJobPodResponseStep<V1Pod> createReadJobPodResponse(Step next) {
-        return new VerifyIntrospectorJobPodResponseStep<>(next);
-      }
-
-      private class VerifyIntrospectorJobPodResponseStep<T> extends ResponseStep<V1PodList> {
-        VerifyIntrospectorJobPodResponseStep(Step next) {
-          super(next);
-        }
-
-        @Override
-        public NextAction onSuccess(Packet packet, CallResponse<V1PodList> callResponse) {
-          V1Pod pod = getJobPod(callResponse);
-          V1Job job = (V1Job) packet.get(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB);
-          boolean hasImagePullError = checkJobPodForImagePullError(pod);
-          if (hasImagePullError) {
-            packet.put(DOMAIN_INTROSPECT_REQUESTED, ReadPodLogResponseStep.INTROSPECTION_FAILED);
-          }
-
-          if (isKnownFailedJob(job) || hasImagePullError) {
-            return doContinueListOrNext(callResponse, packet, cleanUpAndReintrospect());
-          } else if (isJobTimedout(job, pod)) {
-            return doContinueListOrNext(callResponse, packet, deleteJobAndStartNewIntrospection());
-          } else if (job != null) {
-            return doContinueListOrNext(callResponse, packet, processIntrospectionResults());
-          } else if (isIntrospectionNeeded(packet)) {
-            return doContinueListOrNext(callResponse, packet, createIntrospectionSteps());
-          } else {
-            return doContinueListOrNext(callResponse, packet);
-          }
-        }
-
-        private V1Pod getJobPod(CallResponse<V1PodList> callResponse) {
-          return Optional.ofNullable(
-                  callResponse.getResult()).map(V1PodList::getItems).orElseGet(Collections::emptyList).stream()
-                  .filter(pod -> isIntrospectionJobPod(pod)).findAny().orElse(null);
-        }
-
-        private boolean checkJobPodForImagePullError(V1Pod pod) {
-          return Optional.ofNullable(getJobPodContainerWaitingReason(pod))
-                  .map(s -> s.contains("ErrImagePull") || s.contains("ImagePullBackOff"))
-                  .orElse(false);
-        }
-
-        private String getJobPodContainerWaitingReason(V1Pod pod) {
-          return Optional.ofNullable(pod).map(V1Pod::getStatus)
-                  .map(V1PodStatus::getContainerStatuses).map(statuses -> statuses.get(0))
-                  .map(V1ContainerStatus::getState).map(V1ContainerState::getWaiting)
-                  .map(V1ContainerStateWaiting::getReason).orElse(null);
-        }
-
-        private boolean isIntrospectionJobPod(V1Pod pod) {
-          return Optional.ofNullable(pod).map(V1Pod::getMetadata)
-                  .map(meta -> meta.getName().startsWith(getJobName())).orElse(false);
+        if (isKnownFailedJob(job)) {
+          return doNext(cleanUpAndReintrospect(getNext()), packet);
+        } else if (job != null) {
+          return doNext(processIntrospectionResults(getNext()), packet);
+        } else if (isIntrospectionNeeded(packet)) {
+          return doNext(createIntrospectionSteps(getNext()), packet);
+        } else {
+          return doNext(packet);
         }
       }
 
       private boolean isKnownFailedJob(V1Job job) {
         return getUid(job).equals(getLastFailedUid());
-      }
-
-      private boolean isJobTimedout(V1Job introspectorJob, V1Pod pod) {
-        return Optional.ofNullable(introspectorJob)
-                .map(job -> isFailed(job) && isDeadlineExceeded(job, pod)).orElse(false);
-      }
-
-      private boolean isDeadlineExceeded(V1Job job, V1Pod pod) {
-        return "DeadlineExceeded".equals(getFailedReason(job))
-                || "DeadlineExceeded".equals(getPodStatusReason(pod));
-      }
-
-      private String getPodStatusReason(V1Pod pod) {
-        return Optional.ofNullable(pod).map(V1Pod::getStatus).map(V1PodStatus::getReason).orElse(null);
       }
 
       @Nonnull
@@ -312,27 +242,6 @@ public class JobHelper {
       @Nullable
       private String getLastFailedUid() {
         return getDomain().getOrCreateStatus().getFailedIntrospectionUid();
-      }
-
-      private Step cleanUpAndReintrospect() {
-        return Step.chain(deleteIntrospectorJob(), createIntrospectionSteps());
-      }
-
-      private Step createIntrospectionSteps() {
-        return Step.chain(
-                readExistingIntrospectorConfigMap(getNamespace(), getDomainUid()),
-                startNewIntrospection(getNext()));
-      }
-
-      private Step deleteJobAndStartNewIntrospection() {
-        return Step.chain(
-                deleteDomainIntrospectorJobStep(null),
-                startNewIntrospection(getNext()));
-      }
-
-      @Nonnull
-      private Step startNewIntrospection(Step next) {
-        return Step.chain(createNewJob(), processIntrospectionResults(), next);
       }
 
       private boolean isIntrospectionNeeded(Packet packet) {
@@ -396,22 +305,31 @@ public class JobHelper {
       }
     }
 
-    // Returns a chain of steps which attempt to read the introspection result into a config map.
-    private Step processIntrospectionResults() {
+    private Step cleanUpAndReintrospect(Step next) {
+      return Step.chain(deleteIntrospectorJob(), createIntrospectionSteps(next));
+    }
+
+    private Step createIntrospectionSteps(Step next) {
       return Step.chain(
-            waitForIntrospectionToComplete(),
-            findIntrospectorPodName(),
-            readNamedPodLog(),
-            deleteIntrospectorJob(),
-            createIntrospectorConfigMap()
-            );
+              readExistingIntrospectorConfigMap(getNamespace(), getDomainUid()),
+              startNewIntrospection(next));
+    }
+
+    @Nonnull
+    private Step startNewIntrospection(Step next) {
+      return Step.chain(createNewJob(), processIntrospectionResults(next));
+    }
+
+    // Returns a chain of steps which read the job pod and decide how to handle it.
+    private Step processIntrospectionResults(Step next) {
+      return Step.chain(waitForIntrospectionToComplete(), verifyJobPod(), next);
     }
 
     private Step waitForIntrospectionToComplete() {
       return new WatchDomainIntrospectorJobReadyStep();
     }
 
-    private Step findIntrospectorPodName() {
+    private Step verifyJobPod() {
       return new ReadDomainIntrospectorPodStep();
     }
 
@@ -471,7 +389,7 @@ public class JobHelper {
       public NextAction onSuccess(Packet packet, CallResponse<String> callResponse) {
         Optional.ofNullable(callResponse.getResult()).ifPresent(result -> processIntrospectionResult(packet, result));
 
-        final V1Job domainIntrospectorJob = packet.getValue(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB);
+        final V1Job domainIntrospectorJob = packet.getValue(DOMAIN_INTROSPECTOR_JOB);
         if (JobWatcher.isComplete(domainIntrospectorJob)) {
           return doNext(packet);
         } else {
@@ -640,30 +558,54 @@ public class JobHelper {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1PodList> callResponse) {
-        Optional.ofNullable(callResponse.getResult())
+        final V1Pod jobPod
+              = Optional.ofNullable(callResponse.getResult())
               .map(V1PodList::getItems)
               .orElseGet(Collections::emptyList)
               .stream()
-              .map(this::getName)
-              .filter(this::isJobPodName)
+              .filter(this::isJobPod)
               .findFirst()
-              .ifPresent(name -> recordJobPodName(packet, name));
+              .orElse(null);
 
-        return doContinueListOrNext(callResponse, packet);
+        if (jobPod == null) {
+          return doContinueListOrNext(callResponse, packet, processIntrospectorPodLog(getNext()));
+        } else if (hasImagePullFailure(jobPod)) {
+          return doNext(cleanUpAndReintrospect(getNext()), packet);
+        } else {
+          recordJobPodName(packet, getName(jobPod));
+          return doNext(processIntrospectorPodLog(getNext()), packet);
+        }
+      }
+
+      // Returns a chain of steps which read the pod log and create a config map.
+      private Step processIntrospectorPodLog(Step next) {
+        return Step.chain(readNamedPodLog(), deleteIntrospectorJob(), createIntrospectorConfigMap(), next);
       }
 
       private String getName(V1Pod pod) {
         return Optional.of(pod).map(V1Pod::getMetadata).map(V1ObjectMeta::getName).orElse("");
       }
 
-      private boolean isJobPodName(String podName) {
-        return podName.startsWith(getJobName());
+      private boolean isJobPod(V1Pod pod) {
+        return getName(pod).startsWith(getJobName());
+      }
+
+      private boolean hasImagePullFailure(V1Pod pod) {
+        return Optional.ofNullable(getJobPodContainerWaitingReason(pod))
+              .map(s -> s.contains("ErrImagePull") || s.contains("ImagePullBackOff"))
+              .orElse(false);
+      }
+
+      private String getJobPodContainerWaitingReason(V1Pod pod) {
+        return Optional.ofNullable(pod).map(V1Pod::getStatus)
+              .map(V1PodStatus::getContainerStatuses).map(statuses -> statuses.get(0))
+              .map(V1ContainerStatus::getState).map(V1ContainerState::getWaiting)
+              .map(V1ContainerStateWaiting::getReason).orElse(null);
       }
 
       private void recordJobPodName(Packet packet, String podName) {
         packet.put(ProcessingConstants.JOB_POD_NAME, podName);
       }
-
     }
   }
 
@@ -686,7 +628,7 @@ public class JobHelper {
 
   static void logJobDeleted(String domainUid, String namespace, String jobName, Packet packet) {
     V1Job domainIntrospectorJob =
-            (V1Job) packet.remove(ProcessingConstants.DOMAIN_INTROSPECTOR_JOB);
+            (V1Job) packet.remove(DOMAIN_INTROSPECTOR_JOB);
 
     packet.remove(ProcessingConstants.INTROSPECTOR_JOB_FAILURE_LOGGED);
     if (domainIntrospectorJob != null

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -569,12 +569,20 @@ public class JobHelper {
 
         if (jobPod == null) {
           return doContinueListOrNext(callResponse, packet, processIntrospectorPodLog(getNext()));
-        } else if (hasImagePullFailure(jobPod)) {
+        } else if (hasImagePullFailure(jobPod) || isJobPodTimedOut(jobPod)) {
           return doNext(cleanUpAndReintrospect(getNext()), packet);
         } else {
           recordJobPodName(packet, getName(jobPod));
           return doNext(processIntrospectorPodLog(getNext()), packet);
         }
+      }
+
+      private boolean isJobPodTimedOut(V1Pod jobPod) {
+        return "DeadlineExceeded".equals(getJobPodStatusReason(jobPod));
+      }
+
+      private String getJobPodStatusReason(V1Pod jobPod) {
+        return Optional.ofNullable(jobPod.getStatus()).map(V1PodStatus::getReason).orElse(null);
       }
 
       // Returns a chain of steps which read the pod log and create a config map.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -219,7 +219,7 @@ public class JobHelper {
           packet.put(DOMAIN_INTROSPECTOR_JOB, job);
         }
 
-        if (isKnownFailedJob(job)) {
+        if (isKnownFailedJob(job) || JobWatcher.isJobTimedOut(job)) {
           return doNext(cleanUpAndReintrospect(getNext()), packet);
         } else if (job != null) {
           return doNext(processIntrospectionResults(getNext()), packet);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -311,7 +311,12 @@ public class JobStepContext extends BasePodStepContext {
 
   private long getActiveDeadlineSeconds(TuningParameters.PodTuning podTuning) {
     return getIntrospectorJobActiveDeadlineSeconds(podTuning)
-          + (DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS * info.getRetryCount());
+          + (DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS * getIntrospectJobFailureCount());
+  }
+
+  private Integer getIntrospectJobFailureCount() {
+    return Optional.ofNullable(info.getDomain().getStatus())
+            .map(s -> s.getIntrospectJobFailureCount()).orElse(0);
   }
 
   V1JobSpec createJobSpec(TuningParameters tuningParameters) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
@@ -62,12 +62,12 @@ public class SecretHelper {
         secretName = dpi.getDomain().getWebLogicCredentialsSecretName();
         namespace = dpi.getNamespace();
 
-        if (secretName != null) {
-          LOGGER.fine(MessageKeys.RETRIEVING_SECRET, secretName);
-          Step read = new CallBuilder().readSecretAsync(secretName, namespace, new SecretResponseStep(getNext()));
-          return doNext(read, packet);
-        } else {
+        if (secretName == null) {
           return doNext(packet);
+        } else {
+          LOGGER.fine(MessageKeys.RETRIEVING_SECRET, secretName);
+          final Step read = new CallBuilder().readSecretAsync(secretName, namespace, new SecretResponseStep(getNext()));
+          return doNext(read, packet);
         }
       }
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
@@ -62,10 +62,13 @@ public class SecretHelper {
         secretName = dpi.getDomain().getWebLogicCredentialsSecretName();
         namespace = dpi.getNamespace();
 
-        LOGGER.fine(MessageKeys.RETRIEVING_SECRET, secretName);
-        Step read = new CallBuilder().readSecretAsync(secretName, namespace, new SecretResponseStep(getNext()));
-
-        return doNext(read, packet);
+        if (secretName != null) {
+          LOGGER.fine(MessageKeys.RETRIEVING_SECRET, secretName);
+          Step read = new CallBuilder().readSecretAsync(secretName, namespace, new SecretResponseStep(getNext()));
+          return doNext(read, packet);
+        } else {
+          return doNext(packet);
+        }
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/HttpRequestProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/HttpRequestProcessing.java
@@ -58,12 +58,14 @@ abstract class HttpRequestProcessing {
   }
 
   final HttpRequest.Builder createRequestBuilder(String url) {
-    return HttpRequest.newBuilder()
+    HttpRequest.Builder builder = HttpRequest.newBuilder()
           .uri(URI.create(url))
-          .header("Authorization", getAuthorizationSource().createBasicAuthorizationString())
           .header("Accept", "application/json")
           .header("Content-Type", "application/json")
           .header("X-Requested-By", "WebLogic Operator");
+    Optional.ofNullable(getAuthorizationSource())
+            .ifPresent(source -> builder.header("Authorization", source.createBasicAuthorizationString()));
+    return builder;
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/work/FiberGate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/FiberGate.java
@@ -109,14 +109,20 @@ public class FiberGate {
         new CompletionCallback() {
           @Override
           public void onCompletion(Packet packet) {
-            gateMap.remove(key, f);
-            callback.onCompletion(packet);
+            try {
+              callback.onCompletion(packet);
+            } finally {
+              gateMap.remove(key, f);
+            }
           }
 
           @Override
           public void onThrowable(Packet packet, Throwable throwable) {
-            gateMap.remove(key, f);
-            callback.onThrowable(packet, throwable);
+            try {
+              callback.onThrowable(packet, throwable);
+            } finally {
+              gateMap.remove(key, f);
+            }
           }
         });
     return f;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -458,7 +458,7 @@ public class Domain implements KubernetesObject {
    * @return the secret name
    */
   public String getWebLogicCredentialsSecretName() {
-    return spec.getWebLogicCredentialsSecret().getName();
+    return Optional.ofNullable(spec.getWebLogicCredentialsSecret()).map(s -> s.getName()).orElse(null);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -458,7 +458,7 @@ public class Domain implements KubernetesObject {
    * @return the secret name
    */
   public String getWebLogicCredentialsSecretName() {
-    return Optional.ofNullable(spec.getWebLogicCredentialsSecret()).map(s -> s.getName()).orElse(null);
+    return Optional.ofNullable(spec.getWebLogicCredentialsSecret()).map(V1SecretReference::getName).orElse(null);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -295,7 +295,7 @@ public class DomainStatus {
    * @param uid the Kubernetes-assigned UID of the job which discovered the introspection failure
    */
   public void incrementIntrospectJobFailureCount(String uid) {
-    if (!Objects.equals(uid, failedIntrospectionUid)) {
+    if ((uid == null) || (!Objects.equals(uid, failedIntrospectionUid))) {
       introspectJobFailureCount = introspectJobFailureCount + 1;
     }
     failedIntrospectionUid = uid;
@@ -519,5 +519,10 @@ public class DomainStatus {
 
   public void createPatchFrom(JsonPatchBuilder builder, @Nullable DomainStatus oldStatus) {
     statusPatch.createPatch(builder, "/status", oldStatus, this);
+  }
+
+  public DomainStatus withIntrospectJobFailureCount(int failureCount) {
+    this.introspectJobFailureCount = failureCount;
+    return this;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -295,10 +295,18 @@ public class DomainStatus {
    * @param uid the Kubernetes-assigned UID of the job which discovered the introspection failure
    */
   public void incrementIntrospectJobFailureCount(String uid) {
-    if ((uid == null) || (!Objects.equals(uid, failedIntrospectionUid))) {
+    if (fiberException(uid) || failedIntrospectionNotRecorded(uid)) {
       introspectJobFailureCount = introspectJobFailureCount + 1;
     }
     failedIntrospectionUid = uid;
+  }
+
+  private boolean fiberException(String uid) {
+    return uid == null;
+  }
+
+  private boolean failedIntrospectionNotRecorded(String uid) {
+    return !uid.equals(failedIntrospectionUid);
   }
 
   /**

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -107,7 +107,9 @@ WLSKO-0154=Job {0} failed due to reason: DeadlineExceeded. \
   Use kubectl describe for the job and its pod for more job failure information. \
   The job may be retried by the operator up to {3} \
   times with longer ActiveDeadlineSeconds value in each subsequent retry. \
-  Use tuning parameter 'domainPresenceFailureRetryMaxCount' to configure max retries.
+  Use tuning parameter 'domainPresenceFailureRetryMaxCount' to configure max retries. \
+  Use 'spec.configuration.introspectorJobActiveDeadlineSeconds' to increase the job \
+  timeout interval if the job still fails after the retries are exhausted.
 WLSKO-0156=Access denied for operator service account for operation {0} on resource {1} in namespace {2}.
 WLSKO-0157=Domain {0} is not valid: {1}
 WLSKO-162=Unable to read internal certificate at path {0}

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -33,7 +33,12 @@ IMG_MODELS_ROOTDIR="${IMG_MODELS_HOME}"
 IMG_ARCHIVES_ROOTDIR="${IMG_MODELS_HOME}"
 IMG_VARIABLE_FILES_ROOTDIR="${IMG_MODELS_HOME}"
 WDT_ROOT="${WDT_INSTALL_HOME:-/u01/wdt/weblogic-deploy}"
-WDT_OUTPUT="/tmp/wdt_output.log"
+WDT_OUTPUT_DIR="${LOG_HOME:-/tmp}"
+WDT_OUTPUT="${WDT_OUTPUT_DIR}/wdt_output.log"
+WDT_CREATE_DOMAIN_LOG=createDomain.log
+WDT_UPDATE_DOMAIN_LOG=updateDomain.log
+WDT_VALIDATE_MODEL_LOG=validateModel.log
+WDT_COMPARE_MODEL_LOG=compareModel.log
 WDT_BINDIR="${WDT_ROOT}/bin"
 WDT_FILTER_JSON="/weblogic-operator/scripts/model-filters.json"
 WDT_CREATE_FILTER="/weblogic-operator/scripts/model-wdt-create-filter.py"
@@ -71,6 +76,10 @@ export WDT_MODEL_SECRETS_DIRS="/weblogic-operator/config-overrides-secrets"
 #For now:
 export WDT_MODEL_SECRETS_NAME_DIR_PAIRS="__weblogic-credentials__=/weblogic-operator/secrets,__WEBLOGIC-CREDENTIALS__=/weblogic-operator/secrets"
 
+if [ ! -d "${WDT_OUTPUT_DIR}" ]; then
+  trace "Creating WDT standard output directory: '${WDT_OUTPUT_DIR}'"
+  createFolder "${WDT_OUTPUT_DIR}"
+fi
 
 # sort_files  sort the files according to the names and naming conventions and write the result to stdout
 #    $1  directory
@@ -667,6 +676,8 @@ function diff_model() {
     fi
   fi
 
+  wdtRotateAndCopyLogFile "${WDT_COMPARE_MODEL_LOG}"
+
   trace "Exiting diff_model"
 }
 
@@ -836,6 +847,8 @@ function generateMergedModel() {
     exitOrLoop
   fi
 
+  wdtRotateAndCopyLogFile "${WDT_VALIDATE_MODEL_LOG}"
+
   # restore trap
   start_trap
   trace "Exiting generateMergedModel"
@@ -933,6 +946,8 @@ function wdtCreatePrimordialDomain() {
     fi
   fi
 
+  wdtRotateAndCopyLogFile "${WDT_CREATE_DOMAIN_LOG}"
+
   # restore trap
   start_trap
   trace "Exiting wdtCreatePrimordialDomain"
@@ -1005,6 +1020,8 @@ function wdtUpdateModelDomain() {
   base64 ${DOMAIN_HOME}/wlsdeploy/domain_model.json.gz > ${DOMAIN_HOME}/wlsdeploy/domain_model.json.b64 || exitOrLoop
   encrypt_decrypt_model "encrypt" ${DOMAIN_HOME}/wlsdeploy/domain_model.json.b64 ${MII_PASSPHRASE} \
     ${DOMAIN_HOME}/wlsdeploy/domain_model.json
+
+  wdtRotateAndCopyLogFile "${WDT_UPDATE_DOMAIN_LOG}"
 
   # restore trap
   start_trap
@@ -1097,6 +1114,8 @@ function wdtHandleOnlineUpdate() {
   # Restore encrypted merge model otherwise the on in the domain will be the diffed model
 
   cp  /tmp/encrypted_merge_model.json ${DOMAIN_HOME}/wlsdeploy/domain_model.json
+
+  wdtRotateAndCopyLogFile ${WDT_UPDATE_DOMAIN_LOG} 
 
   trace "wrote updateResult"
 
@@ -1325,4 +1344,17 @@ function cleanup_mii() {
 function logSevereAndExit() {
   trace SEVERE "cp '$1' failed"
   exitOrLoop
+}
+
+# Function to rotate WDT script log file and copy the file to WDT output dir.
+# parameter:
+#   1 - Name of the log file to rotate and copy to WDT output directory.
+function wdtRotateAndCopyLogFile() {
+  local logFileName=$1
+  testLogFileRotate "${WDT_OUTPUT_DIR}/${logFileName}"
+  [ $? -ne 0 ] && trace SEVERE "Error accessing '${WDT_OUTPUT_DIR}'. See previous log messages." && exit 1
+
+  logFileRotate ${WDT_OUTPUT_DIR}/${logFileName} ${WDT_LOG_FILE_MAX:-11}
+
+  cp ${WDT_ROOT}/logs/${logFileName} ${WDT_OUTPUT_DIR}/
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -17,6 +17,8 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
+import static oracle.kubernetes.operator.JobWatcher.getFailedReason;
+import static oracle.kubernetes.operator.JobWatcher.isFailed;
 
 /** A test stub for processing domains in unit tests. */
 public abstract class DomainProcessorDelegateStub implements DomainProcessorDelegate {
@@ -99,6 +101,9 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
   private class PassthroughJobAwaiterStepFactory implements JobAwaiterStepFactory {
     @Override
     public Step waitForReady(V1Job job, Step next) {
+      if (isFailed(job) && "DeadlineExceeded".equals(getFailedReason(job))) {
+        throw new RuntimeException("DeadlineExceeded");
+      }
       waitedForIntrospection = true;
       return next;
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -52,7 +52,7 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
 
   @Override
   public JobAwaiterStepFactory getJobAwaiterStepFactory(String namespace) {
-    return new PassthroughJobAwaiterStepFactory();
+    return new TestJobAwaiterStepFactory();
   }
 
   @Override
@@ -98,7 +98,7 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
     }
   }
 
-  private class PassthroughJobAwaiterStepFactory implements JobAwaiterStepFactory {
+  private class TestJobAwaiterStepFactory implements JobAwaiterStepFactory {
     @Override
     public Step waitForReady(V1Job job, Step next) {
       if (isFailed(job) && "DeadlineExceeded".equals(getFailedReason(job))) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -1424,10 +1424,10 @@ class DomainProcessorTest {
   }
 
   @Test
-  @Disabled
-  void whenExceptionDuringProcessing_sendAbortedEvent() {
+  void whenWebLogicCredentialsSecretRemoved_NullPointerExceptionAndAbortedEventNotGenerated() {
+    consoleHandlerMemento.ignoreMessage(NOT_STARTING_DOMAINUID_THREAD);
     DomainProcessorImpl.registerDomainPresenceInfo(new DomainPresenceInfo(domain));
-    forceExceptionDuringProcessing();
+    domain.getSpec().withWebLogicCredentialsSecret(null);
     int time = 0;
 
     for (int numRetries = 0; numRetries < DomainPresence.getDomainPresenceFailureRetryMaxCount(); numRetries++) {
@@ -1436,7 +1436,7 @@ class DomainProcessorTest {
       testSupport.setTime(time, TimeUnit.SECONDS);
     }
 
-    assertThat(getEvents().stream().anyMatch(this::isDomainProcessingAbortedEvent), is(true));
+    assertThat(getEvents().stream().anyMatch(this::isDomainProcessingAbortedEvent), is(false));
   }
 
   private List<CoreV1Event> getEvents() {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -98,6 +98,7 @@ import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR_JOB;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.CONFIG_MAP;
@@ -883,6 +884,71 @@ class DomainProcessorTest {
             .reason("DeadlineExceeded"));
   }
 
+  @Test
+  void whenIntrospectionJobPodTimedOut_jobRecreatedAndFailedConditionCleared() throws Exception {
+    consoleHandlerMemento.ignoringLoggedExceptions(RuntimeException.class);
+    consoleHandlerMemento.ignoreMessage(MessageKeys.NOT_STARTING_DOMAINUID_THREAD);
+    jobStatus = createBackoffStatus();
+    establishPreviousIntrospection(null);
+    defineTimedoutIntrospection();
+    testSupport.doOnDelete(JOB, j -> deletePod());
+    testSupport.doOnCreate(JOB, j -> createJobPodAndSetCompletedStatus(job));
+    domainConfigurator.withIntrospectVersion(NEW_INTROSPECTION_STATE);
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).interrupt().execute();
+
+    assertThat(isDomainConditionFailed(), is(false));
+  }
+
+  private boolean isDomainConditionFailed() {
+    return newDomain.getStatus().getConditions().stream().anyMatch(c -> c.getType() == Failed);
+  }
+
+  V1JobStatus createBackoffStatus() {
+    return new V1JobStatus().addConditionsItem(new V1JobCondition().status("True").type("Failed")
+            .reason("BackoffLimitExceeded"));
+  }
+
+  private void deletePod() {
+    testSupport.deleteResources(new V1Pod().metadata(new V1ObjectMeta().name(getJobName()).namespace(NS)));
+  }
+
+  private static String getJobName() {
+    return LegalNames.toJobIntrospectorName(UID);
+  }
+
+  private void createJobPodAndSetCompletedStatus(V1Job job) {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(LabelConstants.JOBNAME_LABEL, getJobName());
+    testSupport.defineResources(POD,
+            new V1Pod().metadata(new V1ObjectMeta().name(getJobName()).labels(labels).namespace(NS)));
+    job.setStatus(createCompletedStatus());
+  }
+
+  private void defineTimedoutIntrospection() {
+    V1Job job = asTimedoutJob(createIntrospectorJob("TIMEDOUT_JOB"));
+    testSupport.defineResources(job);
+    testSupport.addToPacket(DOMAIN_INTROSPECTOR_JOB, job);
+    setJobPodStatusReasonDeadlineExceeded();
+  }
+
+  private void setJobPodStatusReasonDeadlineExceeded() {
+    testSupport.<V1Pod>getResourceWithName(POD, getJobName()).status(new V1PodStatus().reason("DeadlineExceeded"));
+  }
+
+  private V1Job asTimedoutJob(V1Job job) {
+    job.setStatus(new V1JobStatus().addConditionsItem(new V1JobCondition().status("True").type("Failed")
+            .reason("BackoffLimitExceeded")));
+    return job;
+  }
+
+  private V1Job createIntrospectorJob(String uid) {
+    return new V1Job().metadata(createJobMetadata(uid)).status(new V1JobStatus());
+  }
+
+  private V1ObjectMeta createJobMetadata(String uid) {
+    return new V1ObjectMeta().name(getJobName()).namespace(NS).creationTimestamp(SystemClock.now()).uid(uid);
+  }
+
   private void establishPreviousIntrospection(Consumer<Domain> domainSetup) throws JsonProcessingException {
     establishPreviousIntrospection(domainSetup, Arrays.asList(1,2));
   }
@@ -1412,10 +1478,6 @@ class DomainProcessorTest {
 
   private String getDesiredState(Domain domain, String serverName) {
     return Optional.ofNullable(getServerStatus(domain, serverName)).map(ServerStatus::getDesiredState).orElse("");
-  }
-
-  private String getActualState(Domain domain, String serverName) {
-    return Optional.ofNullable(getServerStatus(domain, serverName)).map(ServerStatus::getState).orElse("");
   }
 
   private ServerStatus getServerStatus(Domain domain, String serverName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -6,7 +6,9 @@ package oracle.kubernetes.operator.helpers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -18,19 +20,26 @@ import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1EmptyDirVolumeSource;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobCondition;
 import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1SecretReference;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.kubernetes.operator.JobAwaiterStepFactory;
+import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.TuningParameters;
 import oracle.kubernetes.operator.calls.unprocessable.UnrecoverableErrorBuilderImpl;
 import oracle.kubernetes.operator.rest.ScanCacheStub;
+import oracle.kubernetes.operator.steps.WatchDomainIntrospectorJobReadyStep;
 import oracle.kubernetes.operator.wlsconfig.WlsClusterConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
@@ -591,6 +600,87 @@ class DomainIntrospectorJobTest {
     assertThat(affectedJob, notNullValue());
   }
 
+  @Test
+  void whenPreviousTimedoutJobExists_createNewJob() {
+    ignoreIntrospectorFailureLogs();
+    ignoreJobCreatedAndDeletedLogs();
+    definePreviousTimedoutIntrospection();
+    testSupport.doOnCreate(JOB, this::recordJob);
+
+    testSupport.runSteps(Step.chain(new WatchDomainIntrospectorJobReadyStep(),
+            JobHelper.createIntrospectionStartStep(null)));
+
+    assertThat(affectedJob, notNullValue());
+  }
+
+  private void definePreviousTimedoutIntrospection() {
+    defineTimedoutIntrospection();
+  }
+
+  private void defineTimedoutIntrospection() {
+    testSupport.defineResources(asTimedoutJob(createIntrospectorJob("TIMEDOUT_JOB")));
+  }
+
+  private V1Job asTimedoutJob(V1Job job) {
+    job.setStatus(new V1JobStatus().addConditionsItem(new V1JobCondition().status("True").type("Failed")
+            .reason("DeadlineExceeded")));
+    return job;
+  }
+
+  private long getIntrospectorJobActiveDeadlineSeconds() {
+    return TuningParameters.getInstance().getPodTuning().introspectorJobActiveDeadlineSeconds;
+  }
+
+  @Test
+  void whenPreviousFailedJobWithImagePullErrorExistsAndMakeRightContinued_createNewJob() {
+    ignoreIntrospectorFailureLogs();
+    ignoreJobCreatedAndDeletedLogs();
+    testSupport.addToPacket(DOMAIN_TOPOLOGY, createDomainConfig("cluster-1"));
+    defineFailedIntrospectionWithImagePullError("ErrImagePull");
+    testSupport.doOnCreate(JOB, this::recordJob);
+
+    testSupport.runSteps(JobHelper.createIntrospectionStartStep(null));
+
+    assertThat(affectedJob, notNullValue());
+  }
+
+  private void defineFailedIntrospectionWithImagePullError(String imagePullError) {
+    testSupport.defineResources(asFailedJobWithBackoffLimitExceeded(createIntrospectorJob()));
+    testSupport.defineResources(asFailedJobPodWithImagePullError(createIntrospectorJobPod(), imagePullError));
+  }
+
+  private V1Pod asFailedJobPodWithImagePullError(V1Pod introspectorJobPod, String imagePullError) {
+    List<V1ContainerStatus> statuses = Arrays.asList(new V1ContainerStatus().state(new V1ContainerState()
+            .waiting(new V1ContainerStateWaiting().reason(imagePullError))));
+    return introspectorJobPod.status(new V1PodStatus().containerStatuses(statuses));
+  }
+
+  private V1Pod createIntrospectorJobPod() {
+    String jobName = UID + "-introspector";
+    Map<String, String> labels = new HashMap<>();
+    labels.put(LabelConstants.JOBNAME_LABEL, jobName);
+    return new V1Pod().metadata(new V1ObjectMeta().name(jobName).labels(labels).namespace(NS));
+  }
+
+  private V1Job asFailedJobWithBackoffLimitExceeded(V1Job job) {
+    job.setStatus(new V1JobStatus().addConditionsItem(new V1JobCondition().status("True").type("Failed")
+            .reason("BackoffLimitExceeded")));
+    return job;
+  }
+
+  @Test
+  void whenPreviousFailedJobWithImagePullBackoffErrorExistsAndMakeRightContinued_createNewJob() {
+    ignoreIntrospectorFailureLogs();
+    ignoreJobCreatedAndDeletedLogs();
+    testSupport.addToPacket(DOMAIN_TOPOLOGY, createDomainConfig("cluster-1"));
+    defineFailedIntrospectionWithImagePullError("ImagePullBackOff");
+    testSupport.doOnCreate(JOB, this::recordJob);
+
+    testSupport.runSteps(JobHelper.createIntrospectionStartStep(null));
+
+    assertThat(affectedJob, notNullValue());
+  }
+
   private V1Job affectedJob;
 
   private void recordJob(Object job) {
@@ -677,11 +767,15 @@ class DomainIntrospectorJobTest {
   }
 
   private V1Job createIntrospectorJob() {
-    return new V1Job().metadata(createJobMetadata()).status(new V1JobStatus());
+    return createIntrospectorJob(JOB_UID);
   }
 
-  private V1ObjectMeta createJobMetadata() {
-    return new V1ObjectMeta().name(getJobName()).namespace(NS).creationTimestamp(SystemClock.now()).uid(JOB_UID);
+  private V1Job createIntrospectorJob(String uid) {
+    return new V1Job().metadata(createJobMetadata(uid)).status(new V1JobStatus());
+  }
+
+  private V1ObjectMeta createJobMetadata(String uid) {
+    return new V1ObjectMeta().name(getJobName()).namespace(NS).creationTimestamp(SystemClock.now()).uid(uid);
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -129,7 +129,6 @@ class DomainIntrospectorJobTest {
   private static final String INFO_MESSAGE = "@[INFO] just letting you know";
   public static final String TEST_VOLUME_NAME = "test";
   private static final String JOB_UID = "FAILED_JOB";
-
   private final TerminalStep terminalStep = new TerminalStep();
   private final Domain domain = createDomain();
   private final DomainPresenceInfo domainPresenceInfo = createDomainPresenceInfo(domain);
@@ -627,10 +626,6 @@ class DomainIntrospectorJobTest {
     return job;
   }
 
-  private long getIntrospectorJobActiveDeadlineSeconds() {
-    return TuningParameters.getInstance().getPodTuning().introspectorJobActiveDeadlineSeconds;
-  }
-
   @Test
   void whenPreviousFailedJobWithImagePullErrorExistsAndMakeRightContinued_createNewJob() {
     ignoreIntrospectorFailureLogs();
@@ -878,7 +873,6 @@ class DomainIntrospectorJobTest {
 
     assertThat(getUpdatedDomain().getStatus().getIntrospectJobFailureCount(), equalTo(2));
   }
-
 
   // create job
   // add job uid to status

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -50,6 +50,7 @@ import oracle.kubernetes.weblogic.domain.ServerConfigurator;
 import oracle.kubernetes.weblogic.domain.model.ConfigurationConstants;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
+import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainValidationBaseTest;
 import oracle.kubernetes.weblogic.domain.model.Istio;
 import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
@@ -677,7 +678,9 @@ class JobHelperTest extends DomainValidationBaseTest {
 
   @Test
   void verify_introspectorPodSpec_activeDeadlineSeconds_retry_values() {
-    int failureCount = domainPresenceInfo.incrementAndGetFailureCount();
+    domainPresenceInfo.getDomain()
+            .setStatus(new DomainStatus().withIntrospectJobFailureCount(1));
+    int failureCount = domainPresenceInfo.getDomain().getStatus().getIntrospectJobFailureCount();
 
     V1JobSpec jobSpec = createJobSpec();
 
@@ -1217,7 +1220,6 @@ class JobHelperTest extends DomainValidationBaseTest {
         not(hasEnvVar(ISTIO_USE_LOCALHOST_BINDINGS, "false"))
     );
   }
-
 
   private V1Job job;
 


### PR DESCRIPTION
This PR is for merging changes from PR 2580 to main. It has below changes -

- Fix for the introspector retry behavior following a introspection job time out.
- Fix for NPE when the domain resource has a missing secret
- Changes to capture the WDT log files to the LOG_HOME directory to facilitate in debugging introspector timeout.
- Improve error message when introspector job times out with suggestion to increase the timeout value.