### PR TITLE
Option to use Ngnix Ingress Image for ocir   

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
@@ -175,7 +175,7 @@ public class LoadBalancerUtils {
                                                  int nodeportshttps,
                                                  String chartVersion) {
     LoggingFacade logger = getLogger();
-    if (! BASE_IMAGES_REPO.contains(OCIR_DEFAULT)) {
+    if (BASE_IMAGES_REPO.contains(OCIR_DEFAULT)) {
       testUntil(
           () -> dockerLogin(OCIR_REGISTRY, OCIR_USERNAME, OCIR_PASSWORD),
           logger, "docker login to be successful");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
@@ -47,6 +47,7 @@ import static oracle.weblogic.kubernetes.TestConstants.NGINX_INGRESS_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.NGINX_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.NGINX_REPO_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.NGINX_REPO_URL;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_NGINX_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_REGISTRY;
@@ -174,17 +175,19 @@ public class LoadBalancerUtils {
                                                  int nodeportshttps,
                                                  String chartVersion) {
     LoggingFacade logger = getLogger();
-    testUntil(
+    if (! BASE_IMAGES_REPO.contains(OCIR_DEFAULT)) {
+      testUntil(
           () -> dockerLogin(OCIR_REGISTRY, OCIR_USERNAME, OCIR_PASSWORD),
           logger, "docker login to be successful");
 
-    String localNginxImage = BASE_IMAGES_REPO + "/" 
+      String localNginxImage = BASE_IMAGES_REPO + "/" 
               + OCIR_NGINX_IMAGE_NAME + ":" + NGINX_INGRESS_IMAGE_TAG;
-    testUntil(
+      testUntil(
           pullImageFromOcirAndTag(localNginxImage),
           logger,
           "pullImageFromOcirAndTag for image {0} to be successful",
           localNginxImage);
+    }
 
     // Helm install parameters
     HelmParams nginxHelmParams = new HelmParams()

--- a/kubernetes/samples/charts/util/setupLoadBalancer.sh
+++ b/kubernetes/samples/charts/util/setupLoadBalancer.sh
@@ -239,7 +239,7 @@ function deleteIngress() {
        --selector=app.kubernetes.io/instance=${type}-release \
        --timeout=120s
     ${kubernetesCli} delete ns ${ns}
-    ${kubernetesCli} wait --for=delete namespace ${ns} --timeout=60s
+    ${kubernetesCli} wait --for=delete namespace ${ns} --timeout=60s || true
     printInfo "Remove ${type} chart repository [${repository}] "
     helm repo remove ${repository}
   else


### PR DESCRIPTION
Here the test infra will optionally pull/tag Nginx Image from OCIR if the base image repository is set to phx.ocir.io 
Otherwise the image will be automatically pulled from k8s.gcr.io/ingress-nginx/

This also makes a change to setupLoadBalancer.sh to resolve intermittent issue in ItWlsSample class

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7138 
https://build.weblogick8s.org:8443/job/wko-oke-nightly-seqential/489/  ( OKE run ) 
