### PR TITLE
OWLS-93783: WLSVERSIONEARLIERTHAN METHOD IS MISSING IN 3.3.3

### DIFF
--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -139,6 +139,13 @@ class OfflineWlstEnv(object):
   def getModel(self):
     return self.model
 
+  def wlsVersionEarlierThan(self, version):
+    # unconventional import within function definition for unit testing
+    from weblogic.management.configuration import LegalHelper
+    # WLS Domain versions supported by operator are 12.2.1.3 + patches, 12.2.1.4
+    # and 14.1.1.0 so current version will only be one of these that are listed.
+    return LegalHelper.versionEarlierThan("14.1.1.0", version)
+
 class SecretManager(object):
 
   def __init__(self, env):

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -62,6 +62,18 @@ class WdtUpdateFilterCase(unittest.TestCase):
 
     return model
 
+  def getModelWithoutMockEnv(self):
+    # Load model as dictionary
+    file = open(r'../resources/model.dynamic_cluster_dict.txt')
+    contents = file.read()
+    model = ast.literal_eval(contents)
+    file.close()
+
+    # Setup environment
+    model_wdt_mii_filter.initOfflineWlstEnv(model)
+
+    return model
+
   def getStaticModel(self):
     # Load model as dictionary
     file = open(r'../resources/model.static_cluster_dict.txt')
@@ -393,6 +405,21 @@ class WdtUpdateFilterCase(unittest.TestCase):
 
     isSecureModeEnabled = model_wdt_mii_filter.isSecureModeEnabledForDomain(topology)
     self.assertTrue(isSecureModeEnabled, "Expected secure mode enabled for domain")
+
+  def test_isSecureModeEnabledForDomain_importLegalHelperError(self):
+    try:
+      model = self.getModelWithoutMockEnv()
+      topology = model['topology']
+
+      topology['ProductionModeEnabled'] = 'true'
+
+      isSecureModeEnabled = model_wdt_mii_filter.isSecureModeEnabledForDomain(topology)
+      self.fail("Expected import error for LegalHelper")
+    except ImportError, ie:
+      self.assertTrue(ie is not None)
+
+
+
 
 class MockOfflineWlstEnv(model_wdt_mii_filter.OfflineWlstEnv):
 

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -371,6 +371,29 @@ class WdtUpdateFilterCase(unittest.TestCase):
       del os.environ['ISTIO_ENABLED']
       del os.environ['ISTIO_USE_LOCALHOST_BINDINGS']
 
+  def test_isSecureModeEnabledForDomain_secureModeEnabled(self):
+    model = self.getModel()
+    topology = model['topology']
+    if 'SecurityConfiguration' not in topology:
+      topology['SecurityConfiguration'] = {}
+
+    if 'SecureMode' not in topology['SecurityConfiguration']:
+      topology['SecurityConfiguration']['SecureMode'] = {}
+
+    topology['SecurityConfiguration']['SecureMode']['SecureModeEnabled'] = 'true'
+
+    isSecureModeEnabled = model_wdt_mii_filter.isSecureModeEnabledForDomain(topology)
+    self.assertTrue(isSecureModeEnabled, "Expected secure mode enabled for domain")
+
+  def test_isSecureModeEnabledForDomain_productionModeEnabled(self):
+    model = self.getModel()
+    topology = model['topology']
+
+    topology['ProductionModeEnabled'] = 'true'
+
+    isSecureModeEnabled = model_wdt_mii_filter.isSecureModeEnabledForDomain(topology)
+    self.assertTrue(isSecureModeEnabled, "Expected secure mode enabled for domain")
+
 class MockOfflineWlstEnv(model_wdt_mii_filter.OfflineWlstEnv):
 
   WLS_CRED_USERNAME = 'weblogic'
@@ -387,6 +410,9 @@ class MockOfflineWlstEnv(model_wdt_mii_filter.OfflineWlstEnv):
       return self.WLS_CRED_USERNAME
 
     return self.WLS_CRED_PASSWORD
+
+  def wlsVersionEarlierThan(self, version):
+    return False
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Add missing wlsVersionEarlierThan method in model filtering for MII and add unit tests to verify isSecureModeEnabled and missing import.