### PR TITLE
Fix for intermittent traefik installation failures in parallel run for MII sample tests

### DIFF
--- a/operator/integration-tests/model-in-image/deploy-traefik.sh
+++ b/operator/integration-tests/model-in-image/deploy-traefik.sh
@@ -31,8 +31,8 @@ source $TESTDIR/test-env.sh
 
 WORKDIR=${WORKDIR:-/tmp/$USER/model-in-image-sample-work-dir}
 
-TRAEFIK_NAME=${TRAEFIK_NAME:-traefik-operator}
 TRAEFIK_NAMESPACE=${TRAEFIK_NAMESPACE:-traefik-operator-ns}
+TRAEFIK_NAME=${TRAEFIK_NAME:-traefik-operator-$TRAEFIK_NAMESPACE}
 TRAEFIK_HTTP_NODEPORT=${TRAEFIK_HTTP_NODEPORT:-30305}
 TRAEFIK_HTTPS_NODEPORT=${TRAEFIK_HTTPS_NODEPORT:-30433}
 
@@ -88,8 +88,7 @@ else
     --namespace $TRAEFIK_NAMESPACE \
     --set "kubernetes.namespaces={$TRAEFIK_NAMESPACE,$DOMAIN_NAMESPACE}" \
     --set "ports.web.nodePort=${TRAEFIK_HTTP_NODEPORT}" \
-    --set "ports.websecure.nodePort=${TRAEFIK_HTTPS_NODEPORT}" \
-    --set "meta.helm.sh/release-namespace=${TRAEFIK_NAMESPACE}"
+    --set "ports.websecure.nodePort=${TRAEFIK_HTTPS_NODEPORT}"
 
   set +x
 

--- a/operator/integration-tests/model-in-image/deploy-traefik.sh
+++ b/operator/integration-tests/model-in-image/deploy-traefik.sh
@@ -88,7 +88,8 @@ else
     --namespace $TRAEFIK_NAMESPACE \
     --set "kubernetes.namespaces={$TRAEFIK_NAMESPACE,$DOMAIN_NAMESPACE}" \
     --set "ports.web.nodePort=${TRAEFIK_HTTP_NODEPORT}" \
-    --set "ports.websecure.nodePort=${TRAEFIK_HTTPS_NODEPORT}" 
+    --set "ports.websecure.nodePort=${TRAEFIK_HTTPS_NODEPORT}" \
+    --set "meta.helm.sh/release-namespace=${TRAEFIK_NAMESPACE}"
 
   set +x
 

--- a/operator/integration-tests/model-in-image/test-env.sh
+++ b/operator/integration-tests/model-in-image/test-env.sh
@@ -37,7 +37,7 @@ export DB_IMAGE_PULL_SECRET=${DB_IMAGE_PULL_SECRET:-docker-secret}
 # ::: Traefik settings/defaults, set NODEPORT values to 0 to have
 #     K8S dynamically choose the values for Traefik
 export TRAEFIK_NAMESPACE=${TRAEFIK_NAMESPACE:-traefik-operator-ns}
-TRAEFIK_NAME=${TRAEFIK_NAME:-traefik-operator-$TRAEFIK_NAMESPACE}
+export TRAEFIK_NAME=${TRAEFIK_NAME:-traefik-operator-$TRAEFIK_NAMESPACE}
 export TRAEFIK_HTTP_NODEPORT=${TRAEFIK_HTTP_NODEPORT:-30305}
 export TRAEFIK_HTTPS_NODEPORT=${TRAEFIK_HTTPS_NODEPORT:-30433}
 

--- a/operator/integration-tests/model-in-image/test-env.sh
+++ b/operator/integration-tests/model-in-image/test-env.sh
@@ -36,8 +36,8 @@ export DB_IMAGE_PULL_SECRET=${DB_IMAGE_PULL_SECRET:-docker-secret}
 
 # ::: Traefik settings/defaults, set NODEPORT values to 0 to have
 #     K8S dynamically choose the values for Traefik
-export TRAEFIK_NAME=${TRAEFIK_NAME:-traefik-operator}
 export TRAEFIK_NAMESPACE=${TRAEFIK_NAMESPACE:-traefik-operator-ns}
+TRAEFIK_NAME=${TRAEFIK_NAME:-traefik-operator-$TRAEFIK_NAMESPACE}
 export TRAEFIK_HTTP_NODEPORT=${TRAEFIK_HTTP_NODEPORT:-30305}
 export TRAEFIK_HTTPS_NODEPORT=${TRAEFIK_HTTPS_NODEPORT:-30433}
 


### PR DESCRIPTION
Make traefik name unique by adding namespace to the name. 

Jenkins results, MII sample tests are not failing -
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7152/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7151/
