### PR TITLE
Fix the nightly DB port conflict issue

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -193,7 +193,7 @@ class ItConfigDistributionStrategy {
     logger.info("mysqlDBPort1 is: " + mysqlDBPort1);
     createMySQLDB("mysqldb-2", "root", "root456", getNextFreePort(), domainNamespace, null);
     mysqlDBPort2 = getMySQLNodePort(domainNamespace, "mysqldb-2");
-    logger.info("mysqlDBPort1 is: " + mysqlDBPort2);
+    logger.info("mysqlDBPort2 is: " + mysqlDBPort2);
 
     if (OKD) {
       mysql1SvcEndpoint = getMySQLSvcEndpoint(domainNamespace, "mysqldb-1");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -188,10 +188,12 @@ class ItConfigDistributionStrategy {
 
 
     //start two MySQL database instances
-    createMySQLDB("mysqldb-1", "root", "root123", 0, domainNamespace, null);
+    createMySQLDB("mysqldb-1", "root", "root123", getNextFreePort(), domainNamespace, null);
     mysqlDBPort1 = getMySQLNodePort(domainNamespace, "mysqldb-1");
-    createMySQLDB("mysqldb-2", "root", "root456", 0, domainNamespace, null);
+    logger.info("mysqlDBPort1 is: " + mysqlDBPort1);
+    createMySQLDB("mysqldb-2", "root", "root456", getNextFreePort(), domainNamespace, null);
     mysqlDBPort2 = getMySQLNodePort(domainNamespace, "mysqldb-2");
+    logger.info("mysqlDBPort1 is: " + mysqlDBPort2);
 
     if (OKD) {
       mysql1SvcEndpoint = getMySQLSvcEndpoint(domainNamespace, "mysqldb-1");


### PR DESCRIPTION
1) Use getNextFreePort() for MySQL DB node port; 2) add logging msg to print out MySQL node port.

On kind new cluster single test passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7169/testReport/

Full test suite result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7170/testReport/