### PR TITLE
OWLS-93641 - Fix for MII auxiliary image negative test case failure on OKD

### DIFF
--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -715,7 +715,7 @@ function checkAuxiliaryImage() {
     rm -f ${AUXILIARY_IMAGE_PATH}/testaccess.tmp || return 1
 
     # The container .out files embed their container name, the names will sort in the same order in which the containers ran
-    out_files=$(set -o pipefail ; ls -1 $AUXILIARY_IMAGE_PATH/auxiliaryImageLogs/*.out 2>1 | sort --version-sort) \
+    out_files=$(set -o pipefail ; ls -1 $AUXILIARY_IMAGE_PATH/auxiliaryImageLogs/*.out 2>&1 | sort --version-sort) \
       || (trace SEVERE "Auxiliary Image: Assertion failure. No files found in '$AUXILIARY_IMAGE_PATH/auxiliaryImageLogs/*.out" \
       && return 1)
     severe_found=false


### PR DESCRIPTION
The permission denied error was because of missing "&" when redirecting the standard error to standard output during `ls -1` command execution. This didn't fail on other platforms but fails on OKD due to different permissions. Maggie has verified that the fix resolves the issue on OKD and entire MIIAuxiliaryImage test suite is passing with this change on OKD.  