### PR TITLE
Correct some status update oversights

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -73,6 +73,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import org.jetbrains.annotations.NotNull;
 
+import static oracle.kubernetes.operator.DomainStatusUpdater.createStatusInitializationStep;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createStatusUpdateStep;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECT_REQUESTED;
@@ -1112,7 +1113,7 @@ public class DomainProcessorImpl implements DomainProcessor {
     Step managedServerStrategy = Step.chain(
         bringManagedServersUp(null),
         MonitoringExporterSteps.updateExporterSidecars(),
-        new TailStep());
+        createStatusUpdateStep(new TailStep()));
 
     Step domainUpStrategy =
         Step.chain(
@@ -1193,8 +1194,8 @@ public class DomainProcessorImpl implements DomainProcessor {
     }
 
     private Step getNextSteps() {
-      if (lookForPodsAndServices()) {
-        return Step.chain(createStatusUpdateStep(null), getRecordExistingResourcesSteps(), getNext());
+      if (lookForPodsAndServices()) {   // REG-> change this to initialize-status-if-needed step
+        return Step.chain(createStatusInitializationStep(), getRecordExistingResourcesSteps(), getNext());
       } else {
         return getNext();
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -14,6 +15,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -84,6 +86,7 @@ import static oracle.kubernetes.operator.logging.MessageKeys.DOMAIN_FATAL_ERROR;
 import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_MAX_ERRORS_EXCEEDED;
 import static oracle.kubernetes.operator.logging.MessageKeys.TOO_MANY_REPLICAS_FAILURE;
 import static oracle.kubernetes.utils.OperatorUtils.onSeparateLines;
+import static oracle.kubernetes.weblogic.domain.model.DomainCondition.TRUE;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Available;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Completed;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.ConfigChangesPendingRestart;
@@ -98,8 +101,6 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed
 public class DomainStatusUpdater {
 
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-  private static final String TRUE = "True";
-  private static final String FALSE = "False";
 
   private DomainStatusUpdater() {
   }
@@ -473,8 +474,8 @@ public class DomainStatusUpdater {
     @Override
     void modifyStatus(DomainStatus status) {
       if (status.getConditions().isEmpty()) {
-        status.addCondition(new DomainCondition(Completed).withStatus("False"));
-        status.addCondition(new DomainCondition(Available).withStatus("False"));
+        status.addCondition(new DomainCondition(Completed).withStatus(false));
+        status.addCondition(new DomainCondition(Available).withStatus(false));
       }
     }
   }
@@ -527,43 +528,32 @@ public class DomainStatusUpdater {
       @Nonnull
       @Override
       List<EventData> createDomainEvents() {
-        List<EventData> list = new ArrayList<>();
-        if (domainJustAvailable()) {
-          list.add(new EventData(DOMAIN_AVAILABLE));
+        return new Conditions().getNewConditions(getStatus()).stream()
+              .map(this::toEvent)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+      }
+
+      private EventData toEvent(DomainCondition newCondition) {
+        switch (newCondition.getType()) {
+          case Completed:
+            return new EventData(DOMAIN_COMPLETE);
+          case Available:
+            return new EventData(DOMAIN_AVAILABLE);
+          default:
+            return null;
         }
-        if (processingJustCompleted()) {
-          list.add(new EventData(DOMAIN_COMPLETE));
-        }
-        return list;
-      }
-
-      private boolean processingJustCompleted() {
-        return allIntendedServersRunning() && !oldStatusWasCompleted();
-      }
-
-      private boolean oldStatusWasCompleted() {
-        return getStatus() != null && getStatus().hasConditionWith(this::isDomainCompleted);
-      }
-
-      private boolean oldStatusWasAvailable() {
-        return getStatus() != null && getStatus().hasConditionWith(this::isDomainAvailable);
-      }
-
-      private boolean domainJustAvailable() {
-        return sufficientServersRunning() && !oldStatusWasAvailable();
       }
 
       private void setStatusConditions(DomainStatus status) {
-        status.addCondition(new DomainCondition(Completed).withStatus(isProcessingCompleted() ? TRUE : FALSE));
-        status.addCondition(new DomainCondition(Available).withStatus(sufficientServersRunning() ? TRUE : FALSE));
-        removeUnneededFailures(status);
-        addTooManyReplicasFailuresIfNeeded(status);
+        Conditions newConditions = new Conditions();
+        newConditions.apply(status);
 
         if (isHasFailedPod()) {
-          status.addCondition(new DomainCondition(Failed).withStatus(TRUE).withReason(ServerPod));
-        } else if (allIntendedServersRunning()) {
-          if (!stillHasPodPendingRestart(status)
-              && status.hasConditionWithType(ConfigChangesPendingRestart)) {
+          status.addCondition(new DomainCondition(Failed).withStatus(true).withReason(ServerPod));
+        } else {
+          status.removeConditionsMatching(c -> c.hasType(Failed) && ServerPod.name().equals(c.getReason()));
+          if (newConditions.allIntendedServersRunning() && !stillHasPodPendingRestart(status)) {
             status.removeConditionWithType(ConfigChangesPendingRestart);
           }
         }
@@ -573,63 +563,143 @@ public class DomainStatusUpdater {
         }
       }
 
-      private boolean isProcessingCompleted() {
-        return !haveTooManyReplicas() && allIntendedServersRunning();
+      private boolean haveServerData() {
+        return this.serverState != null;
       }
 
-      private void removeUnneededFailures(DomainStatus status) {
-        if (allIntendedServersRunning()) {
-          status.removeConditionWithType(Failed);
+      class Conditions {
+
+        private final ClusterCheck[] clusterChecks = createClusterChecks();
+        private final List<DomainCondition> conditions = new ArrayList<>();
+
+        void apply(DomainStatus status) {
+          status.removeConditionsMatching(c -> c.hasType(Failed) && ReplicasTooHigh.name().equals(c.getReason()));
+          conditions.forEach(status::addCondition);
+        }
+
+        List<DomainCondition> getNewConditions(DomainStatus status) {
+          return conditions.stream()
+                .filter(c -> "True".equals(c.getStatus()))
+                .filter(c -> status == null || !status.hasConditionWith(matchFor(c)))
+                .collect(Collectors.toList());
+        }
+
+        Predicate<DomainCondition> matchFor(DomainCondition condition) {
+          return c -> c.getType().equals(condition.getType()) && "True".equals(c.getStatus());
+        }
+
+        @Nonnull
+        private ClusterCheck[] createClusterChecks() {
+          return getConfiguredClusters().stream().map(ClusterCheck::new).toArray(ClusterCheck[]::new);
+        }
+
+        private List<WlsClusterConfig> getConfiguredClusters() {
+          return Optional.ofNullable(config)
+                .map(WlsDomainConfig::getConfiguredClusters)
+                .orElse(Collections.emptyList());
+        }
+
+        public Conditions() {
+          conditions.add(new DomainCondition(Completed).withStatus(isProcessingCompleted()));
+          conditions.add(new DomainCondition(Available).withStatus(sufficientServersRunning()));
+          computeTooManyReplicasFailures();
+        }
+
+        private boolean isProcessingCompleted() {
+          return !haveTooManyReplicas() && allIntendedServersRunning();
+        }
+
+        private boolean haveTooManyReplicas() {
+          return Arrays.stream(clusterChecks).anyMatch(ClusterCheck::hasTooManyReplicas);
+        }
+
+        private boolean allIntendedServersRunning() {
+          return haveServerData()
+                && allStartedServersAreRunning()
+                && allNonStartedServersAreShutdown()
+                && serversMarkedForRoll().isEmpty();
+        }
+
+        private boolean sufficientServersRunning() {
+          return atLeastOneApplicationServerStarted() && allNonClusteredServersRunning() && allClustersAvailable();
+        }
+
+        private boolean allClustersAvailable() {
+          return Arrays.stream(clusterChecks).allMatch(ClusterCheck::isAvailable);
+        }
+
+        private void computeTooManyReplicasFailures() {
+          Arrays.stream(clusterChecks)
+                .filter(ClusterCheck::hasTooManyReplicas)
+                .forEach(check -> conditions.add(check.createFailureCondition()));
         }
       }
 
-      private void addTooManyReplicasFailuresIfNeeded(DomainStatus status) {
-        getConfiguredClusters().stream()
-              .map(TooManyReplicasCheck::new)
-              .filter(TooManyReplicasCheck::isFailure)
-              .forEach(check -> status.addCondition(check.createFailureCondition()));
-      }
-
-      private boolean haveTooManyReplicas() {
-        return getConfiguredClusters().stream()
-              .map(TooManyReplicasCheck::new)
-              .anyMatch(TooManyReplicasCheck::isFailure);
-      }
-
-      private List<WlsClusterConfig> getConfiguredClusters() {
-        return Optional.ofNullable(config).map(WlsDomainConfig::getConfiguredClusters).orElse(Collections.emptyList());
-      }
-
-      private class TooManyReplicasCheck {
+      private class ClusterCheck {
         private final String clusterName;
+        private final int minReplicaCount;
         private final int maxReplicaCount;
         private final int specifiedReplicaCount;
+        private final List<String> startedServers;
 
-        TooManyReplicasCheck(WlsClusterConfig cluster) {
+        ClusterCheck(WlsClusterConfig cluster) {
           clusterName = cluster.getClusterName();
-          maxReplicaCount = cluster.getMaxDynamicClusterSize();
+          minReplicaCount = cluster.getMinClusterSize();
+          maxReplicaCount = cluster.getMaxClusterSize();
           specifiedReplicaCount = getDomain().getReplicaCount(clusterName);
+          startedServers = getStartedServersInCluster(clusterName);
         }
 
-        private boolean isFailure() {
+        boolean isAvailable() {
+          return isClusterIntentionallyShutDown() || sufficientServersRunning();
+        }
+
+        boolean hasTooManyReplicas() {
           return maxReplicaCount > 0 && specifiedReplicaCount > maxReplicaCount;
         }
 
-        private DomainCondition createFailureCondition() {
+        DomainCondition createFailureCondition() {
           return new DomainCondition(Failed).withReason(ReplicasTooHigh).withMessage(createFailureMessage());
+        }
+
+        private boolean isClusterIntentionallyShutDown() {
+          return startedServers.isEmpty();
+        }
+
+        private boolean sufficientServersRunning() {
+          return numServersReady() >= getSufficientServerCount();
+        }
+
+        private long getSufficientServerCount() {
+          return max(1, minReplicas(), specifiedReplicaCount - maxUnavailable());
+        }
+
+        private int max(Integer... inputs) {
+          return Arrays.stream(inputs).reduce(0, Math::max);
+        }
+
+        private int minReplicas() {
+          return getDomain().isAllowReplicasBelowMinDynClusterSize(clusterName) ? 0 : minReplicaCount;
+        }
+
+        private long numServersReady() {
+          return startedServers.stream()
+                .map(StatusUpdateContext.this::getRunningState)
+                .filter(this::isRunning)
+                .count();
+        }
+
+        private int maxUnavailable() {
+          return getDomain().getMaxUnavailable(clusterName);
+        }
+
+        private boolean isRunning(String serverState) {
+          return RUNNING_STATE.equals(serverState);
         }
 
         private String createFailureMessage() {
           return LOGGER.formatMessage(TOO_MANY_REPLICAS_FAILURE, specifiedReplicaCount, clusterName, maxReplicaCount);
         }
-      }
-
-      private boolean isDomainCompleted(DomainCondition condition) {
-        return condition.hasType(Completed) && condition.getStatus().equals("True");
-      }
-
-      private boolean isDomainAvailable(DomainCondition condition) {
-        return condition.hasType(Available) && condition.getStatus().equals("True");
       }
 
       private void setStatusDetails(DomainStatus status) {
@@ -672,9 +742,8 @@ public class DomainStatusUpdater {
       }
 
       private void updateDomainConditions(DomainStatus status, String message) {
-        DomainCondition onlineUpdateCondition = new DomainCondition(ConfigChangesPendingRestart)
-            .withMessage(message)
-            .withStatus("True");
+        DomainCondition onlineUpdateCondition
+              = new DomainCondition(ConfigChangesPendingRestart).withMessage(message).withStatus(true);
 
         status.removeConditionWithType(ConfigChangesPendingRestart);
         status.addCondition(onlineUpdateCondition);
@@ -698,17 +767,6 @@ public class DomainStatusUpdater {
             .orElse(Collections.emptyMap());
       }
 
-      private boolean allIntendedServersRunning() {
-        return haveServerData()
-              && allStartedServersAreRunning()
-              && allNonStartedServersAreShutdown()
-              && serversMarkedForRoll().isEmpty();
-      }
-
-      private boolean haveServerData() {
-        return serverState != null;
-      }
-
       private boolean allStartedServersAreRunning() {
         return expectedRunningServers.stream().allMatch(this::isRunning);
       }
@@ -729,10 +787,6 @@ public class DomainStatusUpdater {
         return getInfo().getServerStartupInfo().size() > 0;
       }
 
-      private boolean sufficientServersRunning() {
-        return atLeastOneApplicationServerStarted() && allNonClusteredServersRunning() && allClustersAvailable();
-      }
-
       private @Nonnull List<String> getNonClusteredServers() {
         return expectedRunningServers.stream().filter(this::isNonClusteredServer).collect(Collectors.toList());
       }
@@ -741,39 +795,10 @@ public class DomainStatusUpdater {
         return getNonClusteredServers().stream().noneMatch(this::isNotRunning);
       }
 
-      private boolean allClustersAvailable() {
-        return getClusterNames().stream().allMatch(this::isAvailable);
-      }
-
-      private boolean isAvailable(String clusterName) {
-        return isClusterIntentionallyShutDown(clusterName) || sufficientServersInClusterRunning(clusterName);
-      }
-
-      private boolean sufficientServersInClusterRunning(String clusterName) {
-        return clusterHasRunningServer(clusterName)
-             && numServersInClusterNotReady(clusterName) <= maxUnavailable(clusterName);
-      }
-
-      private boolean isClusterIntentionallyShutDown(String clusterName) {
-        return getStartedServersInCluster(clusterName).isEmpty();
-      }
-
-      private boolean clusterHasRunningServer(String clusterName) {
-        return getStartedServersInCluster(clusterName).stream().anyMatch(this::isRunning);
-      }
-
-      private long numServersInClusterNotReady(String clusterName) {
-        return getStartedServersInCluster(clusterName).stream().filter(this::isNotRunning).count();
-      }
-
       private List<String> getStartedServersInCluster(String clusterName) {
         return expectedRunningServers.stream()
               .filter(server -> clusterName.equals(getClusterName(server)))
               .collect(Collectors.toList());
-      }
-
-      private int maxUnavailable(String clusterName) {
-        return getDomain().getMaxUnavailable(clusterName);
       }
 
       private Set<String> serversMarkedForRoll() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -46,9 +46,15 @@ public class DomainValidationSteps {
   private static final String SECRETS = "secrets";
   private static final String CONFIGMAPS = "configmaps";
 
-  public static Step createDomainValidationSteps(String namespace, Step next) {
-    return Step.chain(createListSecretsStep(namespace), createListConfigMapsStep(namespace),
-              new DomainValidationStep(next));
+  /**
+   * Returns a chain of steps to validate the domain in the current packet.
+   * @param namespace the namespace for the domain
+   */
+  public static Step createDomainValidationSteps(String namespace) {
+    return Step.chain(
+          createListSecretsStep(namespace),
+          createListConfigMapsStep(namespace),
+          new DomainValidationStep());
   }
 
   static Step createAdditionalDomainValidationSteps(V1PodSpec podSpec) {
@@ -79,7 +85,7 @@ public class DomainValidationSteps {
     }
 
     static List<V1Secret> getSecrets(Packet packet) {
-      return (List<V1Secret>) Optional.ofNullable(packet.get(SECRETS)).orElse(new ArrayList<>());
+      return Optional.ofNullable(packet.<List<V1Secret>>getValue(SECRETS)).orElse(new ArrayList<>());
     }
   }
 
@@ -99,15 +105,11 @@ public class DomainValidationSteps {
     }
 
     static List<V1ConfigMap> getConfigMaps(Packet packet) {
-      return (List<V1ConfigMap>) Optional.ofNullable(packet.get(CONFIGMAPS)).orElse(new ArrayList<>());
+      return Optional.ofNullable(packet.<List<V1ConfigMap>>getValue(CONFIGMAPS)).orElse(new ArrayList<>());
     }
   }
 
   static class DomainValidationStep extends Step {
-
-    DomainValidationStep(Step next) {
-      super(next);
-    }
 
     @Override
     public NextAction apply(Packet packet) {

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
@@ -50,6 +50,16 @@ public abstract class Step {
     return stepGroups[start];
   }
 
+  /**
+   * Chain the specified step groups into a single chain of steps.
+   *
+   * @param stepGroups multiple groups of steps
+   * @return the first step of the resultant chain
+   */
+  public static Step chain(List<Step> stepGroups) {
+    return chain(stepGroups.toArray(new Step[0]));
+  }
+
   private static int getFirstNonNullIndex(Step[] stepGroups) {
     for (int i = 0; i < stepGroups.length; i++) {
       if (stepGroups[i] != null) {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
@@ -21,6 +21,9 @@ import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPa
 /** DomainCondition contains details for the current condition of this domain. */
 public class DomainCondition implements Comparable<DomainCondition>, PatchableComponent<DomainCondition> {
 
+  public static final String TRUE = "True";
+  public static final String FALSE = "False";
+
   @Description(
       "The type of the condition. Valid types are Completed, "
           + "Available, Failed, and ConfigChangesPendingRestart.")
@@ -163,13 +166,25 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
   /**
    * The status of the condition. Can be True, False, Unknown. Required.
    *
-   * @param status status
-   * @return this
+   * @param status the new status value
+   * @return this object
    */
   public DomainCondition withStatus(String status) {
-    assert status.equals("True") || ! type.statusMustBeTrue() : "Attempt to set illegal status value";
+    assert status.equals(TRUE) || ! type.statusMustBeTrue() : "Attempt to set illegal status value";
     lastTransitionTime = SystemClock.now();
     this.status = status;
+    return this;
+  }
+
+  /**
+   * Sets the condition status to a boolean value, which will be converted to a standard string.
+   * @param status the new status value
+   * @return this object
+   */
+  public DomainCondition withStatus(boolean status) {
+    assert status || ! type.statusMustBeTrue() : "Attempt to set illegal status value";
+    lastTransitionTime = SystemClock.now();
+    this.status = status ? TRUE : FALSE;
     return this;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -169,7 +169,15 @@ public class DomainStatus {
    * @param type the type of the condition
    */
   public void removeConditionWithType(DomainConditionType type) {
-    for (DomainCondition condition : getConditionsMatching(c -> c.hasType(type))) {
+    removeConditionsMatching(c -> c.hasType(type));
+  }
+
+  /**
+   * Removes any condition matching the specified predicate.
+   * @param predicate the criteria for removing a condition
+   */
+  public void removeConditionsMatching(Predicate<DomainCondition> predicate) {
+    for (DomainCondition condition : getConditionsMatching(predicate)) {
       removeCondition(condition);
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
@@ -120,7 +120,7 @@ class DomainValidationStepTest {
     testSupport.defineResources(domain);
     testSupport.addDomainPresenceInfo(info);
     DomainProcessorTestSetup.defineRequiredResources(testSupport);
-    domainValidationSteps = DomainValidationSteps.createDomainValidationSteps(NS, terminalStep);
+    domainValidationSteps = Step.chain(DomainValidationSteps.createDomainValidationSteps(NS), terminalStep);
     topologyValidationStep = DomainValidationSteps.createValidateDomainTopologyStep(terminalStep);
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "domainEventK8SObjects", domainEventObjects));
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "namespaceEventK8SObjects", nsEventObjects));

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -219,6 +219,18 @@ class DomainStatusTest {
   }
 
   @Test
+  void whenConditionRemovedAndNoOtherHasMessage_setDomainStatusMessageNull() {
+    domainStatus.addCondition(new DomainCondition(Failed).withStatus("True").withMessage("m1").withReason(Internal));
+    domainStatus.addCondition(new DomainCondition(Completed).withStatus("True"));
+    domainStatus.addCondition(new DomainCondition(Available).withStatus("True"));
+
+    domainStatus.removeConditionWithType(Failed);
+
+    assertThat(domainStatus.getMessage(), nullValue());
+    assertThat(domainStatus.getReason(), nullValue());
+  }
+
+  @Test
   void whenClusterStatusAdded_statusHasClusterStatus() {
     domainStatus.addCluster(new ClusterStatus().withClusterName("cluster1").withReplicas(3));
 


### PR DESCRIPTION
This addresses multiple issues:

1. It brings the life-cycle of the Available condition in line with that of Completed. Both are now created false when the domain is recognized by the operator. (OWLS-93193, OWLS-94048)
2. It defines all servers shut down (such as start policy = NEVER) as Completed/true (OWLS-93493)
3. It corrects a bug in the detection of ReplicasTooHigh (OWLS-93692), but does not completely solve the issue; thus the JIRA remains open.