### PR TITLE
Temporarily disable trap in diff_model as logFileRotate or testLogFileRotate may return non-zero code.

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -1357,13 +1357,8 @@ function logSevereAndExit() {
 #   1 - Name of the log file to rotate and copy to WDT output directory.
 function wdtRotateAndCopyLogFile() {
   local logFileName=$1
-  # temporarily disable the trap as logFileRotate may return non-zero code
-  stop_trap
 
   logFileRotate "${WDT_OUTPUT_DIR}/${logFileName}" "${WDT_LOG_FILE_MAX:-11}"
 
   cp ${WDT_ROOT}/logs/${logFileName} ${WDT_OUTPUT_DIR}/
-
-  # restore trap
-  start_trap
 }

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -1357,10 +1357,13 @@ function logSevereAndExit() {
 #   1 - Name of the log file to rotate and copy to WDT output directory.
 function wdtRotateAndCopyLogFile() {
   local logFileName=$1
-  testLogFileRotate "${WDT_OUTPUT_DIR}/${logFileName}"
-  [ $? -ne 0 ] && trace SEVERE "Error accessing '${WDT_OUTPUT_DIR}'. See previous log messages." && exit 1
+  # temporarily disable the trap as logFileRotate may return non-zero code
+  stop_trap
 
   logFileRotate "${WDT_OUTPUT_DIR}/${logFileName}" "${WDT_LOG_FILE_MAX:-11}"
 
   cp ${WDT_ROOT}/logs/${logFileName} ${WDT_OUTPUT_DIR}/
+
+  # restore trap
+  start_trap
 }

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -626,6 +626,9 @@ function diff_model_v1() {
 
 function diff_model() {
   trace "Entering diff_model"
+  # wdt shell script or logFileRotate may return non-zero code if trap is on, then it will go to trap instead
+  # temporarily disable it
+  stop_trap
 
   export __WLSDEPLOY_STORE_MODEL__=1
   # $1 - new model, $2 original model
@@ -677,6 +680,9 @@ function diff_model() {
   fi
 
   wdtRotateAndCopyLogFile "${WDT_COMPARE_MODEL_LOG}"
+
+  # restore trap
+  start_trap
 
   trace "Exiting diff_model"
 }
@@ -1354,7 +1360,7 @@ function wdtRotateAndCopyLogFile() {
   testLogFileRotate "${WDT_OUTPUT_DIR}/${logFileName}"
   [ $? -ne 0 ] && trace SEVERE "Error accessing '${WDT_OUTPUT_DIR}'. See previous log messages." && exit 1
 
-  logFileRotate ${WDT_OUTPUT_DIR}/${logFileName} ${WDT_LOG_FILE_MAX:-11}
+  logFileRotate "${WDT_OUTPUT_DIR}/${logFileName}" "${WDT_LOG_FILE_MAX:-11}"
 
   cp ${WDT_ROOT}/logs/${logFileName} ${WDT_OUTPUT_DIR}/
 }

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -160,8 +160,10 @@ function logFileRotateInner() {
     _logmax_=$((logmax - 1))
   fi
   for logcur in $(logFilesReverse ${1} | tail -n +${_logmax_}); do
-    [ ! "$3" = "quiet" ] && trace "Removing old log file '${logcur}'."
-    rm $logcur
+    if [ -f "$logcur" ] ; then
+      [ ! "$3" = "quiet" ] && trace "Removing old log file '${logcur}'."
+      rm $logcur
+    fi
   done
 
   # if highest lognum is 99999, renumber existing files starting with 1
@@ -172,7 +174,9 @@ function logFileRotateInner() {
     local logcur
     for logcur in $(logFiles "$1"); do
       lastlognum=$((lastlognum + 1))
-      mv "$logcur" "${1}$(printf "%0.5i" $lastlognum)"
+      if [ -f "$logcur" ] ; then
+        mv "$logcur" "${1}$(printf "%0.5i" $lastlognum)"
+      fi
     done
   fi
 
@@ -182,13 +186,16 @@ function logFileRotateInner() {
     if [ -f "$1" ]; then
       local nextlognum=$((lastlognum + 1))
       [ ! "$3" = "quiet" ] && trace "Rotating '$1' to '${1}$(printf "%0.5i" $nextlognum)'."
-      mv "$1" "${1}$(printf "%0.5i" $nextlognum)"
+      if [ -f "$1" ] ; then
+        mv "$1" "${1}$(printf "%0.5i" $nextlognum)"
+      fi
     fi
   else
-    rm -f "$1"
+    if [ -f "$1" ] ; then
+     rm -f "$1"
+    fi
   fi
 }
-
 #
 # internal helper for logFileRotate():
 #


### PR DESCRIPTION
The wdt shell script or logFileRotate may return non-zero code and it will go to trap if the trap is on. This change temporarily disables the trap and then restores it in the end.