### PR TITLE
Introduce end-of-line normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.py text eol=lf

--- a/documentation/staging/content/faq/external-clients.md
+++ b/documentation/staging/content/faq/external-clients.md
@@ -320,7 +320,7 @@ topology:
                 TunnelingEnabled: true
                 OutboundEnabled: false
                 Enabled: true
-                TwoWaySslEnabled: false
+                TwoWaySSLEnabled: false
                 ClientCertificateEnforced: false
 ```
 


### PR DESCRIPTION
We have lots of shell script in samples folder, it 's easy to run into LF ending issue if customer working with Windows WSL, see #2636

This pr contains:   
- small fix for property `TwoWaySSLEnabled` name in documentation/staging/content/faq/external-clients.md
- .[gitattributes](https://www.git-scm.com/docs/gitattributes#_end_of_line_conversion) to normalize .sh and .py files with LF.

The customer should checkout all .sh and .py files  with LF ending in different platforms.

If you have local .gitattributes, please run the following command to refresh files endings.

```
git rm --cached -r
git reset --hard
```