### PR TITLE
Support hostAliases

### DIFF
--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -782,10 +782,6 @@
           "description": "NodeName is a request to schedule this Pod onto a specific Node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits the resource requirements. See `kubectl explain pods.spec.nodeName`.",
           "type": "string"
         },
-        "livenessProbe": {
-          "description": "Settings for the liveness probe associated with a WebLogic Server instance.",
-          "$ref": "#/definitions/ProbeTuning"
-        },
         "readinessGates": {
           "description": "If specified, all readiness gates will be evaluated for Pod readiness. A Pod is ready when all its containers are ready AND all conditions specified in the readiness gates have a status equal to \"True\". More info: https://github.com/kubernetes/community/blob/master/keps/sig-network/0007-pod-ready%2B%2B.md.",
           "type": "array",
@@ -805,17 +801,6 @@
           "description": "If specified, indicates the Pod\u0027s priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be the default or zero, if there is no default. See `kubectl explain pods.spec.priorityClassName`.",
           "type": "string"
         },
-        "volumes": {
-          "description": "Additional volumes to be created in the server Pod. See `kubectl explain pods.spec.volumes`.",
-          "type": "array",
-          "items": {
-            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
-          }
-        },
-        "resources": {
-          "description": "Memory and CPU minimum requirements and limits for the WebLogic Server instance. See `kubectl explain pods.spec.containers.resources`.",
-          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
         "annotations": {
           "description": "The annotations to be added to generated resources.",
           "additionalProperties": {
@@ -823,16 +808,12 @@
           },
           "$ref": "#/definitions/Map"
         },
-        "env": {
-          "description": "A list of environment variables to set in the container running a WebLogic Server instance. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-resource/#jvm-memory-and-java-option-environment-variables. See `kubectl explain pods.spec.containers.env`.",
+        "hostAliases": {
+          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod\u0027s hosts file if specified. This is only valid for non-hostNetwork pods.",
           "type": "array",
           "items": {
-            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.HostAlias"
           }
-        },
-        "restartPolicy": {
-          "description": "Restart policy for all containers within the Pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy. See `kubectl explain pods.spec.restartPolicy`.",
-          "type": "string"
         },
         "nodeSelector": {
           "description": "Selector which must match a Node\u0027s labels for the Pod to be scheduled on that Node. See `kubectl explain pods.spec.nodeSelector`.",
@@ -848,13 +829,6 @@
             "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
           }
         },
-        "labels": {
-          "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "$ref": "#/definitions/Map"
-        },
         "runtimeClassName": {
           "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this Pod. If no RuntimeClass resource matches the named class, the Pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md This is an alpha feature and may change in the future. See `kubectl explain pods.spec.runtimeClassName`.",
           "type": "string"
@@ -866,23 +840,9 @@
             "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
           }
         },
-        "auxiliaryImages": {
-          "description": "Use an auxiliary image to automatically include directory content from additional images. This is a useful alternative for including Model in Image model files, or other types of files, in a pod without requiring modifications to the pod\u0027s base image \u0027domain.spec.image\u0027. This feature internally uses a Kubernetes emptyDir volume and Kubernetes init containers to share the files from the additional images with the pod.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AuxiliaryImage"
-          }
-        },
         "readinessProbe": {
           "description": "Settings for the readiness probe associated with a WebLogic Server instance.",
           "$ref": "#/definitions/ProbeTuning"
-        },
-        "containers": {
-          "description": "Additional containers to be included in the server Pod. See `kubectl explain pods.spec.containers`.",
-          "type": "array",
-          "items": {
-            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
-          }
         },
         "containerSecurityContext": {
           "description": "Container-level security attributes. Will override any matching Pod-level attributes. See `kubectl explain pods.spec.containers.securityContext`.",
@@ -891,6 +851,53 @@
         "schedulerName": {
           "description": "If specified, the Pod will be dispatched by the specified scheduler. If not specified, the Pod will be dispatched by the default scheduler. See `kubectl explain pods.spec.schedulerName`.",
           "type": "string"
+        },
+        "livenessProbe": {
+          "description": "Settings for the liveness probe associated with a WebLogic Server instance.",
+          "$ref": "#/definitions/ProbeTuning"
+        },
+        "volumes": {
+          "description": "Additional volumes to be created in the server Pod. See `kubectl explain pods.spec.volumes`.",
+          "type": "array",
+          "items": {
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+          }
+        },
+        "resources": {
+          "description": "Memory and CPU minimum requirements and limits for the WebLogic Server instance. See `kubectl explain pods.spec.containers.resources`.",
+          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+        },
+        "env": {
+          "description": "A list of environment variables to set in the container running a WebLogic Server instance. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-resource/#jvm-memory-and-java-option-environment-variables. See `kubectl explain pods.spec.containers.env`.",
+          "type": "array",
+          "items": {
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+          }
+        },
+        "restartPolicy": {
+          "description": "Restart policy for all containers within the Pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy. See `kubectl explain pods.spec.restartPolicy`.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "$ref": "#/definitions/Map"
+        },
+        "auxiliaryImages": {
+          "description": "Use an auxiliary image to automatically include directory content from additional images. This is a useful alternative for including Model in Image model files, or other types of files, in a pod without requiring modifications to the pod\u0027s base image \u0027domain.spec.image\u0027. This feature internally uses a Kubernetes emptyDir volume and Kubernetes init containers to share the files from the additional images with the pod.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuxiliaryImage"
+          }
+        },
+        "containers": {
+          "description": "Additional containers to be included in the server Pod. See `kubectl explain pods.spec.containers`.",
+          "type": "array",
+          "items": {
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+          }
         },
         "initContainers": {
           "description": "Initialization containers to be included in the server Pod. See `kubectl explain pods.spec.initContainers`.",

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -143,6 +143,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `containers` | Array of [Container](k8s1.13.5.md#container) | Additional containers to be included in the server Pod. See `kubectl explain pods.spec.containers`. |
 | `containerSecurityContext` | [Security Context](k8s1.13.5.md#security-context) | Container-level security attributes. Will override any matching Pod-level attributes. See `kubectl explain pods.spec.containers.securityContext`. |
 | `env` | Array of [Env Var](k8s1.13.5.md#env-var) | A list of environment variables to set in the container running a WebLogic Server instance. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-resource/#jvm-memory-and-java-option-environment-variables. See `kubectl explain pods.spec.containers.env`. |
+| `hostAliases` | Array of [Host Alias](k8s1.13.5.md#host-alias) | HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods. |
 | `initContainers` | Array of [Container](k8s1.13.5.md#container) | Initialization containers to be included in the server Pod. See `kubectl explain pods.spec.initContainers`. |
 | `labels` | Map | The labels to be added to generated resources. The label names must not start with "weblogic.". |
 | `livenessProbe` | [Probe Tuning](#probe-tuning) | Settings for the liveness probe associated with a WebLogic Server instance. |

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1703,10 +1703,6 @@ window.onload = function() {
           "description": "NodeName is a request to schedule this Pod onto a specific Node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits the resource requirements. See `kubectl explain pods.spec.nodeName`.",
           "type": "string"
         },
-        "livenessProbe": {
-          "description": "Settings for the liveness probe associated with a WebLogic Server instance.",
-          "$ref": "#/definitions/ProbeTuning"
-        },
         "readinessGates": {
           "description": "If specified, all readiness gates will be evaluated for Pod readiness. A Pod is ready when all its containers are ready AND all conditions specified in the readiness gates have a status equal to \"True\". More info: https://github.com/kubernetes/community/blob/master/keps/sig-network/0007-pod-ready%2B%2B.md.",
           "type": "array",
@@ -1726,17 +1722,6 @@ window.onload = function() {
           "description": "If specified, indicates the Pod\u0027s priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be the default or zero, if there is no default. See `kubectl explain pods.spec.priorityClassName`.",
           "type": "string"
         },
-        "volumes": {
-          "description": "Additional volumes to be created in the server Pod. See `kubectl explain pods.spec.volumes`.",
-          "type": "array",
-          "items": {
-            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
-          }
-        },
-        "resources": {
-          "description": "Memory and CPU minimum requirements and limits for the WebLogic Server instance. See `kubectl explain pods.spec.containers.resources`.",
-          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
         "annotations": {
           "description": "The annotations to be added to generated resources.",
           "additionalProperties": {
@@ -1744,16 +1729,12 @@ window.onload = function() {
           },
           "$ref": "#/definitions/Map"
         },
-        "env": {
-          "description": "A list of environment variables to set in the container running a WebLogic Server instance. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-resource/#jvm-memory-and-java-option-environment-variables. See `kubectl explain pods.spec.containers.env`.",
+        "hostAliases": {
+          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod\u0027s hosts file if specified. This is only valid for non-hostNetwork pods.",
           "type": "array",
           "items": {
-            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.HostAlias"
           }
-        },
-        "restartPolicy": {
-          "description": "Restart policy for all containers within the Pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy. See `kubectl explain pods.spec.restartPolicy`.",
-          "type": "string"
         },
         "nodeSelector": {
           "description": "Selector which must match a Node\u0027s labels for the Pod to be scheduled on that Node. See `kubectl explain pods.spec.nodeSelector`.",
@@ -1769,13 +1750,6 @@ window.onload = function() {
             "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
           }
         },
-        "labels": {
-          "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "$ref": "#/definitions/Map"
-        },
         "runtimeClassName": {
           "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this Pod. If no RuntimeClass resource matches the named class, the Pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md This is an alpha feature and may change in the future. See `kubectl explain pods.spec.runtimeClassName`.",
           "type": "string"
@@ -1787,23 +1761,9 @@ window.onload = function() {
             "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
           }
         },
-        "auxiliaryImages": {
-          "description": "Use an auxiliary image to automatically include directory content from additional images. This is a useful alternative for including Model in Image model files, or other types of files, in a pod without requiring modifications to the pod\u0027s base image \u0027domain.spec.image\u0027. This feature internally uses a Kubernetes emptyDir volume and Kubernetes init containers to share the files from the additional images with the pod.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AuxiliaryImage"
-          }
-        },
         "readinessProbe": {
           "description": "Settings for the readiness probe associated with a WebLogic Server instance.",
           "$ref": "#/definitions/ProbeTuning"
-        },
-        "containers": {
-          "description": "Additional containers to be included in the server Pod. See `kubectl explain pods.spec.containers`.",
-          "type": "array",
-          "items": {
-            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
-          }
         },
         "containerSecurityContext": {
           "description": "Container-level security attributes. Will override any matching Pod-level attributes. See `kubectl explain pods.spec.containers.securityContext`.",
@@ -1812,6 +1772,53 @@ window.onload = function() {
         "schedulerName": {
           "description": "If specified, the Pod will be dispatched by the specified scheduler. If not specified, the Pod will be dispatched by the default scheduler. See `kubectl explain pods.spec.schedulerName`.",
           "type": "string"
+        },
+        "livenessProbe": {
+          "description": "Settings for the liveness probe associated with a WebLogic Server instance.",
+          "$ref": "#/definitions/ProbeTuning"
+        },
+        "volumes": {
+          "description": "Additional volumes to be created in the server Pod. See `kubectl explain pods.spec.volumes`.",
+          "type": "array",
+          "items": {
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+          }
+        },
+        "resources": {
+          "description": "Memory and CPU minimum requirements and limits for the WebLogic Server instance. See `kubectl explain pods.spec.containers.resources`.",
+          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+        },
+        "env": {
+          "description": "A list of environment variables to set in the container running a WebLogic Server instance. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-resource/#jvm-memory-and-java-option-environment-variables. See `kubectl explain pods.spec.containers.env`.",
+          "type": "array",
+          "items": {
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+          }
+        },
+        "restartPolicy": {
+          "description": "Restart policy for all containers within the Pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy. See `kubectl explain pods.spec.restartPolicy`.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "$ref": "#/definitions/Map"
+        },
+        "auxiliaryImages": {
+          "description": "Use an auxiliary image to automatically include directory content from additional images. This is a useful alternative for including Model in Image model files, or other types of files, in a pod without requiring modifications to the pod\u0027s base image \u0027domain.spec.image\u0027. This feature internally uses a Kubernetes emptyDir volume and Kubernetes init containers to share the files from the additional images with the pod.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuxiliaryImage"
+          }
+        },
+        "containers": {
+          "description": "Additional containers to be included in the server Pod. See `kubectl explain pods.spec.containers`.",
+          "type": "array",
+          "items": {
+            "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+          }
         },
         "initContainers": {
           "description": "Initialization containers to be included in the server Pod. See `kubectl explain pods.spec.initContainers`.",

--- a/documentation/domains/k8s1.13.5.md
+++ b/documentation/domains/k8s1.13.5.md
@@ -107,6 +107,15 @@ EnvVar represents an environment variable present in a Container.
 | `value` | string | Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "". |
 | `valueFrom` | [Env Var Source](#env-var-source) | Source for the environment variable's value. Cannot be used if value is not empty. |
 
+### Host Alias
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `hostnames` | Array of string | Hostnames for the above IP address. |
+| `ip` | string | IP address of the host file entry. |
+
 ### Pod Security Context
 
 PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 21125be3ab1a0c88b36729cd786603eeb4ac714740dada219efd7dff179a98b5
+    weblogic.sha256: a9978851bbc86ce4653d328db25d01661829c8531a6971c001fdaa1a00bfa5a6
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -380,36 +380,6 @@ spec:
                           schedules this pod onto that node, assuming that it fits
                           the resource requirements. See `kubectl explain pods.spec.nodeName`.
                         type: string
-                      livenessProbe:
-                        description: Settings for the liveness probe associated with
-                          a WebLogic Server instance.
-                        properties:
-                          failureThreshold:
-                            description: Number of times the check is performed before
-                              giving up. Giving up in case of liveness probe means
-                              restarting the container. In case of readiness probe,
-                              the Pod will be marked Unready. Defaults to 1.
-                            minimum: 1.0
-                            type: number
-                          periodSeconds:
-                            description: The number of seconds between checks.
-                            type: number
-                          timeoutSeconds:
-                            description: The number of seconds with no response that
-                              indicates a failure.
-                            type: number
-                          successThreshold:
-                            description: Minimum number of times the check needs to
-                              pass for the probe to be considered successful after
-                              having failed. Defaults to 1. Must be 1 for liveness
-                              Probe.
-                            minimum: 1.0
-                            type: number
-                          initialDelaySeconds:
-                            description: The number of seconds before the first check
-                              is performed.
-                            type: number
-                        type: object
                       readinessGates:
                         description: 'If specified, all readiness gates will be evaluated
                           for Pod readiness. A Pod is ready when all its containers
@@ -498,6 +468,207 @@ spec:
                           the pod priority will be the default or zero, if there is
                           no default. See `kubectl explain pods.spec.priorityClassName`.
                         type: string
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: The annotations to be added to generated resources.
+                        type: object
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          type: object
+                          properties:
+                            ip:
+                              type: string
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                        type: array
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Selector which must match a Node's labels for
+                          the Pod to be scheduled on that Node. See `kubectl explain
+                          pods.spec.nodeSelector`.
+                        type: object
+                      volumeMounts:
+                        description: Additional volume mounts for the container running
+                          a WebLogic Server instance. See `kubectl explain pods.spec.containers.volumeMounts`.
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                        type: array
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          Pod. If no RuntimeClass resource matches the named class,
+                          the Pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
+                          This is an alpha feature and may change in the future. See
+                          `kubectl explain pods.spec.runtimeClassName`.'
+                        type: string
+                      tolerations:
+                        description: If specified, the Pod's tolerations. See `kubectl
+                          explain pods.spec.tolerations`.
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            tolerationSeconds:
+                              type: number
+                            value:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                        type: array
+                      readinessProbe:
+                        description: Settings for the readiness probe associated with
+                          a WebLogic Server instance.
+                        properties:
+                          failureThreshold:
+                            description: Number of times the check is performed before
+                              giving up. Giving up in case of liveness probe means
+                              restarting the container. In case of readiness probe,
+                              the Pod will be marked Unready. Defaults to 1.
+                            minimum: 1.0
+                            type: number
+                          periodSeconds:
+                            description: The number of seconds between checks.
+                            type: number
+                          timeoutSeconds:
+                            description: The number of seconds with no response that
+                              indicates a failure.
+                            type: number
+                          successThreshold:
+                            description: Minimum number of times the check needs to
+                              pass for the probe to be considered successful after
+                              having failed. Defaults to 1. Must be 1 for liveness
+                              Probe.
+                            minimum: 1.0
+                            type: number
+                          initialDelaySeconds:
+                            description: The number of seconds before the first check
+                              is performed.
+                            type: number
+                        type: object
+                      containerSecurityContext:
+                        description: Container-level security attributes. Will override
+                          any matching Pod-level attributes. See `kubectl explain
+                          pods.spec.containers.securityContext`.
+                        properties:
+                          privileged:
+                            type: boolean
+                          runAsUser:
+                            type: number
+                          capabilities:
+                            properties:
+                              add:
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          seLinuxOptions:
+                            properties:
+                              role:
+                                type: string
+                              level:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              runAsUserName:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                            type: object
+                          procMount:
+                            type: string
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          runAsGroup:
+                            type: number
+                          runAsNonRoot:
+                            type: boolean
+                          readOnlyRootFilesystem:
+                            type: boolean
+                        type: object
+                      schedulerName:
+                        description: If specified, the Pod will be dispatched by the
+                          specified scheduler. If not specified, the Pod will be dispatched
+                          by the default scheduler. See `kubectl explain pods.spec.schedulerName`.
+                        type: string
+                      livenessProbe:
+                        description: Settings for the liveness probe associated with
+                          a WebLogic Server instance.
+                        properties:
+                          failureThreshold:
+                            description: Number of times the check is performed before
+                              giving up. Giving up in case of liveness probe means
+                              restarting the container. In case of readiness probe,
+                              the Pod will be marked Unready. Defaults to 1.
+                            minimum: 1.0
+                            type: number
+                          periodSeconds:
+                            description: The number of seconds between checks.
+                            type: number
+                          timeoutSeconds:
+                            description: The number of seconds with no response that
+                              indicates a failure.
+                            type: number
+                          successThreshold:
+                            description: Minimum number of times the check needs to
+                              pass for the probe to be considered successful after
+                              having failed. Defaults to 1. Must be 1 for liveness
+                              Probe.
+                            minimum: 1.0
+                            type: number
+                          initialDelaySeconds:
+                            description: The number of seconds before the first check
+                              is performed.
+                            type: number
+                        type: object
                       volumes:
                         description: Additional volumes to be created in the server
                           Pod. See `kubectl explain pods.spec.volumes`.
@@ -1252,11 +1423,6 @@ spec:
                               type: string
                             type: object
                         type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: The annotations to be added to generated resources.
-                        type: object
                       env:
                         description: 'A list of environment variables to set in the
                           container running a WebLogic Server instance. More info:
@@ -1332,69 +1498,12 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
                           See `kubectl explain pods.spec.restartPolicy`.'
                         type: string
-                      nodeSelector:
-                        additionalProperties:
-                          type: string
-                        description: Selector which must match a Node's labels for
-                          the Pod to be scheduled on that Node. See `kubectl explain
-                          pods.spec.nodeSelector`.
-                        type: object
-                      volumeMounts:
-                        description: Additional volume mounts for the container running
-                          a WebLogic Server instance. See `kubectl explain pods.spec.containers.volumeMounts`.
-                        items:
-                          type: object
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                        type: array
                       labels:
                         additionalProperties:
                           type: string
                         description: The labels to be added to generated resources.
                           The label names must not start with "weblogic.".
                         type: object
-                      runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object
-                          in the node.k8s.io group, which should be used to run this
-                          Pod. If no RuntimeClass resource matches the named class,
-                          the Pod will not be run. If unset or empty, the "legacy"
-                          RuntimeClass will be used, which is an implicit class with
-                          an empty definition that uses the default runtime handler.
-                          More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
-                          This is an alpha feature and may change in the future. See
-                          `kubectl explain pods.spec.runtimeClassName`.'
-                        type: string
-                      tolerations:
-                        description: If specified, the Pod's tolerations. See `kubectl
-                          explain pods.spec.tolerations`.
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            tolerationSeconds:
-                              type: number
-                            value:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                        type: array
                       auxiliaryImages:
                         description: Use an auxiliary image to automatically include
                           directory content from additional images. This is a useful
@@ -1441,36 +1550,6 @@ spec:
                                 volume.
                               type: string
                         type: array
-                      readinessProbe:
-                        description: Settings for the readiness probe associated with
-                          a WebLogic Server instance.
-                        properties:
-                          failureThreshold:
-                            description: Number of times the check is performed before
-                              giving up. Giving up in case of liveness probe means
-                              restarting the container. In case of readiness probe,
-                              the Pod will be marked Unready. Defaults to 1.
-                            minimum: 1.0
-                            type: number
-                          periodSeconds:
-                            description: The number of seconds between checks.
-                            type: number
-                          timeoutSeconds:
-                            description: The number of seconds with no response that
-                              indicates a failure.
-                            type: number
-                          successThreshold:
-                            description: Minimum number of times the check needs to
-                              pass for the probe to be considered successful after
-                              having failed. Defaults to 1. Must be 1 for liveness
-                              Probe.
-                            minimum: 1.0
-                            type: number
-                          initialDelaySeconds:
-                            description: The number of seconds before the first check
-                              is performed.
-                            type: number
-                        type: object
                       containers:
                         description: Additional containers to be included in the server
                           Pod. See `kubectl explain pods.spec.containers`.
@@ -2052,71 +2131,6 @@ spec:
                           required:
                           - name
                         type: array
-                      containerSecurityContext:
-                        description: Container-level security attributes. Will override
-                          any matching Pod-level attributes. See `kubectl explain
-                          pods.spec.containers.securityContext`.
-                        properties:
-                          privileged:
-                            type: boolean
-                          runAsUser:
-                            type: number
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          seLinuxOptions:
-                            properties:
-                              role:
-                                type: string
-                              level:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          seccompProfile:
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              runAsUserName:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                            type: object
-                          procMount:
-                            type: string
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          runAsGroup:
-                            type: number
-                          runAsNonRoot:
-                            type: boolean
-                          readOnlyRootFilesystem:
-                            type: boolean
-                        type: object
-                      schedulerName:
-                        description: If specified, the Pod will be dispatched by the
-                          specified scheduler. If not specified, the Pod will be dispatched
-                          by the default scheduler. See `kubectl explain pods.spec.schedulerName`.
-                        type: string
                       initContainers:
                         description: Initialization containers to be included in the
                           server Pod. See `kubectl explain pods.spec.initContainers`.
@@ -3159,37 +3173,6 @@ spec:
                             it fits the resource requirements. See `kubectl explain
                             pods.spec.nodeName`.
                           type: string
-                        livenessProbe:
-                          description: Settings for the liveness probe associated
-                            with a WebLogic Server instance.
-                          type: object
-                          properties:
-                            failureThreshold:
-                              description: Number of times the check is performed
-                                before giving up. Giving up in case of liveness probe
-                                means restarting the container. In case of readiness
-                                probe, the Pod will be marked Unready. Defaults to
-                                1.
-                              type: number
-                              minimum: 1.0
-                            periodSeconds:
-                              description: The number of seconds between checks.
-                              type: number
-                            timeoutSeconds:
-                              description: The number of seconds with no response
-                                that indicates a failure.
-                              type: number
-                            successThreshold:
-                              description: Minimum number of times the check needs
-                                to pass for the probe to be considered successful
-                                after having failed. Defaults to 1. Must be 1 for
-                                liveness Probe.
-                              type: number
-                              minimum: 1.0
-                            initialDelaySeconds:
-                              description: The number of seconds before the first
-                                check is performed.
-                              type: number
                         readinessGates:
                           description: 'If specified, all readiness gates will be
                             evaluated for Pod readiness. A Pod is ready when all its
@@ -3280,6 +3263,211 @@ spec:
                             be the default or zero, if there is no default. See `kubectl
                             explain pods.spec.priorityClassName`.
                           type: string
+                        annotations:
+                          description: The annotations to be added to generated resources.
+                          additionalProperties:
+                            type: string
+                          type: object
+                        hostAliases:
+                          description: HostAliases is an optional list of hosts and
+                            IPs that will be injected into the pod's hosts file if
+                            specified. This is only valid for non-hostNetwork pods.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ip:
+                                type: string
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                        nodeSelector:
+                          description: Selector which must match a Node's labels for
+                            the Pod to be scheduled on that Node. See `kubectl explain
+                            pods.spec.nodeSelector`.
+                          additionalProperties:
+                            type: string
+                          type: object
+                        volumeMounts:
+                          description: Additional volume mounts for the container
+                            running a WebLogic Server instance. See `kubectl explain
+                            pods.spec.containers.volumeMounts`.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                        runtimeClassName:
+                          description: 'RuntimeClassName refers to a RuntimeClass
+                            object in the node.k8s.io group, which should be used
+                            to run this Pod. If no RuntimeClass resource matches the
+                            named class, the Pod will not be run. If unset or empty,
+                            the "legacy" RuntimeClass will be used, which is an implicit
+                            class with an empty definition that uses the default runtime
+                            handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
+                            This is an alpha feature and may change in the future.
+                            See `kubectl explain pods.spec.runtimeClassName`.'
+                          type: string
+                        tolerations:
+                          description: If specified, the Pod's tolerations. See `kubectl
+                            explain pods.spec.tolerations`.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              tolerationSeconds:
+                                type: number
+                              value:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                        readinessProbe:
+                          description: Settings for the readiness probe associated
+                            with a WebLogic Server instance.
+                          type: object
+                          properties:
+                            failureThreshold:
+                              description: Number of times the check is performed
+                                before giving up. Giving up in case of liveness probe
+                                means restarting the container. In case of readiness
+                                probe, the Pod will be marked Unready. Defaults to
+                                1.
+                              type: number
+                              minimum: 1.0
+                            periodSeconds:
+                              description: The number of seconds between checks.
+                              type: number
+                            timeoutSeconds:
+                              description: The number of seconds with no response
+                                that indicates a failure.
+                              type: number
+                            successThreshold:
+                              description: Minimum number of times the check needs
+                                to pass for the probe to be considered successful
+                                after having failed. Defaults to 1. Must be 1 for
+                                liveness Probe.
+                              type: number
+                              minimum: 1.0
+                            initialDelaySeconds:
+                              description: The number of seconds before the first
+                                check is performed.
+                              type: number
+                        containerSecurityContext:
+                          description: Container-level security attributes. Will override
+                            any matching Pod-level attributes. See `kubectl explain
+                            pods.spec.containers.securityContext`.
+                          type: object
+                          properties:
+                            privileged:
+                              type: boolean
+                            runAsUser:
+                              type: number
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                role:
+                                  type: string
+                                level:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            seccompProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - type
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                            procMount:
+                              type: string
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            runAsGroup:
+                              type: number
+                            runAsNonRoot:
+                              type: boolean
+                            readOnlyRootFilesystem:
+                              type: boolean
+                        schedulerName:
+                          description: If specified, the Pod will be dispatched by
+                            the specified scheduler. If not specified, the Pod will
+                            be dispatched by the default scheduler. See `kubectl explain
+                            pods.spec.schedulerName`.
+                          type: string
+                        livenessProbe:
+                          description: Settings for the liveness probe associated
+                            with a WebLogic Server instance.
+                          type: object
+                          properties:
+                            failureThreshold:
+                              description: Number of times the check is performed
+                                before giving up. Giving up in case of liveness probe
+                                means restarting the container. In case of readiness
+                                probe, the Pod will be marked Unready. Defaults to
+                                1.
+                              type: number
+                              minimum: 1.0
+                            periodSeconds:
+                              description: The number of seconds between checks.
+                              type: number
+                            timeoutSeconds:
+                              description: The number of seconds with no response
+                                that indicates a failure.
+                              type: number
+                            successThreshold:
+                              description: Minimum number of times the check needs
+                                to pass for the probe to be considered successful
+                                after having failed. Defaults to 1. Must be 1 for
+                                liveness Probe.
+                              type: number
+                              minimum: 1.0
+                            initialDelaySeconds:
+                              description: The number of seconds before the first
+                                check is performed.
+                              type: number
                         volumes:
                           description: Additional volumes to be created in the server
                             Pod. See `kubectl explain pods.spec.volumes`.
@@ -4035,11 +4223,6 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                        annotations:
-                          description: The annotations to be added to generated resources.
-                          additionalProperties:
-                            type: string
-                          type: object
                         env:
                           description: 'A list of environment variables to set in
                             the container running a WebLogic Server instance. More
@@ -4115,70 +4298,12 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
                             See `kubectl explain pods.spec.restartPolicy`.'
                           type: string
-                        nodeSelector:
-                          description: Selector which must match a Node's labels for
-                            the Pod to be scheduled on that Node. See `kubectl explain
-                            pods.spec.nodeSelector`.
-                          additionalProperties:
-                            type: string
-                          type: object
-                        volumeMounts:
-                          description: Additional volume mounts for the container
-                            running a WebLogic Server instance. See `kubectl explain
-                            pods.spec.containers.volumeMounts`.
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              mountPath:
-                                type: string
-                              mountPropagation:
-                                type: string
-                              name:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              subPath:
-                                type: string
-                              subPathExpr:
-                                type: string
-                            required:
-                            - mountPath
-                            - name
                         labels:
                           description: The labels to be added to generated resources.
                             The label names must not start with "weblogic.".
                           additionalProperties:
                             type: string
                           type: object
-                        runtimeClassName:
-                          description: 'RuntimeClassName refers to a RuntimeClass
-                            object in the node.k8s.io group, which should be used
-                            to run this Pod. If no RuntimeClass resource matches the
-                            named class, the Pod will not be run. If unset or empty,
-                            the "legacy" RuntimeClass will be used, which is an implicit
-                            class with an empty definition that uses the default runtime
-                            handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
-                            This is an alpha feature and may change in the future.
-                            See `kubectl explain pods.spec.runtimeClassName`.'
-                          type: string
-                        tolerations:
-                          description: If specified, the Pod's tolerations. See `kubectl
-                            explain pods.spec.tolerations`.
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              effect:
-                                type: string
-                              tolerationSeconds:
-                                type: number
-                              value:
-                                type: string
-                              key:
-                                type: string
-                              operator:
-                                type: string
                         auxiliaryImages:
                           description: Use an auxiliary image to automatically include
                             directory content from additional images. This is a useful
@@ -4225,37 +4350,6 @@ spec:
                                   operator that resolves to the auxiliary image's
                                   internal emptyDir volume.
                                 type: string
-                        readinessProbe:
-                          description: Settings for the readiness probe associated
-                            with a WebLogic Server instance.
-                          type: object
-                          properties:
-                            failureThreshold:
-                              description: Number of times the check is performed
-                                before giving up. Giving up in case of liveness probe
-                                means restarting the container. In case of readiness
-                                probe, the Pod will be marked Unready. Defaults to
-                                1.
-                              type: number
-                              minimum: 1.0
-                            periodSeconds:
-                              description: The number of seconds between checks.
-                              type: number
-                            timeoutSeconds:
-                              description: The number of seconds with no response
-                                that indicates a failure.
-                              type: number
-                            successThreshold:
-                              description: Minimum number of times the check needs
-                                to pass for the probe to be considered successful
-                                after having failed. Defaults to 1. Must be 1 for
-                                liveness Probe.
-                              type: number
-                              minimum: 1.0
-                            initialDelaySeconds:
-                              description: The number of seconds before the first
-                                check is performed.
-                              type: number
                         containers:
                           description: Additional containers to be included in the
                             server Pod. See `kubectl explain pods.spec.containers`.
@@ -4837,72 +4931,6 @@ spec:
                                           type: boolean
                             required:
                             - name
-                        containerSecurityContext:
-                          description: Container-level security attributes. Will override
-                            any matching Pod-level attributes. See `kubectl explain
-                            pods.spec.containers.securityContext`.
-                          type: object
-                          properties:
-                            privileged:
-                              type: boolean
-                            runAsUser:
-                              type: number
-                            capabilities:
-                              type: object
-                              properties:
-                                add:
-                                  type: array
-                                  items:
-                                    type: string
-                                drop:
-                                  type: array
-                                  items:
-                                    type: string
-                            seLinuxOptions:
-                              type: object
-                              properties:
-                                role:
-                                  type: string
-                                level:
-                                  type: string
-                                type:
-                                  type: string
-                                user:
-                                  type: string
-                            seccompProfile:
-                              type: object
-                              properties:
-                                localhostProfile:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - type
-                            windowsOptions:
-                              type: object
-                              properties:
-                                gmsaCredentialSpec:
-                                  type: string
-                                runAsUserName:
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  type: string
-                            procMount:
-                              type: string
-                            allowPrivilegeEscalation:
-                              type: boolean
-                            runAsGroup:
-                              type: number
-                            runAsNonRoot:
-                              type: boolean
-                            readOnlyRootFilesystem:
-                              type: boolean
-                        schedulerName:
-                          description: If specified, the Pod will be dispatched by
-                            the specified scheduler. If not specified, the Pod will
-                            be dispatched by the default scheduler. See `kubectl explain
-                            pods.spec.schedulerName`.
-                          type: string
                         initContainers:
                           description: Initialization containers to be included in
                             the server Pod. See `kubectl explain pods.spec.initContainers`.
@@ -5959,35 +5987,6 @@ spec:
                       this pod onto that node, assuming that it fits the resource
                       requirements. See `kubectl explain pods.spec.nodeName`.
                     type: string
-                  livenessProbe:
-                    description: Settings for the liveness probe associated with a
-                      WebLogic Server instance.
-                    properties:
-                      failureThreshold:
-                        description: Number of times the check is performed before
-                          giving up. Giving up in case of liveness probe means restarting
-                          the container. In case of readiness probe, the Pod will
-                          be marked Unready. Defaults to 1.
-                        minimum: 1.0
-                        type: number
-                      periodSeconds:
-                        description: The number of seconds between checks.
-                        type: number
-                      timeoutSeconds:
-                        description: The number of seconds with no response that indicates
-                          a failure.
-                        type: number
-                      successThreshold:
-                        description: Minimum number of times the check needs to pass
-                          for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness Probe.
-                        minimum: 1.0
-                        type: number
-                      initialDelaySeconds:
-                        description: The number of seconds before the first check
-                          is performed.
-                        type: number
-                    type: object
                   readinessGates:
                     description: 'If specified, all readiness gates will be evaluated
                       for Pod readiness. A Pod is ready when all its containers are
@@ -6076,6 +6075,202 @@ spec:
                       be the default or zero, if there is no default. See `kubectl
                       explain pods.spec.priorityClassName`.
                     type: string
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: The annotations to be added to generated resources.
+                    type: object
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      type: object
+                      properties:
+                        ip:
+                          type: string
+                        hostnames:
+                          type: array
+                          items:
+                            type: string
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Selector which must match a Node's labels for the
+                      Pod to be scheduled on that Node. See `kubectl explain pods.spec.nodeSelector`.
+                    type: object
+                  volumeMounts:
+                    description: Additional volume mounts for the container running
+                      a WebLogic Server instance. See `kubectl explain pods.spec.containers.volumeMounts`.
+                    items:
+                      type: object
+                      properties:
+                        mountPath:
+                          type: string
+                        mountPropagation:
+                          type: string
+                        name:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        subPath:
+                          type: string
+                        subPathExpr:
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                    type: array
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this Pod.
+                      If no RuntimeClass resource matches the named class, the Pod
+                      will not be run. If unset or empty, the "legacy" RuntimeClass
+                      will be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
+                      This is an alpha feature and may change in the future. See `kubectl
+                      explain pods.spec.runtimeClassName`.'
+                    type: string
+                  tolerations:
+                    description: If specified, the Pod's tolerations. See `kubectl
+                      explain pods.spec.tolerations`.
+                    items:
+                      type: object
+                      properties:
+                        effect:
+                          type: string
+                        tolerationSeconds:
+                          type: number
+                        value:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                    type: array
+                  readinessProbe:
+                    description: Settings for the readiness probe associated with
+                      a WebLogic Server instance.
+                    properties:
+                      failureThreshold:
+                        description: Number of times the check is performed before
+                          giving up. Giving up in case of liveness probe means restarting
+                          the container. In case of readiness probe, the Pod will
+                          be marked Unready. Defaults to 1.
+                        minimum: 1.0
+                        type: number
+                      periodSeconds:
+                        description: The number of seconds between checks.
+                        type: number
+                      timeoutSeconds:
+                        description: The number of seconds with no response that indicates
+                          a failure.
+                        type: number
+                      successThreshold:
+                        description: Minimum number of times the check needs to pass
+                          for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness Probe.
+                        minimum: 1.0
+                        type: number
+                      initialDelaySeconds:
+                        description: The number of seconds before the first check
+                          is performed.
+                        type: number
+                    type: object
+                  containerSecurityContext:
+                    description: Container-level security attributes. Will override
+                      any matching Pod-level attributes. See `kubectl explain pods.spec.containers.securityContext`.
+                    properties:
+                      privileged:
+                        type: boolean
+                      runAsUser:
+                        type: number
+                      capabilities:
+                        properties:
+                          add:
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      seLinuxOptions:
+                        properties:
+                          role:
+                            type: string
+                          level:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          runAsUserName:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                        type: object
+                      procMount:
+                        type: string
+                      allowPrivilegeEscalation:
+                        type: boolean
+                      runAsGroup:
+                        type: number
+                      runAsNonRoot:
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        type: boolean
+                    type: object
+                  schedulerName:
+                    description: If specified, the Pod will be dispatched by the specified
+                      scheduler. If not specified, the Pod will be dispatched by the
+                      default scheduler. See `kubectl explain pods.spec.schedulerName`.
+                    type: string
+                  livenessProbe:
+                    description: Settings for the liveness probe associated with a
+                      WebLogic Server instance.
+                    properties:
+                      failureThreshold:
+                        description: Number of times the check is performed before
+                          giving up. Giving up in case of liveness probe means restarting
+                          the container. In case of readiness probe, the Pod will
+                          be marked Unready. Defaults to 1.
+                        minimum: 1.0
+                        type: number
+                      periodSeconds:
+                        description: The number of seconds between checks.
+                        type: number
+                      timeoutSeconds:
+                        description: The number of seconds with no response that indicates
+                          a failure.
+                        type: number
+                      successThreshold:
+                        description: Minimum number of times the check needs to pass
+                          for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness Probe.
+                        minimum: 1.0
+                        type: number
+                      initialDelaySeconds:
+                        description: The number of seconds before the first check
+                          is performed.
+                        type: number
+                    type: object
                   volumes:
                     description: Additional volumes to be created in the server Pod.
                       See `kubectl explain pods.spec.volumes`.
@@ -6830,11 +7025,6 @@ spec:
                           type: string
                         type: object
                     type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: The annotations to be added to generated resources.
-                    type: object
                   env:
                     description: 'A list of environment variables to set in the container
                       running a WebLogic Server instance. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-resource/#jvm-memory-and-java-option-environment-variables.
@@ -6909,67 +7099,12 @@ spec:
                       https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
                       See `kubectl explain pods.spec.restartPolicy`.'
                     type: string
-                  nodeSelector:
-                    additionalProperties:
-                      type: string
-                    description: Selector which must match a Node's labels for the
-                      Pod to be scheduled on that Node. See `kubectl explain pods.spec.nodeSelector`.
-                    type: object
-                  volumeMounts:
-                    description: Additional volume mounts for the container running
-                      a WebLogic Server instance. See `kubectl explain pods.spec.containers.volumeMounts`.
-                    items:
-                      type: object
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                    type: array
                   labels:
                     additionalProperties:
                       type: string
                     description: The labels to be added to generated resources. The
                       label names must not start with "weblogic.".
                     type: object
-                  runtimeClassName:
-                    description: 'RuntimeClassName refers to a RuntimeClass object
-                      in the node.k8s.io group, which should be used to run this Pod.
-                      If no RuntimeClass resource matches the named class, the Pod
-                      will not be run. If unset or empty, the "legacy" RuntimeClass
-                      will be used, which is an implicit class with an empty definition
-                      that uses the default runtime handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
-                      This is an alpha feature and may change in the future. See `kubectl
-                      explain pods.spec.runtimeClassName`.'
-                    type: string
-                  tolerations:
-                    description: If specified, the Pod's tolerations. See `kubectl
-                      explain pods.spec.tolerations`.
-                    items:
-                      type: object
-                      properties:
-                        effect:
-                          type: string
-                        tolerationSeconds:
-                          type: number
-                        value:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                    type: array
                   auxiliaryImages:
                     description: Use an auxiliary image to automatically include directory
                       content from additional images. This is a useful alternative
@@ -7013,35 +7148,6 @@ spec:
                             to the auxiliary image's internal emptyDir volume.
                           type: string
                     type: array
-                  readinessProbe:
-                    description: Settings for the readiness probe associated with
-                      a WebLogic Server instance.
-                    properties:
-                      failureThreshold:
-                        description: Number of times the check is performed before
-                          giving up. Giving up in case of liveness probe means restarting
-                          the container. In case of readiness probe, the Pod will
-                          be marked Unready. Defaults to 1.
-                        minimum: 1.0
-                        type: number
-                      periodSeconds:
-                        description: The number of seconds between checks.
-                        type: number
-                      timeoutSeconds:
-                        description: The number of seconds with no response that indicates
-                          a failure.
-                        type: number
-                      successThreshold:
-                        description: Minimum number of times the check needs to pass
-                          for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness Probe.
-                        minimum: 1.0
-                        type: number
-                      initialDelaySeconds:
-                        description: The number of seconds before the first check
-                          is performed.
-                        type: number
-                    type: object
                   containers:
                     description: Additional containers to be included in the server
                       Pod. See `kubectl explain pods.spec.containers`.
@@ -7623,70 +7729,6 @@ spec:
                       required:
                       - name
                     type: array
-                  containerSecurityContext:
-                    description: Container-level security attributes. Will override
-                      any matching Pod-level attributes. See `kubectl explain pods.spec.containers.securityContext`.
-                    properties:
-                      privileged:
-                        type: boolean
-                      runAsUser:
-                        type: number
-                      capabilities:
-                        properties:
-                          add:
-                            items:
-                              type: string
-                            type: array
-                          drop:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      seLinuxOptions:
-                        properties:
-                          role:
-                            type: string
-                          level:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          runAsUserName:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                        type: object
-                      procMount:
-                        type: string
-                      allowPrivilegeEscalation:
-                        type: boolean
-                      runAsGroup:
-                        type: number
-                      runAsNonRoot:
-                        type: boolean
-                      readOnlyRootFilesystem:
-                        type: boolean
-                    type: object
-                  schedulerName:
-                    description: If specified, the Pod will be dispatched by the specified
-                      scheduler. If not specified, the Pod will be dispatched by the
-                      default scheduler. See `kubectl explain pods.spec.schedulerName`.
-                    type: string
                   initContainers:
                     description: Initialization containers to be included in the server
                       Pod. See `kubectl explain pods.spec.initContainers`.
@@ -8636,37 +8678,6 @@ spec:
                             it fits the resource requirements. See `kubectl explain
                             pods.spec.nodeName`.
                           type: string
-                        livenessProbe:
-                          description: Settings for the liveness probe associated
-                            with a WebLogic Server instance.
-                          type: object
-                          properties:
-                            failureThreshold:
-                              description: Number of times the check is performed
-                                before giving up. Giving up in case of liveness probe
-                                means restarting the container. In case of readiness
-                                probe, the Pod will be marked Unready. Defaults to
-                                1.
-                              type: number
-                              minimum: 1.0
-                            periodSeconds:
-                              description: The number of seconds between checks.
-                              type: number
-                            timeoutSeconds:
-                              description: The number of seconds with no response
-                                that indicates a failure.
-                              type: number
-                            successThreshold:
-                              description: Minimum number of times the check needs
-                                to pass for the probe to be considered successful
-                                after having failed. Defaults to 1. Must be 1 for
-                                liveness Probe.
-                              type: number
-                              minimum: 1.0
-                            initialDelaySeconds:
-                              description: The number of seconds before the first
-                                check is performed.
-                              type: number
                         readinessGates:
                           description: 'If specified, all readiness gates will be
                             evaluated for Pod readiness. A Pod is ready when all its
@@ -8757,6 +8768,211 @@ spec:
                             be the default or zero, if there is no default. See `kubectl
                             explain pods.spec.priorityClassName`.
                           type: string
+                        annotations:
+                          description: The annotations to be added to generated resources.
+                          additionalProperties:
+                            type: string
+                          type: object
+                        hostAliases:
+                          description: HostAliases is an optional list of hosts and
+                            IPs that will be injected into the pod's hosts file if
+                            specified. This is only valid for non-hostNetwork pods.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ip:
+                                type: string
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                        nodeSelector:
+                          description: Selector which must match a Node's labels for
+                            the Pod to be scheduled on that Node. See `kubectl explain
+                            pods.spec.nodeSelector`.
+                          additionalProperties:
+                            type: string
+                          type: object
+                        volumeMounts:
+                          description: Additional volume mounts for the container
+                            running a WebLogic Server instance. See `kubectl explain
+                            pods.spec.containers.volumeMounts`.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                        runtimeClassName:
+                          description: 'RuntimeClassName refers to a RuntimeClass
+                            object in the node.k8s.io group, which should be used
+                            to run this Pod. If no RuntimeClass resource matches the
+                            named class, the Pod will not be run. If unset or empty,
+                            the "legacy" RuntimeClass will be used, which is an implicit
+                            class with an empty definition that uses the default runtime
+                            handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
+                            This is an alpha feature and may change in the future.
+                            See `kubectl explain pods.spec.runtimeClassName`.'
+                          type: string
+                        tolerations:
+                          description: If specified, the Pod's tolerations. See `kubectl
+                            explain pods.spec.tolerations`.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              tolerationSeconds:
+                                type: number
+                              value:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                        readinessProbe:
+                          description: Settings for the readiness probe associated
+                            with a WebLogic Server instance.
+                          type: object
+                          properties:
+                            failureThreshold:
+                              description: Number of times the check is performed
+                                before giving up. Giving up in case of liveness probe
+                                means restarting the container. In case of readiness
+                                probe, the Pod will be marked Unready. Defaults to
+                                1.
+                              type: number
+                              minimum: 1.0
+                            periodSeconds:
+                              description: The number of seconds between checks.
+                              type: number
+                            timeoutSeconds:
+                              description: The number of seconds with no response
+                                that indicates a failure.
+                              type: number
+                            successThreshold:
+                              description: Minimum number of times the check needs
+                                to pass for the probe to be considered successful
+                                after having failed. Defaults to 1. Must be 1 for
+                                liveness Probe.
+                              type: number
+                              minimum: 1.0
+                            initialDelaySeconds:
+                              description: The number of seconds before the first
+                                check is performed.
+                              type: number
+                        containerSecurityContext:
+                          description: Container-level security attributes. Will override
+                            any matching Pod-level attributes. See `kubectl explain
+                            pods.spec.containers.securityContext`.
+                          type: object
+                          properties:
+                            privileged:
+                              type: boolean
+                            runAsUser:
+                              type: number
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                role:
+                                  type: string
+                                level:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            seccompProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - type
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                            procMount:
+                              type: string
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            runAsGroup:
+                              type: number
+                            runAsNonRoot:
+                              type: boolean
+                            readOnlyRootFilesystem:
+                              type: boolean
+                        schedulerName:
+                          description: If specified, the Pod will be dispatched by
+                            the specified scheduler. If not specified, the Pod will
+                            be dispatched by the default scheduler. See `kubectl explain
+                            pods.spec.schedulerName`.
+                          type: string
+                        livenessProbe:
+                          description: Settings for the liveness probe associated
+                            with a WebLogic Server instance.
+                          type: object
+                          properties:
+                            failureThreshold:
+                              description: Number of times the check is performed
+                                before giving up. Giving up in case of liveness probe
+                                means restarting the container. In case of readiness
+                                probe, the Pod will be marked Unready. Defaults to
+                                1.
+                              type: number
+                              minimum: 1.0
+                            periodSeconds:
+                              description: The number of seconds between checks.
+                              type: number
+                            timeoutSeconds:
+                              description: The number of seconds with no response
+                                that indicates a failure.
+                              type: number
+                            successThreshold:
+                              description: Minimum number of times the check needs
+                                to pass for the probe to be considered successful
+                                after having failed. Defaults to 1. Must be 1 for
+                                liveness Probe.
+                              type: number
+                              minimum: 1.0
+                            initialDelaySeconds:
+                              description: The number of seconds before the first
+                                check is performed.
+                              type: number
                         volumes:
                           description: Additional volumes to be created in the server
                             Pod. See `kubectl explain pods.spec.volumes`.
@@ -9512,11 +9728,6 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                        annotations:
-                          description: The annotations to be added to generated resources.
-                          additionalProperties:
-                            type: string
-                          type: object
                         env:
                           description: 'A list of environment variables to set in
                             the container running a WebLogic Server instance. More
@@ -9592,70 +9803,12 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
                             See `kubectl explain pods.spec.restartPolicy`.'
                           type: string
-                        nodeSelector:
-                          description: Selector which must match a Node's labels for
-                            the Pod to be scheduled on that Node. See `kubectl explain
-                            pods.spec.nodeSelector`.
-                          additionalProperties:
-                            type: string
-                          type: object
-                        volumeMounts:
-                          description: Additional volume mounts for the container
-                            running a WebLogic Server instance. See `kubectl explain
-                            pods.spec.containers.volumeMounts`.
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              mountPath:
-                                type: string
-                              mountPropagation:
-                                type: string
-                              name:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              subPath:
-                                type: string
-                              subPathExpr:
-                                type: string
-                            required:
-                            - mountPath
-                            - name
                         labels:
                           description: The labels to be added to generated resources.
                             The label names must not start with "weblogic.".
                           additionalProperties:
                             type: string
                           type: object
-                        runtimeClassName:
-                          description: 'RuntimeClassName refers to a RuntimeClass
-                            object in the node.k8s.io group, which should be used
-                            to run this Pod. If no RuntimeClass resource matches the
-                            named class, the Pod will not be run. If unset or empty,
-                            the "legacy" RuntimeClass will be used, which is an implicit
-                            class with an empty definition that uses the default runtime
-                            handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
-                            This is an alpha feature and may change in the future.
-                            See `kubectl explain pods.spec.runtimeClassName`.'
-                          type: string
-                        tolerations:
-                          description: If specified, the Pod's tolerations. See `kubectl
-                            explain pods.spec.tolerations`.
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              effect:
-                                type: string
-                              tolerationSeconds:
-                                type: number
-                              value:
-                                type: string
-                              key:
-                                type: string
-                              operator:
-                                type: string
                         auxiliaryImages:
                           description: Use an auxiliary image to automatically include
                             directory content from additional images. This is a useful
@@ -9702,37 +9855,6 @@ spec:
                                   operator that resolves to the auxiliary image's
                                   internal emptyDir volume.
                                 type: string
-                        readinessProbe:
-                          description: Settings for the readiness probe associated
-                            with a WebLogic Server instance.
-                          type: object
-                          properties:
-                            failureThreshold:
-                              description: Number of times the check is performed
-                                before giving up. Giving up in case of liveness probe
-                                means restarting the container. In case of readiness
-                                probe, the Pod will be marked Unready. Defaults to
-                                1.
-                              type: number
-                              minimum: 1.0
-                            periodSeconds:
-                              description: The number of seconds between checks.
-                              type: number
-                            timeoutSeconds:
-                              description: The number of seconds with no response
-                                that indicates a failure.
-                              type: number
-                            successThreshold:
-                              description: Minimum number of times the check needs
-                                to pass for the probe to be considered successful
-                                after having failed. Defaults to 1. Must be 1 for
-                                liveness Probe.
-                              type: number
-                              minimum: 1.0
-                            initialDelaySeconds:
-                              description: The number of seconds before the first
-                                check is performed.
-                              type: number
                         containers:
                           description: Additional containers to be included in the
                             server Pod. See `kubectl explain pods.spec.containers`.
@@ -10314,72 +10436,6 @@ spec:
                                           type: boolean
                             required:
                             - name
-                        containerSecurityContext:
-                          description: Container-level security attributes. Will override
-                            any matching Pod-level attributes. See `kubectl explain
-                            pods.spec.containers.securityContext`.
-                          type: object
-                          properties:
-                            privileged:
-                              type: boolean
-                            runAsUser:
-                              type: number
-                            capabilities:
-                              type: object
-                              properties:
-                                add:
-                                  type: array
-                                  items:
-                                    type: string
-                                drop:
-                                  type: array
-                                  items:
-                                    type: string
-                            seLinuxOptions:
-                              type: object
-                              properties:
-                                role:
-                                  type: string
-                                level:
-                                  type: string
-                                type:
-                                  type: string
-                                user:
-                                  type: string
-                            seccompProfile:
-                              type: object
-                              properties:
-                                localhostProfile:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - type
-                            windowsOptions:
-                              type: object
-                              properties:
-                                gmsaCredentialSpec:
-                                  type: string
-                                runAsUserName:
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  type: string
-                            procMount:
-                              type: string
-                            allowPrivilegeEscalation:
-                              type: boolean
-                            runAsGroup:
-                              type: number
-                            runAsNonRoot:
-                              type: boolean
-                            readOnlyRootFilesystem:
-                              type: boolean
-                        schedulerName:
-                          description: If specified, the Pod will be dispatched by
-                            the specified scheduler. If not specified, the Pod will
-                            be dispatched by the default scheduler. See `kubectl explain
-                            pods.spec.schedulerName`.
-                          type: string
                         initContainers:
                           description: Initialization containers to be included in
                             the server Pod. See `kubectl explain pods.spec.initContainers`.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EmptyDirVolumeSource;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1EnvVarSource;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Toleration;
@@ -167,6 +168,7 @@ public abstract class BasePodStepContext extends StepContextBase {
         .priorityClassName(getServerSpec().getPriorityClassName())
         .runtimeClassName(getServerSpec().getRuntimeClassName())
         .tolerations(getTolerations())
+        .hostAliases(getHostAliases())
         .restartPolicy(getServerSpec().getRestartPolicy())
         .securityContext(getServerSpec().getPodSecurityContext())
         .imagePullSecrets(getServerSpec().getImagePullSecrets());
@@ -177,6 +179,10 @@ public abstract class BasePodStepContext extends StepContextBase {
     return tolerations.isEmpty() ? null : tolerations;
   }
 
+  private List<V1HostAlias> getHostAliases() {
+    List<V1HostAlias> hostAliases = getServerSpec().getHostAliases();
+    return hostAliases.isEmpty() ? null : hostAliases;
+  }
 
   /**
    * Abstract method to be implemented by subclasses to return a list of configured and additional

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
@@ -133,6 +134,18 @@ public abstract class DomainConfigurator {
   public DomainConfigurator withDefaultImagePullSecrets(
       V1LocalObjectReference... secretReferences) {
     getDomainSpec().setImagePullSecrets(Arrays.asList(secretReferences));
+    return this;
+  }
+
+  /**
+   * Sets the host aliases in the server pod for the domain.
+   *
+   * @param hostAliases a list of host aliases
+   * @return this object
+   */
+  public DomainConfigurator withHostAliases(
+      V1HostAlias... hostAliases) {
+    getDomainSpec().setHostAliases(Arrays.asList(hostAliases));
     return this;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
@@ -13,6 +13,7 @@ import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
@@ -251,6 +252,18 @@ public abstract class BaseConfiguration {
 
   void addToleration(V1Toleration toleration) {
     serverPod.addToleration(toleration);
+  }
+
+  public List<V1HostAlias> getHostAliases() {
+    return serverPod.getHostAliases();
+  }
+
+  public void setHostAliases(List<V1HostAlias> hostAliases) {
+    serverPod.setHostAliases(hostAliases);
+  }
+
+  void addHostAlias(V1HostAlias hostAlias) {
+    serverPod.addHostAlias(hostAlias);
   }
 
   public V1ResourceRequirements getResources() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.openapi.models.V1Capabilities;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerBuilder;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1HostPathVolumeSource;
 import io.kubernetes.client.openapi.models.V1NodeAffinity;
 import io.kubernetes.client.openapi.models.V1NodeSelector;
@@ -139,6 +140,10 @@ class ServerPod extends KubernetesResource {
       + "ServiceAccount will be used. The ServiceAccount has to exist at the time the Pod is created. "
       + "See `kubectl explain pods.spec.serviceAccountName`.")
   private String serviceAccountName = null;
+
+  @Description("HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file "
+      + "if specified. This is only valid for non-hostNetwork pods.")
+  private List<V1HostAlias> hostAliases = new ArrayList<>();
 
   /**
    * Defines the requirements and limits for the pod server.
@@ -490,6 +495,7 @@ class ServerPod extends KubernetesResource {
       schedulerName = serverPod1.schedulerName;
     }
     tolerations.addAll(serverPod1.tolerations);
+    hostAliases.addAll(serverPod1.hostAliases);
   }
 
   private void addAuxiliaryImage(ServerPod serverPod1) {
@@ -777,6 +783,18 @@ class ServerPod extends KubernetesResource {
     tolerations.add(toleration);
   }
 
+  List<V1HostAlias> getHostAliases() {
+    return hostAliases;
+  }
+
+  void setHostAliases(List<V1HostAlias> hostAliases) {
+    this.hostAliases = hostAliases;
+  }
+
+  void addHostAlias(V1HostAlias hostAlias) {
+    hostAliases.add(hostAlias);
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
@@ -801,6 +819,7 @@ class ServerPod extends KubernetesResource {
         .append("nodeName", nodeName)
         .append("schedulerName", schedulerName)
         .append("tolerations", tolerations)
+        .append("hostAliases", hostAliases)
         .append("serviceAccountName", serviceAccountName)
         .append("auxiliaryImages", auxiliaryImages)
         .toString();
@@ -846,6 +865,7 @@ class ServerPod extends KubernetesResource {
         .append(nodeName, that.nodeName)
         .append(schedulerName, that.schedulerName)
         .append(tolerations, that.tolerations)
+        .append(hostAliases, that.hostAliases)
         .append(serviceAccountName, that.serviceAccountName)
         .append(auxiliaryImages, that.auxiliaryImages)
         .isEquals();
@@ -875,6 +895,7 @@ class ServerPod extends KubernetesResource {
         .append(nodeName)
         .append(schedulerName)
         .append(tolerations)
+        .append(hostAliases)
         .append(serviceAccountName)
         .append(auxiliaryImages)
         .toHashCode();

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpec.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
@@ -148,6 +149,8 @@ public interface ServerSpec {
   String getSchedulerName();
 
   List<V1Toleration> getTolerations();
+
+  List<V1HostAlias> getHostAliases();
 
   V1ResourceRequirements getResources();
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpecBase.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpecBase.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.V1Affinity;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
@@ -105,6 +106,11 @@ public abstract class ServerSpecBase implements ServerSpec {
 
   @Override
   public List<V1Toleration> getTolerations() {
+    return null;
+  }
+
+  @Override
+  public List<V1HostAlias> getHostAliases() {
     return null;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpecCommonImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerSpecCommonImpl.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
@@ -213,6 +214,11 @@ public abstract class ServerSpecCommonImpl extends ServerSpecBase {
   @Override
   public List<V1Toleration> getTolerations() {
     return server.getTolerations();
+  }
+
+  @Override
+  public List<V1HostAlias> getHostAliases() {
+    return server.getHostAliases();
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -34,6 +34,7 @@ import io.kubernetes.client.openapi.models.V1EnvVarSource;
 import io.kubernetes.client.openapi.models.V1ExecAction;
 import io.kubernetes.client.openapi.models.V1HTTPGetAction;
 import io.kubernetes.client.openapi.models.V1Handler;
+import io.kubernetes.client.openapi.models.V1HostAlias;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1LabelSelectorRequirement;
 import io.kubernetes.client.openapi.models.V1Lifecycle;
@@ -690,6 +691,14 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     configureDomain().withDefaultImagePullSecrets(imagePullSecret);
 
     assertThat(getCreatedPod().getSpec().getImagePullSecrets(), hasItem(imagePullSecret));
+  }
+
+  @Test
+  void whenPodCreatedWithHostAliases_addToPod() {
+    V1HostAlias hostAlias = new V1HostAlias().addHostnamesItem("www.test.com").ip("1.1.1.1");
+    configureDomain().withHostAliases(hostAlias);
+
+    assertThat(getCreatedPod().getSpec().getHostAliases(), hasItem(hostAlias));
   }
 
   @Test


### PR DESCRIPTION
A customer asked us to support the `hostAliases` field as part of our `serverPod`. This field allows you to add elements to the `/etc/hosts` file of the containers. 

We had previously not supported most of the networking related fields that could be on a pod because of concern that they could easily be misused; however, the customer found that other workarounds (such as using ExternalName Services) were insufficient.