### PR TITLE
Enhance fiber breadcrumbs

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -364,7 +364,7 @@ public class DomainProcessorImpl implements DomainProcessor {
             (key, fiber) -> Optional.ofNullable(fiber.getSuspendedStep()).ifPresent(suspendedStep -> {
               try (LoggingContext ignored
                   = LoggingContext.setThreadContext().namespace(namespace).domainUid(getDomainUid(fiber))) {
-                LOGGER.fine("Fiber is SUSPENDED at " + suspendedStep.getName());
+                LOGGER.fine("Fiber is SUSPENDED at " + suspendedStep.getResourceName());
               }
             }));
       makeRightFiberGates.forEach(consumer);

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -940,6 +940,11 @@ public class DomainStatusUpdater {
     }
 
     @Override
+    protected String getDetail() {
+      return reason.name();
+    }
+
+    @Override
     void modifyStatus(DomainStatus s) {
       s.addCondition(new DomainCondition(Failed).withStatus(TRUE).withReason(reason).withMessage(message));
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -348,7 +348,7 @@ public class ConfigMapHelper {
       }
 
       private void logConfigMapExists() {
-        LOGGER.fine(MessageKeys.CM_EXISTS, getName(), namespace);
+        LOGGER.fine(MessageKeys.CM_EXISTS, getResourceName(), namespace);
       }
 
       private Step replaceConfigMap(Step next) {
@@ -418,7 +418,7 @@ public class ConfigMapHelper {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1ConfigMap> callResponse) {
-        LOGGER.info(MessageKeys.CM_CREATED, getName(), namespace);
+        LOGGER.info(MessageKeys.CM_CREATED, getResourceName(), namespace);
         recordCurrentMap(packet, callResponse.getResult());
         return doNext(packet);
       }
@@ -440,7 +440,7 @@ public class ConfigMapHelper {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1ConfigMap> callResponse) {
-        LOGGER.info(MessageKeys.CM_REPLACED, getName(), namespace);
+        LOGGER.info(MessageKeys.CM_REPLACED, getResourceName(), namespace);
         recordCurrentMap(packet, callResponse.getResult());
         return doNext(packet);
       }
@@ -459,7 +459,7 @@ public class ConfigMapHelper {
 
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1ConfigMap> callResponse) {
-        LOGGER.info(MessageKeys.CM_PATCHED, getName(), namespace);
+        LOGGER.info(MessageKeys.CM_PATCHED, getResourceName(), namespace);
         return doNext(packet);
       }
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -79,7 +79,7 @@ public class DomainValidationSteps {
     }
 
     static List<V1Secret> getSecrets(Packet packet) {
-      return (List<V1Secret>) Optional.ofNullable(packet.get(SECRETS)).orElse(new ArrayList<>());
+      return Optional.ofNullable(packet.<List<V1Secret>>getValue(SECRETS)).orElse(new ArrayList<>());
     }
   }
 
@@ -99,7 +99,7 @@ public class DomainValidationSteps {
     }
 
     static List<V1ConfigMap> getConfigMaps(Packet packet) {
-      return (List<V1ConfigMap>) Optional.ofNullable(packet.get(CONFIGMAPS)).orElse(new ArrayList<>());
+      return Optional.ofNullable(packet.<List<V1ConfigMap>>getValue(CONFIGMAPS)).orElse(new ArrayList<>());
     }
   }
 
@@ -116,7 +116,7 @@ public class DomainValidationSteps {
       List<String> validationFailures = domain.getValidationFailures(new KubernetesResourceLookupImpl(packet));
 
       if (validationFailures.isEmpty()) {
-        return doNext(packet);
+        return doNext(packet).withDebugComment(packet, this::domainValidated);
       }
 
       LOGGER.severe(DOMAIN_VALIDATION_FAILED, domain.getDomainUid(), perLine(validationFailures));
@@ -126,6 +126,10 @@ public class DomainValidationSteps {
 
     private String perLine(List<String> validationFailures) {
       return String.join(lineSeparator(), validationFailures);
+    }
+
+    private String domainValidated(Packet packet) {
+      return "Validated " + DomainPresenceInfo.fromPacket(packet).orElse(null);
     }
     
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -146,6 +146,7 @@ public class MessageKeys {
   public static final String DOMAIN_FATAL_ERROR = "WLSKO-0195";
   public static final String INTROSPECTOR_MAX_ERRORS_EXCEEDED = "WLSKO-0196";
   public static final String NON_FATAL_INTROSPECTOR_ERROR = "WLSKO-0197";
+  public static final String DUMP_BREADCRUMBS = "WLSKO-0198";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Step.java
@@ -103,7 +103,7 @@ public abstract class Step {
    * The name of the step. This will default to the class name minus "Step".
    * @return The name of the step
    */
-  public String getName() {
+  public String getResourceName() {
     return getBaseName() + getNameSuffix();
   }
 
@@ -130,9 +130,9 @@ public abstract class Step {
   @Override
   public String toString() {
     if (next == null) {
-      return getName();
+      return getResourceName();
     }
-    return getName() + "[" + next.toString() + "]";
+    return getResourceName() + "[" + next.toString() + "]";
   }
 
   /**
@@ -202,6 +202,7 @@ public abstract class Step {
    * @param unit Delay time unit
    * @return The next action
    */
+  @SuppressWarnings("SameParameterValue")
   protected NextAction doRetry(Packet packet, long delay, TimeUnit unit) {
     NextAction na = new NextAction();
     na.delay(this, packet, delay, unit);
@@ -296,7 +297,6 @@ public abstract class Step {
   }
 
   /** Multi-exception. */
-  @SuppressWarnings("serial")
   public static class MultiThrowable extends RuntimeException {
     private final List<Throwable> throwables;
 

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -150,6 +150,7 @@ WLSKO-0196=Stop introspection retry - exceeded configured domainPresenceFailureR
   domainPresenceFailureRetryMaxCount is an operator tuning parameter and can be controlled by adding it to the \
   weblogic-operator-cm configmap. To force the introspector to start retrying again, update 'domain.spec.introspectVersion'.
 WLSKO-0197=Introspection failed on try {0} of {1}.
+WLSKO-0198={0} Fiber {1}
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -726,7 +726,7 @@ class DomainIntrospectorJobTest {
   }
 
   @Test
-  void whenIntrospectorJobNotNeeded_doesNotValidatesDomainTopology() throws JsonProcessingException {
+  void whenIntrospectorJobNotNeeded_doesNotValidateDomainTopology() throws JsonProcessingException {
     // create WlsDomainConfig with "cluster-2" whereas domain spec contains "cluster-1"
     WlsDomainConfig wlsDomainConfig = createDomainConfig("cluster-2");
     IntrospectionTestUtils.defineResources(testSupport, wlsDomainConfig);

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServerUpIteratorStepTest.java
@@ -267,7 +267,7 @@ class ManagedServerUpIteratorStepTest extends ThreadFactoryTestBase implements W
 
     final Step step = createStepWithServerInfos();
 
-    assertThat(step.getName(), allOf(containsString(MS1), containsString(MS2), containsString(MS3)));
+    assertThat(step.getResourceName(), allOf(containsString(MS1), containsString(MS2), containsString(MS3)));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/work/StepChainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/StepChainTest.java
@@ -104,7 +104,7 @@ class StepChainTest {
     List<String> stepNames = new ArrayList<>(maxNumSteps);
     Step s = steps;
     while (s != null && stepNames.size() < maxNumSteps) {
-      stepNames.add(s.getName());
+      stepNames.add(s.getResourceName());
       s = s.getNext();
     }
     return stepNames;
@@ -123,7 +123,7 @@ class StepChainTest {
       this.name = name;
     }
 
-    public String getName() {
+    public String getResourceName() {
       return name;
     }
 


### PR DESCRIPTION
This adds some additional debugging capabilities for fibers:

When returning a NextAction it is now possible to add some static or computed information:
return doNext(getNext(), packet).withDebugComment(() -> "assume presence up-to-date");
indicates that the fiber has chosen a path in which the domain presence is considered to be up-to-date

return doNext(createIntrospectionSteps(), packet)
                    .withDebugComment(packet, this::introspectionNeededReason);
indicates that the fiber has decided that it needs to run an introspection, along with its reasoning, derived from the packet.

In each case, the comment is actually derived from a method, which is not invoked unless the feature is enabled for the current fiber (intended to avoid excess computation). That means that it may safely be left in the code.

To enable the feature, the code must add a string to the packet, using the key Fiber.DEBUG_FIBER

When the fiber terminates, it will be logged, along with the value of the Fiber.DEBUG_FIBER entry as a prefix.

Note that, at present, the feature is disabled unless specifically enabled in the code.

Replaces #2607 