### PR TITLE
Turn on Port forwarding test in ItParameterizedDomain

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -389,20 +389,7 @@ class ItParameterizedDomain {
     verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, true);
 
     stopPortForwardProcess(domainNamespace);
-
-    /*if (!OKD) {
-      // Test that `kubectl port-foward` is able to forward a local port to default channel port (7001 in this test)
-      // and default secure channel port (7002 in this test)
-      // Verify that the WLS admin console can be accessed using http://localhost:localPort/console/login/LoginForm.jsp
-      final String hostName = "localhost";
-      String forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_PORT);
-      verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, false);
-
-      forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_SECURE_PORT);
-      verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, true);
-
-      stopPortForwardProcess(domainNamespace);
-    }*/
+    
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -381,7 +381,16 @@ class ItParameterizedDomain {
           numberOfServers, replicaCount, curlCmd, managedServersBeforeScale);
     }
 
-    if (!OKD) {
+    final String hostName = "localhost";
+      String forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_PORT);
+      verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, false);
+
+      forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_SECURE_PORT);
+      verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, true);
+
+      stopPortForwardProcess(domainNamespace);
+
+    /*if (!OKD) {
       // Test that `kubectl port-foward` is able to forward a local port to default channel port (7001 in this test)
       // and default secure channel port (7002 in this test)
       // Verify that the WLS admin console can be accessed using http://localhost:localPort/console/login/LoginForm.jsp
@@ -393,7 +402,7 @@ class ItParameterizedDomain {
       verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, true);
 
       stopPortForwardProcess(domainNamespace);
-    }
+    }*/
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItParameterizedDomain.java
@@ -382,13 +382,13 @@ class ItParameterizedDomain {
     }
 
     final String hostName = "localhost";
-      String forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_PORT);
-      verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, false);
+    String forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_PORT);
+    verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, false);
 
-      forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_SECURE_PORT);
-      verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, true);
+    forwardedPortNo = startPortForwardProcess(hostName, domainNamespace, domainUid, ADMIN_SERVER_SECURE_PORT);
+    verifyAdminConsoleAccessible(domainNamespace, hostName, forwardedPortNo, true);
 
-      stopPortForwardProcess(domainNamespace);
+    stopPortForwardProcess(domainNamespace);
 
     /*if (!OKD) {
       // Test that `kubectl port-foward` is able to forward a local port to default channel port (7001 in this test)


### PR DESCRIPTION
With port forwarding turned on ItParameterizedDomain test passed at full  OKD suite run:
https://build.weblogick8s.org:8443/job/wko-okd-test/81/testReport/
in the log we can see  msg"Start port forward process"

There are some ItMiiAuxiliaryImage tests failed in the same run. I run the test locally and on Jenkins again. It passed at
https://build.weblogick8s.org:8443/job/wko-okd-test/85/

(pani)  Run the ItParameterizedDomain test in non-okd environment,  It is clean
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7410/testReport/oracle.weblogic.kubernetes/ItParameterizedDomain/ 