### PR TITLE
add docker login in jenkinsScript.sh (#2589)

### DIFF
--- a/jenkinsScript.sh
+++ b/jenkinsScript.sh
@@ -50,6 +50,19 @@ function checkJavaVersion {
     exit 1
   fi
 }
+function dockerLogin {
+  echo "Info: about to do docker login"
+  if [ ! -z ${DOCKER_USERNAME+x} ] && [ ! -z ${DOCKER_PASSWORD+x} ]; then
+    out=$(echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin)
+    res=$?
+    if [ $res -ne 0 ]; then
+      echo 'docker login failed'
+      exit 1
+    fi
+  else
+    echo "Info: Docker credentials DOCKER_USERNAME and DOCKER_PASSWORD are not set."
+  fi
+}
 
 # Record start time in a format appropriate for journalctl --since
 start_time=$(date +"%Y-%m-%d %H:%M:%S")
@@ -131,6 +144,8 @@ echo "Info: soft limits"
 ulimit -a
 echo "Info: hard limits"
 ulimit -aH
+
+dockerLogin
 
 echo 'Info: Run build...'
 mvn clean install


### PR DESCRIPTION
* adding docker login
backport to release/3.3, fwm pipeline team uses this branch and they need this change.

Jenkins -
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7404/