### PR TITLE
Fix intermittent events issue

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -389,8 +389,8 @@ class ItKubernetesEvents {
   @Order(5)
   @Test
   void testK8SEventsMultiClusterEvents() {
-    createNewCluster();
     OffsetDateTime timestamp = now();
+    createNewCluster();
     scaleClusterWithRestApi(domainUid, cluster2Name, 1,
         externalRestHttpsPort, opNamespace, opServiceAccount);
     logger.info("verify the Domain_Available event is generated");


### PR DESCRIPTION
It looks like the event was logged couple of seconds before the timestamp was obtained. The call to now() should be before createNewCluster(), the test should pass without any timing issue.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7417/
