### PR TITLE
OWLS-94649 - Update the domain status in case of auxiliary image pull error and recreate the introspector job after image is fixed

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/IntrospectionStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/IntrospectionStatus.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,8 @@ public class IntrospectionStatus {
   private static final String K8S_POD_UNSCHEDULABLE = "Unschedulable";
 
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+  public static final String ERR_IMAGE_PULL = "ErrImagePull";
+  public static final String IMAGE_PULL_BACK_OFF = "ImagePullBackOff";
 
   static V1ContainerStatus getIntrospectorStatus(@Nonnull V1Pod pod) {
     final String introspectorName = toJobIntrospectorName(getPodDomainUid(pod));
@@ -52,7 +55,8 @@ public class IntrospectionStatus {
   @Nullable
   static Step createStatusUpdateSteps(@Nonnull V1Pod pod) {
     final String terminatedErrorMessage = getTerminatedMessage(pod);
-    final String waitingMessage = getWaitingMessage(pod);
+    final String waitingMessage = getWaitingMessageFromStatus(pod);
+    final String initContainerWaitingMessages = getInitContainerWaitingMessages(pod);
 
     if (FailedPhase.inFailedPhase(pod)) {
       return new FailedPhase(pod).createStatusUpdateSteps();
@@ -64,6 +68,8 @@ public class IntrospectionStatus {
       return new SelectedMessage(pod, terminatedErrorMessage, true).createStatusUpdateSteps();
     } else if (waitingMessage != null) {
       return new SelectedMessage(pod, waitingMessage, false).createStatusUpdateSteps();
+    } else if (initContainerWaitingMessages != null) {
+      return new SelectedMessage(pod, initContainerWaitingMessages, false).createStatusUpdateSteps();
     } else {
       return DomainStatusUpdater.createRemoveFailuresStep();
     }
@@ -77,12 +83,43 @@ public class IntrospectionStatus {
           .orElse(null);
   }
 
-  private static String getWaitingMessage(@Nonnull V1Pod pod) {
-    return Optional.ofNullable(getIntrospectorStatus(pod))
-          .map(V1ContainerStatus::getState)
-          .map(V1ContainerState::getWaiting)
-          .map(V1ContainerStateWaiting::getMessage)
+  private static String getWaitingMessageFromStatus(@Nonnull V1Pod pod) {
+    return Optional.ofNullable(getWaitingMessageFromStatus(getIntrospectorStatus(pod)))
           .orElse(null);
+  }
+
+  private static String getWaitingMessageFromStatus(V1ContainerStatus status) {
+    return Optional.ofNullable(status)
+            .map(V1ContainerStatus::getState)
+            .map(V1ContainerState::getWaiting)
+            .map(V1ContainerStateWaiting::getMessage)
+            .orElse(null);
+  }
+
+  private static String getInitContainerWaitingMessages(@Nonnull V1Pod pod) {
+    List<String> waitingMessages = new ArrayList<>();
+
+    Optional.ofNullable(getInitContainerStatuses(pod)).orElse(emptyList()).stream()
+            .filter(status -> isImagePullError(getWaitingReason(status)))
+            .forEach(status -> waitingMessages.add(getWaitingMessageFromStatus(status)));
+
+    return waitingMessages.isEmpty() ? null : String.join(System.lineSeparator(), waitingMessages);
+  }
+
+  private static List<V1ContainerStatus> getInitContainerStatuses(@Nonnull V1Pod pod) {
+    return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getInitContainerStatuses).orElse(null);
+  }
+
+  public static boolean isImagePullError(String reason) {
+    return ERR_IMAGE_PULL.equals(reason) || IMAGE_PULL_BACK_OFF.equals(reason);
+  }
+
+  private static String getWaitingReason(V1ContainerStatus status) {
+    return Optional.ofNullable(status)
+            .map(V1ContainerStatus::getState)
+            .map(V1ContainerState::getWaiting)
+            .map(V1ContainerStateWaiting::getReason)
+            .orElse(null);
   }
 
   private static boolean isReady(@Nonnull V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -52,6 +52,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static oracle.kubernetes.operator.DomainFailureReason.Introspection;
 import static oracle.kubernetes.operator.DomainSourceType.FromModel;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createFailureRelatedSteps;
+import static oracle.kubernetes.operator.IntrospectionStatus.isImagePullError;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_DOMAIN_SPEC_GENERATION;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR_JOB;
@@ -614,7 +615,7 @@ public class JobHelper {
 
         if (jobPod == null) {
           return doContinueListOrNext(callResponse, packet, processIntrospectorPodLog(getNext()));
-        } else if (hasImagePullFailure(jobPod) || isJobPodTimedOut(jobPod)) {
+        } else if (hasImagePullError(jobPod) || initContainersHaveImagePullError(jobPod) || isJobPodTimedOut(jobPod)) {
           return doNext(cleanUpAndReintrospect(getNext()), packet);
         } else {
           recordJobPodName(packet, getName(jobPod));
@@ -643,9 +644,9 @@ public class JobHelper {
         return getName(pod).startsWith(getJobName());
       }
 
-      private boolean hasImagePullFailure(V1Pod pod) {
+      private boolean hasImagePullError(V1Pod pod) {
         return Optional.ofNullable(getJobPodContainerWaitingReason(pod))
-              .map(s -> s.contains("ErrImagePull") || s.contains("ImagePullBackOff"))
+              .map(reason -> isImagePullError(reason))
               .orElse(false);
       }
 
@@ -654,6 +655,21 @@ public class JobHelper {
               .map(V1PodStatus::getContainerStatuses).map(statuses -> statuses.get(0))
               .map(V1ContainerStatus::getState).map(V1ContainerState::getWaiting)
               .map(V1ContainerStateWaiting::getReason).orElse(null);
+      }
+
+      private boolean initContainersHaveImagePullError(V1Pod pod) {
+        return Optional.ofNullable(getInitContainerStatuses(pod))
+                .map(statuses -> statuses.stream()
+                        .map(V1ContainerStatus::getState)
+                        .map(V1ContainerState::getWaiting).filter(Objects::nonNull)
+                        .map(V1ContainerStateWaiting::getReason)
+                        .anyMatch(reason -> isImagePullError(reason)))
+                .orElse(false);
+
+      }
+
+      private List<V1ContainerStatus> getInitContainerStatuses(V1Pod pod) {
+        return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getInitContainerStatuses).orElse(null);
       }
 
       private void recordJobPodName(Packet packet, String podName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -27,6 +27,9 @@ import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobCondition;
 import io.kubernetes.client.openapi.models.V1JobStatus;
@@ -950,7 +953,7 @@ class DomainProcessorTest {
   }
 
   private void defineTimedoutIntrospection() {
-    V1Job job = asTimedoutJob(createIntrospectorJob("TIMEDOUT_JOB"));
+    V1Job job = asFailedJob(createIntrospectorJob("TIMEDOUT_JOB"));
     testSupport.defineResources(job);
     testSupport.addToPacket(DOMAIN_INTROSPECTOR_JOB, job);
     setJobPodStatusReasonDeadlineExceeded();
@@ -960,10 +963,38 @@ class DomainProcessorTest {
     testSupport.<V1Pod>getResourceWithName(POD, getJobName()).status(new V1PodStatus().reason("DeadlineExceeded"));
   }
 
-  private V1Job asTimedoutJob(V1Job job) {
+  private V1Job asFailedJob(V1Job job) {
     job.setStatus(new V1JobStatus().addConditionsItem(new V1JobCondition().status("True").type("Failed")
             .reason("BackoffLimitExceeded")));
     return job;
+  }
+
+  @Test
+  void whenIntrospectionJobInitContainerHasImagePullFailure_jobRecreatedAndFailedConditionCleared() throws Exception {
+    consoleHandlerMemento.ignoringLoggedExceptions(RuntimeException.class);
+    consoleHandlerMemento.ignoreMessage(MessageKeys.NOT_STARTING_DOMAINUID_THREAD);
+    jobStatus = createBackoffStatus();
+    establishPreviousIntrospection(null);
+    defineIntrospectionWithInitContainerImagePullError();
+    testSupport.doOnDelete(JOB, j -> deletePod());
+    testSupport.doOnCreate(JOB, j -> createJobPodAndSetCompletedStatus(job));
+    domainConfigurator.withIntrospectVersion(NEW_INTROSPECTION_STATE);
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).interrupt().execute();
+
+    assertThat(isDomainConditionFailed(), is(false));
+  }
+
+  private void defineIntrospectionWithInitContainerImagePullError() {
+    V1Job job = asFailedJob(createIntrospectorJob("IMAGE_PULL_FAILURE_JOB"));
+    testSupport.defineResources(job);
+    testSupport.addToPacket(DOMAIN_INTROSPECTOR_JOB, job);
+    setJobPodInitContainerStatusImagePullError();
+  }
+
+  private void setJobPodInitContainerStatusImagePullError() {
+    testSupport.<V1Pod>getResourceWithName(POD, getJobName()).status(new V1PodStatus().initContainerStatuses(
+            Arrays.asList(new V1ContainerStatus().state(new V1ContainerState().waiting(
+                    new V1ContainerStateWaiting().reason("ImagePullBackOff").message("Back-off pulling image"))))));
   }
 
   private V1Job createIntrospectorJob(String uid) {


### PR DESCRIPTION
- Report error in domain status when there is a problem pulling auxiliary image.
- Recreate introspector job when auxiliary image changed from incorrect image to correct image.

Integration test runs - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7423/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7428/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7429/
