### PR TITLE
Modify Auxiliary Image test to accommodate PR#2659 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -498,7 +498,8 @@ class ItMiiAuxiliaryImage {
     assertDoesNotThrow(() -> createDomainCustomResource(domainCR), "createDomainCustomResource throws Exception");
 
     // check the introspector pod log contains the expected error message
-    String expectedErrorMsg = "Auxiliary Image: Dir '/errorpath' doesn't exist or is empty. Exiting.";
+    //String expectedErrorMsg = "Auxiliary Image: Dir '/errorpath' doesn't exist or is empty. Exiting.";
+    String expectedErrorMsg = "cp: can't stat '/errorpath/*': No such file or directory";
     verifyIntrospectorPodLogContainsExpectedErrorMsg(domainUid, errorpathDomainNamespace, expectedErrorMsg);
 
     // check the domain event contains the expected error message

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -498,7 +498,6 @@ class ItMiiAuxiliaryImage {
     assertDoesNotThrow(() -> createDomainCustomResource(domainCR), "createDomainCustomResource throws Exception");
 
     // check the introspector pod log contains the expected error message
-    //String expectedErrorMsg = "Auxiliary Image: Dir '/errorpath' doesn't exist or is empty. Exiting.";
     String expectedErrorMsg = "cp: can't stat '/errorpath/*': No such file or directory";
     verifyIntrospectorPodLogContainsExpectedErrorMsg(domainUid, errorpathDomainNamespace, expectedErrorMsg);
 


### PR DESCRIPTION
Modify Auxiliary Image testErrorPathDomainMismatchMountPath test to accommodate PR#2659 

Single test passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7430/testReport/
Full suite ItMiiAuxiliaryImage passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7432/