### PR TITLE
Improved mkdir error logging

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -77,7 +77,7 @@ traceDirs before LOG_HOME
 
 if [ ! -z "${LOG_HOME}" ] && [ ! -d "${LOG_HOME}" ]; then
   trace "Creating log home directory: '${LOG_HOME}'"
-  createFolder ${LOG_HOME} "This is the 'domain.spec.logHome' LOG_HOME directory that is used when 'domain.spec.logHomeEnabled' is set to 'true'." || exit 1
+  createFolder "${LOG_HOME}" "This is the 'domain.spec.logHome' LOG_HOME directory that is used when 'domain.spec.logHomeEnabled' is set to 'true'." || exit 1
 fi
 
 ilog_dir="${LOG_HOME:-/tmp}"
@@ -141,7 +141,7 @@ function doIntrospect() {
   #
   if [ ! -z "${DATA_HOME}" ] && [ ! -d "${DATA_HOME}" ]; then
     trace "Creating data home directory: '${DATA_HOME}'"
-    createFolder ${DATA_HOME} "This is the 'domain.spec.dataHome' DATA_HOME directory." || exit 1
+    createFolder "${DATA_HOME}" "This is the 'domain.spec.dataHome' DATA_HOME directory." || exit 1
   fi
 
   traceTiming "INTROSPECTOR '${DOMAIN_UID}' MII CREATE DOMAIN START"

--- a/operator/src/main/resources/scripts/introspectDomain.sh
+++ b/operator/src/main/resources/scripts/introspectDomain.sh
@@ -62,19 +62,6 @@ traceTiming "INTROSPECTOR '${DOMAIN_UID}' MAIN START"
 checkAuxiliaryImage || exit 1
 
 #
-# Local createFolder method which does an 'exit 1' instead of exitOrLoop for
-# immediate failure during introspection
-#
-
-function createFolder {
-  mkdir -m 750 -p $1
-  if [ ! -d $1 ]; then
-    trace SEVERE "Unable to create folder $1"
-    exit 1
-  fi
-}
-
-#
 # setup MII functions in case this is a MII domain
 #
 
@@ -90,7 +77,7 @@ traceDirs before LOG_HOME
 
 if [ ! -z "${LOG_HOME}" ] && [ ! -d "${LOG_HOME}" ]; then
   trace "Creating log home directory: '${LOG_HOME}'"
-  createFolder ${LOG_HOME}
+  createFolder ${LOG_HOME} "This is the 'domain.spec.logHome' LOG_HOME directory that is used when 'domain.spec.logHomeEnabled' is set to 'true'." || exit 1
 fi
 
 ilog_dir="${LOG_HOME:-/tmp}"
@@ -98,7 +85,7 @@ ilog_file="${ilog_dir}/introspector_script.out"
 
 if [ ! -d "${ilog_dir}" ]; then
   trace "Creating introspector log directory: '${ilog_dir}'"
-  createFolder "${ilog_dir}"
+  createFolder "${ilog_dir}" "This is the directory for holding introspector output." || exit 1
 fi
 
 testLogFileRotate "${ilog_file}"
@@ -154,7 +141,7 @@ function doIntrospect() {
   #
   if [ ! -z "${DATA_HOME}" ] && [ ! -d "${DATA_HOME}" ]; then
     trace "Creating data home directory: '${DATA_HOME}'"
-    createFolder ${DATA_HOME}
+    createFolder ${DATA_HOME} "This is the 'domain.spec.dataHome' DATA_HOME directory." || exit 1
   fi
 
   traceTiming "INTROSPECTOR '${DOMAIN_UID}' MII CREATE DOMAIN START"
@@ -177,15 +164,7 @@ function doIntrospect() {
     if [ $? -ne 0 ] ; then
       trace SEVERE "DomainSourceType is 'FromModel', 'unzip' is missing in the image. Please use an image with 'unzip' installed" && exit 1
     fi
-    mkdir -p ${DOMAIN_HOME}
-    if [ $? -ne 0 ] ; then
-      trace SEVERE "DomainSourceType is 'FromModel', cannot create domain home directory '${DOMAIN_HOME}'" && exit 1
-    fi
-    touch ${DOMAIN_HOME}/testaccess.tmp
-    if [ $? -ne 0 ]; then
-      trace SEVERE "DomainSourceType is 'FromModel', cannot write to domain home directory '${DOMAIN_HOME}'" && exit 1
-    fi
-    rm -f ${DOMAIN_HOME}/testaccess.tmp
+    createFolder "${DOMAIN_HOME}" "DomainSourceType is 'FromModel' and this is the DOMAIN_HOME directory specified by 'domain.spec.domainHome'." || exit 1
     createWLDomain || exit 1
     created_domain=$DOMAIN_CREATED
     trace "Create domain return code = " ${created_domain}

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -262,7 +262,7 @@ function buildWDTParams_MD5() {
   opss_wallet=$(get_opss_key_wallet)
   if [ -f "${opss_wallet}" ] ; then
     trace "A wallet file was passed in using walletFileSecret, so we're using an existing rcu schema."
-    createFolder /tmp/opsswallet "This folder is used to hold a generated OPSS wallet file." || exitOrLoop
+    createFolder "/tmp/opsswallet" "This folder is used to hold a generated OPSS wallet file." || exitOrLoop
     base64 -d  ${opss_wallet} > /tmp/opsswallet/ewallet.p12
     OPSS_FLAGS="-opss_wallet /tmp/opsswallet"
   else
@@ -559,7 +559,7 @@ function createModelDomain() {
       trace "Using existing primordial domain"
       cd / && base64 -d ${PRIMORDIAL_DOMAIN_ZIPPED} > ${LOCAL_PRIM_DOMAIN_ZIP} && tar -pxzf ${LOCAL_PRIM_DOMAIN_ZIP}
       # create empty lib since we don't archive it in primordial zip and WDT will fail without it
-      createFolder ${DOMAIN_HOME}/lib "This is the './lib' directory within directory 'domain.spec.domainHome'." || exitOrLoop
+      createFolder "${DOMAIN_HOME}/lib" "This is the './lib' directory within directory 'domain.spec.domainHome'." || exitOrLoop
       # Since the SerializedSystem ini is encrypted, restore it first
       local MII_PASSPHRASE=$(cat ${RUNTIME_ENCRYPTION_SECRET_PASSWORD})
       encrypt_decrypt_domain_secret "decrypt" ${DOMAIN_HOME} ${MII_PASSPHRASE}
@@ -1051,7 +1051,7 @@ function wdtHandleOnlineUpdate() {
   # We need to extract all the archives, WDT online checks for file existence
   # even for delete
   #
-  createFolder ${DOMAIN_HOME}/lib "This is the './lib' directory within directory 'domain.spec.domainHome'." || exitOrLoop
+  createFolder "${DOMAIN_HOME}/lib" "This is the './lib' directory within directory 'domain.spec.domainHome'." || exitOrLoop
   for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
     do
         # expand the archive domain libraries to the domain lib
@@ -1281,7 +1281,7 @@ function prepareMIIServer() {
   #
   trace "Model-in-Image: Restoring apps and libraries"
 
-  createFolder ${DOMAIN_HOME}/lib "This is the './lib' directory within DOMAIN_HOME directory 'domain.spec.domainHome'." || return 1
+  createFolder "${DOMAIN_HOME}/lib" "This is the './lib' directory within DOMAIN_HOME directory 'domain.spec.domainHome'." || return 1
   local WLSDEPLOY_DOMAINLIB="wlsdeploy/domainLibraries"
 
   for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -78,7 +78,7 @@ export WDT_MODEL_SECRETS_NAME_DIR_PAIRS="__weblogic-credentials__=/weblogic-oper
 
 if [ ! -d "${WDT_OUTPUT_DIR}" ]; then
   trace "Creating WDT standard output directory: '${WDT_OUTPUT_DIR}'"
-  createFolder "${WDT_OUTPUT_DIR}"
+  createFolder "${WDT_OUTPUT_DIR}"  "This folder is for holding Model In Image WDT command output files for logging purposes. If 'domain.spec.logHomeEnabled' is 'true', then it is located in 'domain.spec.logHome', otherwise it is located within '/tmp'." || exitOrLoop
 fi
 
 # sort_files  sort the files according to the names and naming conventions and write the result to stdout
@@ -262,7 +262,7 @@ function buildWDTParams_MD5() {
   opss_wallet=$(get_opss_key_wallet)
   if [ -f "${opss_wallet}" ] ; then
     trace "A wallet file was passed in using walletFileSecret, so we're using an existing rcu schema."
-    mkdir -p /tmp/opsswallet
+    createFolder /tmp/opsswallet "This folder is used to hold a generated OPSS wallet file." || exitOrLoop
     base64 -d  ${opss_wallet} > /tmp/opsswallet/ewallet.p12
     OPSS_FLAGS="-opss_wallet /tmp/opsswallet"
   else
@@ -559,7 +559,7 @@ function createModelDomain() {
       trace "Using existing primordial domain"
       cd / && base64 -d ${PRIMORDIAL_DOMAIN_ZIPPED} > ${LOCAL_PRIM_DOMAIN_ZIP} && tar -pxzf ${LOCAL_PRIM_DOMAIN_ZIP}
       # create empty lib since we don't archive it in primordial zip and WDT will fail without it
-      mkdir ${DOMAIN_HOME}/lib
+      createFolder ${DOMAIN_HOME}/lib "This is the './lib' directory within directory 'domain.spec.domainHome'." || exitOrLoop
       # Since the SerializedSystem ini is encrypted, restore it first
       local MII_PASSPHRASE=$(cat ${RUNTIME_ENCRYPTION_SECRET_PASSWORD})
       encrypt_decrypt_domain_secret "decrypt" ${DOMAIN_HOME} ${MII_PASSPHRASE}
@@ -1051,7 +1051,7 @@ function wdtHandleOnlineUpdate() {
   # We need to extract all the archives, WDT online checks for file existence
   # even for delete
   #
-  mkdir -p ${DOMAIN_HOME}/lib || exitOrLoop
+  createFolder ${DOMAIN_HOME}/lib "This is the './lib' directory within directory 'domain.spec.domainHome'." || exitOrLoop
   for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
     do
         # expand the archive domain libraries to the domain lib
@@ -1281,11 +1281,7 @@ function prepareMIIServer() {
   #
   trace "Model-in-Image: Restoring apps and libraries"
 
-  mkdir -p ${DOMAIN_HOME}/lib
-  if [ $? -ne 0 ] ; then
-    trace  SEVERE "Domain Source Type is FromModel, cannot create ${DOMAIN_HOME}/lib "
-    return 1
-  fi
+  createFolder ${DOMAIN_HOME}/lib "This is the './lib' directory within DOMAIN_HOME directory 'domain.spec.domainHome'." || return 1
   local WLSDEPLOY_DOMAINLIB="wlsdeploy/domainLibraries"
 
   for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -113,7 +113,7 @@ fi
 
 export NODEMGR_HOME=${NODEMGR_HOME}/${DOMAIN_UID}/${SERVER_NAME}
 
-createFolder ${NODEMGR_HOME} "This is the internal NODEMGR_HOME folder for the node manager for server '$SERVER_NAME' and domain UID '${DOMAIN_UID}'." || exit 1
+createFolder "${NODEMGR_HOME}" "This is the internal NODEMGR_HOME folder for the node manager for server '$SERVER_NAME' and domain UID '${DOMAIN_UID}'." || exit 1
 
 NODEMGR_LOG_HOME=${NODEMGR_LOG_HOME:-${LOG_HOME:-${NODEMGR_HOME}/${DOMAIN_UID}}}
 FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR=${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR:-true}
@@ -125,7 +125,7 @@ trace "DOMAIN_UID='${DOMAIN_UID}'"
 trace "NODEMGR_LOG_HOME='${NODEMGR_LOG_HOME}'"
 trace "FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR='${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR}'"
 
-createFolder ${NODEMGR_LOG_HOME} "This directory is used to hold node manager logs for server '$SERVER_NAME'. If 'domain.spec.logHomeEnabled' is 'true', then it is located within the 'domain.spec.logHome' directory, otherwise it is located within within the NODEMGR_HOME '${NODEMGR_HOME}' directory." || exit 1
+createFolder "${NODEMGR_LOG_HOME}" "This directory is used to hold node manager logs for server '$SERVER_NAME'. If 'domain.spec.logHomeEnabled' is 'true', then it is located within the 'domain.spec.logHome' directory, otherwise it is located within within the NODEMGR_HOME '${NODEMGR_HOME}' directory." || exit 1
 
 nodemgr_log_file=${NODEMGR_LOG_HOME}/${SERVER_NAME}_nodemanager.log
 nodemgr_out_file=${NODEMGR_LOG_HOME}/${SERVER_NAME}_nodemanager.out
@@ -215,7 +215,7 @@ if [ ! "${SERVER_NAME}" = "introspector" ]; then
   wl_state_file=${wl_data_dir}/${SERVER_NAME}.state
   wl_props_file=${wl_data_dir}/startup.properties
 
-  createFolder ${wl_data_dir} "This is a directory the server '$SERVER_NAME' node manager uses to track its state. It is located within the 'domain.spec.domainHome' directory." || exit 1
+  createFolder "${wl_data_dir}" "This is a directory the server '$SERVER_NAME' node manager uses to track its state. It is located within the 'domain.spec.domainHome' directory." || exit 1
 
   # Remove state file, because:
   #   1 - The liveness probe checks this file

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -83,19 +83,6 @@ fi
 [ ! -d "${WL_HOME}" ]                       && trace SEVERE "WL_HOME '${WL_HOME}' not found."                         && exit 1 
 [ ! -f "${stm_script}" ]                    && trace SEVERE "Missing script '${stm_script}' in WL_HOME '${WL_HOME}'." && exit 1 
 
-#
-# Helper fn to create a folder
-# Arg $1 - path of folder to create
-#
-function createFolder {
-  mkdir -m 750 -p "$1"
-  if [ ! -d "$1" ]; then
-    trace SEVERE "Unable to create folder '$1'."
-    exit 1
-  fi
-}
-
-
 ###############################################################################
 #
 # Determine WebLogic server log and out files locations
@@ -114,7 +101,7 @@ else
   export SERVER_PID_FILE="${serverLogHome}/${SERVER_NAME}.pid"
   export SHUTDOWN_MARKER_FILE="${serverLogHome}/${SERVER_NAME}.shutdown"
   serverOutOption="-Dweblogic.Stdout=${SERVER_OUT_FILE}"
-  createFolder "${serverLogHome}"
+  createFolder "${serverLogHome}" "This folder is used to hold server output for server '$SERVER_NAME'. If 'server.spec.logHomeEnabled' is set to true, then it is the 'domain.spec.logHome' directory, otherwise it is located within the 'domain.spec.domainHome' directory." || exit 1
   rm -f ${SHUTDOWN_MARKER_FILE}
 fi
 
@@ -126,7 +113,7 @@ fi
 
 export NODEMGR_HOME=${NODEMGR_HOME}/${DOMAIN_UID}/${SERVER_NAME}
 
-createFolder ${NODEMGR_HOME} 
+createFolder ${NODEMGR_HOME} "This is the internal NODEMGR_HOME folder for the node manager for server '$SERVER_NAME' and domain UID '${DOMAIN_UID}'." || exit 1
 
 NODEMGR_LOG_HOME=${NODEMGR_LOG_HOME:-${LOG_HOME:-${NODEMGR_HOME}/${DOMAIN_UID}}}
 FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR=${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR:-true}
@@ -138,7 +125,7 @@ trace "DOMAIN_UID='${DOMAIN_UID}'"
 trace "NODEMGR_LOG_HOME='${NODEMGR_LOG_HOME}'"
 trace "FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR='${FAIL_BOOT_ON_SITUATIONAL_CONFIG_ERROR}'"
 
-createFolder ${NODEMGR_LOG_HOME}
+createFolder ${NODEMGR_LOG_HOME} "This directory is used to hold node manager logs for server '$SERVER_NAME'. If 'domain.spec.logHomeEnabled' is 'true', then it is located within the 'domain.spec.logHome' directory, otherwise it is located within within the NODEMGR_HOME '${NODEMGR_HOME}' directory." || exit 1
 
 nodemgr_log_file=${NODEMGR_LOG_HOME}/${SERVER_NAME}_nodemanager.log
 nodemgr_out_file=${NODEMGR_LOG_HOME}/${SERVER_NAME}_nodemanager.out
@@ -228,7 +215,7 @@ if [ ! "${SERVER_NAME}" = "introspector" ]; then
   wl_state_file=${wl_data_dir}/${SERVER_NAME}.state
   wl_props_file=${wl_data_dir}/startup.properties
 
-  createFolder ${wl_data_dir}
+  createFolder ${wl_data_dir} "This is a directory the server '$SERVER_NAME' node manager uses to track its state. It is located within the 'domain.spec.domainHome' directory." || exit 1
 
   # Remove state file, because:
   #   1 - The liveness probe checks this file

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -123,7 +123,7 @@ function mockWLS() {
   STATEFILE_DIR=${DOMAIN_HOME}/servers/${SERVER_NAME}/data/nodemanager
   STATEFILE=${STATEFILE_DIR}/${SERVER_NAME}.state
 
-  createFolder $STATEFILE_DIR "This is the directory for holding '${SERVER_NAME}.state' in mock mode for 'server '${SERVER_NAME}' within the 'domain.spec.domainHome' directory." || exitOrLoop
+  createFolder "$STATEFILE_DIR" "This is the directory for holding '${SERVER_NAME}.state' in mock mode for 'server '${SERVER_NAME}' within the 'domain.spec.domainHome' directory." || exitOrLoop
 
   echo "RUNNING:Y:N" > $STATEFILE
 }
@@ -153,7 +153,7 @@ function copySitCfgWhileBooting() {
 
   trace "Copying files starting with '$src_dir/$fil_prefix' to '$tgt_dir' without the prefix."
 
-  createFolder $tgt_dir "This is a directory within directory 'domain.spec.domainHome' that the operator uses for supplying internal or user specified configuration overrides." || exitOrLoop
+  createFolder "$tgt_dir" "This is a directory within directory 'domain.spec.domainHome' that the operator uses for supplying internal or user specified configuration overrides." || exitOrLoop
 
   ls ${src_dir}/${fil_prefix}*.xml > /dev/null 2>&1
   if [ $? = 0 ]; then
@@ -226,7 +226,7 @@ if [ ! -z ${DATA_HOME} ]; then
   # Create $DATA_HOME directory for server if doesn't exist
   if [ ! -d ${DATA_HOME}/${SERVER_NAME}/data ]; then
     trace "Creating directory '${DATA_HOME}/${SERVER_NAME}/data'"
-    createFolder ${DATA_HOME}/${SERVER_NAME}/data "This is the server '$SERVER_NAME' data directory within directory DATA_HOME 'domain.spec.dataHome'." || exitOrLoop
+    createFolder "${DATA_HOME}/${SERVER_NAME}/data" "This is the server '$SERVER_NAME' data directory within directory DATA_HOME 'domain.spec.dataHome'." || exitOrLoop
   else
     trace "Directory '${DATA_HOME}/${SERVER_NAME}/data' exists"
   fi
@@ -287,7 +287,7 @@ fi
 #          trigger unnecessary situational config overhead.
 #
 
-createFolder ${DOMAIN_HOME}/servers/${SERVER_NAME}/security "This is the server '${SERVER_NAME}' security directory within directory DOMAIN_HOME 'domain.spec.domainHome'." || exitOrLoop
+createFolder "${DOMAIN_HOME}/servers/${SERVER_NAME}/security" "This is the server '${SERVER_NAME}' security directory within directory DOMAIN_HOME 'domain.spec.domainHome'." || exitOrLoop
 
 copyIfChanged /weblogic-operator/introspector/boot.properties \
               ${DOMAIN_HOME}/servers/${SERVER_NAME}/security/boot.properties

--- a/operator/src/main/resources/scripts/startServer.sh
+++ b/operator/src/main/resources/scripts/startServer.sh
@@ -123,7 +123,8 @@ function mockWLS() {
   STATEFILE_DIR=${DOMAIN_HOME}/servers/${SERVER_NAME}/data/nodemanager
   STATEFILE=${STATEFILE_DIR}/${SERVER_NAME}.state
 
-  createFolder $STATEFILE_DIR
+  createFolder $STATEFILE_DIR "This is the directory for holding '${SERVER_NAME}.state' in mock mode for 'server '${SERVER_NAME}' within the 'domain.spec.domainHome' directory." || exitOrLoop
+
   echo "RUNNING:Y:N" > $STATEFILE
 }
 
@@ -152,7 +153,7 @@ function copySitCfgWhileBooting() {
 
   trace "Copying files starting with '$src_dir/$fil_prefix' to '$tgt_dir' without the prefix."
 
-  createFolder $tgt_dir
+  createFolder $tgt_dir "This is a directory within directory 'domain.spec.domainHome' that the operator uses for supplying internal or user specified configuration overrides." || exitOrLoop
 
   ls ${src_dir}/${fil_prefix}*.xml > /dev/null 2>&1
   if [ $? = 0 ]; then
@@ -225,7 +226,7 @@ if [ ! -z ${DATA_HOME} ]; then
   # Create $DATA_HOME directory for server if doesn't exist
   if [ ! -d ${DATA_HOME}/${SERVER_NAME}/data ]; then
     trace "Creating directory '${DATA_HOME}/${SERVER_NAME}/data'"
-    createFolder ${DATA_HOME}/${SERVER_NAME}/data
+    createFolder ${DATA_HOME}/${SERVER_NAME}/data "This is the server '$SERVER_NAME' data directory within directory DATA_HOME 'domain.spec.dataHome'." || exitOrLoop
   else
     trace "Directory '${DATA_HOME}/${SERVER_NAME}/data' exists"
   fi
@@ -286,7 +287,8 @@ fi
 #          trigger unnecessary situational config overhead.
 #
 
-createFolder ${DOMAIN_HOME}/servers/${SERVER_NAME}/security
+createFolder ${DOMAIN_HOME}/servers/${SERVER_NAME}/security "This is the server '${SERVER_NAME}' security directory within directory DOMAIN_HOME 'domain.spec.domainHome'." || exitOrLoop
+
 copyIfChanged /weblogic-operator/introspector/boot.properties \
               ${DOMAIN_HOME}/servers/${SERVER_NAME}/security/boot.properties
 

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -594,8 +594,7 @@ function createFolder {
   [ ! -z "$touchOutput" ] && echo "$touchOutput"
 
   if [ ! -f "$touchFile" ] ; then
-    echo "$touchOutput"
-    trace SEVERE "Cannot write to directory '${targetDir}' using command '${touchCommand}', error='${touchOutput}'. ${folderDescription}"
+    trace SEVERE "Cannot write a file to directory '${targetDir}' using command '${touchCommand}', error='${touchOutput}'. ${folderDescription}"
     return 1
   fi
 
@@ -637,7 +636,7 @@ function linkServerDefaultDir() {
     # Create the server's directory in $DOMAIN_HOME/servers
     if [ ! -d ${DOMAIN_HOME}/servers/${SERVER_NAME} ]; then
       trace "Creating directory '${DOMAIN_HOME}/servers/${SERVER_NAME}'"
-      createFolder ${DOMAIN_HOME}/servers/${SERVER_NAME} "This is the server '${SERVER_NAME}' directory within 'spec.domain.domainHome'." || exitOrLoop 
+      createFolder "${DOMAIN_HOME}/servers/${SERVER_NAME}" "This is the server '${SERVER_NAME}' directory within 'spec.domain.domainHome'." || exitOrLoop 
     else
       trace "'${DOMAIN_HOME}/servers/${SERVER_NAME}' already exists as a directory"
     fi

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -568,16 +568,39 @@ function exitOrLoop {
   fi
 }
 
-#
-# Define helper fn to create a folder
-#
-
+# Create a folder and test access to it
+#   Arg $1 - path of folder to create
+#   Arg $2 - optional wording to append to the FINE and SEVERE traces
 function createFolder {
-  mkdir -m 750 -p $1
-  if [ ! -d $1 ]; then
-    trace SEVERE "Unable to create folder $1"
-    exitOrLoop
+  local targetDir="${1}"
+  local folderDescription="${2:-}"
+  local mkdirCommand="mkdir -m 750 -p $targetDir"
+
+  trace FINE "Creating folder '${targetDir}' using command '${mkdirCommand}'. ${folderDescription}"
+
+  local mkdirOutput="$($mkdirCommand 2>&1)"
+  [ ! -z "$mkdirOutput" ] && echo "$mkdirOutput"
+
+  if [ ! -d "$targetDir" ]; then
+    trace SEVERE "Unable to create folder '${targetDir}' using command '${mkdirCommand}', error='${mkdirOutput}'. ${folderDescription}"
+    return 1
   fi
+
+  local touchFile="${targetDir}/testaccess.tmp"
+  local touchCommand="touch $touchFile"
+
+  rm -f "${touchFile}"
+  local touchOutput="$($touchCommand 2>&1)"
+  [ ! -z "$touchOutput" ] && echo "$touchOutput"
+
+  if [ ! -f "$touchFile" ] ; then
+    echo "$touchOutput"
+    trace SEVERE "Cannot write to directory '${targetDir}' using command '${touchCommand}', error='${touchOutput}'. ${folderDescription}"
+    return 1
+  fi
+
+  rm -f "${touchFile}"
+  return 0
 }
 
 # Returns the count of the number of files in the specified directory
@@ -603,6 +626,8 @@ function createSymbolicLink() {
 # 'dataHome' attribute of the CRD ($DATA_HOME/${SERVER_NAME}/data).  If both the ${DOMAIN_HOME}/servers/${SERVER_NAME}/data
 # and $DATA_HOME/${SERVER_NAME}/data directories contain persistent files that the Operator can't resolve
 # than an error message is logged asking the user to manually resolve the files and then exit.
+# Note: This function is experimental, it is only called when
+#       [ ! -z ${EXPERIMENTAL_LINK_SERVER_DEFAULT_DATA_DIR} ] && [ -z ${KEEP_DEFAULT_DATA_HOME} ]
 function linkServerDefaultDir() {
   # if server's default 'data' directory (${DOMAIN_HOME}/servers/${SERVER_NAME}/data) does not exist than create
   # symbolic link to location specified by $DATA_HOME/${SERVER_NAME}/data
@@ -612,7 +637,7 @@ function linkServerDefaultDir() {
     # Create the server's directory in $DOMAIN_HOME/servers
     if [ ! -d ${DOMAIN_HOME}/servers/${SERVER_NAME} ]; then
       trace "Creating directory '${DOMAIN_HOME}/servers/${SERVER_NAME}'"
-      createFolder ${DOMAIN_HOME}/servers/${SERVER_NAME}
+      createFolder ${DOMAIN_HOME}/servers/${SERVER_NAME} "This is the server '${SERVER_NAME}' directory within 'spec.domain.domainHome'." || exitOrLoop 
     else
       trace "'${DOMAIN_HOME}/servers/${SERVER_NAME}' already exists as a directory"
     fi


### PR DESCRIPTION
(1) Expand pod start script "create folder" error logging so that a SEVERE includes information about the purpose of the directory and any related configuration for said directory. Such SEVERE messages are parsed out by the operator and reported in the domain status, so it's helpful to add contextual information.

(2) For any mkdir attempt, also try "touch" a test file in the created directory. This verifies write access.