### PR TITLE
Enabling testReplicasTooHigh test in ItDiagnosticsFailedCondition

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsFailedCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsFailedCondition.java
@@ -198,9 +198,7 @@ class ItDiagnosticsFailedCondition {
    * type: Failed, status: true
    * type: Available, status: false
    * type: Completed, status: false
-   * Disabled due to bug.
    */
-  @Disabled
   @Test
   @DisplayName("Test domain status condition with replicas set to more than available in cluster")
   void testReplicasTooHigh() {


### PR DESCRIPTION
The issue causing the testReplicasTooHigh test in ItDiagnosticsFailedCondition to fail is fixed. 
Enabling the test.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7476/