### PR TITLE
Backport pr2659 to disable validation for AUXILIARY_IMAGE_PATH (Owls-94624) to 3.3 

### DIFF
--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -104,7 +104,7 @@
           "type": "string"
         },
         "mountPath": {
-          "description": "The mount path. The files in the path are populated from the same named directory in the images supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with a different mount path. Required.",
+          "description": "The mount path. The files in the path are populated from the same named directory in the images supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with a different mount path. Defaults to \u0027/auxiliary\u0027.",
           "type": "string"
         },
         "name": {

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -80,7 +80,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | Name | Type | Description |
 | --- | --- | --- |
 | `medium` | string | The emptyDir volume medium. This is an advanced setting that rarely needs to be configured. Defaults to unset, which means the volume's files are stored on the local node's file system for the life of the pod. |
-| `mountPath` | string | The mount path. The files in the path are populated from the same named directory in the images supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with a different mount path. Required. |
+| `mountPath` | string | The mount path. The files in the path are populated from the same named directory in the images supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with a different mount path. Defaults to '/auxiliary'. |
 | `name` | string | The name of the volume. Required. |
 | `sizeLimit` | string | The emptyDir volume size limit. Defaults to unset. |
 

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1025,7 +1025,7 @@ window.onload = function() {
           "type": "string"
         },
         "mountPath": {
-          "description": "The mount path. The files in the path are populated from the same named directory in the images supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with a different mount path. Required.",
+          "description": "The mount path. The files in the path are populated from the same named directory in the images supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with a different mount path. Defaults to \u0027/auxiliary\u0027.",
           "type": "string"
         },
         "name": {

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: a9978851bbc86ce4653d328db25d01661829c8531a6971c001fdaa1a00bfa5a6
+    weblogic.sha256: 5a5f3a7877677f9aca7593f0bd0159cd3c1e8f89251955589a2accd35224c7b9
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -8609,7 +8609,7 @@ spec:
                       description: The mount path. The files in the path are populated
                         from the same named directory in the images supplied by each
                         container in `serverPod.auxiliaryImages`. Each volume must
-                        be configured with a different mount path. Required.
+                        be configured with a different mount path. Defaults to '/auxiliary'.
                       type: string
                     name:
                       description: The name of the volume. Required.

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/AuxiliaryImageVolume.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/AuxiliaryImageVolume.java
@@ -21,7 +21,7 @@ public class AuxiliaryImageVolume {
 
   @Description("The mount path. The files in the path are populated from the same named directory in the images "
           + "supplied by each container in `serverPod.auxiliaryImages`. Each volume must be configured with "
-          + "a different mount path. Required.")
+          + "a different mount path. Defaults to '/auxiliary'.")
   @NotNull
   private String mountPath;
 

--- a/operator/src/main/resources/scripts/utils_base.sh
+++ b/operator/src/main/resources/scripts/utils_base.sh
@@ -238,11 +238,6 @@ function initAuxiliaryImage() {
              "AUXILIARY_IMAGE_PATH is '$AUXILIARY_IMAGE_PATH' and AUXILIARY_IMAGE_TARGET_PATH is '${AUXILIARY_IMAGE_TARGET_PATH}'."
   traceDirs before $AUXILIARY_IMAGE_PATH
 
-  if [ ! -d ${AUXILIARY_IMAGE_PATH} ] ||  [ -z "$(ls -A ${AUXILIARY_IMAGE_PATH})" ]; then
-    trace SEVERE "Auxiliary Image: Dir '${AUXILIARY_IMAGE_PATH}' doesn't exist or is empty. Exiting."
-    return
-  fi
-
   trace FINE "Auxiliary Image: About to execute AUXILIARY_IMAGE_COMMAND='$AUXILIARY_IMAGE_COMMAND' ."
   results=$(eval $AUXILIARY_IMAGE_COMMAND 2>&1)
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
The change also contains a fix to mention the default value of `domain.spec.auxiliaryImageVolumes.mountPath`.

Integration test run started at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7530/console