### PR TITLE
switching to modern python except with argument syntax

### DIFF
--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -415,7 +415,7 @@ class WdtUpdateFilterCase(unittest.TestCase):
 
       isSecureModeEnabled = model_wdt_mii_filter.isSecureModeEnabledForDomain(topology)
       self.fail("Expected import error for LegalHelper")
-    except ImportError, ie:
+    except ImportError as ie:
       self.assertTrue(ie is not None)
 
 


### PR DESCRIPTION
The auto build is running with Python 3.8, which rejects the old-style syntax.