### PR TITLE
Backport OWLS-94649 fix to 3.3 release 

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
@@ -1380,6 +1381,16 @@ public class DomainProcessorImpl implements DomainProcessor {
                             DomainStatusUpdater.createFailureRelatedSteps(
                                     info, waiting.getReason(), waiting.getMessage(), null)));
           break;
+        case INIT_CONTAINERS_NOT_READY:
+          List<String> waitingMessages = new ArrayList<>();
+          List<String> waitingReasons = new ArrayList<>();
+
+          getInitContainersWaitingReasonsAndMessages(introspectorPod, waitingReasons, waitingMessages);
+          if (!waitingReasons.isEmpty()) {
+            delegate.runSteps(DomainStatusUpdater.createFailureRelatedSteps(
+                    info, onSeparateLines(waitingReasons), onSeparateLines(waitingMessages), null));
+          }
+          break;
         case TERMINATED_ERROR_REASON:
           Optional.ofNullable(getMatchingContainerStatus())
                   .map(V1ContainerStatus::getState)
@@ -1406,6 +1417,38 @@ public class DomainProcessorImpl implements DomainProcessor {
           break;
         default:
       }
+    }
+
+    private void getInitContainersWaitingReasonsAndMessages(V1Pod pod, List waitingReasons, List waitingMessages) {
+      Optional.ofNullable(getInitContainerStatuses(pod)).orElseGet(Collections::emptyList).stream()
+              .forEach(status -> {
+                waitingMessages.add(getWaitingMessageFromStatus(status));
+                waitingReasons.add(getWaitingReason(status));
+              });
+    }
+
+    private String getWaitingReason(V1ContainerStatus status) {
+      return Optional.ofNullable(status)
+              .map(V1ContainerStatus::getState)
+              .map(V1ContainerState::getWaiting)
+              .map(V1ContainerStateWaiting::getReason)
+              .orElse(null);
+    }
+
+    private String getWaitingMessageFromStatus(V1ContainerStatus status) {
+      return Optional.ofNullable(status)
+              .map(V1ContainerStatus::getState)
+              .map(V1ContainerState::getWaiting)
+              .map(V1ContainerStateWaiting::getMessage)
+              .orElse(null);
+    }
+
+    private List<V1ContainerStatus> getInitContainerStatuses(V1Pod pod) {
+      return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getInitContainerStatuses).orElse(null);
+    }
+
+    private String onSeparateLines(List<String> waitingReasons) {
+      return String.join(System.lineSeparator(), waitingReasons);
     }
 
     private boolean isNotTerminatedByOperator() {

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -265,9 +265,9 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
     return Optional.ofNullable(podCondition).map(V1PodCondition::getReason).orElse("");
   }
 
-  private static boolean notReady(List<V1ContainerStatus> initContainerStatus) {
-    return Optional.ofNullable(initContainerStatus)
-            .orElseGet(Collections::emptyList).stream().anyMatch(statuses -> notReady(statuses));
+  private static boolean notReady(List<V1ContainerStatus> initContainerStatuses) {
+    return Optional.ofNullable(initContainerStatuses)
+            .orElseGet(Collections::emptyList).stream().anyMatch(status -> notReady(status));
   }
 
   private static boolean notReady(V1ContainerStatus conStatus) {

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -28,6 +28,7 @@ public interface ProcessingConstants {
   String DOMAIN_TOPOLOGY = "domainTopology";
   String JOB_POD_NAME = "jobPodName";
   String JOB_POD_CONTAINER_WAITING_REASON = "jobPodContainerWaitingReason";
+  String JOB_POD_INIT_CONTAINER_WAITING_REASON = "jobPodInitContainerWaitingReason";
   String DOMAIN_INTROSPECTOR_JOB = "domainIntrospectorJob";
   String DOMAIN_INTROSPECTOR_LOG_RESULT = "domainIntrospectorLogResult";
   String DOMAIN_INTROSPECT_REQUESTED = "domainIntrospectRequested";

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -568,9 +568,8 @@ public class JobHelper {
                   .map(V1PodStatus::getContainerStatuses).map(statuses -> statuses.get(0))
                   .map(V1ContainerStatus::getState).map(V1ContainerState::getWaiting)
                   .map(V1ContainerStateWaiting::getReason).orElse(null));
+          packet.put(ProcessingConstants.JOB_POD_INIT_CONTAINER_WAITING_REASON, getInitContainerWaitingMessages(pod));
         }
-
-        packet.put(ProcessingConstants.JOB_POD_INIT_CONTAINER_WAITING_REASON, getInitContainerWaitingMessages(pod));
       }
 
       private Boolean getInitContainerWaitingMessages(V1Pod pod) {
@@ -624,12 +623,8 @@ public class JobHelper {
     }
 
     private static Boolean getjobInitContainerImagePullError(Packet packet) {
-      Boolean containerWaitingReason = packet.getValue(ProcessingConstants.JOB_POD_INIT_CONTAINER_WAITING_REASON);
-      return Optional.ofNullable(containerWaitingReason).orElse(Boolean.FALSE);
-    }
-
-    private static Boolean isNotNull(Boolean jobInitContainerImagePullError) {
-      return Optional.ofNullable(jobInitContainerImagePullError).orElse(false);
+      return Optional.ofNullable(packet.<Boolean>getValue(ProcessingConstants.JOB_POD_INIT_CONTAINER_WAITING_REASON))
+              .orElse(Boolean.FALSE);
     }
   }
 


### PR DESCRIPTION
Backport the fix for OWLS-94649 (PR  #[2662](https://github.com/oracle/weblogic-kubernetes-operator/pull/2662)) to update the domain status update in case of auxiliary image pull error and recreate the introspector job after image is fixed.

Integration test run started at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7580/console
Previous run at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7575/