### PR TITLE
OWLS-94991 - Increase default sleep interval and provide option to override the value in startServer.sh.

### DIFF
--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -548,8 +548,8 @@ function waitForShutdownMarker() {
     if [ -e ${SHUTDOWN_MARKER_FILE} ] ; then
       exit 0
     fi
-    # Set the SERVER_SLEEP_INTERVAL_SECONDS environment variable in the domain specs to
-    # override the default sleep interval value of 1 second.
+    # Set the SERVER_SLEEP_INTERVAL_SECONDS environment variable in the domain specs in
+    # `spec.serverPod.env` stanza to override the default sleep interval value of 1 second.
     sleep ${SERVER_SLEEP_INTERVAL_SECONDS:-1}
   done
 }

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -548,7 +548,9 @@ function waitForShutdownMarker() {
     if [ -e ${SHUTDOWN_MARKER_FILE} ] ; then
       exit 0
     fi
-    sleep 0.1
+    # Set the SERVER_SLEEP_INTERVAL_SECONDS environment variable in the domain specs to
+    # override the default sleep interval value of 1 second.
+    sleep ${SERVER_SLEEP_INTERVAL_SECONDS:-1}
   done
 }
 


### PR DESCRIPTION
Increase default sleep interval and provide option to override the value in startServer.sh to avoid high cpu usage reported in the github issue #[2655](https://github.com/oracle/weblogic-kubernetes-operator/issues/2655).

Integration test results at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7594/