### PR TITLE
Backport fix for GitHub issue #2655 (OWLS-94991) to 3.3 release

### DIFF
--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -548,8 +548,8 @@ function waitForShutdownMarker() {
     if [ -e ${SHUTDOWN_MARKER_FILE} ] ; then
       exit 0
     fi
-    # Set the SERVER_SLEEP_INTERVAL_SECONDS environment variable in the domain specs to
-    # override the default sleep interval value of 1 second.
+    # Set the SERVER_SLEEP_INTERVAL_SECONDS environment variable in the domain specs in
+    # `spec.serverPod.env` stanza to override the default sleep interval value of 1 second.
     sleep ${SERVER_SLEEP_INTERVAL_SECONDS:-1}
   done
 }

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -548,7 +548,9 @@ function waitForShutdownMarker() {
     if [ -e ${SHUTDOWN_MARKER_FILE} ] ; then
       exit 0
     fi
-    sleep 0.1
+    # Set the SERVER_SLEEP_INTERVAL_SECONDS environment variable in the domain specs to
+    # override the default sleep interval value of 1 second.
+    sleep ${SERVER_SLEEP_INTERVAL_SECONDS:-1}
   done
 }
 


### PR DESCRIPTION
Backport fix for GitHub issue #2655 (PR #2682) to increase the default sleep interval and provide an option to override the value to avoid high cpu usage to Operator 3.3 release.

Integration test run for 3.3 - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7610/console .
Previous run with main (had 5 intermittent failures) - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7594/

