### PR TITLE
Fix for DB operator SIDB yaml file changes

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DbUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DbUtils.java
@@ -805,13 +805,13 @@ public class DbUtils {
     boolean response = Command.withParams(params).execute();
     assertTrue(response, "Failed to download Oracle database yaml file");
 
-    replaceStringInFile(dbYaml.toString(), "name: singleinstancedatabase-sample", "name: " + dbName);
+    replaceStringInFile(dbYaml.toString(), "name: sidb-sample", "name: " + dbName);
     replaceStringInFile(dbYaml.toString(), "namespace: default", "namespace: " + namespace);
     replaceStringInFile(dbYaml.toString(), "secretName:", "secretName: " + secretName);
     replaceStringInFile(dbYaml.toString(), "secretKey:", "secretKey: " + secretKey);
     replaceStringInFile(dbYaml.toString(), "pullFrom:", "pullFrom: " + DB_IMAGE_19C);
     replaceStringInFile(dbYaml.toString(), "pullSecrets:", "pullSecrets: " + OCR_SECRET_NAME);
-    replaceStringInFile(dbYaml.toString(), "storageClass: \"\"", "storageClass: dboperatorsc");
+    replaceStringInFile(dbYaml.toString(), "storageClass: \"oci\"", "storageClass: dboperatorsc");
 
     logger.info("Creating Oracle database using yaml file\n {0}", Files.readString(dbYaml));
     params = new CommandParams().defaults();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
@@ -310,9 +310,12 @@ public class FileUtils {
     logger.info("Replacing {0}", src.toString());
     Charset charset = StandardCharsets.UTF_8;
     String content = new String(Files.readAllBytes(src), charset);
-    content = content.replaceAll(regex, replacement);
+    String newcontent = content.replaceAll(regex, replacement);
     logger.info("with {0}", replacement);
-    Files.write(src, content.getBytes(charset));
+    if (content.equals(newcontent)) {
+      logger.info("search string {0} not found to replace with {1}", regex, replacement);
+    }
+    Files.write(src, newcontent.getBytes(charset));
   }
 
   /**
@@ -402,7 +405,7 @@ public class FileUtils {
     return targetFile;
   }
 
-  
+
   /**
    * Check if the required file ls empty.
    *


### PR DESCRIPTION
The default DB name and storageclass name is changed in the template yaml file we se for creating the database. This PR should fix the correct strings to look for the db name and storageclass name.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7669/console