### PR TITLE
Backport fix for OWLS 95240 (PR #2691) to release/3.3

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ReadHealthStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;
@@ -191,6 +191,9 @@ public class ReadHealthStep extends Step {
     @Override
     public NextAction apply(Packet packet) {
       ReadHealthProcessing processing = new ReadHealthProcessing(packet, service, pod);
+      if (processing.getWlsServerConfig() == null) {
+        return doNext(packet);
+      }
       return doNext(createRequestStep(processing.createRequest(), new RecordHealthStep(getNext())), packet);
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -589,7 +589,7 @@ class DomainProcessorTest {
     establishPreviousIntrospection(null, Arrays.asList(1, 3, 4));
 
     for (Integer i : Arrays.asList(3,4)) {
-      domainConfigurator.configureServer(MS_PREFIX + i).withServerStartPolicy(START_ALWAYS);
+      domainConfigurator.configureServer(getManagedServerName(i)).withServerStartPolicy(START_ALWAYS);
     }
 
     domainConfigurator.configureCluster(CLUSTER).withReplicas(4);
@@ -604,7 +604,7 @@ class DomainProcessorTest {
 
     assertServerPodAndServicePresent(info, ADMIN_NAME);
     for (Integer i : Arrays.asList(1,2,3,4)) {
-      assertServerPodAndServicePresent(info, MS_PREFIX + i);
+      assertServerPodAndServicePresent(info, getManagedServerName(i));
     }
 
     assertThat(info.getClusterService(CLUSTER), notNullValue());


### PR DESCRIPTION
Backport  PR #2691 to release/3.3.

Changes to reconcile the running servers after a running domain is updated to delete a cluster and/or an independent managed server from the domain topology.. This change removes the server pods for the clustered servers and the independent managed servers which are not part of the domain topology. It also checks if the server config is null before invoking the health check to avoid the NullPointerException.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7681/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7685/console