### PR TITLE
backport of OWLS-94849 to 3.3 release branch

### DIFF
--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 #
@@ -925,4 +925,27 @@ function checkService(){
    fi
  done
  echo "Service [$svc] found"
+}
+
+# Get pod name when pod available in a given namespace
+function getPodName(){
+
+ local max=$((SECONDS + 120))
+
+ local pod=$1
+ local ns=$2
+
+ local pname=""
+ while [ $SECONDS -le $max ] ; do
+   pname=`kubectl get po -n ${ns} | grep -w ${pod} | awk '{print $1}'`
+   [ -z "${pname}" ] || break
+   sleep 1
+ done
+
+ if [ -z "${pname}" ] ; then
+  echo "[ERROR] Could not find Pod [$pod] after $max seconds";
+  exit 1
+ fi
+
+ echo "${pname}"
 }

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/create-domain.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Description
@@ -212,9 +212,9 @@ function createDomainHome {
   # domain resource is created by exec'ing into the pod to look for the presence of domainCreate.yaml file.
 
   if [ "$useWdt" = true ]; then
-    POD_NAME=`kubectl get pods -n ${namespace} | grep ${JOB_NAME} | awk ' { print $1; } '`
+    POD_NAME=$(getPodName "${JOB_NAME}" "${namespace}")
     echo "Waiting for results to be available from $POD_NAME"
-    kubectl wait --timeout=600s --for=condition=ContainersReady pod $POD_NAME
+    kubectl wait --timeout=600s --for=condition=ContainersReady pod $POD_NAME -n ${namespace}
     #echo "Fetching results"
     sleep 30
     max=30


### PR DESCRIPTION
Backport of OWLS-94849 to release branch 3.3.

ENEL uses the built-in WDT scripts (in the samples) for creating the WebLogic domain with Domain-on-PV model. They are experiencing a timing issue where the pod associated to the create domain job has not been started by the time the script attempts to get the pod name and hence the script execution hangs. The 'workaround' proposed by ENEL was to add a sleep statement to allow the pod to start. This pull request resolves the issue by:

    Retrieving the pod name by continuously checking for the pod, and returning it's name when the pod is started, up to 120 seconds (2 minutes) instead of using a 'sleep'.
    Fix 'kubectl wait' command which is missing the namespace where the create domain job is running.


Ran the ItWlsSamples integration test ,as the change only related to the domain-on-pv sample, and the result can be found at https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7722/ 