### PR TITLE
Remove explicit mention of sample passwords in docs

### DIFF
--- a/documentation/staging/content/faq/cannot-pull-image.md
+++ b/documentation/staging/content/faq/cannot-pull-image.md
@@ -65,15 +65,14 @@ to use that secret when pulling the image.
 To create a secret, you can use the following command:
 
 ```shell
-$ kubectl create secret docker-registry secret1 \
-        --docker-server=some.registry.com \
-        --docker-username=bob \
-        --docker-password=bigSecret \
-        --docker-email=bob@some.com \
-        --namespace=default
+$ kubectl create secret docker-registry <name of the secret> \
+        --docker-server=<the registry host name> \
+        --docker-username=<the username> \
+        --docker-password=<the actual password> \
+        --docker-email=<the user email> \
+        --namespace=<the selected namespace>
 ```
-
-In this command, you would replace `secret1` with the name of the secret; the `docker-server`
+where actual values should replace the strings in angle brackets. Note that the `docker-server`
 is set to the registry name, without the `https://` prefix; the `docker-username`, `docker-password`
 and `docker-email` are set to match the credentials you use to authenticate to the remote
 container registry; and the `namespace` must be set to the same namespace where you intend to

--- a/documentation/staging/content/faq/cannot-pull-image.md
+++ b/documentation/staging/content/faq/cannot-pull-image.md
@@ -67,7 +67,7 @@ To create a secret, you can use the following command:
 ```shell
 $ kubectl create secret docker-registry <name of the secret> \
         --docker-server=<the registry host name> \
-        --docker-username=<the username> \
+        --docker-username=<the user name> \
         --docker-password=<the actual password> \
         --docker-email=<the user email> \
         --namespace=<the selected namespace>

--- a/documentation/staging/content/samples/credentials/_index.md
+++ b/documentation/staging/content/samples/credentials/_index.md
@@ -41,8 +41,8 @@ $ kubectl -n domain-namespace-1 get secret domain1-weblogic-credentials -o yaml
 ```
 apiVersion: v1
 data:
-  password: d2VsY29tZTE=
-  username: d2VibG9naWM=
+  username: <username>
+  password: <password>
 kind: Secret
 metadata:
   creationTimestamp: 2018-12-12T20:25:20Z
@@ -56,3 +56,4 @@ metadata:
   uid: 0c2b3510-fe4c-11e8-994d-00001700101d
 type: Opaque
 ```
+where `<username>` and `<password>` are to be replaced with their actual values.

--- a/documentation/staging/content/samples/credentials/_index.md
+++ b/documentation/staging/content/samples/credentials/_index.md
@@ -41,7 +41,7 @@ $ kubectl -n domain-namespace-1 get secret domain1-weblogic-credentials -o yaml
 ```
 apiVersion: v1
 data:
-  username: <username>
+  username: <user name>
   password: <password>
 kind: Secret
 metadata:
@@ -56,4 +56,4 @@ metadata:
   uid: 0c2b3510-fe4c-11e8-994d-00001700101d
 type: Opaque
 ```
-where `<username>` and `<password>` are to be replaced with their actual values.
+where `<user name>` and `<password>` are to be replaced with their actual values.

--- a/documentation/staging/content/samples/database/_index.md
+++ b/documentation/staging/content/samples/database/_index.md
@@ -41,7 +41,7 @@ The following example shows how to set up an ephemeral Oracle database with the 
 | Kubernetes node port | `30011` |
 | Image | `container-registry.oracle.com/database/enterprise:12.2.0.1-slim` |
 | DBA user (with full privileges) | `sys as sysdba` |
-| DBA password | `Oradoc_db1` |
+| DBA password | `<the DBA user password>` |
 | Database URL inside Kubernetes cluster (from any namespace) | `oracle-db.default.svc.cluster.local:1521/devpdb.k8s` |
 | Database URL outside Kubernetes cluster | `dns-name-that-resolves-to-node-location:30011/devpdb.k8s` |
 
@@ -157,12 +157,16 @@ metadata:
   name: mysql-secret
   namespace: default
 data:
-  # echo -n "root" | base64
-  root-user: cm9vdA==
-  # echo -n "password" | base64
-  root-password: cGFzc3dvcmQ=
+  root-user: <user placeholder>
+  root-password: <password placeholder>
 ```
 
+In file `mysql.yaml`, replace `<user placeholder>` and `<password placeholder>`, respectively, with the output from piping the
+root username and password through base64:
+```
+echo -n <the root username> | base64
+echo -n <the root password> | base64
+```
 Deploy MySQL using the command `kubectl create -f mysql.yaml`.
 
 To shut down and clean up the resources, use `kubectl delete -f mysql.yaml`.

--- a/documentation/staging/content/samples/database/_index.md
+++ b/documentation/staging/content/samples/database/_index.md
@@ -157,14 +157,14 @@ metadata:
   name: mysql-secret
   namespace: default
 data:
-  root-user: <user placeholder>
+  root-user: <user name placeholder>
   root-password: <password placeholder>
 ```
 
 In file `mysql.yaml`, replace `<user placeholder>` and `<password placeholder>`, respectively, with the output from piping the
 root username and password through base64:
 ```
-echo -n <the root username> | base64
+echo -n <the root user name> | base64
 echo -n <the root password> | base64
 ```
 Deploy MySQL using the command `kubectl create -f mysql.yaml`.

--- a/documentation/staging/content/userguide/managing-fmw-domains/_index.md
+++ b/documentation/staging/content/userguide/managing-fmw-domains/_index.md
@@ -225,8 +225,8 @@ spec:
 ```
 
 Notice that you can pass in environment variables to set the SID, the name of the PDB, and
-so on.  The documentation describes the other variables that are available.  The `sys` password
-defaults to `Oradoc_db1`.  Follow the instructions in the documentation to reset this password.
+so on.  The documentation describes the other variables that are available.  
+Follow the instructions in the documentation to set the `sys` password.
 
 You should also create a service to make the database available within the Kubernetes cluster with
 a well known name.  Here is an example:

--- a/kubernetes/hands-on-lab/tutorials/deploy.weblogic_short.ocishell.md
+++ b/kubernetes/hands-on-lab/tutorials/deploy.weblogic_short.ocishell.md
@@ -11,9 +11,10 @@ $ kubectl create namespace sample-domain1-ns
 Create a Kubernetes Secret containing the Administration Server boot credentials:
 ```shell
 $ kubectl -n sample-domain1-ns create secret generic sample-domain1-weblogic-credentials \
-  --from-literal=username=weblogic \
-  --from-literal=password=welcome1
+  --from-literal=username=<a username> \
+  --from-literal=password=<a password>
 ```
+where the actual username and password should be specified instead of `<a username>` and `<a password>`
 
 Label the domain namespace:
 ```shell

--- a/kubernetes/hands-on-lab/tutorials/deploy.weblogic_short.ocishell.md
+++ b/kubernetes/hands-on-lab/tutorials/deploy.weblogic_short.ocishell.md
@@ -11,7 +11,7 @@ $ kubectl create namespace sample-domain1-ns
 Create a Kubernetes Secret containing the Administration Server boot credentials:
 ```shell
 $ kubectl -n sample-domain1-ns create secret generic sample-domain1-weblogic-credentials \
-  --from-literal=username=<a username> \
+  --from-literal=username=<a user name> \
   --from-literal=password=<a password>
 ```
 where the actual username and password should be specified instead of `<a username>` and `<a password>`

--- a/kubernetes/samples/scripts/create-rcu-schema/README.md
+++ b/kubernetes/samples/scripts/create-rcu-schema/README.md
@@ -69,7 +69,7 @@ You can connect to the database in your app using:
 
   java.util.Properties props = new java.util.Properties();
   props.put("user", "sys as sysdba");
-  props.put("password", "Oradoc_db1");
+  props.put("password", <the actual sysdba password>);
   java.sql.Driver d =
     Class.forName("oracle.jdbc.OracleDriver").newInstance();
   java.sql.Connection conn =
@@ -130,16 +130,14 @@ Use this script to drop the RCU schema based `schemaPrefix` and `dburl`.
 $ ./drop-rcu-schema.sh -h
 usage: ./drop-rcu-schema.sh -s <schemaPrefix> -d <dburl> -n <namespace> -q <sysPassword> -r <schemaPassword> [-h]
   -s RCU Schema Prefix (required)
+  -q password for database SYSDBA user. (required)
+  -r password for all schema owner (regular user). (required)
   -t RCU Schema Type (optional)
       (supported values: fmw(default), soa, osb, soaosb, soaess, soaessosb)
   -d Oracle Database URL (optional)
       (default: oracle-db.default.svc.cluster.local:1521/devpdb.k8s)
   -n Namespace where RCU pod is deployed (optional)
       (default: default)
-  -q password for database SYSDBA user. (optional)
-      (default: Oradoc_db1)
-  -r password for all schema owner (regular user). (optional)
-      (default: Oradoc_db1)
   -h Help
 
 $ ./drop-rcu-schema.sh -s domain1
@@ -157,7 +155,7 @@ You can connect to the database in your app using:
 
   java.util.Properties props = new java.util.Properties();
   props.put("user", "sys as sysdba");
-  props.put("password", "Oradoc_db1");
+  props.put("password", <the actual password>);
   java.sql.Driver d =
     Class.forName("oracle.jdbc.OracleDriver").newInstance();
   java.sql.Connection conn =

--- a/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
@@ -12,16 +12,14 @@ source ${scriptDir}/../common/utility.sh
 function usage {
   echo "usage: ${script} -s <schemaPrefix> -d <dburl> -n <namespace> -q <sysPassword> -r <schemaPassword> [-h]"
   echo "  -s RCU Schema Prefix (required)"
+  echo "  -q password for database SYSDBA user. (required)"
+  echo "  -r password for all schema owner (regular user). (required)"
   echo "  -t RCU Schema Type (optional)"
   echo "      (supported values: fmw(default), soa, osb, soaosb, soaess, soaessosb) "
   echo "  -d Oracle Database URL (optional)"
   echo "      (default: oracle-db.default.svc.cluster.local:1521/devpdb.k8s) "
   echo "  -n Namespace where RCU pod is deployed (optional)"
   echo "      (default: default) "
-  echo "  -q password for database SYSDBA user. (optional)"
-  echo "      (default: Oradoc_db1)"
-  echo "  -r password for all schema owner (regular user). (optional)"
-  echo "      (default: Oradoc_db1)"
   echo "  -h Help"
   exit $1
 }
@@ -65,11 +63,13 @@ if [ -z ${namespace} ]; then
 fi
 
 if [ -z ${sysPassword} ]; then
-  sysPassword="Oradoc_db1"
+  echo "${script}: -q <SYSDBA user password> must be specified."
+  usage 1
 fi
 
 if [ -z ${schemaPassword} ]; then
-  schemaPassword="Oradoc_db1"
+  echo "${script}: -r <schema owner password> must be specified."
+  usage 1
 fi
 
 rcupod=`kubectl get po -n ${namespace} | grep rcu | cut -f1 -d " " `

--- a/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
+++ b/kubernetes/samples/scripts/create-rcu-schema/drop-rcu-schema.sh
@@ -45,35 +45,35 @@ while getopts ":h:s:d:t:n:q:r:" opt; do
   esac
 done
 
-if [ -z ${schemaPrefix} ]; then
+if [ -z "${schemaPrefix}" ]; then
   echo "${script}: -s <schemaPrefix> must be specified."
   usage 1
 fi
 
-if [ -z ${dburl} ]; then
+if [ -z "${dburl}" ]; then
   dburl="oracle-db.default.svc.cluster.local:1521/devpdb.k8s"
 fi
 
-if [ -z ${rcuType} ]; then
+if [ -z "${rcuType}" ]; then
   rcuType="fmw"
 fi
 
-if [ -z ${namespace} ]; then
+if [ -z "${namespace}" ]; then
   namespace="default"
 fi
 
-if [ -z ${sysPassword} ]; then
+if [ -z "${sysPassword}" ]; then
   echo "${script}: -q <SYSDBA user password> must be specified."
   usage 1
 fi
 
-if [ -z ${schemaPassword} ]; then
+if [ -z "${schemaPassword}" ]; then
   echo "${script}: -r <schema owner password> must be specified."
   usage 1
 fi
 
 rcupod=`kubectl get po -n ${namespace} | grep rcu | cut -f1 -d " " `
-if [ -z ${rcupod} ]; then
+if [ -z "${rcupod}" ]; then
   echo "RCU deployment pod not found in [$namespace] Namespace"
   exit -2
 fi

--- a/kubernetes/samples/scripts/create-weblogic-domain-credentials/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain-credentials/README.md
@@ -31,8 +31,8 @@ including the output:
 $ kubectl -n domain-namespace-1 get secret domain1-weblogic-credentials -o yaml
 apiVersion: v1
 data:
-  password: d2VsY29tZTE=
-  username: d2VibG9naWM=
+  username: <username>
+  password: <password>
 kind: Secret
 metadata:
   creationTimestamp: 2018-12-12T20:25:20Z
@@ -47,3 +47,4 @@ metadata:
 type: Opaque
 
 ```
+where `<username>` and `<password>` are to be replaced with their actual values.

--- a/kubernetes/samples/scripts/create-weblogic-domain-credentials/README.md
+++ b/kubernetes/samples/scripts/create-weblogic-domain-credentials/README.md
@@ -31,7 +31,7 @@ including the output:
 $ kubectl -n domain-namespace-1 get secret domain1-weblogic-credentials -o yaml
 apiVersion: v1
 data:
-  username: <username>
+  username: <user name>
   password: <password>
 kind: Secret
 metadata:
@@ -47,4 +47,4 @@ metadata:
 type: Opaque
 
 ```
-where `<username>` and `<password>` are to be replaced with their actual values.
+where `<user name>` and `<password>` are to be replaced with their actual values.


### PR DESCRIPTION
This change edits the current documentation (and one corresponding shell script) to remove explicit sample passwords, out of concern that uses will use them and thus have well-known passwords in their systems - a possible vulnerability.