### PR TITLE
Fixed sticky session failure on nightly

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItStickySession.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItStickySession.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItStickySession.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItStickySession.java
@@ -576,7 +576,7 @@ class ItStickySession {
 
     // send a HTTP request to set http session state(count number) and save HTTP session info
     Map<String, String> httpDataInfo = getServerAndSessionInfoAndVerify(hostname,
-            servicePort, webServiceSetUrl, " -D ", clusterAddress);
+            servicePort, webServiceSetUrl, " -c ", clusterAddress);
     // get server and session info from web service deployed on the cluster
     String serverName1 = httpDataInfo.get(serverNameAttr);
     String sessionId1 = httpDataInfo.get(sessionIdAttr);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItStickySession.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItStickySession.java
@@ -474,7 +474,8 @@ class ItStickySession {
           .append(httpHeaderFile);
     } else {
       //use cluster service to build the curl command to run in admin pod
-      final String httpHeaderFile = "/u01/oracle/header";
+      // save the cookie file to /u01 in order to run the test on openshift env
+      final String httpHeaderFile = "/u01/header";
       logger.info("Build a curl command with pod name {0}, curl URL path {1} and HTTP header option {2}",
           clusterAddress[0], curlUrlPath, headerOption);
 


### PR DESCRIPTION
The issue is the second http request sent by curl get command doesn't load the cookie file saved by the first HTTP request. the test used -D to Write the received protocol headers to the specified file. the cause is unknown. So i changed the test to use -c to writes and save all cookies from its in-memory cookie storage to the given file at the end of operations. now the test passed again

jenkins job:

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/7726/

