### PR TITLE
Added Operator release 3.3.7 to the Upgrade scenerio 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorFmwUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorFmwUpgrade.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -223,12 +223,12 @@ class ItOperatorFmwUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.3.6 to latest with a FMW Domain.
+   * Operator upgrade from 3.3.7 to latest with a FMW Domain.
    */
   @Test
-  @DisplayName("Upgrade Operator from 3.3.6 to latest")
-  void testOperatorFmwUpgradeFrom336ToLatest() {
-    installAndUpgradeOperator("3.3.6", "v8", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
+  @DisplayName("Upgrade Operator from 3.3.7 to latest")
+  void testOperatorFmwUpgradeFrom337ToLatest() {
+    installAndUpgradeOperator("3.3.7", "v8", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
   }
 
   private void installAndUpgradeOperator(
@@ -447,7 +447,7 @@ class ItOperatorFmwUpgrade {
                 .adminService(new AdminService()
                     .addChannelsItem(new Channel()
                         .channelName("default")
-                        .nodePort(0))
+                        .nodePort(getNextFreePort()))
                     .addChannelsItem(new Channel()
                         .channelName("T3Channel")
                         .nodePort(t3ChannelPort))))

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -168,14 +168,14 @@ class ItOperatorWlsUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.3.6 to latest.
+   * Operator upgrade from 3.3.7 to latest.
    */
   @ParameterizedTest
-  @DisplayName("Upgrade Operator from 3.3.6 to latest")
+  @DisplayName("Upgrade Operator from 3.3.7 to latest")
   @ValueSource(strings = { "Image", "FromModel" })
-  void testOperatorWlsUpgradeFrom336ToLatest(String domainType) {
-    logger.info("Starting test testOperatorWlsUpgradeFrom336ToLatest with domain type {0}", domainType);
-    installAndUpgradeOperator(domainType, "3.3.6", OLD_DOMAIN_VERSION, DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
+  void testOperatorWlsUpgradeFrom337ToLatest(String domainType) {
+    logger.info("Starting test testOperatorWlsUpgradeFrom337ToLatest with domain type {0}", domainType);
+    installAndUpgradeOperator(domainType, "3.3.7", OLD_DOMAIN_VERSION, DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
   }
 
   /**


### PR DESCRIPTION
1. Added new release 3.3.7 to upgrade usecase
2. Modified the domain resource creation method to get next free port for admin node port in FMW domain  ( resolution to intermittent nightly failure ) 

The jenkin results 
https://build.weblogick8s.org:8443/job/wko-kind-nightly-seqential/532
