### PR TITLE
OWLS-92959: Doc: kubectl port-forward does not allow to access thru WLST in istio-domain for Istio version previous to 1.10

### DIFF
--- a/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
+++ b/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
@@ -67,13 +67,13 @@ This behavior depends on your version and domain resource configuration:
   configured with the following attributes:
   * Protocol defined as `t3`.
   * Listen address defined with `localhost`.
-  * Listen port. Note, you should choose a port value that does not conflict with any ports defined 
+  * Listen port. Note: Choose a port value that does not conflict with any ports defined 
   in any of the additional network channels created for use with Istio versions prior to v1.10.
   For more details, see [Added network channels for Istio versions prior to v1.10]({{< relref "/userguide/istio/istio#added-network-channels-for-istio-versions-prior-to-v110" >}}).
   * Enable `HTTP` protocol for this network channel.
   * Do _NOT_ set an `external listen address` or `external listen port`.
   
-For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward` for the Admin Server
+For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward` for the Administration Server.
 ```xml
 <server>
   <name>admin-server</name>
@@ -86,7 +86,7 @@ For example, here is a snippet of a WebLogic domain `config.xml` file for channe
   </network-access-point>
 </server>
 ```
-For Model in Image (MII) and Domain Home in Image (DII), here is a snippet model configuration for channel `PortForward` for the Admin Server
+For Model in Image (MII) and Domain in Image (DII), here is a snippet model configuration for channel `PortForward` for the Administration Server.
 ```yaml
 topology:
     ...

--- a/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
+++ b/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
@@ -62,16 +62,23 @@ This behavior depends on your version and domain resource configuration:
   command or see the domain resource
   [schema](https://github.com/oracle/weblogic-kubernetes-operator/blob/main/documentation/domains/Domain.md).
 
-* For Istio-enabled domains running Istio versions prior to 1.10,
+* If WLST access is required for Istio-enabled domains running Istio versions prior to 1.10,
   you must add an additional network channel to the WebLogic Administration Server 
   configured with the following attributes:
   * Protocol defined as `t3`.
-  * Listen address defined with `localhost`.
+  * Listen address defined with `localhost`. (Note: Stting the address to localhost is solely 
+  for self documenting purposes. The address can be set to any value, and the operator will override 
+  it to the required value regardless.)
   * Listen port. Note: Choose a port value that does not conflict with any ports defined 
   in any of the additional network channels created for use with Istio versions prior to v1.10.
   For more details, see [Added network channels for Istio versions prior to v1.10]({{< relref "/userguide/istio/istio#added-network-channels-for-istio-versions-prior-to-v110" >}}).
   * Enable `HTTP` protocol for this network channel.
   * Do _NOT_ set an `external listen address` or `external listen port`.
+  
+{{% notice note %}}
+It is not necessary to add an additional network channel, for Istio-enabled domains running Istio 
+versions prior to 1.10, to the WebLogic Administration Server if only console access is required .
+{{% /notice %}}
   
 For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward` for the Administration Server.
 ```xml

--- a/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
+++ b/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
@@ -66,9 +66,9 @@ This behavior depends on your version and domain resource configuration:
   you must add an additional network channel to the WebLogic Administration Server 
   configured with the following attributes:
   * Protocol defined as `t3`.
-  * Listen address defined with `localhost`. (Note: Stting the address to localhost is solely 
-  for self documenting purposes. The address can be set to any value, and the operator will override 
-  it to the required value regardless.)
+  * Listen address defined with `localhost`. (Note: Setting the address to localhost is solely 
+  for self-documenting purposes. The address can be set to any value, and the operator will override 
+  it to the required value.)
   * Listen port. Note: Choose a port value that does not conflict with any ports defined 
   in any of the additional network channels created for use with Istio versions prior to v1.10.
   For more details, see [Added network channels for Istio versions prior to v1.10]({{< relref "/userguide/istio/istio#added-network-channels-for-istio-versions-prior-to-v110" >}}).
@@ -76,8 +76,8 @@ This behavior depends on your version and domain resource configuration:
   * Do _NOT_ set an `external listen address` or `external listen port`.
   
 {{% notice note %}}
-It is not necessary to add an additional network channel, for Istio-enabled domains running Istio 
-versions prior to 1.10, to the WebLogic Administration Server if only console access is required .
+For Istio-enabled domains running Istio versions prior to 1.10, if console only access is required, 
+then it is not necessary to add an additional network channel to the WebLogic Administration Server.
 {{% /notice %}}
   
 For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward` for the Administration Server.

--- a/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
+++ b/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
@@ -63,11 +63,26 @@ This behavior depends on your version and domain resource configuration:
   [schema](https://github.com/oracle/weblogic-kubernetes-operator/blob/main/documentation/domains/Domain.md).
 
 * For Istio-enabled domains running Istio versions prior to 1.10,
-  the operator already adds a
-  network channel with a `localhost` listen address for each
-  existing port. This means that no additional configuration is required
-  to enable port forwarding when Istio is enabled.
+  you must add an additional network channel to the WebLogic Administration Server 
+  configured with the following attributes:
+  * Protocol defined as `t3`.
+  * Listen address defined with `localhost`.
+  * Listen port. Note, you should choose a port that does not conflict with any ports defined 
+  in any of the additional network channels created for use with Istio versions prior to v1.10.
   For more details, see [Added network channels for Istio versions prior to v1.10]({{< relref "/userguide/istio/istio#added-network-channels-for-istio-versions-prior-to-v110" >}}).
+  * Enable `HTTP` protocol for this network channel.
+  * Do _NOT_ set an `external listen address` or `external listen port` on the network access point.
+  
+For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward`
+```xml
+<network-access-point>
+  <name>PortForward</name>
+  <protocol>t3</protocol>
+  <listen-address>localhost</listen-address>
+  <listen-port>8989</listen-port>
+  <http-enabled-for-this-protocol>true</http-enabled-for-this-protocol>
+</network-access-point>
+```
 
 {{% notice note %}}
 If your domain is already running, and you have made configuration changes,

--- a/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
+++ b/documentation/staging/content/userguide/managing-domains/accessing-the-domain/port-forward.md
@@ -67,21 +67,38 @@ This behavior depends on your version and domain resource configuration:
   configured with the following attributes:
   * Protocol defined as `t3`.
   * Listen address defined with `localhost`.
-  * Listen port. Note, you should choose a port that does not conflict with any ports defined 
+  * Listen port. Note, you should choose a port value that does not conflict with any ports defined 
   in any of the additional network channels created for use with Istio versions prior to v1.10.
   For more details, see [Added network channels for Istio versions prior to v1.10]({{< relref "/userguide/istio/istio#added-network-channels-for-istio-versions-prior-to-v110" >}}).
   * Enable `HTTP` protocol for this network channel.
-  * Do _NOT_ set an `external listen address` or `external listen port` on the network access point.
+  * Do _NOT_ set an `external listen address` or `external listen port`.
   
-For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward`
+For example, here is a snippet of a WebLogic domain `config.xml` file for channel `PortForward` for the Admin Server
 ```xml
-<network-access-point>
-  <name>PortForward</name>
-  <protocol>t3</protocol>
-  <listen-address>localhost</listen-address>
-  <listen-port>8989</listen-port>
-  <http-enabled-for-this-protocol>true</http-enabled-for-this-protocol>
-</network-access-point>
+<server>
+  <name>admin-server</name>
+  <network-access-point>
+    <name>PortForward</name>
+    <protocol>t3</protocol>
+    <listen-address>localhost</listen-address>
+    <listen-port>7890</listen-port>
+    <http-enabled-for-this-protocol>true</http-enabled-for-this-protocol>
+  </network-access-point>
+</server>
+```
+For Model in Image (MII) and Domain Home in Image (DII), here is a snippet model configuration for channel `PortForward` for the Admin Server
+```yaml
+topology:
+    ...
+    Server:
+        'admin-server':
+            ListenPort: 7001
+            NetworkAccessPoint:
+                PortForward:
+                    Protocol: 't3'
+                    ListenAddress: 'localhost'
+                    ListenPort: '7890'
+                    HttpEnabledForThisProtocol: true
 ```
 
 {{% notice note %}}
@@ -90,7 +107,8 @@ then you will need to rerun its introspector job and ensure that the admin pod
 restarts for the configuration changes to take effect.
 {{% /notice %}}
 
-When administration channel port forwarding is enabled,
+If Istio is _not_ enabled on the domain or for Istio enabled domains running
+Istio 1.10 and later, when administration channel port forwarding is enabled,
 the operator automatically adds the following network channels
 (also known as Network Access Points) to the WebLogic Administration Server Pod:
 


### PR DESCRIPTION
Online WLST cannot successfully connect to the Admin Server via k8s port-forward when the WebLogic domain is integrated with Istio versions prior to v1.10.  The generated WebLogic network channels, specifically for use with Istio versions prior to v1.10,  define a public listen address that is only resolvable within the k8s cluster and this prevents online WLST from successfully establishing a 't3' connection.  Since Istio versions prior to v1.10 are not officially supported (have reached end-of-life), we are updating the documentation for Operator release 3.3.x to describe the additional network channel configuration needed to allow k8s port-forwarding to work when Istio version prior to v1.10 is integrated with the WebLogic domain.