### PR TITLE
Fix OKD nightly FMW and WLS sample failures

### DIFF
--- a/operator/integration-tests/model-in-image/run-test.sh
+++ b/operator/integration-tests/model-in-image/run-test.sh
@@ -384,7 +384,9 @@ if [ "$DO_INITIAL_MAIN" = "true" ]; then
 
   doCommand    "\$MIIWRAPPERDIR/stage-domain-resource.sh"
   doCommand    "\$MIIWRAPPERDIR/create-secrets.sh"
-  doCommand    "\$MIIWRAPPERDIR/stage-and-create-ingresses.sh"
+  if [ "$OKD" = "false" ]; then
+    doCommand    "\$MIIWRAPPERDIR/stage-and-create-ingresses.sh"
+  fi
 
   doCommand -c "kubectl -n \$DOMAIN_NAMESPACE delete domain \$DOMAIN_UID --ignore-not-found"
   doPodWait 0
@@ -482,7 +484,9 @@ if [ "$DO_UPDATE2" = "true" ]; then
 
   doCommand    "\$MIIWRAPPERDIR/stage-domain-resource.sh"
   doCommand    "\$MIIWRAPPERDIR/create-secrets.sh"
-  doCommand    "\$MIIWRAPPERDIR/stage-and-create-ingresses.sh"
+  if [ "$OKD" = "false" ]; then
+    doCommand    "\$MIIWRAPPERDIR/stage-and-create-ingresses.sh"
+  fi
   doCommand -c "\$WORKDIR/utils/create-configmap.sh -c \${DOMAIN_UID}-wdt-config-map -f \${WORKDIR}/model-configmaps/datasource -d \$DOMAIN_UID -n \$DOMAIN_NAMESPACE"
 
   doCommand -c "kubectl -n \$DOMAIN_NAMESPACE delete domain \$DOMAIN_UID --ignore-not-found"


### PR DESCRIPTION
With this fix,  OKD FMW suite run clean
https://build.weblogick8s.org:8443/job/wko-okd-test/139/
OKD WLS suite run with sample tests clean and only 2 other failures
https://build.weblogick8s.org:8443/job/wko-okd-test/140/

Kind new Mii Sample tests(FMW and WLS) passed at:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8125/testReport/