### PR TITLE
Owls 93559 enable and fix the disabled test case (no product code change needed)

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -14,7 +14,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonTestUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -337,9 +336,7 @@ class ItDiagnosticsCompleteAvailableCondition {
    * type: Completed, status: false
    * type: Available, status: true
    * Verify no Failed type condition generated.
-   * Disabled due to bug.
    */
-  @Disabled
   @Test
   @DisplayName("Test domain status condition with cluster replica set to larger than max size of cluster")
   void testCompleteAvailableConditionWithReplicaExceedMaxSize() {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -725,6 +725,7 @@ abstract class DomainStatusUpdateTestBase {
     updateDomainStatus();
 
     assertThat(getRecordedDomain(), hasCondition(Failed).withReason(ReplicasTooHigh).withMessageContaining("cluster1"));
+    assertThat(getRecordedDomain(), hasCondition(Completed).withStatus(FALSE));;
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -718,7 +718,7 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
-  void whenReplicaCountExceedsMaxReplicasForDynamicCluster_addFailedCondition() {
+  void whenReplicaCountExceedsMaxReplicasForDynamicCluster_addFailedAndCompletedFalseCondition() {
     domain.setReplicaCount("cluster1", 5);
     defineScenario().withDynamicCluster("cluster1", 0, 4).build();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;


### PR DESCRIPTION
Enable the disabled test case that verifies when the replicas are set higher that the max number of servers in the cluster, the domain completed condition is false, and Failed condition is true.
Note that the max number of servers is configured as 5 on WebLogic cluster (not 2 as the test code originally assumed), I changed the test code to align with this.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8130/