### PR TITLE
Fixes build warning in integration-tests project

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -154,6 +154,16 @@
                             <skip>${skipITs}</skip>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>validate-shell-scripts</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${project.basedir}/../validateScripts.sh</executable>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -192,22 +202,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>validate-shell-scripts</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${project.basedir}/../validateScripts.sh</executable>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Updates integration-tests/pom.xml to fix the following warning during maven build:

[WARNING] Some problems were encountered while building the effective model for oracle.kubernetes:integration-tests:jar:4.0.0
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:exec-maven-plugin @ line 196, column 21

It was caused by a change in PR 2715

jenkins run: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8203/

compared to jenkins run on main: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8204/