### PR TITLE
Resolution to syntax error in kindtest.sh  and create a new profile to certify WDT/WIT release 

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -448,5 +448,21 @@
                 </includes-failsafe>
             </properties>
         </profile>
+        <profile>
+            <id>toolkits-srg</id>
+            <properties>
+                <skipITs>false</skipITs>
+                <includes-failsafe>
+                    **/ItParameterizedDomain,
+                    **/ItMiiUpdateDomainConfig,
+                    **/ItMiiAuxiliaryImage40,
+                    **/ItMiiNewCreateAuxImage40,
+                    **/ItMiiDynamicUpdate*,
+                    **/ItMiiSampleWlsMain,
+                    **/ItMiiSampleWlsAux,
+                    **/ItMiiMultiModel
+                </includes-failsafe>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -400,7 +400,7 @@
                   **/ItProductionSecureMode,
                   **/ItRemoteConsole,
                   **/ItServerStartPolicy,
-		          **/ItServiceStartPolicyDynamicCluster,
+		  **/ItServiceStartPolicyDynamicCluster,
                   **/ItServerStartPolicyConfigCluster,
                   **/ItSessionMigration,
                   **/ItStickySession,

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -308,7 +308,7 @@ if [ "${test_filter}" != "**/It*" ]; then
   echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
   time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
 else
-  if [ "${maven_profile_name}" = "wls-image-cert" ] || [ "${maven_profile_name}" = "fmw-pipeline" ] || [ "${maven_profile_name}" = "fmw-image-cert" ] || [ "${maven_profile_name}" = "kind-sequential" ]; then
+  if [ "${maven_profile_name}" = "toolkits-srg" ] || [ "${maven_profile_name}" = "wls-image-cert" ] || [ "${maven_profile_name}" = "fmw-pipeline" ] || [ "${maven_profile_name}" = "fmw-image-cert" ] || [ "${maven_profile_name}" = "kind-sequential" ]; then
     echo "Running mvn -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads} -pl integration-tests -P ${maven_profile_name} verify"
     time mvn -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
   else

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -304,7 +304,7 @@ rm -rf "${RESULT_ROOT:?}/*"
 
 echo "Run tests..."
 
-if [ ${test_filter} != "**/It*" ]; then
+if [ "${test_filter}" != "**/It*" ]; then
   echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
   time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
 else


### PR DESCRIPTION
(a) Resolved the syntax error while passing multiple class to IT_TEST parameter in jenkin job.

 '[' ItParameterizedDomain, ItMiiUpdateDomainConfig, ItMiiAuxiliaryImage40, ItMiiNewCreateAuxImage40,ItMiiDynamicUpdate*,ItMiiMultiModel '!=' '**/It*' ']'
./kindtest.sh: line 307: [: too many arguments

( https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8272/ )

(b) add a new maven profile toolkits-srg which includes minimum set of tests needed to 
verify a per-release version of WDT and/or WIT

(https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8273/ )