### PR TITLE
create OKD srg profile 

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -432,6 +432,30 @@
             </properties>
         </profile>
         <profile>
+            <id>wko-okd-crio-job</id>
+            <properties>
+                <skipITs>false</skipITs>
+                <includes-failsafe>
+                  **/ItConfigDistributionStrategy,
+                  **/ItMiiAuxiliaryImage,
+                  **/ItMiiDomain,
+                  **/ItMiiDynamicUpdate,
+                  **/ItMiiNewCreateAuxImage,
+                  **/ItMiiSampleWlsAux,
+                  **/ItMiiSampleWlsMain,
+                  **/ItMiiSampleFmwMain,
+                  **/ItMiiSampleFmwAux,
+                  **/ItMiiServiceMigration,
+                  **/ItParameterizedDomain,
+                  **/ItPodsShutdownOption,
+                  **/ItProductionSecureMode,
+                  **/ItSessionMigration,
+                  **/ItSystemResOverrides,
+                  **/ItFmwMiiDomain
+                </includes-failsafe>
+            </properties>
+        </profile>
+        <profile>
             <id>fmw-pipeline</id>
             <properties>
                 <skipITs>false</skipITs>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -432,7 +432,7 @@
             </properties>
         </profile>
         <profile>
-            <id>wko-okd-crio-job</id>
+            <id>wko-okd-srg</id>
             <properties>
                 <skipITs>false</skipITs>
                 <includes-failsafe>
@@ -441,16 +441,10 @@
                   **/ItMiiDomain,
                   **/ItMiiDynamicUpdate,
                   **/ItMiiNewCreateAuxImage,
-                  **/ItMiiSampleWlsAux,
-                  **/ItMiiSampleWlsMain,
-                  **/ItMiiSampleFmwMain,
-                  **/ItMiiSampleFmwAux,
-                  **/ItMiiServiceMigration,
                   **/ItParameterizedDomain,
                   **/ItPodsShutdownOption,
-                  **/ItProductionSecureMode,
-                  **/ItSessionMigration,
                   **/ItSystemResOverrides,
+                  **/ItFmwDynamicDomainInPV,
                   **/ItFmwMiiDomain
                 </includes-failsafe>
             </properties>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -443,7 +443,6 @@
                   **/ItMiiNewCreateAuxImage,
                   **/ItParameterizedDomain,
                   **/ItPodsShutdownOption,
-                  **/ItSystemResOverrides,
                   **/ItFmwDynamicDomainInPV,
                   **/ItFmwMiiDomain
                 </includes-failsafe>

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -338,7 +338,7 @@ class ItMiiDomain {
                 MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG);
 
     // set low introspectorJobActiveDeadlineSeconds and verify introspector retries on timeouts
-    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(100L);
+    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(90L);
 
     // create model in image domain
     logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -338,7 +338,7 @@ class ItMiiDomain {
                 MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG);
 
     // set low introspectorJobActiveDeadlineSeconds and verify introspector retries on timeouts
-    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(30L);
+    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(60L);
 
     // create model in image domain
     logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -338,7 +338,7 @@ class ItMiiDomain {
                 MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG);
 
     // set low introspectorJobActiveDeadlineSeconds and verify introspector retries on timeouts
-    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(60L);
+    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(100L);
 
     // create model in image domain
     logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -306,6 +307,7 @@ class ItMiiDomain {
   @Test
   @Order(2)
   @DisplayName("Create a second domain with the image from the the first test")
+  @DisabledIfEnvironmentVariable(named = "OKD", matches = "true")
   void testCreateMiiSecondDomainDiffNSSameImage() {
     // admin/managed server name here should match with model yaml in MII_BASIC_WDT_MODEL_FILE
     final String adminServerPodName = domainUid1 + "-admin-server";
@@ -338,7 +340,7 @@ class ItMiiDomain {
                 MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG);
 
     // set low introspectorJobActiveDeadlineSeconds and verify introspector retries on timeouts
-    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(45L);
+    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(30L);
 
     // create model in image domain
     logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -338,7 +338,7 @@ class ItMiiDomain {
                 MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG);
 
     // set low introspectorJobActiveDeadlineSeconds and verify introspector retries on timeouts
-    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(90L);
+    domain.getSpec().configuration().introspectorJobActiveDeadlineSeconds(45L);
 
     // create model in image domain
     logger.info("Creating model in image domain {0} in namespace {1} using docker image {2}",


### PR DESCRIPTION
Create srg profile on OKD
Also as we discussed the test verifying low introspectorJobActiveDeadlineSeconds setting is disabled on OKD.
Jenkins job:
https://build.weblogick8s.org:8443/job/wko-okd-test/157/   --all passed
https://build.weblogick8s.org:8443/job/wko-okd-test/158/   --all passed
https://build.weblogick8s.org:8443/job/wko-okd-test/159/   --one failure (after enabling auto nightly run I will continue to monitor)