### PR TITLE
Modify shell script to generate a valid tag for the operator image in local run

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Operator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Operator.java
@@ -79,10 +79,10 @@ public class Operator {
           .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
           .toString();
     } else  {
-      // Remove (if needed) / from branch name and replace with - 
-      // e.g. replace release/3.x.y with release-3.x.y
+      // Remove all non-alphanumeric character(s) in the branch name 
+      // e.g. replace release/3.x.y with release3xy
       CommandParams params = Command.defaultCommandParams()
-          .command("git branch | grep \\* | cut -d ' ' -f2- | tr '/' '-' ")
+          .command("git branch|grep \\* |cut -d ' ' -f2- |tr -dc 'a-zA-Z0-9'")
           .saveResults(true)
           .redirect(false);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Operator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Operator.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.actions.impl;
@@ -79,8 +79,10 @@ public class Operator {
           .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
           .toString();
     } else  {
+      // Remove (if needed) / from branch name and replace with - 
+      // e.g. replace release/3.x.y with release-3.x.y
       CommandParams params = Command.defaultCommandParams()
-          .command("git branch | grep \\* | cut -d ' ' -f2-")
+          .command("git branch | grep \\* | cut -d ' ' -f2- | tr '/' '-' ")
           .saveResults(true)
           .redirect(false);
 


### PR DESCRIPTION
Currently the test build fails if the branch name contains a "/"  e.g. release/3.3  with the following Error
......
Building image ‘oracle/weblogic-kubernetes-operator:release/3.3’ ...
There was an error building the image.
<01-27-2022 17:48:02> <SEVERE> <oracle.weblogic.kubernetes.actions.impl.primitive.Command execute> <The command execution failed because it returned non-zero exit value: ExecResult: exitValue = 1, stdout = Proxy settings were found and will be used during build.
Building image ‘oracle/weblogic-kubernetes-operator:release/3.3’ ...
There was an error building the image., stderr = invalid argument “oracle/weblogic-kubernetes-operator:release/3.3” for “-t, --tag” flag: invalid reference format
.......

We need to replace the tag with a valid character 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8355/