### PR TITLE
Fix integration test failure for sitconfig

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1371,12 +1371,9 @@ class SitConfigGenerator(Generator):
     self.writeln('<d:public-address %s>%s.%s</d:public-address>' % (action, listen_address,
                                     self.env.getEnvOrDef("ISTIO_POD_NAMESPACE", "default")))
     self.writeln('<d:listen-port %s>%s</d:listen-port>' % (action, listen_port))
-    self.writeln('<d:http-enabled-for-this-protocol %s>false</d:http-enabled-for-this-protocol>' %
-                 (action))
     self.writeln('<d:enabled %s>true</d:enabled>' % action)
     self.writeln('<d:outbound-enabled %s>false</d:outbound-enabled>' % action)
     self.writeln('<d:use-fast-serialization %s>true</d:use-fast-serialization>' % action)
-    self.writeln('<d:tunneling-enabled %s>true</d:tunneling-enabled>' % action)
     self.undent()
     self.writeln('</d:network-access-point>')
 


### PR DESCRIPTION
Fix istio sitconfig replication channel regression in integration test.

kind new test 8382 ran successfully and no longer seeing the replication channel error message 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8382/  (ItIstioDomainInPV)

All Istio Tests Results 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8387/