### PR TITLE
Resolution to regression on FMW sample with WDT release 2.0 

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -477,6 +477,9 @@
                     **/ItMiiDynamicUpdate*,
                     **/ItMiiSampleWlsMain,
                     **/ItMiiSampleWlsAux,
+                    **/ItMiiSampleFmwAux,
+                    **/ItFmwSample,
+                    **/ItWlsSamples,
                     **/ItMiiMultiModel
                 </includes-failsafe>
             </properties>

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -88,7 +88,7 @@ kubernetes:
       %EXPOSE_ANY_CHANNEL_PREFIX%    default:
       %EXPOSE_ADMIN_PORT_PREFIX%       nodePort: %ADMIN_NODE_PORT%
       # Uncomment to export the T3Channel as a service
-      %EXPOSE_T3_CHANNEL_PREFIX%     T3Channel:
+      %EXPOSE_T3_CHANNEL_PREFIX%    T3Channel:
 
     # Istio service mesh support is experimental.
     %ISTIO_PREFIX%configuration:

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 
 #
 # This is the template for kubernetes section for wdt_model file. This

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 
 #
 # This is the template for kubernetes section for wdt_model file. This
@@ -89,7 +89,7 @@ kubernetes:
       %EXPOSE_ANY_CHANNEL_PREFIX%    default:
       %EXPOSE_ADMIN_PORT_PREFIX%       nodePort: %ADMIN_NODE_PORT%
       # Uncomment to export the T3Channel as a service
-      %EXPOSE_T3_CHANNEL_PREFIX%     T3Channel:
+      %EXPOSE_T3_CHANNEL_PREFIX%    T3Channel:
 
     # clusters is used to configure the desired behavior for starting member servers of a cluster.
     # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.


### PR DESCRIPTION
This PR covers  
  a)  the resolution to issue described in the the JIRA
  b) add new Integration test class to toolkit-srg profile

Here are the jenkin run 
  (a)  https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8403   ( ItFmwSample only) 
  (b) https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8408/  ( toolkits-srg profile ) 
    All tests passed.  ItParameterizedDomain.testScaleClustersByPatchingDomainResource fails due to OWLS-96280
  