### PR TITLE
Remove duplicate calls to TestUtils.silenceOperatorLogger

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -200,8 +200,6 @@ class DomainProcessorTest {
     consoleHandlerMemento = TestUtils.silenceOperatorLogger()
             .collectLogMessages(logRecords, NOT_STARTING_DOMAINUID_THREAD).withLogLevel(Level.FINE);
     mementos.add(consoleHandlerMemento);
-    mementos.add(TestUtils.silenceOperatorLogger()
-          .collectLogMessages(logRecords, NOT_STARTING_DOMAINUID_THREAD).withLogLevel(Level.FINE));
     mementos.add(testSupport.install());
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "DOMAINS", presenceInfoMap));
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "domainEventK8SObjects", domainEventObjects));

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -64,13 +64,13 @@ class NamespaceTest {
   private final DomainNamespaces domainNamespaces = new DomainNamespaces(null);
   private final DomainProcessorStub dp = Stub.createNiceStub(DomainProcessorStub.class);
   private final MainDelegateStub delegate = createStrictStub(MainDelegateStub.class, dp, domainNamespaces);
-  private final TestUtils.ConsoleHandlerMemento loggerControl = TestUtils.silenceOperatorLogger();
+  private TestUtils.ConsoleHandlerMemento loggerControl;
   private final Collection<LogRecord> logRecords = new ArrayList<>();
   private final EventRetryStrategyStub retryStrategy = createStrictStub(EventRetryStrategyStub.class);
 
   @BeforeEach
   public void setUp() throws Exception {
-    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(loggerControl = TestUtils.silenceOperatorLogger());
     mementos.add(StubWatchFactory.install());
     mementos.add(NoopWatcherStarter.install());
     mementos.add(HelmAccessStub.install());

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/AdminPodHelperTest.java
@@ -24,7 +24,6 @@ import oracle.kubernetes.operator.utils.InMemoryCertificates;
 import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
-import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.ServerConfigurator;
 import org.junit.jupiter.api.Test;
 
@@ -73,8 +72,6 @@ class AdminPodHelperTest extends PodHelperTestBase {
   private static final String END_MOUNT_PATH_1 = "/u01/oracle/user_projects/domains/servers/ADMIN_SERVER";
   public static final String CUSTOM_MOUNT_PATH2 = "/common1";
   public static final String TEST_MEDIUM = "TestMedium";
-
-  private TestUtils.ConsoleHandlerMemento consoleHandlerMemento = TestUtils.silenceOperatorLogger();
 
   public AdminPodHelperTest() {
     super(ADMIN_SERVER, ADMIN_PORT);
@@ -831,7 +828,7 @@ class AdminPodHelperTest extends PodHelperTestBase {
   @Test
   void whenDomainHomeChanged_generateExpectedLogMessage()
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    consoleHandlerMemento.collectLogMessages(logRecords, getCyclePodKey());
+    getConsoleHandlerMemento().collectLogMessages(logRecords, getCyclePodKey(), getReplacedMessageKey());
     initializeExistingPod();
     getConfiguredDomainSpec().setDomainHome("adfgg");
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -114,13 +114,13 @@ class EventHelperTest {
   private final MakeRightDomainOperation makeRightOperation
       = processor.createMakeRightOperation(info);
   private final String jobPodName = LegalNames.toJobIntrospectorName(UID);
-  private final TestUtils.ConsoleHandlerMemento loggerControl = TestUtils.silenceOperatorLogger();
+  private TestUtils.ConsoleHandlerMemento loggerControl;
   private final Collection<LogRecord> logRecords = new ArrayList<>();
   private final EventRetryStrategyStub retryStrategy = createStrictStub(EventRetryStrategyStub.class);
 
   @BeforeEach
   public void setUp() throws Exception {
-    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(loggerControl = TestUtils.silenceOperatorLogger());
     mementos.add(testSupport.install());
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "DOMAINS", presenceInfoMap));
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "domainEventK8SObjects", domainEventObjects));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -224,7 +224,7 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   private Memento hashMemento;
   private final Map<String, Map<String, KubernetesEventObjects>> domainEventObjects = new ConcurrentHashMap<>();
 
-  private TestUtils.ConsoleHandlerMemento consoleHandlerMemento = TestUtils.silenceOperatorLogger();
+  private TestUtils.ConsoleHandlerMemento consoleHandlerMemento;
 
   PodHelperTestBase(String serverName, int listenPort) {
     this.serverName = serverName;
@@ -302,8 +302,8 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
     mementos.add(hashMemento = UnitTestHash.install());
     mementos.add(InMemoryCertificates.install());
     mementos.add(setProductVersion(TEST_PRODUCT_VERSION));
-    mementos.add(
-        TestUtils.silenceOperatorLogger()
+    mementos.add(consoleHandlerMemento
+          = TestUtils.silenceOperatorLogger()
             .collectLogMessages(logRecords, getMessageKeys())
             .withLogLevel(Level.FINE)
             .ignoringLoggedExceptions(ApiException.class));
@@ -326,6 +326,10 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
         ProcessingConstants.PODWATCHER_COMPONENT_NAME,
         PodAwaiterStepFactory.class,
         new PassthroughPodAwaiterStepFactory());
+  }
+
+  TestUtils.ConsoleHandlerMemento getConsoleHandlerMemento() {
+    return consoleHandlerMemento;
   }
 
   private Memento setProductVersion(String productVersion) throws NoSuchFieldException {
@@ -2153,7 +2157,7 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   @Test
   void whenImageChanged_expectedLogMessageFound()
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    consoleHandlerMemento.collectLogMessages(logRecords, getDomainRollStartingKey());
+    getConsoleHandlerMemento().collectLogMessages(logRecords, getDomainRollStartingKey());
     initializeExistingPod();
     getConfiguredDomainSpec().setImage("adfgg");
 
@@ -2245,7 +2249,7 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   @Test
   void whenImageDomainHomeAndRestartVersionChanged_expectedLogMessageFound()
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    consoleHandlerMemento.collectLogMessages(logRecords, getDomainRollStartingKey());
+    getConsoleHandlerMemento().collectLogMessages(logRecords, getDomainRollStartingKey());
     initializeExistingPod();
     getConfiguredDomainSpec().setImage("adfgg");
     getConfiguredDomainSpec().setDomainHome("12345");
@@ -2260,7 +2264,7 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   @Test
   void whenImageDomainHomeAndRestartVersionChanged_domainRollStartEventCreatedWithCorrectMessage()
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    consoleHandlerMemento.collectLogMessages(logRecords, getDomainRollStartingKey());
+    getConsoleHandlerMemento().collectLogMessages(logRecords, getDomainRollStartingKey());
     initializeExistingPod();
     getConfiguredDomainSpec().setImage("adfgg");
     getConfiguredDomainSpec().setDomainHome("12345");
@@ -2287,7 +2291,7 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   @Test
   void whenImageDomainHomeAndWebLogicZipHashChanged_domainRollStartEventCreatedWithCorrectMessage()
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    consoleHandlerMemento.collectLogMessages(logRecords, getDomainRollStartingKey());
+    getConsoleHandlerMemento().collectLogMessages(logRecords, getDomainRollStartingKey());
     initializeExistingPod();
     getConfiguredDomainSpec().setImage("adfgg");
     getConfiguredDomainSpec().setDomainHome("12345");

--- a/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
@@ -29,6 +29,7 @@ public class TestUtils {
    */
   public static ConsoleHandlerMemento silenceOperatorLogger() {
     Logger logger = LoggingFactory.getLogger("Operator", "Operator").getUnderlyingLogger();
+    Arrays.stream(logger.getHandlers()).filter(TestUtils::isTestLogHandler).forEach(TestUtils::rejectCall);
     List<Handler> savedHandlers = new ArrayList<>();
     for (Handler handler : logger.getHandlers()) {
       if (handler instanceof ConsoleHandler) {
@@ -44,6 +45,14 @@ public class TestUtils {
     logger.addHandler(testHandler);
 
     return new ConsoleHandlerMemento(logger, testHandler, savedHandlers);
+  }
+
+  private static boolean isTestLogHandler(Handler handler) {
+    return handler instanceof TestLogHandler;
+  }
+
+  private static void rejectCall(Handler handler) {
+    throw new IllegalStateException("silenceOperatorLogger may only called once");
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.utils;


### PR DESCRIPTION
The problem was caused by multiple calls to TestUtils.silenceOperatorLogger. Each one removes the existing log handlers and adds a new test one. The result was to confuse the special handling of log messages in unit tests. This change removes the duplicates and modifies the call to report an error on an attempt to invoke it more than once in a test.