### PR TITLE
backport owls-96203  ( FmwSample Failure ) 

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -361,6 +361,8 @@
                     **/ItMiiDynamicUpdate,
                     **/ItMiiSampleWlsMain,
                     **/ItMiiSampleWlsAux,
+                    **/ItFmwSample,
+                    **/ItWlsSamples,
                     **/ItMiiMultiModel
                 </includes-failsafe>
             </properties>

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -87,7 +87,6 @@ class ItWlsSamples {
 
   private static String traefikNamespace = null;
   private static String nginxNamespace = null;
-  private static String voyagerNamespace = null;
   private static String domainNamespace = null;
   private static final String domainName = "domain1";
   private static final String diiImageNameBase = "domain-home-in-image";
@@ -119,7 +118,7 @@ class ItWlsSamples {
    * @param namespaces injected by JUnit
    */
   @BeforeAll
-  public static void initAll(@Namespaces(5) List<String> namespaces) {
+  public static void initAll(@Namespaces(4) List<String> namespaces) {
     logger = getLogger();
 
     logger.info("Assign a unique namespace for operator");
@@ -136,10 +135,6 @@ class ItWlsSamples {
     logger.info("Assign a unique namespace for Nginx controller");
     assertNotNull(namespaces.get(3), "Namespace is null");
     nginxNamespace = namespaces.get(3);
-
-    logger.info("Assign a unique namespace for Voyager controller");
-    assertNotNull(namespaces.get(4), "Namespace is null");
-    voyagerNamespace = namespaces.get(4);
 
     // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
     // this secret is used only for non-kind cluster
@@ -369,22 +364,9 @@ class ItWlsSamples {
   }
 
   /**
-   * Verify setupLoadBalancer scripts for managing Voyager LoadBalancer.
-   */
-  @Order(8)
-  @Test
-  @DisplayName("Manage Voyager Ingress Controller with setupLoadBalancer")
-  void testVoyagerIngressController() {
-    setupSample();
-    Path scriptBase = Paths.get(tempSamplePath.toString(), "charts/util");
-    setupLoadBalancer(scriptBase, "voyager", " -c -n " + voyagerNamespace);
-    setupLoadBalancer(scriptBase, "voyager", " -d -n " + voyagerNamespace);
-  }
-
-  /**
    * Verify setupLoadBalancer scripts for managing Nginx LoadBalancer.
    */
-  @Order(9)
+  @Order(8)
   @Test
   @DisplayName("Manage Nginx Ingress Controller with setupLoadBalancer")
   void testNginxIngressController() {

--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 
 #
 # This is the template for kubernetes section for wdt_model file. This
@@ -88,7 +88,7 @@ kubernetes:
       %EXPOSE_ANY_CHANNEL_PREFIX%    default:
       %EXPOSE_ADMIN_PORT_PREFIX%       nodePort: %ADMIN_NODE_PORT%
       # Uncomment to export the T3Channel as a service
-      %EXPOSE_T3_CHANNEL_PREFIX%     T3Channel:
+      %EXPOSE_T3_CHANNEL_PREFIX%    T3Channel:
 
     # Istio service mesh support is experimental.
     %ISTIO_PREFIX%configuration:

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 
 #
 # This is the template for kubernetes section for wdt_model file. This
@@ -89,7 +89,7 @@ kubernetes:
       %EXPOSE_ANY_CHANNEL_PREFIX%    default:
       %EXPOSE_ADMIN_PORT_PREFIX%       nodePort: %ADMIN_NODE_PORT%
       # Uncomment to export the T3Channel as a service
-      %EXPOSE_T3_CHANNEL_PREFIX%     T3Channel:
+      %EXPOSE_T3_CHANNEL_PREFIX%    T3Channel:
 
     # clusters is used to configure the desired behavior for starting member servers of a cluster.
     # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.


### PR DESCRIPTION
backport the resolution to the issue described in JIRA owls-96203 into release/3.3

Jenkin Run 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8413/ 
One failure oracle.weblogic.kubernetes.ItWlsSamples.testVoyagerIngressController  (Need to comment out this test)

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8433/   ( all passed ) 
Removed the Voyager Test