### PR TITLE
Remove duplicate calls to TestUtils.silenceOperatorLogger

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -64,13 +64,14 @@ class NamespaceTest {
   private final DomainNamespaces domainNamespaces = new DomainNamespaces(null);
   private final DomainProcessorStub dp = Stub.createNiceStub(DomainProcessorStub.class);
   private final MainDelegateStub delegate = createStrictStub(MainDelegateStub.class, dp, domainNamespaces);
-  private final TestUtils.ConsoleHandlerMemento loggerControl = TestUtils.silenceOperatorLogger();
   private final Collection<LogRecord> logRecords = new ArrayList<>();
   private final OnConflictRetryStrategyStub retryStrategy = createStrictStub(OnConflictRetryStrategyStub.class);
 
+  private TestUtils.ConsoleHandlerMemento loggerControl;
+
   @BeforeEach
   public void setUp() throws Exception {
-    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(loggerControl = TestUtils.silenceOperatorLogger());
     mementos.add(StubWatchFactory.install());
     mementos.add(NoopWatcherStarter.install());
     mementos.add(HelmAccessStub.install());

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -116,13 +116,13 @@ class EventHelperTest {
   private final MakeRightDomainOperation makeRightOperation
       = processor.createMakeRightOperation(info);
   private final String jobPodName = LegalNames.toJobIntrospectorName(UID);
-  private final TestUtils.ConsoleHandlerMemento loggerControl = TestUtils.silenceOperatorLogger();
   private final Collection<LogRecord> logRecords = new ArrayList<>();
   private final OnConflictRetryStrategyStub retryStrategy = createStrictStub(OnConflictRetryStrategyStub.class);
+  private TestUtils.ConsoleHandlerMemento loggerControl;
 
   @BeforeEach
   void setUp() throws Exception {
-    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(loggerControl = TestUtils.silenceOperatorLogger());
     mementos.add(testSupport.install());
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "DOMAINS", presenceInfoMap));
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "domainEventK8SObjects", domainEventObjects));

--- a/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/utils/TestUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.utils;
@@ -29,6 +29,7 @@ public class TestUtils {
    */
   public static ConsoleHandlerMemento silenceOperatorLogger() {
     Logger logger = LoggingFactory.getLogger("Operator", "Operator").getUnderlyingLogger();
+    Arrays.stream(logger.getHandlers()).filter(TestUtils::isTestLogHandler).forEach(TestUtils::rejectCall);
     List<Handler> savedHandlers = new ArrayList<>();
     for (Handler handler : logger.getHandlers()) {
       if (handler instanceof ConsoleHandler) {
@@ -44,6 +45,14 @@ public class TestUtils {
     logger.addHandler(testHandler);
 
     return new ConsoleHandlerMemento(logger, testHandler, savedHandlers);
+  }                                                                                                
+
+  private static boolean isTestLogHandler(Handler handler) {
+    return handler instanceof TestLogHandler;
+  }
+
+  private static void rejectCall(Handler handler) {
+    throw new IllegalStateException("silenceOperatorLogger may only called once");
   }
 
   /**


### PR DESCRIPTION
Similar to PR #2760 (for the 3.3 branch), removes duplicate calls to TestUtils.silenceOperatorLogger and adds a check to prevent them from being created in the future.