### PR TITLE
Skip validating domain list ability if operator has already read, created, or updated CRD

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MainDelegate.java
@@ -1,11 +1,13 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.SemanticVersion;
 import oracle.kubernetes.operator.work.Packet;
@@ -14,7 +16,7 @@ import oracle.kubernetes.operator.work.Step;
 /**
  * Definition of an interface that returns values that the Main class requires.
  */
-interface MainDelegate {
+public interface MainDelegate {
 
   SemanticVersion getProductVersion();
 
@@ -33,4 +35,6 @@ interface MainDelegate {
   KubernetesVersion getKubernetesVersion();
 
   ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
+
+  AtomicReference<V1CustomResourceDefinition> getCrdReference();
 }


### PR DESCRIPTION
We have functionality in Main that trails the behavior in CRDHelper and additionally does a list of domains to validate the the custom type is available. Oddly, I could consistently reproduce getting a 404 trying to list domains immediately after creating the CRD. This meant that most customers would see a SEVERE message in the operator's log when the operator was started pointing at a fresh cluster. 

Looking at the requirement, we added the domain list as a CRD "presence check" in response to use cases where the operator did not have privilege to read the CRD. We don't actually need this extra check if the operator was able to read, create, or update the CRD.

This PR skips the presence check if the operator was able to read, create, or update the CRD.