### PR TITLE
backport change from OWLS-96280 to release 3.3 branch

### DIFF
--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -363,7 +363,7 @@ def getAdministrationPort(server, topology):
 def isAdministrationPortEnabledForServer(server, topology):
   administrationPortEnabled = False
   if 'AdministrationPortEnabled' in server:
-    administrationPortEnabled = server['AdministrationPortEnabled'] == 'true'
+    administrationPortEnabled = server['AdministrationPortEnabled']
   else:
     administrationPortEnabled = isAdministrationPortEnabledForDomain(topology)
   return administrationPortEnabled
@@ -373,7 +373,7 @@ def isAdministrationPortEnabledForDomain(topology):
   administrationPortEnabled = False
 
   if 'AdministrationPortEnabled' in topology:
-    administrationPortEnabled = topology['AdministrationPortEnabled'] == 'true'
+    administrationPortEnabled = topology['AdministrationPortEnabled']
   else:
     # AdministrationPortEnabled is not explicitly set so going with the default
     # Starting with 14.1.2.0, the domain's AdministrationPortEnabled default is derived from the domain's SecureMode
@@ -385,11 +385,11 @@ def isAdministrationPortEnabledForDomain(topology):
 def isSecureModeEnabledForDomain(topology):
   secureModeEnabled = False
   if 'SecurityConfiguration' in topology and 'SecureMode' in topology['SecurityConfiguration'] and 'SecureModeEnabled' in topology['SecurityConfiguration']['SecureMode']:
-    secureModeEnabled = topology['SecurityConfiguration']['SecureMode']['SecureModeEnabled'] == 'true'
+    secureModeEnabled = topology['SecurityConfiguration']['SecureMode']['SecureModeEnabled']
   else:
     is_production_mode_enabled = False
     if 'ProductionModeEnabled' in topology:
-      is_production_mode_enabled = topology['ProductionModeEnabled'] == 'true'
+      is_production_mode_enabled = topology['ProductionModeEnabled']
     secureModeEnabled = is_production_mode_enabled and not env.wlsVersionEarlierThan("14.1.2.0")
   return secureModeEnabled
 
@@ -429,7 +429,7 @@ def _get_ssl_listen_port(server):
   ssl = getSSLOrNone(server)
   ssl_listen_port = None
   model = env.getModel()
-  if ssl is not None and 'Enabled' in ssl and ssl['Enabled'] == 'true':
+  if ssl is not None and 'Enabled' in ssl and ssl['Enabled']:
     ssl_listen_port = ssl['ListenPort']
     if ssl_listen_port is None:
       ssl_listen_port = "7002"
@@ -611,7 +611,7 @@ def customizeManagedIstioNetworkAccessPoint(template, listen_address):
     ssl = getSSLOrNone(template)
     ssl_listen_port = None
     model = env.getModel()
-    if ssl is not None and 'Enabled' in ssl and ssl['Enabled'] == 'true':
+    if ssl is not None and 'Enabled' in ssl and ssl['Enabled']:
       ssl_listen_port = ssl['ListenPort']
       if ssl_listen_port is None:
         ssl_listen_port = "7002"
@@ -676,7 +676,7 @@ def addAdminChannelPortForwardNetworkAccessPoints(server):
 
     ssl = getSSLOrNone(server)
     ssl_listen_port = None
-    if ssl is not None and 'Enabled' in ssl and ssl['Enabled'] == 'true':
+    if ssl is not None and 'Enabled' in ssl and ssl['Enabled']:
       ssl_listen_port = ssl['ListenPort']
       if ssl_listen_port is None:
         ssl_listen_port = "7002"

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -294,6 +294,21 @@ class WdtUpdateFilterCase(unittest.TestCase):
     domain_name = model_wdt_mii_filter.env.getDomainName()
     self.assertEqual('wls-domain1', domain_name, "Expected domain name to be \'wls-domain1\'")
 
+  def test_isAdministrationPortEnabledForDomain(self):
+    model = self.getModel()
+    self.assertTrue(model_wdt_mii_filter.isAdministrationPortEnabledForDomain(model['topology']))
+
+  def test_isAdministrationPortEnabledForServer(self):
+    model = self.getModel()
+
+    # disable Administration port for domain
+    model['topology']['AdministrationPortEnabled'] = False
+
+    # enable Administration port for server
+    model['topology']['Server']['admin-server']['AdministrationPortEnabled'] = True
+
+    self.assertTrue(model_wdt_mii_filter.isAdministrationPortEnabledForServer(model['topology']['Server']['admin-server'], model['topology']))
+
   def test_istioVersionRequiresLocalHostBindings(self):
     model = self.getModel()
     self.assertTrue(model_wdt_mii_filter.istioVersionRequiresLocalHostBindings())


### PR DESCRIPTION
Backport of OWLS-96280 to release 3.3 branch.

Integration test run:  [Kind 8785](https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8785/) and [Kind 8799](https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8799/)