### PR TITLE
Ignore exception if elasticsearch already installed

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.actions.impl;
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 
 import io.kubernetes.client.custom.IntOrString;
 import io.kubernetes.client.openapi.ApiException;
@@ -28,7 +29,6 @@ import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServicePort;
 import io.kubernetes.client.openapi.models.V1ServiceSpec;
-import java.util.logging.Level;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Installer;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.assertions.impl.Deployment;


### PR DESCRIPTION
Currently the tests fail if elasticsearch was already installed. This PR ignores the error if the elasticsearch was already installed.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/8818/