### PR TITLE
Fix intermittent ItServerStartPolicy test failure - Warning msg is not logged in operator log

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicy.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
-import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isPodRestarted;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
+import static oracle.weblogic.kubernetes.utils.LoggingUtil.checkPodLogContainsString;
 import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.PatchDomainUtils.patchServerStartPolicy;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDeleted;
@@ -499,11 +499,9 @@ class ItServerStartPolicy {
     String operatorPodName =
         assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
     logger.info("operator pod name: {0}", operatorPodName);
-    String operatorPodLog = assertDoesNotThrow(() -> getPodLog(operatorPodName, opNamespace));
-    logger.info("operator pod log: {0}", operatorPodLog);
-    assertTrue(operatorPodLog.contains("WARNING"));
-    assertTrue(operatorPodLog.contains(
-        "management/weblogic/latest/serverRuntime/search failed with exception java.net.ConnectException"));
+    checkPodLogContainsString(opNamespace, operatorPodName, "WARNING");
+    checkPodLogContainsString(opNamespace, operatorPodName,
+        "management/weblogic/latest/serverRuntime/search failed with exception java.net.ConnectException");
   }
 
   /**


### PR DESCRIPTION
Fix intermittent ItServerStartPolicy test failure - Warning msg is not logged in operator log

Jenkins result:
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/9064/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/9061/