### PR TITLE
First steps in new status cleanup

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainPresence.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainPresence.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -15,7 +15,11 @@ public class DomainPresence {
         .orElse(DEFAULT_TIMEOUT_SECONDS);
   }
 
-  static int getDomainPresenceFailureRetryMaxCount() {
+  /**
+   * Returns the maximum number of failures permitted before a retryable operation aborts make-right.
+   * This is derived from the "domainPresenceFailureRetryMaxCount" tuning parameter.
+   */
+  public static int getFailureRetryMaxCount() {
     return Optional.ofNullable(TuningParameters.getInstance())
         .map(parameters -> parameters.getMainTuning().domainPresenceFailureRetryMaxCount)
         .orElse(DEFAULT_RETRY_MAX_COUNT);

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -354,7 +354,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
           job.getMetadata().getName(),
           job.getSpec().getActiveDeadlineSeconds(),
           getJobStartedSeconds(),
-          DomainPresence.getDomainPresenceFailureRetryMaxCount());
+          DomainPresence.getFailureRetryMaxCount());
     }
 
     private long getJobStartedSeconds() {

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -51,8 +51,6 @@ public interface ProcessingConstants {
 
   String FATAL_INTROSPECTOR_ERROR = "FatalIntrospectorError";
 
-  String INTROSPECTION_ERROR = "Introspection Error: ";
-
   String FATAL_INTROSPECTOR_ERROR_MSG = "Stop introspection retry - MII Fatal Error: ";
 
   String OPERATOR_EVENT_LABEL_FILTER = LabelConstants.getCreatedByOperatorSelector();

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -460,13 +460,13 @@ public class JobHelper {
         }
       }
 
-      private String createFailureMessage(Packet packet, V1Job job) {
+      private String createFailureMessage(Packet packet, @Nullable V1Job job) {
         String jobName = Optional.ofNullable(job).map(V1Job::getMetadata).map(V1ObjectMeta::getName).orElse("");
         String jobPodName = (String) packet.get(ProcessingConstants.JOB_POD_NAME);
         return LOGGER.formatMessage(INTROSPECTOR_JOB_FAILED,
             Objects.requireNonNull(jobName),
-            job.getMetadata().getNamespace(),
-            job.getStatus(),
+            Optional.ofNullable(job).map(V1Job::getMetadata).map(V1ObjectMeta::getNamespace).orElse(""),
+            Optional.ofNullable(job).map(V1Job::getStatus).orElse(null),
             jobPodName);
       }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -587,7 +587,7 @@ public class ServiceHelper {
               .withLabelSelectors(forDomainUidSelector(info.getDomainUid()), getCreatedByOperatorSelector())
               .listServiceAsync(
                       getNamespace(),
-                      new ActionResponseStep<>() {
+                      new ActionResponseStep<V1ServiceList>() {
                       public Step createSuccessStep(V1ServiceList result, Step next) {
                         Collection<V1Service> c = Optional.ofNullable(result).map(list -> list.getItems().stream()
                                   .filter(ServiceHelper::isNodePortType)

--- a/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/logging/MessageKeys.java
@@ -14,6 +14,7 @@ public class MessageKeys {
   public static final String ENABLED_FEATURES = "WLSKO-0003";
   public static final String OPERATOR_SHUTTING_DOWN = "WLSKO-0005";
   public static final String EXCEPTION = "WLSKO-0006";
+  public static final String NO_FORMATTING = "WLSKO-0007";
   public static final String CREATING_CRD = "WLSKO-0012";
   public static final String SECRET_NOT_FOUND = "WLSKO-0018";
   public static final String RETRIEVING_SECRET = "WLSKO-0019";

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -602,7 +602,7 @@ public class DomainStatus {
   @NotNull
   private FailureLevel getFailureLevel(String jobUid, String message) {
     if (jobUid == null) {
-      return FailureLevel.NON_FATAL;
+      return FailureLevel.NON_INTROSPECTION;
     } else if (hasReachedMaximumFailureCount()) {
       return FailureLevel.RETRIES_EXCEEDED;
     } else if (isFatalError(message)) {
@@ -624,7 +624,7 @@ public class DomainStatus {
   }
 
   private enum FailureLevel {
-    NON_FATAL,
+    NON_INTROSPECTION,
     FATAL {
       @NotNull
       @Override

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -20,12 +20,21 @@ import jakarta.json.JsonPatchBuilder;
 import jakarta.validation.Valid;
 import oracle.kubernetes.json.Description;
 import oracle.kubernetes.json.Range;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.utils.SystemClock;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jetbrains.annotations.NotNull;
 
+import static oracle.kubernetes.operator.DomainPresence.getFailureRetryMaxCount;
+import static oracle.kubernetes.operator.ProcessingConstants.FATAL_INTROSPECTOR_ERROR;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
+import static oracle.kubernetes.operator.logging.MessageKeys.DOMAIN_FATAL_ERROR;
+import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_MAX_ERRORS_EXCEEDED;
+import static oracle.kubernetes.operator.logging.MessageKeys.NON_FATAL_INTROSPECTOR_ERROR;
+import static oracle.kubernetes.operator.logging.MessageKeys.NO_FORMATTING;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Progressing;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Rolling;
@@ -37,6 +46,8 @@ import static oracle.kubernetes.weblogic.domain.model.ObjectPatch.createObjectPa
  */
 @Description("The current status of the operation of the WebLogic domain. Updated automatically by the operator.")
 public class DomainStatus {
+
+  public static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   @Description("Current service state of the domain.")
   @Valid
@@ -576,5 +587,69 @@ public class DomainStatus {
   public DomainStatus upgrade() {
     Optional.ofNullable(conditions).ifPresent(x -> x.removeIf(cond -> cond.hasType(Progressing)));
     return this;
+  }
+
+  public String createDomainStatusMessage(String jobUid, String message) {
+    return LOGGER.formatMessage(getMessageKey(jobUid, message),
+          message, getIntrospectJobFailureCount(), getFailureRetryMaxCount());
+  }
+
+  @NotNull
+  private String getMessageKey(String jobUid, String message) {
+    return getFailureLevel(jobUid, message).getMessageKey();
+  }
+
+  @NotNull
+  private FailureLevel getFailureLevel(String jobUid, String message) {
+    if (jobUid == null) {
+      return FailureLevel.NON_FATAL;
+    } else if (hasReachedMaximumFailureCount()) {
+      return FailureLevel.RETRIES_EXCEEDED;
+    } else if (isFatalError(message)) {
+      return FailureLevel.FATAL;
+    } else {
+      return FailureLevel.WILL_RETRY;
+    }
+  }
+
+  private boolean isFatalError(String message) {
+    return Optional.ofNullable(message).map(m -> m.contains(FATAL_INTROSPECTOR_ERROR)).orElse(false);
+  }
+
+  /**
+   * Returns true if the failure count in the status is equal to or greater than the configured maximum.
+   */
+  public boolean hasReachedMaximumFailureCount() {
+    return getIntrospectJobFailureCount() >= getFailureRetryMaxCount();
+  }
+
+  private enum FailureLevel {
+    NON_FATAL,
+    FATAL {
+      @NotNull
+      @Override
+      String getMessageKey() {
+        return DOMAIN_FATAL_ERROR;
+      }
+    },
+    WILL_RETRY {
+      @NotNull
+      @Override
+      String getMessageKey() {
+        return NON_FATAL_INTROSPECTOR_ERROR;
+      }
+    },
+    RETRIES_EXCEEDED {
+      @NotNull
+      @Override
+      String getMessageKey() {
+        return INTROSPECTOR_MAX_ERRORS_EXCEEDED;
+      }
+    };
+
+    @NotNull
+    String getMessageKey() {
+      return NO_FORMATTING;
+    }
   }
 }

--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -4,6 +4,7 @@ WLSKO-0002=The Kubernetes Master URL is set to {0}
 WLSKO-0003=The following optional operator features are enabled: {0}
 WLSKO-0005=The Oracle WebLogic Kubernetes Operator is shutting down
 WLSKO-0006=Exception thrown
+WLSKO-0007={0}
 WLSKO-0012=Create Custom Resource Definition: {0}
 WLSKO-0018={2} secret ''{0}'' not found in namespace ''{1}''
 WLSKO-0019=Retrieving secret: {0}
@@ -144,12 +145,13 @@ WLSKO-0191=Rolling restart of WebLogic domain {0} completed
 WLSKO-0192=Executing make right domain operation, recheck count for server {0} is {1}.
 WLSKO-0193=Waiting for server {0} to start, recheck count is {1}.
 WLSKO-0194=Internal identity initialization step failed with exception {0}.
-WLSKO-0195=Introspection encountered a fatal error and will not retry automatically. \
+WLSKO-0195=Introspection encountered a fatal error: ''{0}'' and will not retry automatically. \
   Please resolve the error and then update 'domain.spec.introspectVersion' to force a retry.
-WLSKO-0196=Stop introspection retry - exceeded configured domainPresenceFailureRetryMaxCount: {0}. The \
-  domainPresenceFailureRetryMaxCount is an operator tuning parameter and can be controlled by adding it to the \
-  weblogic-operator-cm configmap. To force the introspector to start retrying again, update 'domain.spec.introspectVersion'.
-WLSKO-0197=Introspection failed on try {0} of {1}.
+WLSKO-0196=Introspection failed: ''{0}'' after {1} attempt(s) and will not retry. \
+  Please correct the error and force the operator to try again by updating 'domain.spec.introspectVersion'. \
+  The number of retries is controlled by the operator tuning parameter 'domainPresenceFailureRetryMaxCount', \
+  which may be specified in the weblogic-operator-cm configmap.
+WLSKO-0197=Introspection failed: ''{0}'' and will retry. Attempt {1} of {2}.
 WLSKO-0198={0} Fiber {1}
 WLSKO-0199=WL pod shutdown: Initiating shutdown of WebLogic server {0} via REST interface.
 WLSKO-0200=WL pod shutdown: Successfully shutdown WebLogic server {0} via REST interface.

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
@@ -6,12 +6,10 @@ package oracle.kubernetes.operator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -31,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static oracle.kubernetes.operator.DomainConditionMatcher.hasCondition;
 import static oracle.kubernetes.operator.DomainFailureReason.Internal;
+import static oracle.kubernetes.operator.DomainFailureReason.Introspection;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createInternalFailureSteps;
@@ -41,7 +40,6 @@ import static oracle.kubernetes.operator.EventConstants.INTERNAL_ERROR;
 import static oracle.kubernetes.operator.EventMatcher.hasEvent;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR_JOB;
 import static oracle.kubernetes.operator.ProcessingConstants.FATAL_INTROSPECTOR_ERROR;
-import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.EVENT;
 import static oracle.kubernetes.operator.logging.MessageKeys.DOMAIN_ROLL_START;
 import static oracle.kubernetes.utils.LogMatcher.containsInfo;
 import static oracle.kubernetes.weblogic.domain.model.DomainCondition.TRUE;
@@ -49,7 +47,10 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Rolling;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 /**
@@ -165,15 +166,14 @@ class DomainStatusUpdaterTest {
 
     testSupport.runSteps(createInternalFailureSteps(failure, null));
 
-    assertThat(getEvents().stream().anyMatch(this::isInternalFailedEvent), is(true));
+    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(INTERNAL_ERROR));
   }
 
   @Test
   void failedStepWithFailureMessage_doesNotContainValidationWarnings() {
     info.addValidationWarning(validationWarning);
 
-    testSupport.runSteps(createInternalFailureSteps(failure,
-        testSupport.getPacket().getValue(DOMAIN_INTROSPECTOR_JOB)));
+    testSupport.runSteps(createInternalFailureSteps(failure, job));
 
     assertThat(getRecordedDomain().getStatus().getMessage(), not(containsString(validationWarning)));
   }
@@ -182,8 +182,7 @@ class DomainStatusUpdaterTest {
   void whenDomainLacksStatus_failedStepUpdatesDomainWithFailedTrueAndException() {
     domain.setStatus(null);
 
-    testSupport.runSteps(createInternalFailureSteps(failure,
-        testSupport.getPacket().getValue(DOMAIN_INTROSPECTOR_JOB)));
+    testSupport.runSteps(createInternalFailureSteps(failure, job));
 
     assertThat(
         getRecordedDomain(),
@@ -194,14 +193,9 @@ class DomainStatusUpdaterTest {
   void whenDomainLacksStatus_generateFailedEvent() {
     domain.setStatus(null);
 
-    testSupport.runSteps(createInternalFailureSteps(failure,
-        testSupport.getPacket().getValue(DOMAIN_INTROSPECTOR_JOB)));
+    testSupport.runSteps(createInternalFailureSteps(failure, job));
 
-    assertThat(getEvents().stream().anyMatch(this::isInternalFailedEvent), is(true));
-  }
-
-  private boolean isInternalFailedEvent(CoreV1Event e) {
-    return DOMAIN_FAILED_EVENT.equals(e.getReason()) && getMessage(e).contains(INTERNAL_ERROR);
+    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(INTERNAL_ERROR));
   }
 
   @Test
@@ -224,18 +218,16 @@ class DomainStatusUpdaterTest {
 
   @Test
   void whenDomainLacksFailedCondition_failedStepUpdatesDomainWithFailedTrueAndException() {
-    testSupport.runSteps(createInternalFailureSteps(failure,
-        testSupport.getPacket().getValue(DOMAIN_INTROSPECTOR_JOB)));
+    testSupport.runSteps(createInternalFailureSteps(failure, job));
 
-    assertThat(getEvents().stream().anyMatch(this::isInternalFailedEvent), is(true));
+    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(INTERNAL_ERROR));
   }
 
   @Test
   void afterIntrospectionFailure_generateDomainAbortedEvent() {
-    testSupport.runSteps(DomainStatusUpdater.createIntrospectionFailureSteps(FATAL_INTROSPECTOR_ERROR,
-        testSupport.getPacket().getValue(DOMAIN_INTROSPECTOR_JOB)));
+    testSupport.runSteps(DomainStatusUpdater.createIntrospectionFailureSteps(FATAL_INTROSPECTOR_ERROR, job));
 
-    assertThat(getEvents().stream().anyMatch(this::isDomainAbortedEvent), is(true));
+    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(ABORTED_ERROR));
   }
 
   private V1Job createIntrospectorJob(String uid) {
@@ -250,22 +242,41 @@ class DomainStatusUpdaterTest {
     return LegalNames.toJobIntrospectorName(UID);
   }
 
-  private List<CoreV1Event> getEvents() {
-    return testSupport.getResources(EVENT);
-  }
-
-  private boolean isDomainAbortedEvent(CoreV1Event e) {
-    return DOMAIN_FAILED_EVENT.equals(e.getReason()) && getMessage(e).contains(ABORTED_ERROR);
-  }
-
-  private String getMessage(CoreV1Event e) {
-    return Optional.ofNullable(e.getMessage()).orElse("");
-  }
-
   private Domain getRecordedDomain() {
     return testSupport.getResourceWithName(KubernetesTestSupport.DOMAIN, NAME);
   }
 
   // todo when new failures match old ones, leave the old matches
 
+  // temporary tests
+
+
+  @Test
+  void whenFailureStepCreatedWithoutCount_uidIsNull() {
+    final DomainStatusUpdater.FailureStep failureSteps = DomainStatusUpdater.createFailedStep(Introspection, "");
+
+    assertThat(failureSteps.jobUid, nullValue());
+  }
+
+
+  @Test
+  void whenFailureStepCreatedWithCountOnNullJob_uidIsEmpty() {
+    final DomainStatusUpdater.FailureStep failureSteps
+          = (DomainStatusUpdater.FailureStep) DomainStatusUpdater.createFailedStep(Internal, "").trackingRetries(null);
+
+    assertThat(failureSteps.jobUid, emptyString());
+  }
+
+
+  @Test
+  void whenFailureStepCreatedWithCountOnJob_uidMatchesJobUid() {
+    final DomainStatusUpdater.FailureStep failureSteps = (DomainStatusUpdater.FailureStep)
+          DomainStatusUpdater.createFailedStep(Introspection, "").trackingRetries(createIntrospectorJob("abcd"));
+
+    assertThat(failureSteps.jobUid, equalTo("abcd"));
+  }
+
+  @Test
+  void whenFailureContains() {
+  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -64,6 +64,7 @@ import static oracle.kubernetes.operator.EventConstants.START_MANAGING_NAMESPACE
 import static oracle.kubernetes.operator.EventConstants.STOP_MANAGING_NAMESPACE_EVENT;
 import static oracle.kubernetes.operator.EventConstants.TOPOLOGY_MISMATCH_ERROR;
 import static oracle.kubernetes.operator.EventConstants.WILL_NOT_RETRY;
+import static oracle.kubernetes.operator.EventMatcher.hasEvent;
 import static oracle.kubernetes.operator.EventTestUtils.containsEvent;
 import static oracle.kubernetes.operator.EventTestUtils.containsEventWithInvolvedObject;
 import static oracle.kubernetes.operator.EventTestUtils.containsEventWithLabels;
@@ -184,8 +185,7 @@ class EventHelperTest {
     dispatchAddedEventWatches();
     testSupport.runSteps(createTopologyMismatchFailureSteps("Test failure"));
 
-    assertThat("Found DOMAIN_FAILED event",
-        containsOneEventWithCount(getEvents(testSupport), DOMAIN_FAILED_EVENT, 2), is(true));
+    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).inNamespace(NS).withCount(2));
   }
 
   @Test
@@ -214,8 +214,7 @@ class EventHelperTest {
     dispatchAddedEventWatches();
     testSupport.runSteps(createDomainInvalidFailureSteps("Test failure"));
 
-    assertThat("Found DOMAIN_FAILED event",
-        containsOneEventWithCount(getEvents(testSupport), DOMAIN_FAILED_EVENT, 2), is(true));
+    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).inNamespace(NS).withCount(2));
   }
 
   @Test


### PR DESCRIPTION
As we've added a fair bit of changes, we've not kept the code as well-factored as it could be. This is an attempt to improve the code structure that needs to change to deal with the status fixes we've discussed, including better aligning failures and their corresponding events. This change also contains an adjustment to the understanding of maximum retries.

Jenkins run at https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9198/