### PR TITLE
first pass at install and upgrade

### DIFF
--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -12,7 +12,6 @@ description: "How to install, upgrade, and uninstall the operator."
 - [Set up domain namespaces](#set-up-domain-namespaces)
 - [Update a running operator](#update-a-running-operator)
 - [Upgrade the operator](#upgrade-the-operator)
-  - [Upgrading a 3.x operator](#upgrading-a-3x-operator)
 - [Uninstall the operator](#uninstall-the-operator)
 - [Installation sample](#installation-sample)
 
@@ -179,8 +178,6 @@ Example updates:
 
 You can upgrade a 3.x operator while the operator's domain resources are deployed and running.
 
-#### Upgrading a 3.x operator
-
 The following instructions will be applicable to upgrade operators
 as additional versions are released.
 
@@ -190,6 +187,9 @@ When upgrading the operator:
 - Use the `helm upgrade` command with the `--reuse-values` parameter.
 - Supply a new `image` value.
 
+This is because, even with a new version of the Helm chart,
+`--reuse-values` will retain the previous image value from when it was installed.  To upgrade,
+you must override the image value to use the new operator image version.
 
 For example:
 
@@ -213,7 +213,7 @@ during the upgrade.
 {{% notice note %}}
 If you uninstall an operator, then any domains that it is managing will continue running;
 however, any changes to a domain resource that was managed by the operator
-will not be be detected or automatically handled, and, if you
+will not be detected or automatically handled, and, if you
 want to clean up such a domain, then you will need to manually delete
 all of the domain's resources (domain, pods, services, and such).
 {{% /notice %}}

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -88,6 +88,13 @@ Each version of the Helm chart defaults to using an image from the matching vers
 ```text
 $ helm repo add weblogic-operator https://oracle.github.io/weblogic-kubernetes-operator/charts --force-update  
 ```
+- To get information about the operator Helm chart, use the `helm show` command. For example,
+using `helm show` with an operator Helm chart where the repository is named `weblogic-operator`:
+```text
+$ helm show chart weblogic-operator/weblogic-operator
+$ helm show values weblogic-operator/weblogic-operator
+```
+
 - To list the versions of the operator that you can install from the Helm chart repository:
 
   ```text

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -39,7 +39,7 @@ Minimally you should specify:
 - The Helm chart location
 - The operator namespace
 - The platform (if required)
-- The name space selection settings.
+- The name space selection settings
 
 A typical Helm release name is `weblogic-operator`.
 The operator samples and documentation
@@ -181,29 +181,29 @@ You can upgrade a 3.x operator while the operator's domain resources are deploye
 
 #### Upgrading a 3.x operator
 
-The following instructions will be applicable to upgrade operators within the 3.x releases,
+The following instructions will be applicable to upgrade operators
 as additional versions are released.
 
 When upgrading the operator:
 
+- Use `helm repo add` to supply a new version of the Helm chart.
 - Use the `helm upgrade` command with the `--reuse-values` parameter.
 - Supply a new `image` value.
-- Supply a new Helm chart that corresponds to the image.
+
 
 For example:
 
 ```text
+$ helm repo add weblogic-operator https://oracle.github.io/weblogic-kubernetes-operator/charts --force-update
 $ helm upgrade sample-weblogic-operator \
   weblogic-operator/weblogic-operator \
   --reuse-values \
   --set image=ghcr.io/oracle/weblogic-kubernetes-operator:{{< latestVersion >}} \
   --namespace sample-weblogic-operator-ns \
-  --wait \
-  sample-weblogic-operator \
-  kubernetes/charts/weblogic-operator
+  --wait
 ```
 
-Upgrading a 3.x operator within the 3.x releases will _not_ automatically roll
+Upgrading a 3.x operator will _not_ automatically roll
 any running WebLogic Server instances created by the original operator. It
 is not necessary and such instances will continue to run without interruption
 during the upgrade.

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -65,6 +65,7 @@ If the namespace already exists, then Helm will use it. These are standard Helm 
 Similarly, you may override the default `serviceAccount` configuration value
 to specify a service account in the operator's namespace that the operator will use.
 If not specified, then it defaults to `default` (the namespace's default service account).
+For common use cases, the namespace `default` service account is sufficient.
 If you want to use a different service account (recommended),
 then you must create the operator's namespace
 and the service account before installing the operator Helm chart
@@ -77,17 +78,12 @@ For example, using Helm 3.x, with the following settings:
 |Helm release name|`sample-weblogic-operator` (you may choose any name)|
 |Helm chart repo location|`https://oracle.github.io/weblogic-kubernetes-operator/charts`|
 |`namespace`|`sample-weblogic-operator-ns`|
-|`serviceAccount`|`sample-weblogic-operator-sa`|
 |`enableClusterRoleBinding`|`true` (gives operator permission to automatically install the Domain CRD and to manage domain resources in any namespace)|
 |`domainNamespaceSelectionStrategy`|`LabelSelector` (limits operator to managing namespaces that match the specified label selector)|
 |`domainNamespaceLabelSelector`|`weblogic-operator\=enabled` (the label and expected value for the label)|
 
 ```text
 $ kubectl create namespace sample-weblogic-operator-ns
-```
-
-```text
-$ kubectl create serviceaccount -n sample-weblogic-operator-ns sample-weblogic-operator-sa
 ```
 Access the operator Helm chart using this format: `helm repo add <helm-repo-name> <helm-repo-url>`
 ```text
@@ -100,14 +96,13 @@ $ helm repo add weblogic-operator https://oracle.github.io/weblogic-kubernetes-o
   ```
 
 - For a specified version of the Helm chart and operator, use the `--version <value>` option with `helm install`
-  to choose the version that you want, with the `latest` value being the default. 
+  to choose the version that you want, with the `latest` value being the default.
 
 Install the operator using this format: `helm install <helm-release-name> <helm-repo-name>/weblogic-operator ...`
 ```text
 $ helm install sample-weblogic-operator \
   weblogic-operator/weblogic-operator \
   --namespace sample-weblogic-operator-ns \
-  --set serviceAccount=sample-weblogic-operator-sa \
   --set "enableClusterRoleBinding=true" \
   --set "domainNamespaceSelectionStrategy=LabelSelector" \
   --set "domainNamespaceLabelSelector=weblogic-operator\=enabled" \
@@ -118,7 +113,6 @@ Or, instead of using the previous `helm install` command,
 create a YAML file named `custom-values.yaml` with the following contents:
 
 ```
-serviceAcount: "sample-weblogic-operator-sa"
 enableClusterRoleBinding: true
 domainNamespaceSelectionStrategy: LabelSelector
 domainNamespaceLabelSelector: "weblogic-operator=enabled"

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -12,7 +12,6 @@ description: "How to install, upgrade, and uninstall the operator."
 - [Set up domain namespaces](#set-up-domain-namespaces)
 - [Update a running operator](#update-a-running-operator)
 - [Upgrade the operator](#upgrade-the-operator)
-  - [Upgrading a 2.6 operator to a 3.x operator](#upgrading-a-26-operator-to-a-3x-operator)
   - [Upgrading a 3.x operator](#upgrading-a-3x-operator)
 - [Uninstall the operator](#uninstall-the-operator)
 - [Installation sample](#installation-sample)
@@ -31,23 +30,22 @@ Before installing the operator, ensure that each of its prerequisite requirement
 See [Prepare for installation]({{<relref "/userguide/managing-operators/preparation.md">}}).
 {{% /notice %}}
 
-To install the operator, first ensure that each of its prerequisite requirements is met,
-see [Prepare for installation]({{<relref "/userguide/managing-operators/preparation.md">}}),
-and then use the `helm install` command with the operator Helm chart as
-per the following instructions.
+After meeting the [prerequisite requirements]({{<relref "/userguide/managing-operators/preparation.md">}}),
+install the operator using the `helm install` command with the operator Helm chart according
+to the following instructions.
 
-As part of this, you should minimally specify
-a Helm "release" name for the operator,
-the Helm chart location,
-the operator namespace and service account,
-the platform (if required),
-and name space selection settings.
+Minimally you should specify:
+- A Helm "release" name for the operator
+- The Helm chart location
+- The operator namespace
+- The platform (if required)
+- The name space selection settings.
 
 A typical Helm release name is `weblogic-operator`.
 The operator samples and documentation
 often use `sample-weblogic-operator`.
 
-You can override default configuration values in the chart by doing one of the following:
+You can override default configuration values in the Helm chart by doing one of the following:
 
 - Creating a custom YAML file containing the values to be overridden,
   and specifying the `--value` option on the Helm command line.
@@ -58,18 +56,17 @@ You supply the `--namespace` argument from the `helm install` command line
 to specify the namespace in which the operator will be installed.
 If not specified, then it defaults to `default`.
 If the namespace does not already exist, then Helm will automatically create it
-(and create Kubernetes will also create a default service account named `-default` in the new namespace),
+(and will also create a default Kubernetes service account named `-default` in the new namespace),
 but note that Helm will not remove the namespace or service account when the release is uninstalled.
 If the namespace already exists, then Helm will use it. These are standard Helm behaviors.
 
 Similarly, you may override the default `serviceAccount` configuration value
 to specify a service account in the operator's namespace that the operator will use.
-If not specified, then it defaults to `default` (the namespace's default service account).
 For common use cases, the namespace `default` service account is sufficient.
 If you want to use a different service account (recommended),
 then you must create the operator's namespace
 and the service account before installing the operator Helm chart
-(for instructions, see [Prepare for installation]({{<relref "/userguide/managing-operators/preparation.md">}})).
+(for instructions, see [Prepare for installation]({{<relref "/userguide/managing-operators/preparation#prepare-an-operator-namespace-and-service-account">}})).
 
 For example, using Helm 3.x, with the following settings:
 
@@ -77,6 +74,7 @@ For example, using Helm 3.x, with the following settings:
 |-|-|
 |Helm release name|`sample-weblogic-operator` (you may choose any name)|
 |Helm chart repo location|`https://oracle.github.io/weblogic-kubernetes-operator/charts`|
+|Helm repo name|`weblogic-operator`|
 |`namespace`|`sample-weblogic-operator-ns`|
 |`enableClusterRoleBinding`|`true` (gives operator permission to automatically install the Domain CRD and to manage domain resources in any namespace)|
 |`domainNamespaceSelectionStrategy`|`LabelSelector` (limits operator to managing namespaces that match the specified label selector)|
@@ -85,7 +83,8 @@ For example, using Helm 3.x, with the following settings:
 ```text
 $ kubectl create namespace sample-weblogic-operator-ns
 ```
-Access the operator Helm chart using this format: `helm repo add <helm-repo-name> <helm-repo-url>`
+Access the operator Helm chart using this format: `helm repo add <helm-repo-name> <helm-repo-url>`.
+Each version of the Helm chart defaults to using an image from the matching version.
 ```text
 $ helm repo add weblogic-operator https://oracle.github.io/weblogic-kubernetes-operator/charts --force-update  
 ```
@@ -139,20 +138,20 @@ To check if the operator is deployed and running,
 see [Troubleshooting]({{<relref "/userguide/managing-operators/troubleshooting.md">}}).
 
 **Notes**:
-- We have not set the `kubernetesPlatform` in this example, but this may be required
+- In this example, you have not set the `kubernetesPlatform`, but this may be required
   for your environment.
   See [Determine the platform setting]({{<relref "/userguide/managing-operators/preparation#determine-the-platform-setting">}}).
 - For more information on specifying the registry credentials when the operator image is stored in a private registry, see
-  See [Customizing operator image name, pull secret, and private registry]({{<relref "/userguide/managing-operators/preparation#customizing-operator-image-name-pull-secret-and-private-registry">}}).
+  [Customizing operator image name, pull secret, and private registry]({{<relref "/userguide/managing-operators/preparation#customizing-operator-image-name-pull-secret-and-private-registry">}}).
 - Do not include a backslash (`\`) before the equals sign (`=`) in a domain namespace label selector
-  when specifying the selector in YAML.
+  when specifying the selector in a YAML file.
   A backslash (`\`) is only required when specifying the selector on the command line using `--set`,
-  as in the previous example.
+  as shown in the previous example.
 
 ### Set up domain namespaces
 
 To configure or alter the namespaces that an operator will check for domain resources,
-see the operator [Namespace management]({{<relref "/userguide/managing-operators/namespace-management.md">}}).
+see [Namespace management]({{<relref "/userguide/managing-operators/namespace-management.md">}}).
 
 ### Update a running operator
 
@@ -164,9 +163,9 @@ have already specified (otherwise the operator
 will revert to using the default for all values).
 
 Example updates:
-- Change the image of a running operator, see [Upgrade the operator](#upgrade-the-operator).
-- Change the logging level, see [Operator logging level]({{< relref "/userguide/managing-operators/troubleshooting#operator-logging-level" >}}).
-- Change the managed namespaces, see
+- Change the image of a running operator; see [Upgrade the operator](#upgrade-the-operator).
+- Change the logging level; see [Operator logging level]({{< relref "/userguide/managing-operators/troubleshooting#operator-logging-level" >}}).
+- Change the managed namespaces; see
   [Namespace management]({{<relref "/userguide/managing-operators/namespace-management.md">}}).
 
 ### Upgrade the operator
@@ -182,7 +181,7 @@ When upgrading the operator:
 
 - Use the `helm upgrade` command with the `--reuse-values` parameter.
 - Supply a new `image` value.
-- Supply a new Helm chart the corresponds to the image.
+- Supply a new Helm chart that corresponds to the image.
 
 For example:
 

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -99,8 +99,8 @@ $ helm repo add weblogic-operator https://oracle.github.io/weblogic-kubernetes-o
   $ helm search repo weblogic-operator/weblogic-operator --versions
   ```
 
-- For a specified version of the Helm chart, use the `--version <value>` option with `helm install`
-  to choose the version that you want, with the `latest` value being the default.
+- For a specified version of the Helm chart and operator, use the `--version <value>` option with `helm install`
+  to choose the version that you want, with the `latest` value being the default. 
 
 Install the operator using this format: `helm install <helm-release-name> <helm-repo-name>/weblogic-operator ...`
 ```text

--- a/documentation/staging/content/userguide/managing-operators/preparation.md
+++ b/documentation/staging/content/userguide/managing-operators/preparation.md
@@ -95,7 +95,7 @@ You can set up access to the operator Helm chart using the GitHub chart reposito
   $ helm search repo weblogic-operator/weblogic-operator --versions
   ```
 
-- For a specified version of the Helm chart, with `helm pull` and `helm install`, use the `--version <value>` option
+- For a specified version of the Helm chart and operator, with `helm pull` and `helm install`, use the `--version <value>` option
   to choose the version that you want, with the `latest` value being the default.
 
 #### Inspect the operator Helm chart

--- a/documentation/staging/content/userguide/managing-operators/preparation.md
+++ b/documentation/staging/content/userguide/managing-operators/preparation.md
@@ -101,17 +101,17 @@ You can set up access to the operator Helm chart using the GitHub chart reposito
 #### Inspect the operator Helm chart
 
 You can find out the configuration values that the operator Helm chart supports,
-as well as the default values, using the `helm inspect` command.
+as well as the default values, using the `helm show` command.
 
   ```text
-  $ helm inspect values kubernetes/charts/weblogic-operator
+  $ helm show values kubernetes/charts/weblogic-operator
   ```
-- Here's an example of using `helm inspect`
+- Here's an example of using `helm show`
   with a GitHub chart repository-based operator Helm chart:
   ```text
-  $ helm inspect values weblogic-operator/weblogic-operator
+  $ helm show values weblogic-operator/weblogic-operator
   ```
-- Here's an example of using `helm inspect`
+- Here's an example of using `helm show`
   with the local file-based operator Helm chart:
   ```text
   $ cd /tmp/weblogic-kubernetes-operator

--- a/documentation/staging/content/userguide/managing-operators/using-helm.md
+++ b/documentation/staging/content/userguide/managing-operators/using-helm.md
@@ -65,8 +65,8 @@ and [Installation and upgrade]({{< relref "/userguide/managing-operators/install
 ### Useful Helm operations
 
 - You can find out the configuration values that the operator Helm chart supports,
-  as well as the default values, using the `helm inspect` command.
-  - Here's an example of using `helm inspect`
+  as well as the default values, using the `helm show` command.
+  - Here's an example of using `helm show`
     with the local file based operator Helm chart
     assuming the operator source code is in
     `/tmp/weblogic-kubernetes-operator`.
@@ -74,13 +74,13 @@ and [Installation and upgrade]({{< relref "/userguide/managing-operators/install
     $ cd /tmp/weblogic-kubernetes-operator
     ```
     ```text
-    $ helm inspect values kubernetes/charts/weblogic-operator
+    $ helm show values kubernetes/charts/weblogic-operator
     ```
-  - Here's an example of using `helm inspect`
+  - Here's an example of using `helm show`
     with a GitHub chart repository based operator Helm chart
     where the repository is named `weblogic-operator`:
     ```text
-    $ helm inspect values weblogic-operator/weblogic-operator
+    $ helm show values weblogic-operator/weblogic-operator
     ```
   Alternatively, you can view most of the configuration values
   and their defaults in the operator source in the
@@ -191,7 +191,7 @@ See [Ensuring the operator has permission to manage a namespace]({{< relref "/us
 Specifies the container image containing the operator code.
 
 Defaults to `ghcr.io/oracle/weblogic-kubernetes-operator:{{< latestVersion >}}`
-or similar (based on the default in your Helm chart, see `helm inspect`
+or similar (based on the default in your Helm chart, see `helm show`
 in [Useful Helm operations](#useful-helm-operations)).
 
 Example:
@@ -506,11 +506,11 @@ elasticSearchPort: 9201
 ```
 
 ##### `createLogStashConfigMap`
-Specifies whether a ConfigMap named `weblogic-operator-logstash-cm` should be created during `helm install`. 
+Specifies whether a ConfigMap named `weblogic-operator-logstash-cm` should be created during `helm install`.
 The ConfigMap contains the Logstash pipeline configuration for the Logstash container running in the operator pod.
 If set to `true`, a ConfigMap will be created during `helm install` using the `logstash.conf` file in the `kubernetes/samples/charts/weblogic-operator` directory.
 Set `createLogStashConfigMap` to `false` if the ConfigMap already exists in the operator's namespace with the Logstash configuration provided by the customer.
-This parameter is ignored if `elkIntegrationEnabled` is false. 
+This parameter is ignored if `elkIntegrationEnabled` is false.
 
 Defaults to `true`.
 


### PR DESCRIPTION
PR to update the Installation and Upgrade doc as per [OWLS-95907](https://jira.oraclecorp.com/jira/browse/OWLS-95907) Operator User Guide Feedback and Updates for 4.0. 

**NOTE**: The upgrade section is preliminarily modified _only_: 

- I created JIRA [OWLS-97331](https://jira.oraclecorp.com/jira/browse/OWLS-97331) for development input. 
- In this PR, I removed the section "Upgrading a 2.6 operator to a 3.x operator" as explained in [OWLS-95907](https://jira.oraclecorp.com/jira/browse/OWLS-95907).
- 
@rjeberhard @tbarnes-us 
**ALSO**: Please answer whether this text in the Uninstall section is needed:
After removing the operator deployment,
you should also remove the Domain custom resource definition (CRD) if it is no longer needed:
```text
$ kubectl delete customresourcedefinition domains.weblogic.oracle
```
Note that the Domain custom resource definition is shared.
Do not delete the CRD if there are other operators in the same cluster
or you have running domain resources.