### PR TITLE
OWLS-96905 - Fixes NPE in ManagedServersUpStep.scaleDownIfNecessary()

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -64,7 +64,9 @@ public class ManagedServersUpStep extends Step {
     List<Step> steps = new ArrayList<>(Collections.singletonList(next));
 
     if (info.getDomain().isShuttingDown()) {
-      factory.shutdownInfos.add(new ServerShutdownInfo(domainTopology.getAdminServerName(), null));
+      Optional.ofNullable(domainTopology).ifPresent(
+          wlsDomainConfig ->
+              factory.shutdownInfos.add(new ServerShutdownInfo(wlsDomainConfig.getAdminServerName(), null)));
     }
 
     List<ServerShutdownInfo> serversToStop = getServersToStop(info, factory.shutdownInfos);

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;
@@ -522,6 +522,14 @@ class ManagedServersUpStepTest {
   }
 
   @Test
+  void whenShuttingDown_withNullWlsDomainConfig_ensureNoException() {
+    configurator.setShuttingDown(true);
+
+    assertThat(createNextStepWithNullWlsDomainConfig(), instanceOf(ClusterServicesStep.class));
+  }
+
+
+  @Test
   void whenClusterStartupDefinedWithPreCreateServerService_addAllToServers() {
     configureCluster("cluster1").withPrecreateServerService(true);
     addWlsCluster("cluster1", "ms1", "ms2");
@@ -693,6 +701,14 @@ class ManagedServersUpStepTest {
             .forEach(s -> addShutdownServerInfo(s, servers, ssi));
     serversUpStepFactory.shutdownInfos.addAll(ssi);
     return factory.createServerStep(domainPresenceInfo, config, serversUpStepFactory, nextStep);
+  }
+
+  private Step createNextStepWithNullWlsDomainConfig() {
+    configSupport.setAdminServerName(ADMIN);
+    ManagedServersUpStep.NextStepFactory factory = factoryMemento.getOriginalValue();
+    ServersUpStepFactory serversUpStepFactory = new ServersUpStepFactory(null, domainPresenceInfo, false);
+    List<DomainPresenceInfo.ServerShutdownInfo> ssi = new ArrayList<>();
+    return factory.createServerStep(domainPresenceInfo, null, serversUpStepFactory, nextStep);
   }
 
   private void addShutdownServerInfo(String serverName, List<String> servers,


### PR DESCRIPTION
domainTopology (a WlsDomainConfig) could be null if domain is created with NEVER serverStartPolicy.

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9201/