### PR TITLE
Fix the OKD nightly regression introduced by ItMultiDomainModels

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -329,7 +329,8 @@
                 <includes-failsafe>
                   **/ItCrossDomainTransaction,
                   **/ItKubernetesEvents,
-                  **/ItMiiAuxiliaryImage, **/ItMiiCreateAuxImageWithImageTool,
+                  **/ItMiiAuxiliaryImage,
+                  **/ItMiiCreateAuxImageWithImageTool,
                   **/ItMiiAuxiliaryImageCluster,
                   **/ItMiiDomain,
                   **/ItMiiDomainModelInPV,

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -338,7 +338,6 @@
                   **/ItMiiNewCreateAuxImage,
                   **/ItMiiUpdateDomainConfig,
                   **/ItMiiNewCreateAuxImage,
-                  **/ItMultiDomainModelsWithLoadBalancer,
                   **/ItPodsRestart
                 </includes-failsafe>
             </properties>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -329,8 +329,7 @@
                 <includes-failsafe>
                   **/ItCrossDomainTransaction,
                   **/ItKubernetesEvents,
-                  **/ItMiiAuxiliaryImage,
-		  **/ItMiiCreateAuxImageWithImageTool,
+                  **/ItMiiAuxiliaryImage, **/ItMiiCreateAuxImageWithImageTool,
                   **/ItMiiAuxiliaryImageCluster,
                   **/ItMiiDomain,
                   **/ItMiiDomainModelInPV,
@@ -338,6 +337,7 @@
                   **/ItMiiNewCreateAuxImage,
                   **/ItMiiUpdateDomainConfig,
                   **/ItMiiNewCreateAuxImage,
+                  **/ItMultiDomainModels,
                   **/ItPodsRestart
                 </includes-failsafe>
             </properties>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -458,7 +458,7 @@
                   **/ItMiiDomain,
                   **/ItMiiDynamicUpdate,
                   **/ItMiiNewCreateAuxImage,
-                  **/ItMultiDomainModelsWithLoadBalancer,
+                  **/ItMultiDomainModels,
                   **/ItPodsShutdownOption,
                   **/ItFmwDynamicDomainInPV,
                   **/ItFmwMiiDomain

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -143,18 +143,7 @@ class ItMultiDomainModels {
     managedServersBeforeScale = listManagedServersBeforeScale(numberOfServers);
     scaleAndVerifyCluster(clusterName, domainUid, domainNamespace, managedServerPodNamePrefix,
         numberOfServers, replicaCount, null, managedServersBeforeScale);
-
-    /*String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
-    logger.info("Getting node port for default channel");
-    int serviceNodePort = assertDoesNotThrow(() -> getServiceNodePort(
-        domainNamespace, getExternalServicePodName(adminServerPodName), "default"),
-        "Getting admin server node port failed");
-
-    // In OKD cluster, we need to get the routeHost for the external admin service
-    String routeHost = getRouteHost(domainNamespace, getExternalServicePodName(adminServerPodName));
-
-     */
-
+    
     logger.info("Validating WebLogic admin server access by login to console");
     testUntil(
         assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -31,6 +31,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createAndVerifyDomainInImageUsingWdt;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainOnPvUsingWdt;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.shutdownDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.OKDUtils.getRouteHost;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -139,10 +140,13 @@ class ItMultiDomainModels {
         domainNamespace, getExternalServicePodName(adminServerPodName), "default"),
         "Getting admin server node port failed");
 
+    // In OKD cluster, we need to get the routeHost for the external admin service
+    String routeHost = getRouteHost(domainNamespace, getExternalServicePodName(adminServerPodName));
+
     logger.info("Validating WebLogic admin server access by login to console");
     testUntil(
         assertDoesNotThrow(() -> {
-          return adminNodePortAccessible(serviceNodePort, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
+          return adminNodePortAccessible(serviceNodePort, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, routeHost);
         }, "Access to admin server node port failed"),
         logger,
         "Console login validation");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -31,7 +31,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createAndVerifyDomainInImageUsingWdt;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainOnPvUsingWdt;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.shutdownDomainAndVerify;
-import static oracle.weblogic.kubernetes.utils.OKDUtils.getRouteHost;
+import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -120,6 +120,16 @@ class ItMultiDomainModels {
 
     String managedServerPodNamePrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
 
+    String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+    logger.info("Getting node port for default channel");
+    int serviceNodePort = assertDoesNotThrow(() -> getServiceNodePort(
+        domainNamespace, getExternalServicePodName(adminServerPodName), "default"),
+        "Getting admin server node port failed");
+
+    // In OKD cluster, we need to get the routeHost for the external admin service
+    String routeHost = createRouteForOKD(getExternalServicePodName(adminServerPodName), domainNamespace);
+
+
     int numberOfServers = 3;
     logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers.",
         clusterName, domainUid, domainNamespace, numberOfServers);
@@ -134,7 +144,7 @@ class ItMultiDomainModels {
     scaleAndVerifyCluster(clusterName, domainUid, domainNamespace, managedServerPodNamePrefix,
         numberOfServers, replicaCount, null, managedServersBeforeScale);
 
-    String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
+    /*String adminServerPodName = domainUid + "-" + ADMIN_SERVER_NAME_BASE;
     logger.info("Getting node port for default channel");
     int serviceNodePort = assertDoesNotThrow(() -> getServiceNodePort(
         domainNamespace, getExternalServicePodName(adminServerPodName), "default"),
@@ -142,6 +152,8 @@ class ItMultiDomainModels {
 
     // In OKD cluster, we need to get the routeHost for the external admin service
     String routeHost = getRouteHost(domainNamespace, getExternalServicePodName(adminServerPodName));
+
+     */
 
     logger.info("Validating WebLogic admin server access by login to console");
     testUntil(

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -70,6 +70,7 @@ import static oracle.weblogic.kubernetes.TestConstants.HTTPS_PROXY;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_MODEL_PROPERTIES_FILE;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_IMAGE_DOMAINHOME_BASE_DIR;
@@ -759,19 +760,10 @@ public class DomainUtils {
                                       String namespace,
                                       V1Container jobContainer) {
     getLogger().info("Running Kubernetes job to create domain");
-    V1Job jobBody = new V1Job()
-        .metadata(
-            new V1ObjectMeta()
-                .name("create-domain-onpv-job-" + pvName) // name of the create domain job
-                .namespace(namespace))
-        .spec(new V1JobSpec()
-            .backoffLimit(0) // try only once
-            .template(new V1PodTemplateSpec()
-                .spec(new V1PodSpec()
-                    .restartPolicy("Never")
-                    .addInitContainersItem(createfixPVCOwnerContainer(pvName, "/u01/shared"))
-                    .addContainersItem(jobContainer  // container containing WLST or WDT details
-                        .name("create-weblogic-domain-onpv-container")
+    V1PodSpec podSpec = new V1PodSpec()
+        .restartPolicy("Never")
+        .addContainersItem(jobContainer  // container containing WLST or WDT details
+               .name("create-weblogic-domain-onpv-container")
                         .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                         .imagePullPolicy("IfNotPresent")
                         .addPortsItem(new V1ContainerPort()
@@ -779,7 +771,7 @@ public class DomainUtils {
                         .volumeMounts(Arrays.asList(
                             new V1VolumeMount()
                                 .name("create-weblogic-domain-job-cm-volume") // domain creation scripts volume
-                                .mountPath("/u01/weblogic"), // availble under /u01/weblogic inside pod
+                                  .mountPath("/u01/weblogic"), // availble under /u01/weblogic inside pod
                             new V1VolumeMount()
                                 .name(pvName) // location to write domain
                                 .mountPath("/u01/shared")))) // mounted under /u01/shared inside pod
@@ -794,9 +786,23 @@ public class DomainUtils {
                             .configMap(
                                 new V1ConfigMapVolumeSource()
                                     .name(domainScriptCM)))) //config map containing domain scripts
-                    .imagePullSecrets(Collections.singletonList(
+                    .imagePullSecrets(Arrays.asList(
                         new V1LocalObjectReference()
-                            .name(BASE_IMAGES_REPO_SECRET))))));  // this secret is used only for non-kind cluster
+                            .name(BASE_IMAGES_REPO_SECRET)));  // this secret is used only for non-kind cluster
+    if (!OKD) {
+      podSpec.initContainers(Arrays.asList(createfixPVCOwnerContainer(pvName, "/u01/shared")));
+    }
+
+    V1PodTemplateSpec podTemplateSpec = new V1PodTemplateSpec();
+    podTemplateSpec.spec(podSpec);
+    V1Job jobBody = new V1Job()
+        .metadata(
+            new V1ObjectMeta()
+                .name("create-domain-onpv-job-" + pvName) // name of the create domain job
+                .namespace(namespace))
+        .spec(new V1JobSpec()
+            .backoffLimit(0) // try only once
+            .template(podTemplateSpec));
 
     String jobName = createJobAndWaitUntilComplete(jobBody, namespace);
 


### PR DESCRIPTION
wko-okd-wls-srg passed without any failure
https://build.weblogick8s.org:8443/job/wko-okd-test/227/
kind new:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9216/ 
The only failure ItPodsRestart.testServerPodsRestartByChangingIncludeServerOutInPodLog is mii domain, while the fix of this PR is for domain on PV