### PR TITLE
back port elasticlogging and elasticloggingfluentd changes from main

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -81,6 +81,7 @@ import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAnd
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.verifyLoggingExporterReady;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.upgradeAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
@@ -186,6 +187,9 @@ class ItElasticLogging {
     installAndVerifyOperator(opNamespace, opNamespace + "-sa",
         false, 0, true, domainNamespace);
 
+    String operatorPodName = assertDoesNotThrow(
+        () -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
+
     // install WebLogic Logging Exporter
     installAndVerifyWlsLoggingExporter(managedServerFilter,
         wlsLoggingExporterYamlFileLoc, elasticSearchNs);
@@ -214,6 +218,9 @@ class ItElasticLogging {
 
     assertTrue(upgradeAndVerifyOperator(opNamespace, opParams),
         String.format("Failed to upgrade operator in namespace %s", opNamespace));
+
+    // check operator pod is not running
+    checkPodDoesNotExist(operatorPodName, null, opNamespace);
 
     // wait for the operator to be ready
     logger.info("Wait for the operator pod is ready in namespace {0}", opNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -203,8 +203,8 @@ class ItElasticLogging {
     logger.info("Elasticsearch URL {0}", k8sExecCmdPrefix);
 
     // Verify that ELK Stack is ready to use
-    testVarMap = verifyLoggingExporterReady(opNamespace, null, LOGSTASH_INDEX_KEY);
-    Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, null, KIBANA_INDEX_KEY);
+    testVarMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, LOGSTASH_INDEX_KEY);
+    Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, KIBANA_INDEX_KEY);
 
     // merge testVarMap and kibanaMap
     testVarMap.putAll(kibanaMap);
@@ -301,7 +301,7 @@ class ItElasticLogging {
   @Test
   @DisplayName("Use Elasticsearch Search APIs to query WebLogic log info in WLS server pod and verify")
   void testWlsLoggingExporter() throws Exception {
-    Map<String, String> wlsMap = verifyLoggingExporterReady(opNamespace, null, WEBLOGIC_INDEX_KEY);
+    Map<String, String> wlsMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, WEBLOGIC_INDEX_KEY);
     // merge testVarMap and wlsMap
     testVarMap.putAll(wlsMap);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -23,6 +23,8 @@ import oracle.weblogic.domain.DomainSpec;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.actions.impl.LoggingExporterParams;
+import oracle.weblogic.kubernetes.actions.impl.OperatorParams;
+import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -52,6 +54,7 @@ import static oracle.weblogic.kubernetes.TestConstants.KIBANA_TYPE;
 import static oracle.weblogic.kubernetes.TestConstants.LOGSTASH_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
@@ -62,8 +65,10 @@ import static oracle.weblogic.kubernetes.actions.ActionConstants.WLE_DOWNLOAD_FI
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getNextFreePort;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createMiiImageAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
@@ -75,6 +80,7 @@ import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAnd
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyKibana;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.verifyLoggingExporterReady;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.OperatorUtils.upgradeAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
@@ -194,12 +200,33 @@ class ItElasticLogging {
     testVarMap = new HashMap<String, String>();
     elasticSearchHost = "elasticsearch." + elasticSearchNs + ".svc.cluster.local";
 
-    StringBuffer elasticsearchUrlBuff =
-        new StringBuffer("curl http://")
-            .append(elasticSearchHost)
-            .append(":")
-            .append(ELASTICSEARCH_HTTP_PORT);
-    k8sExecCmdPrefix = elasticsearchUrlBuff.toString();
+    // upgrade to latest operator
+    HelmParams upgradeHelmParams = new HelmParams()
+        .releaseName(OPERATOR_RELEASE_NAME)
+        .namespace(opNamespace)
+        .chartDir(OPERATOR_CHART_DIR);
+
+    // build operator chart values
+    OperatorParams opParams = new OperatorParams()
+        .helmParams(upgradeHelmParams)
+        .elkIntegrationEnabled(true)
+        .elasticSearchHost(elasticSearchHost);
+
+    assertTrue(upgradeAndVerifyOperator(opNamespace, opParams),
+        String.format("Failed to upgrade operator in namespace %s", opNamespace));
+
+    // wait for the operator to be ready
+    logger.info("Wait for the operator pod is ready in namespace {0}", opNamespace);
+    testUntil(
+        assertDoesNotThrow(() -> operatorIsReady(opNamespace),
+            "operatorIsReady failed with ApiException"),
+        logger,
+        "operator to be running in namespace {0}",
+        opNamespace);
+
+    String elasticsearchUrlBuff
+        = "curl http://" + elasticSearchHost + ":" + ELASTICSEARCH_HTTP_PORT;
+    k8sExecCmdPrefix = elasticsearchUrlBuff;
     logger.info("Elasticsearch URL {0}", k8sExecCmdPrefix);
 
     // Verify that ELK Stack is ready to use

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -329,11 +329,9 @@ class ItElasticLoggingFluentd {
         "Failed to copy fluentd.configmap.elk.yaml");
 
     // replace weblogic.domainUID, namespace in fluentd.configmap.elk.yaml
-    assertDoesNotThrow(() -> replaceStringInFile(
-        destFluentdYamlFile.toString(), "fluentd-domain", domainUid),
+    assertDoesNotThrow(() -> replaceStringInFile(destFluentdYamlFile, "fluentd-domain", domainUid),
         "Could not modify weblogic.domainUID in fluentd.configmap.elk.yaml");;
-    assertDoesNotThrow(() -> replaceStringInFile(
-        destFluentdYamlFile.toString(), "fluentd-namespace", domainNamespace),
+    assertDoesNotThrow(() -> replaceStringInFile(destFluentdYamlFile, "fluentd-namespace", domainNamespace),
         "Could not modify namespace in fluentd.configmap.elk.yaml");
 
     // create fluentd configuration

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -202,8 +202,8 @@ class ItElasticLoggingFluentd {
     logger.info("Elasticsearch URL {0}", k8sExecCmdPrefix);
 
     // Verify that ELK Stack is ready to use
-    testVarMap = verifyLoggingExporterReady(opNamespace, null, FLUENTD_INDEX_KEY);
-    Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, null, KIBANA_INDEX_KEY);
+    testVarMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, FLUENTD_INDEX_KEY);
+    Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, KIBANA_INDEX_KEY);
 
     // merge testVarMap and kibanaMap
     testVarMap.putAll(kibanaMap);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -360,21 +360,18 @@ class ItElasticLoggingFluentd {
 
   private static void createAndVerifyDomain(String miiImage) {
     // create secret for admin credentials
-    final String elasticSearchHost = "elasticsearch.default.svc.cluster.local";
-    final String elasticSearchPort = "9200";
-
     logger.info("Create secret for admin credentials");
     final String adminSecretName = "weblogic-credentials";
     assertDoesNotThrow(() -> createSecretWithUsernamePasswordElk(adminSecretName, domainNamespace,
         ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT,
-        elasticSearchHost, elasticSearchPort),
+        elasticSearchHost, String.valueOf(ELASTICSEARCH_HTTP_PORT)),
         String.format("create secret for admin credentials failed for %s", adminSecretName));
 
     // create encryption secret
     logger.info("Create encryption secret");
     final String encryptionSecretName = "encryptionsecret";
     assertDoesNotThrow(() -> createSecretWithUsernamePasswordElk(encryptionSecretName, domainNamespace,
-        "weblogicenc", "weblogicenc", elasticSearchHost, elasticSearchPort),
+        "weblogicenc", "weblogicenc", elasticSearchHost, String.valueOf(ELASTICSEARCH_HTTP_PORT)),
         String.format("create encryption secret failed for %s", encryptionSecretName));
 
     // create domain and verify

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -191,6 +191,17 @@ class ItElasticLoggingFluentd {
         () -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
 
     elasticSearchHost = "elasticsearch." + elasticSearchNs + ".svc.cluster.local";
+
+    // create fluentd configuration
+    configFluentd();
+
+    // create and verify WebLogic domain image using model in image with model files
+    String imageName = createAndVerifyDomainImage();
+
+    // create and verify one cluster domain
+    logger.info("Create domain and verify that it's running");
+    createAndVerifyDomain(imageName);
+
     // upgrade to latest operator
     HelmParams upgradeHelmParams = new HelmParams()
         .releaseName(OPERATOR_RELEASE_NAME)
@@ -217,16 +228,6 @@ class ItElasticLoggingFluentd {
         logger,
         "operator to be running in namespace {0}",
         opNamespace);
-
-    // create fluentd configuration
-    configFluentd();
-
-    // create and verify WebLogic domain image using model in image with model files
-    String imageName = createAndVerifyDomainImage();
-
-    // create and verify one cluster domain
-    logger.info("Create domain and verify that it's running");
-    createAndVerifyDomain(imageName);
 
     testVarMap = new HashMap<>();
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -1519,16 +1519,18 @@ public class TestActions {
   /**
    * Verify that the logging exporter is ready to use in Operator pod or WebLogic server pod.
    *
-   * @param namespace namespace of Operator pod (for ELK Stack) or
+   * @param opNamespace namespace of Operator pod (for ELK Stack) or
    *                  WebLogic server pod (for WebLogic logging exporter)
+   * @param esNamespace namespace of Elastic search component
    * @param labelSelector string containing the labels the Operator or WebLogic server is decorated with
    * @param index index key word used to search the index status of the logging exporter
    * @return a map containing key and value pair of logging exporter index
    */
-  public static Map<String, String> verifyLoggingExporterReady(String namespace,
-                                                               String labelSelector,
-                                                               String index) {
-    return LoggingExporter.verifyLoggingExporterReady(namespace, labelSelector, index);
+  public static Map<String, String> verifyLoggingExporterReady(String opNamespace,
+      String esNamespace,
+      String labelSelector,
+      String index) {
+    return LoggingExporter.verifyLoggingExporterReady(opNamespace, esNamespace, labelSelector, index);
   }
 
   // --------------------------- WebLogic Logging Exporter---------------------------------

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -176,7 +176,7 @@ public class TestActions {
   public static boolean createDomainCustomResource(oracle.weblogic.domain.Domain domain,
                                                    String... domainVersion) throws ApiException {
     return Domain.createDomainCustomResource(domain, domainVersion);
-  } 
+  }
 
   /**
    * List Domain Custom Resources.
@@ -1537,12 +1537,13 @@ public class TestActions {
    *
    * @param filter the value of weblogicLoggingExporterFilters to be added to WebLogic Logging Exporter YAML file
    * @param wlsLoggingExporterYamlFileLoc the directory where WebLogic Logging Exporter YAML file stores
+   * @param namespace logging exporter publish host namespace
    * @return true if WebLogic Logging Exporter is successfully installed, false otherwise.
    */
   public static boolean installWlsLoggingExporter(String filter,
-                                                  String wlsLoggingExporterYamlFileLoc) {
+                                                  String wlsLoggingExporterYamlFileLoc, String namespace) {
     return LoggingExporter.installWlsLoggingExporter(filter,
-        wlsLoggingExporterYamlFileLoc);
+        wlsLoggingExporterYamlFileLoc, namespace);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -39,7 +39,6 @@ import org.awaitility.core.ConditionFactory;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
@@ -503,7 +502,7 @@ public class LoggingExporter {
     String elasticSearchHost = "elasticsearch." + esNamespace + ".svc.cluster.local";
     StringBuffer k8sExecCmdPrefixBuff = new StringBuffer("curl http://");
     String cmd = k8sExecCmdPrefixBuff
-        .append(ELASTICSEARCH_HOST)
+        .append(elasticSearchHost)
         .append(":")
         .append(ELASTICSEARCH_HTTP_PORT)
         .append("/_cat/indices/")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -322,10 +322,11 @@ public class LoggingExporter {
    *
    * @param filter the value of weblogicLoggingExporterFilters to be added to WebLogic Logging Exporter YAML file
    * @param wlsLoggingExporterYamlFileLoc the directory where WebLogic Logging Exporter YAML file stores
+   * @param namespace logging exporter publish host namespace
    * @return true if WebLogic Logging Exporter is successfully installed, false otherwise.
    */
   public static boolean installWlsLoggingExporter(String filter,
-                                                  String wlsLoggingExporterYamlFileLoc) {
+                                                  String wlsLoggingExporterYamlFileLoc, String namespace) {
     // Copy WebLogic Logging Exporter files to WORK_DIR
     String[] loggingExporterFiles =
         {WLS_LOGGING_EXPORTER_YAML_FILE_NAME, COPY_WLS_LOGGING_EXPORTER_FILE_NAME};
@@ -336,6 +337,8 @@ public class LoggingExporter {
       assertDoesNotThrow(() -> FileUtils.copy(srcPath, destPath),
           String.format("Failed to copy %s to %s", srcPath, destPath));
       logger.info("Copied {0} to {1}}", srcPath, destPath);
+      assertDoesNotThrow(() -> FileUtils.replaceStringInFile(destPath.toString(), "default", namespace),
+          String.format("Failed to replace namespace default to %s", namespace));
     }
 
     // Add filter to weblogicLoggingExporterFilters in WebLogic Logging Exporter YAML file

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
@@ -13,7 +13,6 @@ import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTPS_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.ELKSTACK_NAMESPACE;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_PORT;
@@ -65,9 +64,10 @@ public class LoggingExporterUtils {
   /**
    * Install Elasticsearch and wait up to five minutes until Elasticsearch pod is ready.
    *
+   * @param namespace namespace in which to install elastic search
    * @return Elasticsearch installation parameters
    */
-  public static LoggingExporterParams installAndVerifyElasticsearch() {
+  public static LoggingExporterParams installAndVerifyElasticsearch(String namespace) {
     LoggingFacade logger = getLogger();
     final String elasticsearchPodNamePrefix = ELASTICSEARCH_NAME;
 
@@ -77,7 +77,7 @@ public class LoggingExporterUtils {
         .elasticsearchImage(ELASTICSEARCH_IMAGE)
         .elasticsearchHttpPort(ELASTICSEARCH_HTTP_PORT)
         .elasticsearchHttpsPort(ELASTICSEARCH_HTTPS_PORT)
-        .loggingExporterNamespace(ELKSTACK_NAMESPACE);
+        .loggingExporterNamespace(namespace);
 
     // install Elasticsearch
     assertThat(installElasticsearch(elasticsearchParams))
@@ -90,10 +90,10 @@ public class LoggingExporterUtils {
         .conditionEvaluationListener(
             condition -> logger.info(
                 "Waiting for Elasticsearch to be ready in namespace {0} (elapsed time {1}ms, remaining time {2}ms)",
-                ELKSTACK_NAMESPACE,
+                namespace,
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> isElkStackPodReady(ELKSTACK_NAMESPACE, elasticsearchPodNamePrefix),
+        .until(assertDoesNotThrow(() -> isElkStackPodReady(namespace, elasticsearchPodNamePrefix),
             "isElkStackPodReady failed with ApiException"));
 
     return elasticsearchParams;
@@ -102,9 +102,10 @@ public class LoggingExporterUtils {
   /**
    * Install Kibana and wait up to five minutes until Kibana pod is ready.
    *
+   * @param namespace namespace in which to install kibana
    * @return Kibana installation parameters
    */
-  public static LoggingExporterParams installAndVerifyKibana() {
+  public static LoggingExporterParams installAndVerifyKibana(String namespace) {
     LoggingFacade logger = getLogger();
     final String kibanaPodNamePrefix = ELASTICSEARCH_NAME;
 
@@ -113,7 +114,7 @@ public class LoggingExporterUtils {
         .kibanaName(KIBANA_NAME)
         .kibanaImage(KIBANA_IMAGE)
         .kibanaType(KIBANA_TYPE)
-        .loggingExporterNamespace(ELKSTACK_NAMESPACE)
+        .loggingExporterNamespace(namespace)
         .kibanaContainerPort(KIBANA_PORT);
 
     // install Kibana
@@ -127,10 +128,10 @@ public class LoggingExporterUtils {
         .conditionEvaluationListener(
             condition -> logger.info(
                 "Waiting for Kibana to be ready in namespace {0} (elapsed time {1}ms, remaining time {2}ms)",
-                ELKSTACK_NAMESPACE,
+                namespace,
                 condition.getElapsedTimeInMS(),
                 condition.getRemainingTimeInMS()))
-        .until(assertDoesNotThrow(() -> isElkStackPodReady(ELKSTACK_NAMESPACE, kibanaPodNamePrefix),
+        .until(assertDoesNotThrow(() -> isElkStackPodReady(namespace, kibanaPodNamePrefix),
             "isElkStackPodReady failed with ApiException"));
 
     return kibanaParams;
@@ -141,13 +142,14 @@ public class LoggingExporterUtils {
    *
    * @param filter the value of weblogicLoggingExporterFilters to be added to WebLogic Logging Exporter YAML file
    * @param wlsLoggingExporterYamlFileLoc the directory where WebLogic Logging Exporter YAML file stores
+   * @param namespace logging exporter publish host namespace
    * @return true if WebLogic Logging Exporter is successfully installed, false otherwise.
    */
   public static boolean installAndVerifyWlsLoggingExporter(String filter,
-                                                           String wlsLoggingExporterYamlFileLoc) {
+                                                           String wlsLoggingExporterYamlFileLoc, String namespace) {
     // Install WebLogic Logging Exporter
     assertThat(TestActions.installWlsLoggingExporter(filter,
-        wlsLoggingExporterYamlFileLoc))
+        wlsLoggingExporterYamlFileLoc, namespace))
         .as("WebLogic Logging Exporter installation succeeds")
         .withFailMessage("WebLogic Logging Exporter installation failed")
         .isTrue();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
@@ -160,15 +160,17 @@ public class LoggingExporterUtils {
   /**
    * Verify that the logging exporter is ready to use in Operator pod or WebLogic server pod.
    *
-   * @param namespace namespace of Operator pod (for ELK Stack) or
-   *                  WebLogic server pod (for WebLogic Logging Exporter)
+   * @param opNamespace namespace of Operator pod (for ELK Stack) or
+   *                  WebLogic server pod (for WebLogic logging exporter)
+   * @param esNamespace namespace of Elastic search component
    * @param labelSelector string containing the labels the Operator or WebLogic server is decorated with
    * @param index key word used to search the index status of the logging exporter
    * @return a map containing key and value pair of logging exporter index
    */
-  public static Map<String, String> verifyLoggingExporterReady(String namespace,
+  public static Map<String, String> verifyLoggingExporterReady(String opNamespace,
+                                                               String esNamespace,
                                                                String labelSelector,
                                                                String index) {
-    return TestActions.verifyLoggingExporterReady(namespace, labelSelector, index);
+    return TestActions.verifyLoggingExporterReady(opNamespace, esNamespace, labelSelector, index);
   }
 }


### PR DESCRIPTION
The Elastic search and kibana were installed in default namespace and it caused issues when tests are running in parallel. It was fixed to use custom namespace in main, this PR backports those changes from main to release/3.3

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9313/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9316/

