### PR TITLE
create pv and pvc objects with unique names to reduce failures due to existing aftifacts

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -95,6 +95,7 @@ import static oracle.weblogic.kubernetes.utils.MySQLDBUtils.createMySQLDB;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
@@ -130,8 +131,8 @@ class ItConfigDistributionStrategy {
   final String managedServerNameBase = "ms-";
   final int managedServerPort = 8001;
   int t3ChannelPort;
-  final String pvName = domainUid + "-pv"; // name of the persistent volume
-  final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+  final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   final String wlSecretName = "weblogic-credentials";
   final String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
   int replicaCount = 2;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -45,6 +45,7 @@ import static oracle.weblogic.kubernetes.utils.JobUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -151,8 +152,8 @@ class ItFmwDomainInPVUsingWDT {
   @Test
   @DisplayName("Create a FMW domainon on PV using WDT")
   void testFmwDomainOnPVUsingWdt() {
-    final String pvName = domainUid + "-" + domainNamespace + "-pv";
-    final String pvcName = domainUid + "-" + domainNamespace + "-pvc";
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
     final int t3ChannelPort = getNextFreePort();
 
     // create FMW domain credential secret

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
@@ -57,6 +57,7 @@ import static oracle.weblogic.kubernetes.utils.JobUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
@@ -159,8 +160,8 @@ class ItFmwDomainInPVUsingWLST {
     final int replicaCount = 2;
     final int t3ChannelPort = getNextFreePort();
 
-    final String pvName = domainUid + "-pv";
-    final String pvcName = domainUid + "-pvc";
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
 
     // create pull secrets for jrfDomainNamespace when running in non Kind Kubernetes cluster
     // this secret is used only for non-kind cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDynamicDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDynamicDomainInPV.java
@@ -59,6 +59,7 @@ import static oracle.weblogic.kubernetes.utils.JobUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
@@ -162,8 +163,8 @@ class ItFmwDynamicDomainInPV {
   }
 
   private void createFmwDomainAndVerify() {
-    final String pvName = domainUid + "-" + domainNamespace + "-pv";
-    final String pvcName = domainUid + "-" + domainNamespace + "-pvc";
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
     final int t3ChannelPort = getNextFreePort();
 
     // create pull secrets for domainNamespace when running in non Kind Kubernetes cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -109,6 +109,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.PatchDomainUtils.patchDomainResource;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
@@ -228,8 +229,8 @@ class ItIntrospectVersion {
 
     final int t3ChannelPort = getNextFreePort();
 
-    final String pvName = domainUid + "-pv"; // name of the persistent volume
-    final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
 
     // create WebLogic domain credential secret
     createSecretWithUsernamePassword(wlSecretName, introDomainNamespace,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
@@ -69,6 +69,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.PatchDomainUtils.patchServerStartPolicy;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDeleted;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
@@ -152,8 +153,8 @@ class ItIstioDomainInPV  {
     final int replicaCount = 2;
     final int t3ChannelPort = getNextFreePort();
 
-    final String pvName = domainUid + "-pv"; // name of the persistent volume
-    final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
 
     // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
     // this secret is used only for non-kind cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -104,6 +104,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.upgradeAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.PatchDomainUtils.patchDomainResource;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
@@ -153,8 +154,8 @@ class ItKubernetesEvents {
   final int managedServerPort = 8001;
   int replicaCount = 2;
 
-  final String pvName = domainUid + "-pv"; // name of the persistent volume
-  final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+  final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   private static final String domainUid = "k8seventsdomain";
   private final String wlSecretName = "weblogic-credentials";
 
@@ -496,8 +497,10 @@ class ItKubernetesEvents {
   void testDomainK8sEventsProcessingFailed() {
     OffsetDateTime timestamp = now();
     try {
-      createPV("sample-pv", domainUid, this.getClass().getSimpleName());
-      createPVC("sample-pv", "sample-pvc", domainUid, domainNamespace1);
+      String pvName = getUniquePvOrPvcName("sample-pv-");
+      String pvcName = getUniquePvOrPvcName("sample-pvc-");
+      createPV(pvName, domainUid, this.getClass().getSimpleName());
+      createPVC(pvName, pvcName, domainUid, domainNamespace1);
       String introspectVersion = assertDoesNotThrow(() -> getNextIntrospectVersion(domainUid, domainNamespace1));
       String patchStr
           = "["

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCustomSslStore.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCustomSslStore.java
@@ -42,6 +42,7 @@ import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseIma
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.SslUtils.generateJksStores;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
@@ -53,14 +54,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This test class verifies usage of CustomIdentityCustomTrust on PV.
  * Create an MII domain with an attached persistent volume.
  * Configure custom identity and custom trust on server template
- * Don't explicitly set the SSL port on the server template. 
+ * Don't explicitly set the SSL port on the server template.
  * The default will be set to 8100.
- * Put the IdentityKeyStore.jks  and TrustKeyStore.jks on /shared directory 
- *  after administration server pod is started so that it can be accessible 
+ * Put the IdentityKeyStore.jks  and TrustKeyStore.jks on /shared directory
+ *  after administration server pod is started so that it can be accessible
  *  from all managed server pods
- * Once all servers are started get the JNDI initial context using cluster 
+ * Once all servers are started get the JNDI initial context using cluster
  *  service URL with t3s protocol.
- * Repeat the same after scaling the cluster 
+ * Repeat the same after scaling the cluster
  */
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -73,8 +74,8 @@ class ItMiiCustomSslStore {
   private static ConditionFactory withStandardRetryPolicy = null;
   private static int replicaCount = 2;
   private static final String domainUid = "mii-custom-ssl";
-  private static String pvName = domainUid + "-pv"; 
-  private static String pvcName = domainUid + "-pvc"; 
+  private static final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  private static final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   private static final String adminServerPodName = domainUid + "-admin-server";
   private static final String managedServerPrefix = domainUid + "-managed-server";
   private static LoggingFacade logger = null;
@@ -83,7 +84,7 @@ class ItMiiCustomSslStore {
   /**
    * Install Operator.
    * Create domain resource definition.
-   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the 
+   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
    *     JUnit engine parameter resolution mechanism
    */
   @BeforeAll
@@ -102,7 +103,7 @@ class ItMiiCustomSslStore {
     logger.info("Creating unique namespace for Domain");
     assertNotNull(namespaces.get(1), "Namespace list is null");
     domainNamespace = namespaces.get(1);
- 
+
     // Create the repo secret to pull the image
     // this secret is used only for non-kind cluster
     createOcirRepoSecret(domainNamespace);
@@ -111,11 +112,11 @@ class ItMiiCustomSslStore {
     installAndVerifyOperator(opNamespace, domainNamespace);
 
     // create secret for admin credential with special characters
-    // the resultant password is ##W%*}!"'"`']\\\\//1$$~x 
+    // the resultant password is ##W%*}!"'"`']\\\\//1$$~x
     // let the user name be something other than weblogic say wlsadmin
     logger.info("Create secret for admin credentials");
     String adminSecretName = "weblogic-credentials";
-    assertDoesNotThrow(() -> createDomainSecret(adminSecretName, 
+    assertDoesNotThrow(() -> createDomainSecret(adminSecretName,
             "wlsadmin", "##W%*}!\"'\"`']\\\\//1$$~x", domainNamespace),
             String.format("createSecret failed for %s", adminSecretName));
 
@@ -163,7 +164,7 @@ class ItMiiCustomSslStore {
     logger.info("Check admin service and pod {0} is created in namespace {1}",
         adminServerPodName, domainNamespace);
     checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
-    // Generate JKS Keystore using openssl before 
+    // Generate JKS Keystore using openssl before
     // managed server services and pods are ready
     generateJksStores();
     assertDoesNotThrow(() -> copyFileToPod(domainNamespace,
@@ -190,7 +191,7 @@ class ItMiiCustomSslStore {
   @Order(1)
   @DisplayName("Verify JNDI Context can be accessed using t3s cluster URL")
   void testMiiGetCustomSSLContext() {
-   
+
     // build the standalone Client on Admin pod after rolling restart
     String destLocation = "/u01/SslTestClient.java";
     assertDoesNotThrow(() -> copyFileToPod(domainNamespace,
@@ -198,7 +199,7 @@ class ItMiiCustomSslStore {
         Paths.get(RESOURCE_DIR, "ssl", "SslTestClient.java"),
         Paths.get(destLocation)));
     runJavacInsidePod(adminServerPodName, domainNamespace, destLocation);
-    
+
     runClientOnAdminPod();
 
     boolean psuccess = assertDoesNotThrow(() ->

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -79,6 +79,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createfixPVCOwnerContainer;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.execInPod;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
@@ -114,8 +115,8 @@ public class ItMiiDomainModelInPV {
   private static String adminSecretName;
   private static String encryptionSecretName;
 
-  private static String pvName = domainUid1 + "-wdtmodel-pv"; // name of the persistent volume
-  private static String pvcName = domainUid1 + "-wdtmodel-pvc"; // name of the persistent volume claim
+  private static final String pvName = getUniquePvOrPvcName(domainUid1 + "-wdtmodel-pv-");
+  private static final String pvcName = getUniquePvOrPvcName(domainUid1 + "-wdtmodel-pvc-");
 
   private static Path clusterViewAppPath;
   private static String modelFile = "modelinpv-with-war.yaml";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdate.java
@@ -89,6 +89,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.PatchDomainUtils.patchDomainResourceWithNewReplicaCountAtSpecLevel;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDeleted;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
@@ -123,8 +124,8 @@ class ItMiiDynamicUpdate {
   private static ConditionFactory withQuickRetryPolicy;
   private static int replicaCount = 2;
   private static final String domainUid = "mii-dynamic-update";
-  private static String pvName = domainUid + "-pv"; // name of the persistent volume
-  private static String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+  private static final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  private static final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   private static final String configMapName = "dynamicupdate-test-configmap";
   private final String adminServerPodName = domainUid + "-admin-server";
   private final String managedServerPrefix = domainUid + "-managed-server";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiServiceMigration.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiServiceMigration.java
@@ -57,6 +57,7 @@ import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseIma
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -97,8 +98,8 @@ class ItMiiServiceMigration {
   private static ConditionFactory withStandardRetryPolicy = null;
   private static int replicaCount = 2;
   private static final String domainUid = "mii-jms-recovery";
-  private static String pvName = domainUid + "-pv";
-  private static String pvcName = domainUid + "-pvc";
+  private static final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  private static final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   private static final String adminServerPodName = domainUid + "-admin-server";
   private static final String managedServerPrefix = domainUid + "-managed-server";
   private static LoggingFacade logger = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -99,6 +99,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createfixPVCOwnerContainer;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDeleted;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
@@ -131,8 +132,8 @@ class ItMiiUpdateDomainConfig {
   private static ConditionFactory withStandardRetryPolicy = null;
   private static int replicaCount = 2;
   private static final String domainUid = "mii-add-config";
-  private static String pvName = domainUid + "-pv"; // name of the persistent volume
-  private static String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+  private static final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  private static final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   private StringBuffer curlString = null;
   private StringBuffer checkCluster = null;
   private V1Patch patch = null;
@@ -334,7 +335,7 @@ class ItMiiUpdateDomainConfig {
   }
 
   /**
-   * Create a WebLogic domain with a defined configmap in the 
+   * Create a WebLogic domain with a defined configmap in the
    * configuration/model section of the domain resource.
    * The configmap has multiple sparse WDT model files that define
    * a JDBCSystemResource, a JMSSystemResource and a WLDFSystemResource.
@@ -725,7 +726,7 @@ class ItMiiUpdateDomainConfig {
    * Set allowReplicasBelowMinDynClusterSize to false.
    * Make sure that the cluster can be scaled up to 5 servers and
    * scaled down to 1 server.
-   * Create a configmap with a sparse model file with the following attributes 
+   * Create a configmap with a sparse model file with the following attributes
    * Cluster/cluster-1/DynamicServers
    *   MaxDynamicClusterSize(4) and MinDynamicClusterSize(2)
    * Patch the domain resource with the configmap and update the restartVersion.
@@ -947,7 +948,7 @@ class ItMiiUpdateDomainConfig {
   }
 
   // Add an environmental variable with special character
-  // Make sure the variable is available in domain resource with right value 
+  // Make sure the variable is available in domain resource with right value
   private static void createDomainResource(
       String domainUid, String domNamespace, String adminSecretName,
       String repoSecretName, String encryptionSecretName,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOpUpgradeFmwDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOpUpgradeFmwDomainInPV.java
@@ -76,6 +76,7 @@ import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOpe
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.upgradeAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
@@ -426,8 +427,8 @@ class ItOpUpgradeFmwDomainInPV {
   }
 
   private void createFmwDomainAndVerify(String domainVersion) {
-    final String pvName = domainUid + "-" + domainNamespace + "-pv";
-    final String pvcName = domainUid + "-" + domainNamespace + "-pvc";
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
     final int t3ChannelPort = getNextFreePort();
 
     // create pull secrets for domainNamespace when running in non Kind Kubernetes cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
@@ -71,6 +71,7 @@ import static oracle.weblogic.kubernetes.utils.JobUtils.getIntrospectJobName;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodExists;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
@@ -102,8 +103,8 @@ class ItSystemResOverrides {
   final String managedServerNameBase = "ms-";
   final int managedServerPort = 8001;
   int t3ChannelPort;
-  final String pvName = domainUid + "-pv"; // name of the persistent volume
-  final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+  final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+  final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
   final String wlSecretName = "weblogic-credentials";
   final String managedServerPodNamePrefix = domainUid + "-" + managedServerNameBase;
   int replicaCount = 2;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItT3Channel.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItT3Channel.java
@@ -64,6 +64,7 @@ import static oracle.weblogic.kubernetes.utils.JobUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPV;
 import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createPVC;
+import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.getUniquePvOrPvcName;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -142,8 +143,8 @@ class ItT3Channel {
 
     final int t3ChannelPort = getNextFreePort();
 
-    final String pvName = domainUid + "-pv"; // name of the persistent volume
-    final String pvcName = domainUid + "-pvc"; // name of the persistent volume claim
+    final String pvName = getUniquePvOrPvcName(domainUid + "-pv-");
+    final String pvcName = getUniquePvOrPvcName(domainUid + "-pvc-");
 
     // create WebLogic domain credential secret
     String wlSecretName = "t3weblogic-credentials";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/UniqueName.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/UniqueName.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.actions.impl;
+
+import java.util.Random;
+
+public class UniqueName {
+  public static Random random = new Random(System.currentTimeMillis());
+
+  /**
+   * Generates a "unique" name by choosing a random name from
+   * 26^6 possible combinations.
+   *
+   * @param prefix Name prefix
+   * @return name
+   */
+  public static String uniqueName(String prefix) {
+    char[] nsName = new char[6];
+    for (int i = 0; i < nsName.length; i++) {
+      nsName[i] = (char) (random.nextInt(25) + (int) 'a');
+    }
+    return prefix + new String(nsName);
+  }
+
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PersistentVolumeUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PersistentVolumeUtils.java
@@ -33,8 +33,12 @@ import static oracle.weblogic.kubernetes.TestConstants.PV_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
 import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolume;
 import static oracle.weblogic.kubernetes.actions.TestActions.createPersistentVolumeClaim;
+import static oracle.weblogic.kubernetes.actions.TestActions.deletePersistentVolume;
+import static oracle.weblogic.kubernetes.actions.impl.UniqueName.random;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.pvExists;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.pvNotExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.pvcExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withStandardRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
@@ -150,6 +154,11 @@ public class PersistentVolumeUtils {
   public static void createPV(String pvName, String domainUid, String className) {
 
     LoggingFacade logger = getLogger();
+    logger.info("deleting persistent volume pvName {0} if it exists", pvName);
+    deletePersistentVolume(pvName);
+    testUntil(
+        assertDoesNotThrow(() -> pvNotExists(pvName, null),
+            String.format("pvNotExists failedfor pv %s", pvName)), logger, "pv {0} to be deleted", pvName);
     logger.info("creating persistent volume for pvName {0}, domainUid: {1}, className: {2}",
         pvName, domainUid, className);
     Path pvHostPath = null;
@@ -273,4 +282,20 @@ public class PersistentVolumeUtils {
             .runAsUser(0L));
     return container;
   }
+
+  /**
+   * Get a unique name for pv or pvc with a supplied prefix.
+   * @param prefix prefix for pv or pvc name
+   * @return full pv or pvc name
+   */
+  public static String getUniquePvOrPvcName(String prefix) {
+    char[] name = new char[6];
+    for (int i = 0; i < name.length; i++) {
+      name[i] = (char) (random.nextInt(25) + (int) 'a');
+    }
+    String pvOrPvcName = prefix + new String(name);
+    getLogger().info("Creating unique pv|pvc name {0}", pvOrPvcName);
+    return pvOrPvcName;
+  }
+
 }


### PR DESCRIPTION
Unique names were used to create pv and pvc to avoid test failures due to leftover resources. This was addressed in main branch and this PR backports those changes from main.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9286/