### PR TITLE
Backport selected changes to CRD helper and introspector job/pod helper from PR2816 to 3.4 branch

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -123,7 +123,7 @@ class DomainResourcesValidation {
   }
 
   private void addDomainList(DomainList list) {
-    list.getItems().forEach(this::addDomain);
+    Optional.ofNullable(list).ifPresent(l -> l.getItems().forEach(this::addDomain));
   }
 
   private void addDomain(Domain domain) {

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -67,5 +67,8 @@ public interface ProcessingConstants {
   String FATAL_ERROR_DOMAIN_STATUS_MESSAGE = "Introspection encountered a fatal error and will not retry automatically."
           + " Please resolve the error and then update 'domain.spec.introspectVersion' to force a retry.";
 
+  String WEBHOOK = "Webhook";
+
+  String COMPATIBILITY_MODE = "compatibility-mode-";
 
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -62,6 +62,7 @@ import static oracle.kubernetes.operator.DomainStatusUpdater.createProgressingSt
 import static oracle.kubernetes.operator.DomainStatusUpdater.recordLastIntrospectJobProcessedUid;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_DOMAIN_SPEC_GENERATION;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
+import static oracle.kubernetes.operator.ProcessingConstants.COMPATIBILITY_MODE;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECT_REQUESTED;
 import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_JOB_FAILED;
 import static oracle.kubernetes.operator.logging.MessageKeys.INTROSPECTOR_JOB_FAILED_DETAIL;
@@ -279,12 +280,29 @@ public class JobHelper {
 
     @Override
     protected List<V1Volume> getAdditionalVolumes() {
-      return getDomain().getSpec().getAdditionalVolumes();
+      List<V1Volume> volumes = getDomain().getSpec().getAdditionalVolumes();
+      getServerSpec().getAdditionalVolumes().stream().forEach(volume -> addVolumeIfMissing(volume, volumes));
+      return volumes;
+    }
+
+    private void addVolumeIfMissing(V1Volume volume, List<V1Volume> volumes) {
+      if (!volumes.contains(volume) && volume.getName().startsWith(COMPATIBILITY_MODE)) {
+        volumes.add(volume);
+      }
     }
 
     @Override
     protected List<V1VolumeMount> getAdditionalVolumeMounts() {
-      return getDomain().getSpec().getAdditionalVolumeMounts();
+      List<V1VolumeMount> volumeMounts = getDomain().getSpec().getAdditionalVolumeMounts();
+      getServerSpec().getAdditionalVolumeMounts().stream()
+              .forEach(mount -> addVolumeMountIfMissing(mount, volumeMounts));
+      return volumeMounts;
+    }
+
+    private void addVolumeMountIfMissing(V1VolumeMount mount, List<V1VolumeMount> volumeMounts) {
+      if (!volumeMounts.contains(mount) && mount.getName().startsWith(COMPATIBILITY_MODE)) {
+        volumeMounts.add(mount);
+      }
     }
 
     private String getAsName() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -967,10 +967,6 @@ public abstract class PodStepContext extends BasePodStepContext {
     if (wdtInstallHome != null && !wdtInstallHome.isEmpty() && !wdtInstallHome.equals(DEFAULT_WDT_INSTALL_HOME)) {
       addEnvVar(vars, IntrospectorJobEnvVars.WDT_INSTALL_HOME, wdtInstallHome);
     }
-    String wdtModelHome = getModelHome();
-    if (wdtModelHome != null && !wdtModelHome.isEmpty() && !wdtModelHome.equals(DEFAULT_WDT_MODEL_HOME)) {
-      addEnvVar(vars, IntrospectorJobEnvVars.WDT_MODEL_HOME, wdtModelHome);
-    }
     Optional.ofNullable(getServerSpec().getAuxiliaryImages()).ifPresent(cm -> addAuxiliaryImageEnv(cm, vars));
     addEnvVarIfTrue(mockWls(), vars, "MOCK_WLS");
     Optional.ofNullable(getKubernetesPlatform(tuningParameters)).ifPresent(v ->

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -94,6 +94,8 @@ import static oracle.kubernetes.operator.helpers.CompatibilityCheck.Compatibilit
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_ROLL_STARTING;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.POD_CYCLE_STARTING;
 import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
+import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_INSTALL_HOME;
+import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_MODEL_HOME;
 
 public abstract class PodStepContext extends BasePodStepContext {
 
@@ -961,6 +963,14 @@ public abstract class PodStepContext extends BasePodStepContext {
     addEnvVar(vars, ServerEnvVars.SERVICE_NAME, LegalNames.toServerServiceName(getDomainUid(), getServerName()));
     addEnvVar(vars, ServerEnvVars.AS_SERVICE_NAME, LegalNames.toServerServiceName(getDomainUid(), getAsName()));
     Optional.ofNullable(getDataHome()).ifPresent(v -> addEnvVar(vars, ServerEnvVars.DATA_HOME, v));
+    String wdtInstallHome = getWdtInstallHome();
+    if (wdtInstallHome != null && !wdtInstallHome.isEmpty() && !wdtInstallHome.equals(DEFAULT_WDT_INSTALL_HOME)) {
+      addEnvVar(vars, IntrospectorJobEnvVars.WDT_INSTALL_HOME, wdtInstallHome);
+    }
+    String wdtModelHome = getModelHome();
+    if (wdtModelHome != null && !wdtModelHome.isEmpty() && !wdtModelHome.equals(DEFAULT_WDT_MODEL_HOME)) {
+      addEnvVar(vars, IntrospectorJobEnvVars.WDT_MODEL_HOME, wdtModelHome);
+    }
     Optional.ofNullable(getServerSpec().getAuxiliaryImages()).ifPresent(cm -> addAuxiliaryImageEnv(cm, vars));
     addEnvVarIfTrue(mockWls(), vars, "MOCK_WLS");
     Optional.ofNullable(getKubernetesPlatform(tuningParameters)).ifPresent(v ->
@@ -969,8 +979,6 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   protected void addAuxiliaryImageEnv(List<AuxiliaryImage> auxiliaryImageList, List<V1EnvVar> vars) {
     Optional.ofNullable(auxiliaryImageList).ifPresent(auxiliaryImages -> {
-      addEnvVar(vars, IntrospectorJobEnvVars.WDT_INSTALL_HOME, getWdtInstallHome());
-      addEnvVar(vars, IntrospectorJobEnvVars.WDT_MODEL_HOME, getModelHome());
       Optional.ofNullable(getAuxiliaryImagePaths(auxiliaryImageList, getDomain().getAuxiliaryImageVolumes()))
               .ifPresent(c -> addEnvVar(vars, AuxiliaryImageEnvVars.AUXILIARY_IMAGE_PATHS, c));
     });

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -95,7 +95,6 @@ import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_RO
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.POD_CYCLE_STARTING;
 import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_INSTALL_HOME;
-import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_MODEL_HOME;
 
 public abstract class PodStepContext extends BasePodStepContext {
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -84,6 +84,7 @@ import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABE
 import static oracle.kubernetes.operator.LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.MODEL_IN_IMAGE_DOMAINZIP_HASH;
 import static oracle.kubernetes.operator.LabelConstants.OPERATOR_VERSION;
+import static oracle.kubernetes.operator.ProcessingConstants.COMPATIBILITY_MODE;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_ROLL_START_EVENT_GENERATED;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE_SUCCESS;
@@ -861,8 +862,10 @@ public abstract class PodStepContext extends BasePodStepContext {
   private List<V1EnvVar> createEnv(V1Container c, TuningParameters tuningParameters) {
     List<V1EnvVar> initContainerEnvVars = new ArrayList<>();
     Optional.ofNullable(c.getEnv()).ifPresent(initContainerEnvVars::addAll);
-    getEnvironmentVariables(tuningParameters).forEach(envVar ->
-            addIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue(), envVar.getValueFrom()));
+    if (!c.getName().startsWith(COMPATIBILITY_MODE)) {
+      getEnvironmentVariables(tuningParameters).forEach(envVar ->
+              addIfMissing(initContainerEnvVars, envVar.getName(), envVar.getValue(), envVar.getValueFrom()));
+    }
     return initContainerEnvVars;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Model.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Model.java
@@ -14,8 +14,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class Model {
-  static final String DEFAULT_WDT_MODEL_HOME = "/u01/wdt/models";
-  static final String DEFAULT_WDT_INSTALL_HOME = "/u01/wdt/weblogic-deploy";
+  public static final String DEFAULT_WDT_MODEL_HOME = "/u01/wdt/models";
+  public static final String DEFAULT_WDT_INSTALL_HOME = "/u01/wdt/weblogic-deploy";
 
   @EnumClass(value = ModelInImageDomainType.class)
   @Description("WebLogic Deploy Tooling domain type. Legal values: WLS, RestrictedJRF, JRF. Defaults to WLS.")

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -18,6 +18,7 @@ import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
+import io.kubernetes.client.openapi.models.V1CustomResourceConversion;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionNames;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionSpec;
@@ -197,6 +198,19 @@ class CrdHelperTest {
             .map(labels -> labels.get(LabelConstants.OPERATOR_VERSION))
             .map(SemanticVersion::new)
             .orElse(null);
+  }
+
+  @Test
+  void whenExistingCrdHasFutureVersionWithConversionWebhook_dontReplaceIt() {
+    MainDelegateStub delegate = createStrictStub(MainDelegateStub.class, KUBERNETES_VERSION_16, PRODUCT_VERSION_FUTURE);
+
+    V1CustomResourceDefinition existing = defineCrd(PRODUCT_VERSION_FUTURE);
+    existing.getSpec().addVersionsItem(
+            new V1CustomResourceDefinitionVersion().served(true).name(KubernetesConstants.DOMAIN_VERSION))
+            .conversion(new V1CustomResourceConversion().strategy("Webhook"));
+    testSupport.defineResources(existing);
+
+    testSupport.runSteps(CrdHelper.createDomainCrdStep(delegate));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -61,6 +61,7 @@ import static com.meterware.simplestub.Stub.createNiceStub;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.createTestDomain;
+import static oracle.kubernetes.operator.ProcessingConstants.COMPATIBILITY_MODE;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 import static oracle.kubernetes.operator.ProcessingConstants.JOBWATCHER_COMPONENT_NAME;
 import static oracle.kubernetes.operator.helpers.BasePodStepContext.KUBERNETES_PLATFORM_HELM_VARIABLE;
@@ -754,15 +755,28 @@ class JobHelperTest extends DomainValidationBaseTest {
   @Test
   void introspectorPodSpec_createdWithoutConfiguredInitContainers() {
     configureDomain()
-        .withInitContainer(
-            createContainer(
-                "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"));
+            .withInitContainer(
+                    createContainer(
+                            "container1", "busybox", "sh", "-c", "echo managed server && sleep 120"));
 
     V1JobSpec jobSpec = createJobSpec();
 
     assertThat(
-        getPodSpec(jobSpec).getInitContainers(),
-        nullValue());
+            getPodSpec(jobSpec).getInitContainers().size(), equalTo(0));
+  }
+
+  @Test
+  void introspectorPodSpec_createdWithCompatibilityAuxImageInitContainers() {
+    configureDomain()
+            .withInitContainer(
+                    createContainer(
+                            COMPATIBILITY_MODE + "aux-image-container", "busybox", "sh", "-c",
+                            "echo managed server && sleep 120"));
+
+    V1JobSpec jobSpec = createJobSpec();
+
+    assertThat(
+            getPodSpec(jobSpec).getInitContainers().size(), equalTo(1));
   }
 
   @Test


### PR DESCRIPTION
Backport selected changes from PR2816 to allow 3.4 to be compatible with 4.0. The changes include -
1. When both 3.4 and 4.x operators are running in the k8s cluster, the 3.4 operator should not update the CRD that has the conversion webhook added by 4.x conversion webhook.
2. Include compatibility aux image init containers, volume and volume mounts specified in `ServerPod` section in the introspector job pod.
3. Conditionally add the WDT_INSTALL_HOME and WDT_MODEL_HOME env variables to server pod if they are at non-default values.

The change also backports existing unit tests for these changes. There are two integration test failures but they don't seem related to these changes. Results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9321/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9322/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9323/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9325/

