### PR TITLE
Fix OKD nightly Elasticsearch installation failure

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -400,7 +400,6 @@
                   **/ItManagedCoherence,
                   **/ItManageNameSpace,
                   **/ItMiiAuxiliaryImage,
-                  **/ItMiiCreateAuxImageWithImageTool,
                   **/ItMiiAuxiliaryImageCluster,
                   **/ItMiiCustomSslStore,
                   **/ItMiiDomain,

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -395,7 +395,6 @@
                   **/ItExternalNodePortService,
                   **/ItInitContainers,
                   **/ItIntrospectVersion,
-                  **/ItKubernetesEvents,
                   **/ItLiftAndShiftFromOnPremDomain,
                   **/ItLivenessProbeCustomization,
                   **/ItManagedCoherence,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -63,6 +63,7 @@ import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVe
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyElasticsearch;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyKibana;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.verifyLoggingExporterReady;
+import static oracle.weblogic.kubernetes.utils.OKDUtils.addSccToNsSvcAccount;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.upgradeAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -145,6 +146,9 @@ class ItElasticLogging {
 
     // install and verify Elasticsearch
     elasticSearchNs = namespaces.get(2);
+    if (OKD) {
+      addSccToNsSvcAccount("default", elasticSearchNs);
+    }
     logger.info("install and verify Elasticsearch");
     elasticsearchParams = assertDoesNotThrow(() -> installAndVerifyElasticsearch(elasticSearchNs),
             String.format("Failed to install Elasticsearch"));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -66,6 +66,7 @@ import static oracle.weblogic.kubernetes.TestConstants.KIBANA_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_TYPE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
@@ -84,6 +85,7 @@ import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVe
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyElasticsearch;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyKibana;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.verifyLoggingExporterReady;
+import static oracle.weblogic.kubernetes.utils.OKDUtils.addSccToNsSvcAccount;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.upgradeAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodReady;
@@ -159,6 +161,9 @@ class ItElasticLoggingFluentd {
 
     // install and verify Elasticsearch
     elasticSearchNs = namespaces.get(2);
+    if (OKD) {
+      addSccToNsSvcAccount("default", elasticSearchNs);
+    }
     logger.info("install and verify Elasticsearch");
     elasticsearchParams = assertDoesNotThrow(() -> installAndVerifyElasticsearch(elasticSearchNs),
             String.format("Failed to install Elasticsearch"));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OKDUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OKDUtils.java
@@ -339,4 +339,16 @@ public class OKDUtils {
     getLogger().info("ingress {0} was created in namespace {1}", ingressName, namespace);
     return host;
   }
+
+  /**
+   * add security context constraints to the service account of namespace.
+   * @param serviceAccount - service account to add to scc
+   * @param namespace - namespace to which the service account belongs
+   */
+  public static void addSccToNsSvcAccount(String serviceAccount, String namespace) {
+    assertTrue(new Command()
+        .withParams(new CommandParams()
+            .command("oc adm policy add-scc-to-user privileged -z " + serviceAccount + " -n " + namespace))
+        .execute(), "oc expose service failed");
+  }
 }


### PR DESCRIPTION
2 failed test classes ItElasticLogging and ItElasticLoggingFluentd after passed on OKD:
https://build.weblogick8s.org:8443/job/wko-okd-test/237/testReport/

No regression in kind-new Jenkins run:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9306/testReport/