### PR TITLE
Owls 97124 - Fix for a negative auxiliary image 4.0 test case

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -903,7 +903,7 @@ class ItMiiAuxiliaryImage {
     assertDoesNotThrow(() -> createDomainCustomResource(domainCR), "createDomainCustomResource throws Exception");
 
     // check the introspector pod log contains the expected error message
-    String expectedErrorMsg = "cp: can't open '/aux/models/multi-model-one-ds.20.yaml: "
+    String expectedErrorMsg = "cp: can't open '/auxiliary/models/multi-model-one-ds.20.yaml': "
         + "Permission denied";
 
     // check the domain event contains the expected error message

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -22,7 +22,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonMiiTestUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -860,7 +859,6 @@ class ItMiiAuxiliaryImage {
    * Check the error message is in introspector pod log, domain events and operator pod log.
    */
   @Test
-  @Disabled("Regression bug, test fails")
   @DisplayName("Negative Test to create domain with file in auxiliary image not accessible by oracle user")
   void testErrorPathFilePermission() {
     final String domainUid2 = "domain8";

--- a/operator/src/main/resources/scripts/utils_base.sh
+++ b/operator/src/main/resources/scripts/utils_base.sh
@@ -266,7 +266,7 @@ createFolder() {
 initAuxiliaryImage() {
   local copyWdtInstallFiles=true
   local copyModelFiles=true
-  local cpOut
+  local cpOut=""
 
   local sourceWdtInstallHome=$(echo $AUXILIARY_IMAGE_SOURCE_WDT_INSTALL_HOME |  tr '[a-z]' '[A-Z]')
   if [ "${sourceWdtInstallHome}" != "NONE" ]; then

--- a/operator/src/main/resources/scripts/utils_base.sh
+++ b/operator/src/main/resources/scripts/utils_base.sh
@@ -266,6 +266,7 @@ createFolder() {
 initAuxiliaryImage() {
   local copyWdtInstallFiles=true
   local copyModelFiles=true
+  local cpOut
 
   local sourceWdtInstallHome=$(echo $AUXILIARY_IMAGE_SOURCE_WDT_INSTALL_HOME |  tr '[a-z]' '[A-Z]')
   if [ "${sourceWdtInstallHome}" != "NONE" ]; then
@@ -293,7 +294,7 @@ initAuxiliaryImage() {
         "don't want to have an install copy. Exiting."
         return 1
       fi
-      local cpOut=$(cp -R ${AUXILIARY_IMAGE_SOURCE_WDT_INSTALL_HOME}/* \
+      cpOut=$(cp -R ${AUXILIARY_IMAGE_SOURCE_WDT_INSTALL_HOME}/* \
                                           ${AUXILIARY_IMAGE_TARGET_PATH}/weblogic-deploy \
                                           2>&1)
       if [ $? -ne 0 ]; then
@@ -322,7 +323,7 @@ initAuxiliaryImage() {
     fi
     if [ "${copyModelFiles}" == "true" ]; then
       createFolder "${AUXILIARY_IMAGE_TARGET_PATH}/models" "This is the target directory for WDT model files." || return 1
-      local cpOut=$(cp -R ${AUXILIARY_IMAGE_SOURCE_MODEL_HOME}/* \
+      cpOut=$(cp -R ${AUXILIARY_IMAGE_SOURCE_MODEL_HOME}/* \
                                           ${AUXILIARY_IMAGE_TARGET_PATH}/models \
                                           2>&1)
       if [ $? -ne 0 ]; then


### PR DESCRIPTION
OWLS-97124 - This PR fixes the bug that allowed creation of domain with file in auxiliary image 4.0 not accessible by oracle user. The local variable needs to be initialized in the beginning of function instead of initializing during the copy command. Also fixed the validation logic for the integration test. 

Complete integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9349/
Test run for failing test - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9342/