### PR TITLE
Owls 97601 - Changes to prevent pod roll when upgrading operator 3.3.8 to 3.4

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -95,6 +95,7 @@ import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_RO
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.POD_CYCLE_STARTING;
 import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_INSTALL_HOME;
+import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_MODEL_HOME;
 
 public abstract class PodStepContext extends BasePodStepContext {
 
@@ -965,6 +966,10 @@ public abstract class PodStepContext extends BasePodStepContext {
     String wdtInstallHome = getWdtInstallHome();
     if (wdtInstallHome != null && !wdtInstallHome.isEmpty() && !wdtInstallHome.equals(DEFAULT_WDT_INSTALL_HOME)) {
       addEnvVar(vars, IntrospectorJobEnvVars.WDT_INSTALL_HOME, wdtInstallHome);
+    }
+    String modelHome = getModelHome();
+    if (modelHome != null && !modelHome.isEmpty() && !modelHome.equals(DEFAULT_WDT_MODEL_HOME)) {
+      addEnvVar(vars, IntrospectorJobEnvVars.WDT_MODEL_HOME, modelHome);
     }
     Optional.ofNullable(getServerSpec().getAuxiliaryImages()).ifPresent(cm -> addAuxiliaryImageEnv(cm, vars));
     addEnvVarIfTrue(mockWls(), vars, "MOCK_WLS");

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -94,6 +94,7 @@ import static oracle.kubernetes.operator.helpers.CompatibilityCheck.Compatibilit
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_ROLL_STARTING;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.POD_CYCLE_STARTING;
 import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
+import static oracle.kubernetes.utils.OperatorUtils.isNullOrEmpty;
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_INSTALL_HOME;
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_MODEL_HOME;
 
@@ -964,11 +965,11 @@ public abstract class PodStepContext extends BasePodStepContext {
     addEnvVar(vars, ServerEnvVars.AS_SERVICE_NAME, LegalNames.toServerServiceName(getDomainUid(), getAsName()));
     Optional.ofNullable(getDataHome()).ifPresent(v -> addEnvVar(vars, ServerEnvVars.DATA_HOME, v));
     String wdtInstallHome = getWdtInstallHome();
-    if (wdtInstallHome != null && !wdtInstallHome.isEmpty() && !wdtInstallHome.equals(DEFAULT_WDT_INSTALL_HOME)) {
+    if (!isNullOrEmpty(wdtInstallHome) && !wdtInstallHome.equals(DEFAULT_WDT_INSTALL_HOME)) {
       addEnvVar(vars, IntrospectorJobEnvVars.WDT_INSTALL_HOME, wdtInstallHome);
     }
     String modelHome = getModelHome();
-    if (modelHome != null && !modelHome.isEmpty() && !modelHome.equals(DEFAULT_WDT_MODEL_HOME)) {
+    if (!isNullOrEmpty(modelHome) && !modelHome.equals(DEFAULT_WDT_MODEL_HOME)) {
       addEnvVar(vars, IntrospectorJobEnvVars.WDT_MODEL_HOME, modelHome);
     }
     Optional.ofNullable(getServerSpec().getAuxiliaryImages()).ifPresent(cm -> addAuxiliaryImageEnv(cm, vars));


### PR DESCRIPTION
Owls 97601 - This change adds the WDT_MODEL_HOME env variable to prevent roll during upgrade as this env variable is added in 3.3.8 for auxiliary images. 

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9359/console