### PR TITLE
Simply computation of events from conditions

### DIFF
--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -311,10 +311,6 @@
           "description": "Human-readable message indicating details about last transition.",
           "type": "string"
         },
-        "introspectionUid": {
-          "description": "The uid of an introspection job associated with this failed condition",
-          "type": "string"
-        },
         "lastProbeTime": {
           "description": "Last time we probed the condition.",
           "$ref": "#/definitions/DateTime"

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -176,7 +176,6 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `introspectionUid` | string | The uid of an introspection job associated with this failed condition |
 | `lastProbeTime` | DateTime | Last time we probed the condition. |
 | `lastTransitionTime` | DateTime | Last time the condition transitioned from one status to another. |
 | `message` | string | Human-readable message indicating details about last transition. |

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1232,10 +1232,6 @@ window.onload = function() {
           "description": "Human-readable message indicating details about last transition.",
           "type": "string"
         },
-        "introspectionUid": {
-          "description": "The uid of an introspection job associated with this failed condition",
-          "type": "string"
-        },
         "lastProbeTime": {
           "description": "Last time we probed the condition.",
           "$ref": "#/definitions/DateTime"

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 88c7ac43694c6ec693d8d66a210fcd6861c6de6e4972047f15b541349901512d
+    weblogic.sha256: ccba65c72537d8324372ffe85a02867bc7dfcbbfbb93dda11e52a439ac3242da
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -11859,10 +11859,6 @@ spec:
                     message:
                       description: Human-readable message indicating details about
                         last transition.
-                      type: string
-                    introspectionUid:
-                      description: The uid of an introspection job associated with
-                        this failed condition
                       type: string
                     lastProbeTime:
                       format: date-time

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -806,7 +806,7 @@ public class EventHelper {
 
     @Override
     public String toString() {
-      return "EventData: " + eventItem;
+      return "EventData: " + eventItem + "; with reason: " + failureReason;
     }
 
     /**

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainCondition.java
@@ -55,9 +55,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
   @NotNull
   private String status = "True";
 
-  @Description("The uid of an introspection job associated with this failed condition")
-  private String introspectionUid;
-
   /**
    * Creates a new domain condition, initialized with its type.
    * @param conditionType the enum that designates the condition type
@@ -74,7 +71,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
     this.message = other.message;
     this.reason = other.reason;
     this.status = other.status;
-    this.introspectionUid = other.introspectionUid;
   }
 
   /**
@@ -224,14 +220,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
     return type == this.type;
   }
 
-  public String getIntrospectionUid() {
-    return introspectionUid;
-  }
-
-  public void setIntrospectionUid(String introspectionUid) {
-    this.introspectionUid = introspectionUid;
-  }
-
   @Override
   public boolean isPatchableFrom(DomainCondition other) {
     return false; // domain conditions are never patched
@@ -244,7 +232,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
     Optional.ofNullable(status).ifPresent(s -> sb.append("/").append(s));
     Optional.ofNullable(reason).ifPresent(r -> sb.append(" reason: ").append(r));
     Optional.ofNullable(message).ifPresent(m -> sb.append(" message: ").append(m));
-    Optional.ofNullable(introspectionUid).ifPresent(u -> sb.append(" introspection job UID: ").append(u));
     return sb.toString();
   }
 
@@ -255,7 +242,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
         .append(message)
         .append(type)
         .append(status)
-        .append(introspectionUid)
         .toHashCode();
   }
 
@@ -273,7 +259,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
         .append(message, rhs.message)
         .append(type, rhs.type)
         .append(status, rhs.status)
-        .append(introspectionUid, rhs.introspectionUid)
         .isEquals();
   }
 
@@ -292,7 +277,6 @@ public class DomainCondition implements Comparable<DomainCondition>, PatchableCo
         .withStringField("message", DomainCondition::getMessage)
         .withStringField("reason", DomainCondition::getReason)
         .withStringField("status", DomainCondition::getStatus)
-        .withStringField("introspectionUid", DomainCondition::getIntrospectionUid)
         .withEnumField("type", DomainCondition::getType);
 
   static ObjectPatch<DomainCondition> getObjectPatch() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainConditionType.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainConditionType.java
@@ -4,9 +4,18 @@
 package oracle.kubernetes.weblogic.domain.model;
 
 import oracle.kubernetes.json.Obsoleteable;
+import oracle.kubernetes.operator.helpers.EventHelper;
+
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_AVAILABLE;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_COMPLETE;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_FAILURE_RESOLVED;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_INCOMPLETE;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_ROLL_COMPLETED;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_ROLL_STARTING;
+import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_UNAVAILABLE;
 
 public enum DomainConditionType implements Obsoleteable {
-  Failed {
+  Failed(null, DOMAIN_FAILURE_RESOLVED) {
     @Override
     boolean allowMultipleConditionsWithThisType() {
       return true;
@@ -17,10 +26,10 @@ public enum DomainConditionType implements Obsoleteable {
       return false;
     }
   },
-  Available,
-  Completed,
+  Available(DOMAIN_AVAILABLE, DOMAIN_UNAVAILABLE),
+  Completed(DOMAIN_COMPLETE, DOMAIN_INCOMPLETE),
   ConfigChangesPendingRestart,
-  Rolling {
+  Rolling(DOMAIN_ROLL_STARTING,DOMAIN_ROLL_COMPLETED) {
     @Override
     boolean statusMayBeFalse() {
       return false;
@@ -33,12 +42,32 @@ public enum DomainConditionType implements Obsoleteable {
     }
   };
 
+  private final EventHelper.EventItem addedEvent;
+  private final EventHelper.EventItem removedEvent;
+
+  DomainConditionType(EventHelper.EventItem addedEvent, EventHelper.EventItem removedEvent) {
+    this.addedEvent = addedEvent;
+    this.removedEvent = removedEvent;
+  }
+
+  DomainConditionType() {
+    this(null, null);
+  }
+
   boolean allowMultipleConditionsWithThisType() {
     return false;
   }
 
   boolean statusMayBeFalse() {
     return true;
+  }
+
+  public EventHelper.EventItem getAddedEvent() {
+    return addedEvent;
+  }
+
+  public EventHelper.EventItem getRemovedEvent() {
+    return removedEvent;
   }
 
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -92,6 +92,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStub;
 import static oracle.kubernetes.operator.DomainConditionMatcher.hasCondition;
+import static oracle.kubernetes.operator.DomainFailureReason.Aborted;
 import static oracle.kubernetes.operator.DomainFailureReason.Internal;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.SECRET_NAME;
@@ -935,6 +936,15 @@ class DomainProcessorTest {
     executeScheduledRetry();
 
     assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(ABORTED_ERROR));
+  }
+
+  @Test
+  void whenIntrospectionJobTimedOut_createFailureWithAbortedReason() throws Exception {
+    runMakeRight_withIntrospectionTimeout();
+
+    executeScheduledRetry();
+
+    assertThat(getRecordedDomain(), hasCondition(Failed).withReason(Aborted));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import static oracle.kubernetes.operator.DomainConditionMatcher.hasCondition;
 import static oracle.kubernetes.operator.DomainFailureReason.Internal;
-import static oracle.kubernetes.operator.DomainFailureReason.Introspection;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createInternalFailureSteps;
@@ -48,10 +47,7 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Rolling;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 /**
@@ -232,6 +228,7 @@ class DomainStatusUpdaterTest {
     assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(ABORTED_ERROR));
   }
 
+  @SuppressWarnings("SameParameterValue")
   private V1Job createIntrospectorJob(String uid) {
     return new V1Job().metadata(createJobMetadata(uid)).status(new V1JobStatus());
   }
@@ -250,35 +247,4 @@ class DomainStatusUpdaterTest {
 
   // todo when new failures match old ones, leave the old matches
 
-  // temporary tests
-
-
-  @Test
-  void whenFailureStepCreatedWithoutCount_uidIsNull() {
-    final DomainStatusUpdater.FailureStep failureSteps = DomainStatusUpdater.createFailedStep(Introspection, "");
-
-    assertThat(failureSteps.jobUid, nullValue());
-  }
-
-
-  @Test
-  void whenFailureStepCreatedWithCountOnNullJob_uidIsEmpty() {
-    final DomainStatusUpdater.FailureStep failureSteps
-          = (DomainStatusUpdater.FailureStep) DomainStatusUpdater.createFailedStep(Internal, "").forIntrospection(null);
-
-    assertThat(failureSteps.jobUid, emptyString());
-  }
-
-
-  @Test
-  void whenFailureStepCreatedWithCountOnJob_uidMatchesJobUid() {
-    final DomainStatusUpdater.FailureStep failureSteps = (DomainStatusUpdater.FailureStep)
-          DomainStatusUpdater.createFailedStep(Introspection, "").forIntrospection(createIntrospectorJob("abcd"));
-
-    assertThat(failureSteps.jobUid, equalTo("abcd"));
-  }
-
-  @Test
-  void whenFailureContains() {
-  }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainConditionTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainConditionTest.java
@@ -16,7 +16,6 @@ import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Availa
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Completed;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.ConfigChangesPendingRestart;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.Failed;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -52,14 +51,6 @@ class DomainConditionTest {
     SystemClockTestSupport.increment();
 
     assertThat(oldCondition.equals(new DomainCondition(Available).withStatus("True")), is(true));
-  }
-
-  @Test
-  void failedConditionMayIncludeIntrospectionJobUid() {
-    final DomainCondition condition = new DomainCondition(Failed);
-    condition.setIntrospectionUid("abcde");
-
-    assertThat(condition.getIntrospectionUid(), equalTo("abcde"));
   }
 
   @Test


### PR DESCRIPTION
Wherever possible, events are now computed directly from added or removed conditions. Failures are now created in a single place, which will allow us to log them at the appropriate severity level once we add that functionality.