### PR TITLE
3.3 branch - OWLS-97340 - HTTP warnings logged continuously after changing serverStartPolicy to NEVER

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -103,8 +103,13 @@ public class ServerStatusReader {
       AtomicInteger remainingServerHealthToRead = new AtomicInteger();
       packet.put(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ, remainingServerHealthToRead);
 
+      DomainPresenceInfo currentInfo =
+          Optional.ofNullable(
+              DomainProcessorImpl.getExistingDomainPresenceInfo(info.getNamespace(), info.getDomainUid()))
+              .orElse(info);
+
       Collection<StepAndPacket> startDetails =
-          info.getServerPods()
+          currentInfo.getServerPods()
               .map(pod -> createStatusReaderStep(packet, pod))
               .collect(Collectors.toList());
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -71,7 +71,9 @@ public class ManagedServersUpStep extends Step {
 
     if (info.getDomain().isShuttingDown()) {
       insert(steps, createAvailableHookStep());
-      factory.shutdownInfos.add(new ServerShutdownInfo(domainTopology.getAdminServerName(), null));
+      Optional.ofNullable(domainTopology).ifPresent(
+          wlsDomainConfig ->
+              factory.shutdownInfos.add(new ServerShutdownInfo(wlsDomainConfig.getAdminServerName(), null)));
     }
 
     List<ServerShutdownInfo> serversToStop = getServersToStop(info, factory.shutdownInfos);

--- a/operator/src/test/java/oracle/kubernetes/operator/ServerStatusReaderTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ServerStatusReaderTest.java
@@ -57,7 +57,7 @@ class ServerStatusReaderTest extends HttpUserAgentTest {
   private final FiberTestSupport testSupport = new FiberTestSupport();
   private final List<Memento> mementos = new ArrayList<>();
   private final Domain domain =
-      new Domain().withMetadata(new V1ObjectMeta().namespace(NS)).withSpec(new DomainSpec());
+      new Domain().withMetadata(new V1ObjectMeta().namespace(NS)).withSpec(new DomainSpec().withDomainUid(UID));
   private final DomainPresenceInfo info = new DomainPresenceInfo(domain);
 
   @BeforeEach

--- a/operator/src/test/java/oracle/kubernetes/operator/ServerStatusReaderTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/ServerStatusReaderTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -59,6 +59,7 @@ class ServerStatusReaderTest extends HttpUserAgentTest {
   private final Domain domain =
       new Domain().withMetadata(new V1ObjectMeta().namespace(NS)).withSpec(new DomainSpec().withDomainUid(UID));
   private final DomainPresenceInfo info = new DomainPresenceInfo(domain);
+  private final Map<String, Map<String, DomainPresenceInfo>> presenceInfoMap = new HashMap<>();
 
   @BeforeEach
   public void setUp() throws NoSuchFieldException {
@@ -69,6 +70,7 @@ class ServerStatusReaderTest extends HttpUserAgentTest {
     mementos.add(ClientFactoryStub.install());
 
     testSupport.addDomainPresenceInfo(info);
+    mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "DOMAINS", presenceInfoMap));
   }
 
   private V1Pod createPod(String serverName) {
@@ -125,6 +127,23 @@ class ServerStatusReaderTest extends HttpUserAgentTest {
   void createDomainStatusReaderStep_initializesRemainingServersHealthRead_withNumServers() {
     info.setServerPod("server1", createPod("server1"));
     info.setServerPod("server2", createPod("server2"));
+
+    Packet packet =
+        testSupport.runSteps(ServerStatusReader.createDomainStatusReaderStep(info, 0, endStep));
+
+    assertThat(
+        ((AtomicInteger) packet.get(ProcessingConstants.REMAINING_SERVERS_HEALTH_TO_READ)).get(),
+        is(2));
+  }
+
+  @Test
+  void createDomainStatusReaderStep_usesInfoFromDomainProcessorIfAvailable() {
+    info.setServerPod("server1", createPod("server1"));
+
+    DomainPresenceInfo latestInfo = new DomainPresenceInfo(domain);
+    latestInfo.setServerPod("server1", createPod("server1"));
+    latestInfo.setServerPod("server2", createPod("server2"));
+    presenceInfoMap.put(NS, Map.of(UID, latestInfo));
 
     Packet packet =
         testSupport.runSteps(ServerStatusReader.createDomainStatusReaderStep(info, 0, endStep));

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ManagedServersUpStepTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;
@@ -532,6 +532,13 @@ class ManagedServersUpStepTest {
   }
 
   @Test
+  void whenShuttingDown_withNullWlsDomainConfig_ensureNoException() {
+    configurator.setShuttingDown(true);
+
+    createNextStepWithNullWlsDomainConfig();
+  }
+
+  @Test
   void whenClusterStartupDefinedWithPreCreateServerService_addAllToServers() {
     configureCluster("cluster1").withPrecreateServerService(true);
     addWlsCluster("cluster1", "ms1", "ms2");
@@ -785,6 +792,14 @@ class ManagedServersUpStepTest {
             .forEach(s -> addShutdownServerInfo(s, servers, ssi));
     serversUpStepFactory.shutdownInfos.addAll(ssi);
     return factory.createServerStep(domainPresenceInfo, config, serversUpStepFactory, nextStep);
+  }
+
+  private Step createNextStepWithNullWlsDomainConfig() {
+    configSupport.setAdminServerName(ADMIN);
+    ManagedServersUpStep.NextStepFactory factory = factoryMemento.getOriginalValue();
+    ServersUpStepFactory serversUpStepFactory = new ServersUpStepFactory(null, domain, domainPresenceInfo, false);
+    List<DomainPresenceInfo.ServerShutdownInfo> ssi = new ArrayList<>();
+    return factory.createServerStep(domainPresenceInfo, null, serversUpStepFactory, nextStep);
   }
 
   private void addShutdownServerInfo(String serverName, List<String> servers,


### PR DESCRIPTION
This PR fixes owls-97340 in the release/3.3 branch. The issue cannot be reproduced in main branch. Since the code has been changed quite extensively, I was not able to isolate a subset of changes to backport to the release/3.3 branch. Thus a different fix to address this bug in the release/3.3 branch.

This PR also contains backport for owls-96905 - Fixes NPE in ManagedServersUpStep.scaleDownIfNecessary() from [PR 2825](url) to the release/3.3 branch.

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9375/

_Summary of issue in owls-97340:_

After server pods are shut down, operator were still trying to poll server pods that no longer exist, thus resulting in the warning messages such as:

```
{"timestamp":"2022-03-09T08:55:08.487148894Z","thread":339,"fiber":"","namespace":"oms","domainUID":"billingcare-domain","level":"WARNING","class":"oracle.kubernetes.operator.http.HttpAsyncRequestStep$AsyncProcessing","method":"recordThrowableResponse","timeInMillis":1646816108487,"message":"HTTP request method POST to
http://10.244.0.196:7011/management/weblogic/latest/serverRuntime/search failed with exception java.net.ConnectException: No route to host.","exception":"","code":"","headers":{},"body":""}
```
Fix for release/3.3 branch is made to DomainStatusReaderStep, where it now uses the more up-to-date DomainPresenceInfo obtained from DomainProcessorImpl, instead of the possibly stale info passed into its constructor, for creating status readers.