### PR TITLE
Avoid adding two copies of subsequent steps

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -318,8 +318,9 @@ public class DomainStatusUpdater {
       return doNext(createContext(packet).createUpdateSteps(getNext()), packet);
     }
 
+    // Note: this step is created with no next step, as that is added via a call to Step.chain, later.
     private ResponseStep<Domain> createResponseStep(DomainStatusUpdaterContext context) {
-      return new StatusReplaceResponseStep(this, context, getNext());
+      return new StatusReplaceResponseStep(this, context, null);
     }
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/work/TerminalStep.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/TerminalStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.work;
@@ -18,6 +18,6 @@ public class TerminalStep extends Step {
   @Override
   public NextAction apply(Packet packet) {
     executed = true;
-    return doNext(packet);
+    return doNext(null, packet);
   }
 }


### PR DESCRIPTION
Addresses bug OWLS-97689

The problem was caused by the DomainStatusUpdater adding two copies of the `next` step chain to the fiber: one as part of creating the status update step, and one after the event steps. In production, that chain ends with the DomainProcessorImpl.TailStep, which terminates the fiber. As a result, the event steps were never being run (nor the duplicate domain processing).

The unit tests did not catch it because the unit test equivalent, _TerminalStep_ was invoking the default `doNext` method, which does run the subsequent steps. Changing that explicitly to select `null` as the next step, reproduces the error and confirms that avoiding the duplication solves the problem.

Jenkins jobs:
[ItKubernetesEvents](https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9416/)
[ItPodsRestart](https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9420/)
[ItIntrospectVersion](https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9418/)



