### PR TITLE
update namespace management doc

### DIFF
--- a/documentation/staging/content/samples/azure-kubernetes-service/model-in-image.md
+++ b/documentation/staging/content/samples/azure-kubernetes-service/model-in-image.md
@@ -294,7 +294,7 @@ The model file:
         - This secret is in turn referenced using the `webLogicCredentialsSecret` field in the Domain.
         - The `weblogic-credentials` is a reserved name that always dereferences to the owning Domain actual WebLogic credentials secret name.
 
-A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete discussion of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) files in the Model in Image user documentation.
+A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete description of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) files in the Model in Image user documentation.
 
 ##### Creating the image with WIT
 

--- a/documentation/staging/content/samples/domains/model-in-image/initial.md
+++ b/documentation/staging/content/samples/domains/model-in-image/initial.md
@@ -316,7 +316,7 @@ The model files:
     - This secret is in turn referenced using the `webLogicCredentialsSecret` field in the Domain.
     - The `weblogic-credentials` is a reserved name that always dereferences to the owning Domain actual WebLogic credentials secret name.
 
-A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete discussion of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) in the Model in Image user documentation.
+A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete description of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) in the Model in Image user documentation.
 
 
 #### Creating the image with WIT

--- a/documentation/staging/content/samples/domains/model-in-image/update1.md
+++ b/documentation/staging/content/samples/domains/model-in-image/update1.md
@@ -10,7 +10,7 @@ This use case demonstrates dynamically adding a data source to your running doma
 - A domain's model can be updated dynamically by supplying a model update in a file in a Kubernetes ConfigMap.
 - Model updates can be as simple as changing the value of a single attribute, or more complex, such as adding a JMS Server.
 
-For a detailed discussion of model updates, see [Runtime Updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) in the Model in Image user guide.
+For a detailed description of model updates, see [Runtime Updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) in the Model in Image user guide.
 
 {{% notice warning %}}
 The operator does not support all possible dynamic model updates. For model update limitations, consult [Runtime Updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) in the Model in Image user docs, and carefully test any model update before attempting a dynamic update in production.

--- a/documentation/staging/content/samples/tanzu-kubernetes-service/_index.md
+++ b/documentation/staging/content/samples/tanzu-kubernetes-service/_index.md
@@ -310,7 +310,7 @@ The model files:
         - This secret is in turn referenced using the `webLogicCredentialsSecret` field in the Domain.
         - The `weblogic-credentials` is a reserved name that always dereferences to the owning Domain actual WebLogic credentials secret name.
 
-A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete discussion of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) files in the Model in Image user documentation.
+A Model in Image image can contain multiple properties files, archive ZIP files, and YAML files but in this sample you use just one of each. For a complete description of Model in Images model file naming conventions, file loading order, and macro syntax, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) files in the Model in Image user documentation.
 
 ##### Creating the image with WIT
 

--- a/documentation/staging/content/userguide/base-images/_index.md
+++ b/documentation/staging/content/userguide/base-images/_index.md
@@ -698,7 +698,7 @@ from a base Oracle Linux image, a WebLogic installer download, and a JRE install
      and the `wlsdev` type to the WLS developer install.
      See
      [Understand Oracle Container Registry images](#understand-oracle-container-registry-images)
-     for a discussion of each installation type.
+     for a description of each installation type.
    - The `--recommendedPatches` parameter finds and applies the latest PatchSet Update (PSU)
      and recommended patches for each of the products included in the installer. For example, for WebLogic Server, the recommended patches for Coherence and TopLink are included.
    - These sample commands use a default base image, which is an Oracle Linux OS image,

--- a/documentation/staging/content/userguide/managing-domains/configoverrides/_index.md
+++ b/documentation/staging/content/userguide/managing-domains/configoverrides/_index.md
@@ -95,7 +95,7 @@ Typical attributes for overrides include:
 * Debugging
 * Tuning (`MaxMessageSize`, and such)
 
-See [overrides distribution](#overrides-distribution) for a discussion of distributing new or changed configuration overrides to already running WebLogic Server instances.
+See [overrides distribution](#overrides-distribution) for a description of distributing new or changed configuration overrides to already running WebLogic Server instances.
 
 ---
 ### Unsupported overrides

--- a/documentation/staging/content/userguide/managing-domains/domain-resource.md
+++ b/documentation/staging/content/userguide/managing-domains/domain-resource.md
@@ -189,12 +189,12 @@ Elements related to specifying and overriding WebLogic domain configuration:
     to verify that the pod is ready
     for application traffic. Defaults to 8888.
   * `replicationChannelPort`:
-    The operator will create a `T3` protocol 
+    The operator will create a `T3` protocol
     WebLogic network access point
-    on each WebLogic Server that is part of a cluster with this port 
+    on each WebLogic Server that is part of a cluster with this port
     to handle EJB and servlet session state replication traffic
-    between servers. This setting is ignored for clusters 
-    where the WebLogic cluster configuration already 
+    between servers. This setting is ignored for clusters
+    where the WebLogic cluster configuration already
     defines a `replication-channel` attribute. Defaults to 4564.
   * `localhostBindingsEnabled`:
     This setting was added in operator version 3.3.3,
@@ -250,7 +250,7 @@ You can use the following environment variables to specify JVM memory and JVM op
   * If `NODEMGR_MEM_ARGS` is not defined, then default memory and Java security property values (`-Xms64m -Xmx100m -Djava.security.egd=file:/dev/./urandom`) will be applied to the Node Manager instance. It can be explicitly set to another value in your Domain YAML file using the `env` attribute under the `serverPod` configuration.
 * The `USER_MEM_ARGS` and `WLST_EXTRA_PROPERTIES` environment variables both default to `-Djava.security.egd=file:/dev/./urandom` in all WebLogic Server pods and the WebLogic introspection job. They can be explicitly set to another value in your Domain YAML file using the `env` attribute under the `serverPod` configuration.
 * Notice that the `NODEMGR_MEM_ARGS`, `USER_MEM_ARGS`, and `WLST_EXTRA_PROPERTIES` environment variables all include `-Djava.security.egd=file:/dev/./urandom` by default. This helps to speed up the Node Manager and WebLogic Server startup on systems with low entropy, plus similarly helps to speed up introspection job usage of the WLST `encrypt` command.
-* For a detailed discussion of Java and pod memory tuning see the [Pod memory and CPU resources FAQ]({{<relref "/faq/resource-settings.md">}}).
+* For a detailed description of Java and pod memory tuning see the [Pod memory and CPU resources FAQ]({{<relref "/faq/resource-settings.md">}}).
 * You can use `JAVA_OPTIONS` and `WLSDEPLOY_PROPERTIES` to disable Fast Application Notifications (FAN); see the [Disable Fast Application Notifications FAQ]({{<relref "/faq/fan.md">}}) for details.
 
 This example snippet illustrates how to add some of the above environment variables using the `env` attribute under the `serverPod` configuration in your Domain YAML file.

--- a/documentation/staging/content/userguide/managing-domains/model-in-image/debugging.md
+++ b/documentation/staging/content/userguide/managing-domains/model-in-image/debugging.md
@@ -140,7 +140,7 @@ Common issues that have corresponding documentation include:
   plus the operator log contains no mention of the domain,
   then check to make sure that the Domain's namespace has been set up to be monitored by an operator.
   See the operator [Namespace management]({{<relref "userguide/managing-operators/namespace-management.md">}})
-  and operator [Common mistakes]({{<relref "userguide/managing-operators/common-mistakes.md">}}) documentation.
+  and operator [Common mistakes and solutions]({{<relref "userguide/managing-operators/common-mistakes.md">}}) documentation.
 - If a `describe` of an introspector job or WebLogic Server pod reveals image access errors,
   see the [Cannot pull image]({{<relref "/faq/cannot-pull-image">}}) FAQ.
 

--- a/documentation/staging/content/userguide/managing-domains/model-in-image/runtime-updates.md
+++ b/documentation/staging/content/userguide/managing-domains/model-in-image/runtime-updates.md
@@ -143,22 +143,22 @@ It is important to avoid applying unsupported model updates to a running domain.
 
 The following summarizes the types of runtime update configuration that are _not_ supported in this release of Model in Image unless a workaround or alternative is documented:
 
-  - Decreasing dynamic cluster size (see detailed discussion below for an alternative)
+  - Decreasing dynamic cluster size (see the following detailed description for an alternative)
   - Adding WebLogic Servers to a configured cluster or removing them
   - Default and custom network channel configuration for an existing WebLogic cluster or server. Specifically:
     - Adding or removing Network Access Points (custom channels) for existing servers
     - Changing a Default, SSL, Admin, or custom channel, `Enabled`, listen address, protocol, or port
   - Node Manager related configuration
-  - Log related settings (see the detailed discussion below for when this applies)
+  - Log related settings (see the following detailed description for when this applies)
   - Changing the domain name
-  - Deleting an MBean attribute (see the detailed discussion below for workaround)
-  - Changing any existing MBean name (see the detailed discussion below for workaround)
-  - Embedded LDAP entries (see detailed discussion below for alternatives)
+  - Deleting an MBean attribute (see the following detailed description for a workaround)
+  - Changing any existing MBean name (see the following detailed description for a workaround)
+  - Embedded LDAP entries (see the following detailed description for alternatives)
   - Any Model YAML `topology:` stanza changes
   - Dependency deletion in combination with online updates
   - Various security related changes in combination with online updates
 
-Here is a detailed discussion of each unsupported runtime update
+Here is a detailed description of each unsupported runtime update
 and a description of workarounds and alternatives when applicable:
 
  - There is no way to directly delete an attribute from an MBean that's already been specified by a model file.
@@ -282,11 +282,11 @@ plus, an offline update, if there are any accompanying model changes.
 
 Model updates can include additions, changes, and deletions. For help generating model changes:
 
- - For a discussion of model file syntax, see the
+ - For a description of model file syntax, see the
    [WebLogic Deploy Tool](https://oracle.github.io/weblogic-deploy-tooling/) documentation
    and Model in Image [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) documentation.
 
- - For a discussion about helper tooling that you can use to generate model change YAML,
+ - For a description of helper tooling that you can use to generate model change YAML,
    see [Using the WDT Discover and Compare Model Tools](#using-the-wdt-discover-domain-and-compare-model-tools).
 
  - If you specify multiple model files in your image, volumes (including those based on images from the [auxiliary images]({{< relref "/userguide/managing-domains/model-in-image/auxiliary-images.md" >}}) feature), or WDT ConfigMap,
@@ -694,7 +694,7 @@ _Here is how to interpret each domain resource's `domain.status.conditions` type
       * Processing successfully completed, including the introspector job.
       * The administrator has not subsequently rolled/restarted each WebLogic Server pod
         (in order to propagate the pending non-dynamic changes).
-        * See the following discussion of WebLogic pod labels to see which pods are awaiting restart.
+        * See the following description of WebLogic pod labels to see which pods are awaiting restart.
     * For example:
       ```
       Status:

--- a/documentation/staging/content/userguide/managing-domains/model-in-image/usage.md
+++ b/documentation/staging/content/userguide/managing-domains/model-in-image/usage.md
@@ -117,7 +117,7 @@ For example, place additional `.yaml` and `.properties` files in a directory cal
     weblogic.domainUID=MY-DOMAINUID
   ```
 
-See [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) for a discussion of model file syntax and loading order, and see [Runtime updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) for a discussion of using WDT model ConfigMaps to update the model configuration of a running domain.
+See [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}) for a description of model file syntax and loading order, and see [Runtime updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) for a description of using WDT model ConfigMaps to update the model configuration of a running domain.
 
 
 ### Required runtime encryption secret
@@ -149,7 +149,7 @@ Corresponding Domain YAML file snippet:
 
 #### Secrets for model macros
 
-Create additional secrets as needed by macros in your model files. For example, these can store database URLs and credentials that are accessed using `@@SECRET` macros in your model that reference the secrets.  For a discussion of model macros, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}).
+Create additional secrets as needed by macros in your model files. For example, these can store database URLs and credentials that are accessed using `@@SECRET` macros in your model that reference the secrets.  For a description of model macros, see [Model files]({{< relref "/userguide/managing-domains/model-in-image/model-files.md" >}}).
 
 #### Domain fields
 

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -188,7 +188,7 @@ When upgrading the operator:
 - Use the `helm upgrade` command with the `--reuse-values` parameter.
 - Supply a new `image` value.
 
-This rationale for this is because, even with a new version of the Helm chart,
+The rationale for this is because, even with a new version of the Helm chart,
 `--reuse-values` will retain the previous image value from when it was installed.  To upgrade,
 you must override the image value to use the new operator image version.
 

--- a/documentation/staging/content/userguide/managing-operators/namespace-management.md
+++ b/documentation/staging/content/userguide/managing-operators/namespace-management.md
@@ -23,7 +23,7 @@ An operator deployment must be configured to manage Kubernetes namespaces,
 and a number of Kubernetes resources
 must be present in a namespace before any WebLogic Server instances can be successfully
 started by operator. These Kubernetes resources are created either as part of the installation
-of a release of the operator's Helm chart, or are created by the operator.
+of the operator's Helm chart, or are created by the operator.
 
 An operator can manage all WebLogic domains in all namespaces in a Kubernetes cluster,
 or only manage domains in a specific subset of the namespaces,
@@ -31,14 +31,14 @@ or manage only the domains that are located in the same namespace as the operato
 You can change the namespaces that an operator deployment manages while the operator is still running.
 You can also create and prepare a namespace for the operator to manage while the operator is still running.
 
-* For considerations for configuring which namespaces that an operator manages,
+* For considerations for configuring which namespaces an operator manages,
 see [Choose a domain namespace selection strategy](#choose-a-domain-namespace-selection-strategy),
 * For some considerations to be aware of when
 you manage the namespaces while the operator is running,
 see [Altering namespaces for a running operator](#altering-namespaces-for-a-running-operator).
 * For namespace management information that is external to this document,
 see [WebLogic domain management]({{<relref "/userguide/managing-operators/using-helm.md#weblogic-domain-management">}})
-and [Common Mistakes and Solutions]({{< relref "/userguide/managing-operators/common-mistakes.md" >}}).
+and [Common mistakes and solutions]({{< relref "/userguide/managing-operators/common-mistakes.md" >}}).
 
 {{% notice warning %}}
 There can be multiple operators in a Kubernetes cluster,
@@ -52,16 +52,16 @@ _At most, a namespace can be managed by one operator._
 An operator can manage domain resources in multiple namespaces,
 including its own namespace,
 but two operators cannot manage domains that are in the same namespace.
-The operator install Helm chart
+The operator installation Helm chart
 [domainNamespaceSelectionStrategy]({{<relref "/userguide/managing-operators/using-helm#domainnamespaceselectionstrategy">}})
-configuration setting controls which namespaces that an operator manages.
+configuration setting controls which namespaces an operator manages.
 
 |Strategy|Description|Example|
 |-|-|-|
-|`Dedicated`|The operator will manage only domains that are in the same namespace as the operator.|If the operator is deployed to namespace `my-operator-ns` and was installed using `--set "domainNamespaceSelectionStrategy=Dedicated"` in its Helm chart configuration, then the operator will only manage domains in the `my-operator-ns` namespace.|
-|`List`|This is the default. The operator will manage the namespaces included in the `domainNamespaces` operator install Helm chart configuration value which is a list that defaults to `{default}`.|If you want to manage namespaces `default` and `ns1`, then use `--set "domainNamespaceSelectionStrategy=List"` and `--set "domainNamespaces={default,ns1}"` in your operator install Helm chart configuration.|
-|`LabelSelector`|The operator will manage namespaces with Kubernetes labels that match the label selector defined by your Helm chart configuration `domainNamespaceLabelSelector` attribute.|If your operator Helm chart configuration has `--set "domainNamespaceSelectionStrategy=LabelSelector"` and you define the label selector in your operator install using `--set "domainNamespaceLabelSelector=weblogic-operator\=enabled"`, then the operator will manage namespaces with label name `weblogic-operator` when this label has value `enabled`, and you can label namespace `sample-domain1-ns` using the command `kubectl label namespace sample-domain1-ns weblogic-operator=enabled`. See [domainNamespaceLabelSelector]({{<relref "/userguide/managing-operators/using-helm#domainnamespacelabelselector">}}) in the Configuration Reference for detailed syntax requirements. |
-|`RegExp`|The operator will manage namespaces that match the regular expression set by your `domainNamespaceRegExp` Helm chart configuration attribute.|If you want an operator to manage namespaces that start with the string "prod", then use `--set "domainNamespaceSelectionStrategy=RegExp"` for your operator Helm configuration setting, and set the `domainNamespaceRegExp` Helm chart configuration attribute using `--set "domainNamespaceRegExp=^prod"`.|
+|`Dedicated`|The operator will manage only domains that are in the same namespace as the operator.|If the operator is deployed to namespace `my-operator-ns` and was installed using `--set "domainNamespaceSelectionStrategy=Dedicated"` in its Helm chart configuration, then the operator will manage only domains in the `my-operator-ns` namespace.|
+|`List`|This is the default. The operator will manage the namespaces included in the `domainNamespaces` operator installation Helm chart configuration value which is a list that defaults to `{default}`.|If you want to manage namespaces `default` and `ns1`, then in your operator installation Helm chart configuration, use `--set "domainNamespaceSelectionStrategy=List"` and `--set "domainNamespaces={default,ns1}"`.|
+|`LabelSelector`|The operator will manage namespaces with Kubernetes labels that match the label selector defined by your Helm chart configuration `domainNamespaceLabelSelector` attribute.|If your operator Helm chart configuration has `--set "domainNamespaceSelectionStrategy=LabelSelector"` and you define the label selector in your operator installation using `--set "domainNamespaceLabelSelector=weblogic-operator\=enabled"`, then the operator will manage namespaces with label name `weblogic-operator` when this label has value `enabled`, and you can label namespace `sample-domain1-ns` using the command `kubectl label namespace sample-domain1-ns weblogic-operator=enabled`. For detailed syntax requirements, see [domainNamespaceLabelSelector]({{<relref "/userguide/managing-operators/using-helm#domainnamespacelabelselector">}}) in the Configuration Reference. |
+|`RegExp`|The operator will manage namespaces that match the regular expression set by your `domainNamespaceRegExp` Helm chart configuration attribute.|If you want an operator to manage namespaces that start with the string `prod`, then use `--set "domainNamespaceSelectionStrategy=RegExp"` for your operator Helm configuration setting, and set the `domainNamespaceRegExp` Helm chart configuration attribute using `--set "domainNamespaceRegExp=^prod"`.|
 
 For detailed reference information about each setting,
 see [WebLogic domain management]({{<relref "/userguide/managing-operators/using-helm#weblogic-domain-management">}}).
@@ -70,11 +70,11 @@ see [WebLogic domain management]({{<relref "/userguide/managing-operators/using-
 
 - Your security strategy may determine which namespace strategy you should choose,
   see [Choose a security strategy]({{<relref "/userguide/managing-operators/preparation#choose-a-security-strategy">}}).
-- As has already been noted previously,
+- As has been noted previously,
   two operators cannot manage domains that are in the same namespace.
   If two operators are configured to manage the same namespace,
   then their behavior is undefined
-  but it is likely that the second operator install will
+  but it is likely that the second operator installation will
   deploy a `FAILED` Helm release and generate an error similar to
   `Error: release op2 failed: rolebindings.rbac.authorization.k8s.io "weblogic-operator-rolebinding-namespace" already exists`.
 - For more information about ensuring an operator has permission to manage a namespace,
@@ -83,10 +83,7 @@ see [WebLogic domain management]({{<relref "/userguide/managing-operators/using-
   that an already running operator manages,
   see [Altering namespaces for a running operator](#altering-namespaces-for-a-running-operator).
 - For more information about common namespace management issues,
-  see [Common Mistakes]({{<relref "/userguide/managing-operators/common-mistakes.md">}}).
-- If the deprecated `dedicated` operator Helm chart configuration setting is set to `true`,
-  then the `domainNamespaceSelectionStrategy` setting will be ignored
-  and the operator will force the selection strategy to be `Dedicated`.
+  see [Common mistakes and solutions]({{<relref "/userguide/managing-operators/common-mistakes.md">}}).
 
 ### Ensuring the operator has permission to manage a namespace
 
@@ -102,20 +99,16 @@ If your operator Helm `enableClusterRoleBinding` configuration value is `false`,
   the operator's domain namespace selection criteria
   at the time the chart is installed or upgraded.
 - If you later create namespaces
-  that match a `List`, `LabelSelector`, or `RegExp` selector
-  _then the operator will not have privilege in these namespaces until you upgrade the Helm release_.
+  that match a `List`, `LabelSelector`, or `RegExp` selector,
+  then the operator will _not_ have privilege in these namespaces until you upgrade the Helm release.
   You can resolve this issue by performing
-  a `helm upgrade` on an already installed operator Helm release, for example:
+  a `helm upgrade` on an already installed operator Helm release.
+
+  For example, with an operator release name `weblogic-operator`:
   ```shell
-  $ helm upgrade \
-      weblogic-operator \
-      kubernetes/charts/weblogic-operator \
-      --reuse-values
+  $ helm upgrade weblogic-operator/weblogic-operator --reuse-values
   ```
-  **Note:** This example assumes you used a local file-based Helm chart
-  in local directory `kubernetes/charts/weblogic-operator` when first
-  installing the operator, and that the operator release name is `weblogic-operator`.
-- If you still run into problems after you perform the `helm upgrade` to re-initialize a namespace
+  **Note:** If you still run into problems after you perform the `helm upgrade` to re-initialize a namespace
   that is deleted and recreated, then you can
   try [forcing the operator to restart]({{< relref "/userguide/managing-operators/troubleshooting#force-the-operator-to-restart" >}}).
 
@@ -194,6 +187,8 @@ This section describes the steps for adding, deleting, or recreated namespaces t
 
 #### Add a Kubernetes namespace to a running operator
 
+The following are steps for adding namespaces that are managed by a running operator.
+
 **When using a namespace list**
 
 When the operator is configured to manage a list of namespaces and you want the operator to manage an additional namespace,
@@ -203,12 +198,11 @@ using the `kubectl create` command.
 Adding a namespace to the `domainNamespaces` list tells the operator to initialize the necessary
 Kubernetes resources so that the operator is ready to manage WebLogic Server instances in that namespace.
 
-When the operator is managing the `default` namespace, the following example Helm command adds the namespace `ns1` to the `domainNamespaces` list, where `weblogic-operator` is the release name of the operator, and `kubernetes/charts/weblogic-operator` is the location of the operator's Helm charts:
+When the operator is managing the `default` namespace, the following example Helm command adds the namespace `ns1` to the `domainNamespaces` list, where `weblogic-operator` is the release name of the operator:
 
 ```shell
 $ helm upgrade \
-  weblogic-operator \
-  kubernetes/charts/weblogic-operator \
+  weblogic-operator/weblogic-operator \
   --reuse-values \
   --set "domainNamespaces={default,ns1}" \
   --wait
@@ -234,7 +228,7 @@ weblogic-scripts-cm   14        12m
 **When using a label selector or regular expression**
 
 For operators configured to select managed namespaces through the use of a label selector or regular expression,
-you simply need to create a namespace with the appropriate labels or with a name that matches the expression, respectively.
+you  need to create a namespace with the appropriate labels or with a name that matches the expression, respectively.
 
 {{% notice warning %}}
 If your operator Helm `enableClusterRoleBinding` configuration value is `false`, then
@@ -245,40 +239,41 @@ See [Ensuring the operator has permission to manage a namespace](#ensuring-the-o
 
 ####  Delete a Kubernetes namespace from a running operator
 
+The following are steps for deleting namespaces that are managed by a running operator.
+
 **When using a namespace list**
 
-When the operator is configured to manage a list of namespaces and you no longer want a namespace to be managed by the operator, you need to remove it from
-the operator's `domainNamespaces` list, so that the resources that are
-associated with the namespace can be cleaned up.
+When the operator is configured to manage a list of namespaces and you no longer want a namespace to be managed by the operator, you need to:
+- First, remove the namespace from the operator's `domainNamespaces` list.
+- Then, delete the namespace.
 
 While the operator is running and managing the `default` and `ns1` namespaces, the following example Helm
 command removes the namespace `ns1` from the `domainNamespaces` list, where `weblogic-operator` is the release
-name of the operator, and `kubernetes/charts/weblogic-operator` is the location of the operator Helm charts:
+name of the operator:
 
 ```shell
 $ helm upgrade \
-    --reuse-values \
-    --set "domainNamespaces={default}" \
-    --wait \
-    weblogic-operator \
-    kubernetes/charts/weblogic-operator
+  weblogic-operator/weblogic-operator \
+  --reuse-values \
+  --set "domainNamespaces={default}" \
+  --wait
 ```
 
 **When using a label selector or regular expression**
 
 For operators configured to select managed namespaces through the use of a label selector or regular expression,
-you simply need to delete the namespace. For the label selector option, you can also adjust the labels on the namespace
+you  need to delete the namespace. For the label selector option, you can also adjust the labels on the namespace
 so that the namespace no longer matches the selector.
 
 #### Recreate a previously deleted Kubernetes namespace with a running operator
 
+The following are steps for recreating previously deleted namespaces that are managed by a running operator.
+
 **When using a namespace list**
 
-When the operator is configured to manage a list of namespaces
-and if you need to delete a namespace (and the resources in it) and then recreate it,
-remember to remove the namespace from the operator's `domainNamespaces` list
-after you delete the namespace, and add it back to the `domainNamespaces` list after you recreate the namespace
-using the `helm upgrade` commands that were illustrated previously.
+If you deleted a namespace (and the resources in it) and then want to recreate it:
+- First, add back (recreate) the namespace, for example, using the `kubectl create` command.
+- Then, add the namespace back to the `domainNamespaces` list using the `helm upgrade` command illustrated [previously](#add-a-kubernetes-namespace-to-a-running-operator).
 
 If a domain custom resource is created before the namespace is ready, you might see that the introspector job pod
 fails to start, with a warning like the following, when you review the description of the introspector pod.
@@ -295,7 +290,7 @@ Events:
 ```
 
 If you still run into problems after you perform the `helm upgrade` to re-initialize a namespace
-that is deleted and recreated, then you can
+that was deleted and recreated, then you can
 try [forcing the operator to restart]({{< relref "/userguide/managing-operators/troubleshooting#force-the-operator-to-restart" >}}).
 
 **When using a label selector or regular expression**

--- a/documentation/staging/content/userguide/managing-operators/overview.md
+++ b/documentation/staging/content/userguide/managing-operators/overview.md
@@ -80,5 +80,5 @@ There can be multiple operators in a Kubernetes cluster,
 and in that case, you must ensure that the namespaces managed by these operators do not overlap.
 _At most, a namespace can be managed by one operator._
 In addition, you cannot deploy more than operator to a particular namespace.
-See [Common Mistakes]({{<relref "/userguide/managing-operators/common-mistakes.md">}}).
+See [Common mistakes and solutions]({{<relref "/userguide/managing-operators/common-mistakes.md">}}).
 {{% /notice %}}

--- a/documentation/staging/content/userguide/managing-operators/preparation.md
+++ b/documentation/staging/content/userguide/managing-operators/preparation.md
@@ -47,7 +47,7 @@ Before installing an operator, ensure that each of these prerequisite requiremen
 
 1. If it is not already installed, then install Helm.
    To install an operator, it is required to install Helm in your Kubernetes cluster.
-   The operator uses Helm to create necessary resources and then deploy the operator in a Kubernetes cluster.
+   The operator uses Helm to create the necessary resources and then deploy the operator in a Kubernetes cluster.
 
    To check if you already have Helm available, try the `helm version` command.
 
@@ -174,7 +174,7 @@ The operator image must be available to all nodes of your Kubernetes cluster.
 
 ##### Locating an operator image
 
-Production ready operator images for various supported versions of the operator are
+Production-ready operator images for various supported versions of the operator are
 publicly located in the operator
 [GitHub Container Registry](https://github.com/orgs/oracle/packages/container/package/weblogic-kubernetes-operator).
 Operator GitHub container registry images can be directly referenced using an image name similar to
@@ -185,6 +185,7 @@ see the [Developer Guide]({{<relref "/developerguide/_index.md">}}).
 
 ##### Default operator image
 
+Each Helm chart version defaults to using an operator image from the matching version.
 To find the default image name that will be used when installing the operator,
 see [Inspect the operator Helm chart](#inspect-the-operator-helm-chart) and look for the `image` value.
 The value will look something like `ghcr.io/oracle/weblogic-kubernetes-operator:N.N.N`.
@@ -226,7 +227,7 @@ provide security credentials.
   for example `--set "image=my-image-registry.io/my-operator-image:1.0"`.
 - To create an image pull registry secret, create a Kubernetes Secret of type `docker-registry`
   in the namespace where the operator is to be deployed, as described
-  in [Specifying ImagePullSecrets on a Pod](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
+  in [Specifying `imagePullSecrets` on a Pod](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 - To reference an image pull registry secret from an operator installation, there are two options:
   - Use the `imagePullSecrets` operator Helm chart
     configuration setting when installing the operator.
@@ -242,7 +243,7 @@ for the `kubernetesPlatform` Helm chart configuration setting when installing th
 
 In particular, beginning with operator version 3.3.2,
 specify the operator `kubernetesPlatform` Helm chart setting
-with value `OpenShift` when using the `OpenShift` Kubernetes platform,
+with the value `OpenShift` when using the `OpenShift` Kubernetes platform,
 for example `--set "kubernetesPlatform=OpenShift"`.
 This accommodates OpenShift security requirements.
 
@@ -257,7 +258,7 @@ There are three commonly used security strategies for deploying an operator:
 1. [Any namespace with cluster role binding disabled](#any-namespace-with-cluster-role-binding-disabled)
 1. [Local namespace only with cluster role binding disabled](#local-namespace-only-with-cluster-role-binding-disabled)
 
-For a detailed discussion of the operator's security-related resources,
+For a detailed description of the operator's security-related resources,
 see the operator's role-based access control (RBAC) requirements,
 which are documented [here]({{< relref "/userguide/managing-operators/rbac.md" >}}).
 
@@ -311,11 +312,11 @@ choose the value for its `domainNamespaceSelectionStrategy` Helm chart configura
 See [Choose a domain namespace section strategy]({{<relref "/userguide/managing-operators/namespace-management#choose-a-domain-namespace-selection-strategy">}}).
 
 Note that if you choose the `Dedicated` value for the `domainNamespaceSelectionStrategy`,
-then you should also set `enableClusterRoleBinding` to false.
+then you should also set `enableClusterRoleBinding` to `false`.
 See [Choose a security strategy](#choose-a-security-strategy).
 
-For a discussion about common namespace management issues,
-see [Common Mistakes]({{<relref "/userguide/managing-operators/common-mistakes.md">}}).
+For a description of common namespace management issues,
+see [Common mistakes and solutions]({{<relref "/userguide/managing-operators/common-mistakes.md">}}).
 For reference, see [WebLogic domain management]({{<relref "/userguide/managing-operators/using-helm#weblogic-domain-management">}}).
 
 #### Choose a Helm release name

--- a/documentation/staging/content/userguide/managing-operators/troubleshooting.md
+++ b/documentation/staging/content/userguide/managing-operators/troubleshooting.md
@@ -90,7 +90,7 @@ A pod `describe` usefully includes any events that might be associated with the 
 
 ### Check common issues
 
-- See [Common Mistakes and Solutions]({{< relref "/userguide/managing-operators/common-mistakes.md" >}}).
+- See [Common mistakes and solutions]({{< relref "/userguide/managing-operators/common-mistakes.md" >}}).
 - Check the [FAQs]({{<relref "/faq/_index.md">}}).
 
 ### Check for events


### PR DESCRIPTION
Update the Namespace management doc as per [OWLS-95907](https://jira.oraclecorp.com/jira/browse/OWLS-95907): Operator User Guide Feedback and Updates for 4.0. Also, minor edits elsewhere to conform to Oracle Style Guide.