### PR TITLE
OWLS-96978 fix intermittent failures in ItPodsRestart

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
@@ -183,6 +183,9 @@ class ItPodsRestart {
               + "a different value", cpuRequest));
     }
 
+    //get current timestamp before domain rolling restart to verify domain roll events
+    OffsetDateTime timestamp = now();
+
     // add/modify the server pod resources by patching the domain custom resource
     assertTrue(addServerPodResources(cpuLimit, cpuRequest),
         String.format("Failed to add server pod compute resources for domain %s in namespace %s",
@@ -227,9 +230,6 @@ class ItPodsRestart {
     assertEquals(0, requests.get("cpu").getNumber().compareTo(cpuRequest),
         String.format("server pod compute resources requests was not updated correctly, set cpu request to %s, got %s",
             cpuRequest, requests.get("cpu").getNumber()));
-
-    //get current timestamp before domain rolling restart to verify domain roll events
-    OffsetDateTime timestamp = now();
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -282,6 +282,9 @@ class ItPodsRestart {
         .append("}]");
     logger.info("PatchStr for includeServerOutInPodLog: {0}", patchStr.toString());
 
+    //get current timestamp before domain rolling restart to verify domain roll events
+    OffsetDateTime timestamp = now();
+
     boolean cmPatched = patchDomainResource(domainUid, domainNamespace, patchStr);
     assertTrue(cmPatched, "patchDomainCustomResource(IncludeServerOutInPodLog) failed");
 
@@ -295,9 +298,6 @@ class ItPodsRestart {
     logger.info("In the new patched domain IncludeServerOutInPodLog is: {0}",
         includeServerOutInPodLog);
     assertFalse(includeServerOutInPodLog, "IncludeServerOutInPodLog was not updated");
-
-    //get current timestamp before domain rolling restart to verify domain roll events
-    OffsetDateTime timestamp = now();
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -338,6 +338,9 @@ class ItPodsRestart {
     // get the map with server pods and their original creation timestamps
     podsWithTimeStamps = getPodsWithTimeStamps();
 
+    //get current timestamp before domain rolling restart to verify domain roll events
+    OffsetDateTime timestamp = now();
+
     //print out the original env
     List<V1EnvVar> envList = domain1.getSpec().getServerPod().getEnv();
     envList.forEach(env -> {
@@ -374,9 +377,6 @@ class ItPodsRestart {
     logger.info("In the new patched domain envValue is: {0}", envValue);
     assertTrue(envValue.equalsIgnoreCase("-Dweblogic.StdoutDebugEnabled=true"), "JAVA_OPTIONS was not updated"
         + " in the new patched domain");
-
-    //get current timestamp before domain rolling restart to verify domain roll events
-    OffsetDateTime timestamp = now();
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -508,6 +508,9 @@ class ItPodsRestart {
         .append("\"}]");
     logger.info("PatchStr for imagePullPolicy: {0}", patchStr.toString());
 
+    //get current timestamp before domain rolling restart to verify domain roll events
+    OffsetDateTime timestamp = now();
+
     boolean cmPatched = patchDomainResource(domainUid, domainNamespace, patchStr);
     assertTrue(cmPatched, "patchDomainCustomResource(imagePullPolicy) failed");
 
@@ -522,9 +525,6 @@ class ItPodsRestart {
     logger.info("In the new patched domain imagePullPolicy is: {0}", imagePullPolicy);
     assertEquals(V1Container.ImagePullPolicyEnum.NEVER, imagePullPolicy, "imagePullPolicy was not updated"
         + " in the new patched domain");
-
-    //get current timestamp before domain rolling restart to verify domain roll events
-    OffsetDateTime timestamp = now();
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -566,6 +566,8 @@ class ItPodsRestart {
         -> getDomainCustomResource(domainUid, domainNamespace).getSpec().getRestartVersion());
     int newVersion = oldVersion == null ? 1 : Integer.valueOf(oldVersion) + 1;
 
+    OffsetDateTime timestamp = now();
+
     logger.info("patch the domain resource with new WebLogic secret, restartVersion and introspectVersion");
     String patchStr
         = "["
@@ -576,8 +578,6 @@ class ItPodsRestart {
     V1Patch patch = new V1Patch(patchStr);
     assertTrue(patchDomainCustomResource(domainUid, domainNamespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
         "Failed to patch domain");
-
-    OffsetDateTime timestamp = now();
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -621,6 +621,8 @@ class ItPodsRestart {
     // get the map with server pods and their original creation timestamps
     podsWithTimeStamps = getPodsWithTimeStamps();
 
+    OffsetDateTime timestamp = now();
+
     logger.info("patch the domain resource with new image");
     String patchStr
         = "["
@@ -631,8 +633,6 @@ class ItPodsRestart {
     V1Patch patch = new V1Patch(patchStr);
     assertTrue(patchDomainCustomResource(domainUid, domainNamespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
         "Failed to patch domain");
-
-    OffsetDateTime timestamp = now();
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",


### PR DESCRIPTION
The ItPodsRestart test cases patch the domain to trigger a rolling restart. It then uses a timestamp to filter the events to verify if the expected events are generated after this timestamp. In multiple test cases, the timestamp is taken AFTER the domain is patched so that intermittently, so that the expected events are not found. It has caused the test class to fail in different test cases intermittently on Jenkins.

The fix in this branch is to record the timestamp before the domain is patched.

So far, with this change, ItPodsRestart passed in all 8 runs on Jenkins, while with main branch ItPodsRestart failed 4 out of 8 runs.

main: 9648, 9650, 9652, 9654, 9656, 9658, 9664, 9666
it_test_debugging: 9657, 9659, 9660, 9660, 9662, 9663, 9665, 9667

Example runs:
Main -  https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9648
it_test_debugging -  https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9657

