### PR TITLE
backport fix for Intermittent failure of ItElasticLogging and ItElasticLoggingFluentd

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -69,6 +69,7 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsRea
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getNextFreePort;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withStandardRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createMiiImageAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
@@ -88,6 +89,7 @@ import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsern
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -290,7 +292,10 @@ class ItElasticLogging {
     String regex = ".*count\":(\\d+),.*failed\":(\\d+)";
     String queryCriteria = "/_count?q=level:INFO";
 
-    verifyCountsHitsInSearchResults(queryCriteria, regex, LOGSTASH_INDEX_KEY, true);
+    // verify log level query results
+    withStandardRetryPolicy.untilAsserted(
+        () -> assertTrue(verifyCountsHitsInSearchResults(queryCriteria, regex, LOGSTASH_INDEX_KEY, true),
+            String.format("Query logs of level=INFO failed")));
 
     logger.info("Query logs of level=INFO succeeded");
   }
@@ -507,12 +512,14 @@ class ItElasticLogging {
     logger.info("query result is {0}", queryResult);
   }
 
-  private void verifyCountsHitsInSearchResults(String queryCriteria, String regex,
-                                   String index, boolean checkCount, String... args) {
+  private boolean verifyCountsHitsInSearchResults(String queryCriteria, String regex,
+                                                  String index, boolean checkCount, String... args) {
     String checkExist = (args.length == 0) ? "" : args[0];
+    boolean testResult = false;
     int count = -1;
     int failedCount = -1;
     String hits = "";
+
     String results = execSearchQuery(queryCriteria, index);
     Pattern pattern = Pattern.compile(regex, Pattern.DOTALL | Pattern.MULTILINE);
     Matcher matcher = pattern.matcher(results);
@@ -527,17 +534,21 @@ class ItElasticLogging {
 
     logger.info("Total count of logs: " + count);
     if (!checkExist.equalsIgnoreCase("notExist")) {
-      assertTrue(kibanaParams != null, "Failed to install Kibana");
+      assertNotNull(kibanaParams, "Failed to install Kibana");
       assertTrue(count > 0, "Total count of logs should be more than 0!");
       if (checkCount) {
-        assertTrue(failedCount == 0, "Total failed count should be 0!");
         logger.info("Total failed count: " + failedCount);
+        assertEquals(0, failedCount, "Total failed count should be 0!");
       } else {
         assertFalse(hits.isEmpty(), "Total hits of search is empty!");
       }
+      testResult = true;
     } else {
-      assertTrue(count == 0, "Total count of logs should be zero!");
+      assertEquals(0, count, "Total count of logs should be zero!");
+      testResult = true;
     }
+
+    return testResult;
   }
 
   private String execSearchQuery(String queryCriteria, String index) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -79,6 +79,7 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.operatorIsRea
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getNextFreePort;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withStandardRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createMiiImageAndVerify;
@@ -289,6 +290,19 @@ class ItElasticLoggingFluentd {
   @Test
   @DisplayName("Use Fluentd to send log information to Elasticsearch and verify")
   void testFluentdQuery() {
+    // verify Fluentd query results
+    withStandardRetryPolicy.untilAsserted(
+        () -> assertTrue(queryAndVerify(),
+            String.format("Query logs of serverName=%s failed", adminServerPodName)));
+
+    logger.info("Query logs of serverName={0} succeeded", adminServerPodName);
+  }
+
+  private boolean queryAndVerify() {
+    String queryCriteria0 = "/_search?q=serverName:" + adminServerPodName;
+    String results0 = execSearchQuery(queryCriteria0, FLUENTD_INDEX_KEY);
+    logger.info("_search?q=serverName:{0} result ===> {1}", adminServerPodName, results0);
+
     // Verify that number of logs is not zero and failed if count is zero
     String regex = ".*count\":(\\d+),.*failed\":(\\d+)";
     String queryCriteria = "/_count?q=serverName:" + adminServerPodName;
@@ -303,11 +317,13 @@ class ItElasticLoggingFluentd {
     }
 
     logger.info("Total count of logs: " + count);
-    assertTrue(count > 0, "Total count of logs should be more than 0!");
-    assertTrue(failedCount == 0, "Total failed count should be 0!");
     logger.info("Total failed count: " + failedCount);
 
-    logger.info("Query logs of serverName={0} succeeded", adminServerPodName);
+    if (count > 0 && failedCount == 0) {
+      return true;
+    }
+
+    return false;
   }
 
   private static void configFluentd() {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -318,12 +318,8 @@ class ItElasticLoggingFluentd {
 
     logger.info("Total count of logs: " + count);
     logger.info("Total failed count: " + failedCount);
-
-    if (count > 0 && failedCount == 0) {
-      return true;
-    }
-
-    return false;
+ 
+    return count > 0 && failedCount == 0;
   }
 
   private static void configFluentd() {


### PR DESCRIPTION
with latest changes, the failures are not seen in following jobs

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9765
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9766
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9763

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9756
to https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9761