### PR TITLE
fix typo in file name

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItAuxV8DomainImplicitUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItAuxV8DomainImplicitUpgrade.java
@@ -209,7 +209,7 @@ class ItAuxV8DomainImplicitUpgrade {
     templateMap.put("BASE_IMAGE", WEBLOGIC_IMAGE_TO_USE_IN_SPEC);
     templateMap.put("API_VERSION", "v8");
     Path srcDomainFile = Paths.get(RESOURCE_DIR,
-        "upgrade", "aux.muti.images.template.yaml");
+        "upgrade", "auxilary.multi.images.template.yaml");
     Path targetDomainFile = assertDoesNotThrow(
         () -> generateFileFromTemplate(srcDomainFile.toString(),
         "domain.yaml", templateMap));


### PR DESCRIPTION
The ItAuxV8DomainImplicitUpgrade.java had typo in file name causing failure. 
This PR fixes the typo.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/9834/artifact/logdir/jenkins-weblogic-kubernetes-operator-kind-new-9834/wl_k8s_test_results/diagnostics/ItAuxV8DomainImplicitUpgrade/ItAuxV8DomainImplicitUpgrade.out/*view*/