### PR TITLE
Add checks to test

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesEvents.java
@@ -38,7 +38,6 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.DomainUtils;
-import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import io.kubernetes.client.custom.Quantity;
@@ -50,10 +51,12 @@ import oracle.weblogic.domain.Configuration;
 import oracle.weblogic.domain.Domain;
 import oracle.weblogic.domain.DomainCondition;
 import oracle.weblogic.domain.DomainSpec;
+import oracle.weblogic.domain.DomainStatus;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import org.jetbrains.annotations.NotNull;
 
 import static java.io.File.createTempFile;
 import static java.nio.file.Files.copy;
@@ -988,5 +991,28 @@ public class DomainUtils {
       String managedServerPodName = domainUid + "-" + MANAGED_SERVER_NAME_BASE + i;
       checkPodDoesNotExist(managedServerPodName, domainUid, domainNamespace);
     }
+  }
+
+  /**
+   * Obtains the specified domain, validates that it has a spec and no rolling condition.
+   * @param domainNamespace the namespace
+   * @param domainUid the UID
+   */
+  @NotNull
+  public static Domain getAndValidateInitialDomain(String domainNamespace, String domainUid) {
+    Domain domain = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
+        String.format("getDomainCustomResource failed with ApiException when tried to get domain %s in namespace %s",
+            domainUid, domainNamespace));
+
+    assertNotNull(domain, "Got null domain resource");
+    assertNotNull(domain.getSpec(), domain + "/spec is null");
+    assertFalse(domainHasRollingCondition(domain), "Found rolling condition at start of test");
+    return domain;
+  }
+
+  private static boolean domainHasRollingCondition(Domain domain) {
+    return Optional.ofNullable(domain.getStatus())
+          .map(DomainStatus::conditions).orElse(Collections.emptyList()).stream()
+          .map(DomainCondition::getType).anyMatch("Rolling"::equals);
   }
 }


### PR DESCRIPTION
Adds to selected ItKubernetesEvents tests, the same kinds of checks previously added to ItPodRestart tests - to catch leftover Rolling conditions.