### PR TITLE
Describe service ports with appProtocol

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-external-svc.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-external-svc.tpl
@@ -19,11 +19,13 @@ spec:
     {{- if .externalRestEnabled }}
     - name: "rest"
       port: 8081
+      appProtocol: https
       nodePort: {{ .externalRestHttpsPort }}
     {{- end }}
     {{- if .remoteDebugNodePortEnabled }}
     - name: "debug"
       port: {{ .internalDebugHttpPort }}
+      appProtocol: http
       nodePort: {{ .externalDebugHttpPort }}
     {{- end }}
 {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-internal-svc.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-internal-svc.tpl
@@ -17,6 +17,7 @@ spec:
   ports:
     - port: 8082
       name: "rest"
+      appProtocol: https
 ---
 apiVersion: "v1"
 kind: "Service"
@@ -32,4 +33,5 @@ spec:
   ports:
     - port: 8084
       name: "restwebhook"
+      appProtocol: https
 {{- end }}

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -325,6 +325,7 @@ abstract class CreateOperatorGeneratedFilesTestBase {
           newServicePort()
               .name("rest")
               .port(8081)
+              .appProtocol("https")
               .nodePort(Integer.parseInt(getInputs().getExternalRestHttpsPort())));
     }
     if (debuggingEnabled) {
@@ -332,6 +333,7 @@ abstract class CreateOperatorGeneratedFilesTestBase {
           newServicePort()
               .name("debug")
               .port(Integer.parseInt(getInputs().getInternalDebugHttpPort()))
+              .appProtocol("http")
               .nodePort(Integer.parseInt(getInputs().getExternalDebugHttpPort())));
     }
     return newService()
@@ -365,7 +367,7 @@ abstract class CreateOperatorGeneratedFilesTestBase {
             newServiceSpec()
                 .type(V1ServiceSpec.TypeEnum.CLUSTERIP)
                 .putSelectorItem(APP_LABEL, "weblogic-operator")
-                .addPortsItem(newServicePort().name("rest").port(8082)));
+                .addPortsItem(newServicePort().name("rest").appProtocol("https").port(8082)));
   }
 
   @Test


### PR DESCRIPTION
V8o noticed that the ports for the operator's services were causing warnings for Kiali because they don't follow the Istio guidelines on port-naming and/or protocol designation, as described here: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection.

I choose not to rename the ports because the port names are references in some of our scripts, e.g. `scalingAction.sh`, therefore, I choose the other alternative which is to add the `appProtocol` field with the protocol information.

We didn't need to change the operator runtime because Services created by the operator are already sensitive to Istio's port naming requirements.