### PR TITLE
Fix for failing tests in release/3.4 OKD SRG

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -1063,6 +1063,10 @@ class ItMiiAuxiliaryImage {
     createDomainAndVerify(domainUid, domainCR, wdtDomainNamespace,
         adminServerPodName, managedServerPrefix, replicaCount);
 
+    //create route for admin service on OKD in wdtDomainNamespace
+    adminSvcExtHost = createRouteForOKD(getExternalServicePodName(adminServerPodName), wdtDomainNamespace);
+    logger.info("admin svc host = {0}", adminSvcExtHost);
+
     // check configuration for DataSource in the running domain
     int adminServiceNodePort
         = getServiceNodePort(wdtDomainNamespace, getExternalServicePodName(adminServerPodName), "default");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -662,7 +662,7 @@ public class DomainUtils {
         .spec(new DomainSpec()
             .domainUid(domainUid)
             .domainHome(WDT_IMAGE_DOMAINHOME_BASE_DIR + "/" + domainUid)
-            .dataHome("/u01/oracle/mydata")
+            .dataHome("/u01/mydata")
             .domainHomeSourceType("Image")
             .image(imageName)
             .addImagePullSecretsItem(new V1LocalObjectReference()


### PR DESCRIPTION
This PR fixes the tests testScaleClustersAndAdminConsoleLogin in ItMiiAuxiliaryImage.java by changing the dataHome directory to /u01/mydata and testUpdateWDTVersionUsingMultipleAuxiliaryImages in ItMultiDomainModels by creating a adminHost route for the new domain.