### PR TITLE
fix datahome override test issue in release/3.4

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -662,7 +662,7 @@ public class DomainUtils {
         .spec(new DomainSpec()
             .domainUid(domainUid)
             .domainHome(WDT_IMAGE_DOMAINHOME_BASE_DIR + "/" + domainUid)
-            .dataHome("/u01/mydata")
+            .dataHome("/u01/oracle/mydata")
             .domainHomeSourceType("Image")
             .image(imageName)
             .addImagePullSecretsItem(new V1LocalObjectReference()


### PR DESCRIPTION
fix dataHome override test issue in release/3.4

Jenkins result:
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/10156/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/10152/