### PR TITLE
Fix ItManageNameSpace test failures.

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -456,6 +456,7 @@
                   **/ItIntrospectVersion,
                   **/ItLiftAndShiftFromOnPremDomain,
                   **/ItLivenessProbeCustomization,
+                  **/ItManageNameSpace,
                   **/ItManagedCoherence,
                   **/ItMiiDynamicUpdate*,
                   **/ItMiiCustomSslStore,

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -519,6 +519,7 @@
                   **/ItIntrospectVersion,
                   **/ItLiftAndShiftFromOnPremDomain,
                   **/ItLivenessProbeCustomization,
+                  **/ItManageNameSpace,
                   **/ItManagedCoherence,
                   **/ItMiiDynamicUpdate*,
                   **/ItMiiCustomSslStore,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
@@ -314,7 +314,7 @@ class ItManageNameSpace {
     logger.info("check that with specific Selector default namespace is not under operator management");
     checkDomainNotStartedInDefaultNS();
 
-    logger.info("check that another operator with selector=List matching domain namespace,"
+    logger.info("check that another operator with selector=List matching domain namespace, "
         + "managed by first operator fails to install");
     checkSecondOperatorFailedToShareSameNS(domainNamespaces[0]);
 
@@ -401,7 +401,7 @@ class ItManageNameSpace {
 
   private void checkUpgradeFailedToAddNSManagedByAnotherOperator() {
     logger.info("upgrade operator1 to replace managing domains using RegExp namespaces"
-        + " for ns names starting from weblogic, there one of domains"
+        + " for ns names starting from weblogic, there one of domains "
         + "in namespace weblogic* is managed by operator2");
     int externalRestHttpsPort = getServiceNodePort(opNamespaces[0], "external-weblogic-operator-svc");
     logger.info("set helm params to use domainNamespaceSelectionStrategy=RegExp "
@@ -526,7 +526,7 @@ class ItManageNameSpace {
   }
 
   private void checkDomainNotStartedInDefaultNS() {
-    logger.info("verify operator can't start domain in the default namespace when domainNsSelectionStrategy not List"
+    logger.info("verify operator can't start domain in the default namespace when domainNsSelectionStrategy not List "
         + "and selector does not match default");
     checkPodNotCreated("defaultuid" + adminServerPrefix, "defaultuid", "default");
     logger.info("Delete defaultuid custom resource in namespace {0}", "default");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
@@ -464,14 +464,15 @@ class ItManageNameSpace {
   }
 
   private static void setLabelToNamespace(String domainNS, Map<String, String> labels) {
-    V1Namespace namespaceObject1 = assertDoesNotThrow(() -> Kubernetes.getNamespaceAsObject(domainNS));
-    assertNotNull(namespaceObject1, "Can't find namespace with name " + domainNS);
+    V1Namespace namespaceObject = assertDoesNotThrow(() -> Kubernetes.getNamespaceAsObject(domainNS));
+    assertNotNull(namespaceObject, "Can't find namespace with name " + domainNS);
     logger.info("add label {0} to namespace {1}", Collections.singletonList(labels), domainNS);
-    namespaceObject1.getMetadata().setLabels(labels);
+    namespaceObject.getMetadata().setLabels(labels);
     try {
-      V1Namespace namespaceAsObject = Kubernetes.getNamespaceAsObject(domainNS);
-      logger.info("Replacing the namespace object\n {0}", Yaml.dump(namespaceAsObject));
-      Kubernetes.replaceNamespace(namespaceAsObject);
+      logger.info("Before replacing the namespace object\n {0}", Yaml.dump(namespaceObject));
+      Kubernetes.replaceNamespace(namespaceObject);
+      logger.info("After replacing the namespace object\n {0}",
+          Yaml.dump(Kubernetes.getNamespaceAsObject(domainNS)));
     } catch (ApiException e) {
       logger.warning(e.getResponseBody());
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
@@ -466,7 +466,7 @@ class ItManageNameSpace {
     V1Namespace namespaceObject1 = assertDoesNotThrow(() -> Kubernetes.getNamespaceAsObject(domainNS));
     assertNotNull(namespaceObject1, "Can't find namespace with name " + domainNS);
     namespaceObject1.getMetadata().setLabels(labels);
-    assertDoesNotThrow(() -> Kubernetes.replaceNamespace(namespaceObject1));
+    assertDoesNotThrow(() -> Kubernetes.replaceNamespace(Kubernetes.getNamespaceAsObject(domainNS)));
   }
 
   private void checkOperatorCanScaleDomain(String opNamespace, String domainUid) {


### PR DESCRIPTION
This PR fixes the test failures caused by replaceNameSpaceObject failures. The test will retry the labeling process and replace the namespace object until it succeeds.

In OKD

https://build.weblogick8s.org:8443/job/wko-okd-test/297
https://build.weblogick8s.org:8443/job/wko-okd-test/299

In Kind
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10271

