### PR TITLE
Remove hardcoded OCIR in Dockerfile and change dataHome to run tests in OKD

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -1234,9 +1234,10 @@ class ItMiiAuxiliaryImage {
   private void createAuxiliaryImage(String stageDirPath, String dockerFileLocation, String auxiliaryImage) {
     //replace the BUSYBOX_IMAGE and BUSYBOX_TAG in Dockerfile
     Path dockerDestFile = Paths.get(WORK_DIR, "auximages", "Dockerfile");
-    assertDoesNotThrow(() -> Files.copy(Paths.get(dockerFileLocation),
-        dockerDestFile, StandardCopyOption.REPLACE_EXISTING));
     assertDoesNotThrow(() -> {
+      Files.createDirectories(dockerDestFile.getParent());
+      Files.copy(Paths.get(dockerFileLocation),
+          dockerDestFile, StandardCopyOption.REPLACE_EXISTING);
       replaceStringInFile(dockerDestFile.toString(), "BUSYBOX_IMAGE", BUSYBOX_IMAGE);
       replaceStringInFile(dockerDestFile.toString(), "BUSYBOX_TAG", BUSYBOX_TAG);
     });

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
@@ -146,7 +146,7 @@ class ItMultiDomainModelsWithLoadBalancer {
   private static final String WLDF_OPENSESSION_APP = "opensessionapp";
   private static final String WLDF_OPENSESSION_APP_CONTEXT_ROOT = "opensession";
   private static final String wlSecretName = "weblogic-credentials";
-  private static final String DATA_HOME_OVERRIDE = "/u01/oracle/mydata";
+  private static final String DATA_HOME_OVERRIDE = "/u01/mydata";
   private static final String miiImageName = "mii-image";
   private static final String wdtModelFileForMiiDomain = "model-multiclusterdomain-sampleapp-wls.yaml";
   private static final String miiDomainUid = "miidomain";
@@ -552,7 +552,7 @@ class ItMultiDomainModelsWithLoadBalancer {
 
   /**
    * Verify dataHome override in a domain with domain in image type.
-   * In this domain, set dataHome to /u01/oracle/mydata in domain custom resource
+   * In this domain, set dataHome to /u01/mydata in domain custom resource
    * The domain contains JMS and File Store configuration
    * File store directory is set to /u01/oracle/customFileStore in the model file which should be overridden by dataHome
    * File store and JMS server are targeted to the WebLogic cluster cluster-1

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -242,7 +242,7 @@ public interface TestConstants {
   public static final String MII_AUXILIARY_IMAGE_NAME = DOMAIN_IMAGES_REPO + "mii-ai-image";
   public static final boolean SKIP_BUILD_IMAGES_IF_EXISTS =
       Boolean.parseBoolean(getNonEmptySystemProperty("wko.it.skip.build.images.if.exists", "false"));
-  public static final String BUSYBOX_IMAGE = "phx.ocir.io/weblogick8s/test-images/docker/busybox";
+  public static final String BUSYBOX_IMAGE = OCIR_REGISTRY + "/weblogick8s/test-images/docker/busybox";
   public static final String BUSYBOX_TAG = "1.34.1";
 
   // Skip the mii/wdt basic image build locally if needed

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -662,7 +662,7 @@ public class DomainUtils {
         .spec(new DomainSpec()
             .domainUid(domainUid)
             .domainHome(WDT_IMAGE_DOMAINHOME_BASE_DIR + "/" + domainUid)
-            .dataHome("/u01/oracle/mydata")
+            .dataHome("/u01/mydata")
             .domainHomeSourceType("Image")
             .image(imageName)
             .addImagePullSecretsItem(new V1LocalObjectReference()

--- a/integration-tests/src/test/resources/auxiliaryimage/Dockerfile
+++ b/integration-tests/src/test/resources/auxiliaryimage/Dockerfile
@@ -16,7 +16,7 @@
 #   Default '/auxiliary'.
 #
 
-FROM phx.ocir.io/weblogick8s/test-images/docker/busybox:1.34.1
+FROM BUSYBOX_IMAGE:BUSYBOX_TAG
 ARG AUXILIARY_IMAGE_PATH=/auxiliary
 ARG USER=oracle
 ARG USERID=1000

--- a/integration-tests/src/test/resources/auxiliaryimage/negative/Dockerfile
+++ b/integration-tests/src/test/resources/auxiliaryimage/negative/Dockerfile
@@ -16,7 +16,7 @@
 #   Default '/auxiliary'.
 #
 
-FROM phx.ocir.io/weblogick8s/test-images/docker/busybox:1.34.1
+FROM BUSYBOX_IMAGE:BUSYBOX_TAG
 ARG AUXILIARY_IMAGE_PATH=/auxiliary
 ARG USER=tester
 ARG USERID=1001


### PR DESCRIPTION
Altran is running into pull issues when running okd srg tests with hard coded location for busybox image in Dockerfile.

Reviewers please comment on the BUSYBOX value assigned in this PR. This forces whoever running the tests to upload the busybox image in to their DOMAIN_IMAGES_REPO in location `OCIR_REGISTRY + "/weblogick8s/test-images/docker/busybox";`

Also while running the tests in OKD the dataHome in domain resource configuration must be set to /u01/... instead of /u01/oracle/... This PR fixes these 2 issues in release/3.4

OKD
https://build.weblogick8s.org:8443/job/wko-okd-test/301/

Kind
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10304/