### PR TITLE
Changes to update the CRD webhook config if the existing config is incompatible with config generated by runtime

### DIFF
--- a/domain-upgrader/src/main/java/oracle/kubernetes/operator/DomainUpgrader.java
+++ b/domain-upgrader/src/main/java/oracle/kubernetes/operator/DomainUpgrader.java
@@ -9,6 +9,7 @@ import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.IntConsumer;
 
 import oracle.kubernetes.common.logging.CommonLoggingFacade;
 import oracle.kubernetes.common.logging.CommonLoggingFactory;
@@ -30,6 +31,8 @@ public class DomainUpgrader {
   private static final CommonLoggingFacade LOGGER =
           CommonLoggingFactory.getLogger("DomainUpgrader", "Operator");
   private static SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+
+  private static IntConsumer exitCall = System::exit;
 
   String inputFileName;
   String outputDir;
@@ -137,7 +140,7 @@ public class DomainUpgrader {
                     + "<input-file> [-d <output_dir>] [-f <output_file_name>] [-o --overwriteExistingFile] "
                     + "[-h --help]",
             "", options, "");
-    System.exit(1);
+    exitCall.accept(1);
   }
 
   static class DomainUpgraderException extends RuntimeException {

--- a/domain-upgrader/src/main/java/oracle/kubernetes/operator/DomainUpgrader.java
+++ b/domain-upgrader/src/main/java/oracle/kubernetes/operator/DomainUpgrader.java
@@ -9,7 +9,6 @@ import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.function.IntConsumer;
 
 import oracle.kubernetes.common.logging.CommonLoggingFacade;
 import oracle.kubernetes.common.logging.CommonLoggingFactory;
@@ -31,8 +30,6 @@ public class DomainUpgrader {
   private static final CommonLoggingFacade LOGGER =
           CommonLoggingFactory.getLogger("DomainUpgrader", "Operator");
   private static SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
-
-  private static IntConsumer exitCall = System::exit;
 
   String inputFileName;
   String outputDir;
@@ -88,13 +85,17 @@ public class DomainUpgrader {
           String outputFileName,
           boolean overwriteExistingFile,
           String inputFileName) {
-    this.outputDir = Optional.ofNullable(outputDir).orElse(new File(inputFileName).getParent());
+    this.outputDir = Optional.ofNullable(outputDir).orElse(getDefaultOutputDir(inputFileName));
     String inputFileNameBase = FilenameUtils.getBaseName(inputFileName);
     String inputFileNameExtension  = FilenameUtils.getExtension(inputFileName);
     this.outputFileName = Optional.ofNullable(outputFileName)
             .orElse(inputFileNameBase + "__converted." + inputFileNameExtension);
     this.inputFileName = inputFileName;
     this.overwriteExistingFile = overwriteExistingFile;
+  }
+
+  private String getDefaultOutputDir(String inputFileName) {
+    return Optional.ofNullable(new File(inputFileName).getParent()).orElse(".");
   }
 
   private static DomainUpgrader parseCommandLine(String[] args) {
@@ -136,7 +137,7 @@ public class DomainUpgrader {
                     + "<input-file> [-d <output_dir>] [-f <output_file_name>] [-o --overwriteExistingFile] "
                     + "[-h --help]",
             "", options, "");
-    exitCall.accept(1);
+    System.exit(1);
   }
 
   static class DomainUpgraderException extends RuntimeException {

--- a/operator/src/main/java/oracle/kubernetes/operator/ConversionWebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ConversionWebhookMain.java
@@ -12,6 +12,8 @@ import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.CrdHelper;
 import oracle.kubernetes.operator.helpers.EventHelper;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.BaseRestServer;
 import oracle.kubernetes.operator.rest.RestConfig;
 import oracle.kubernetes.operator.rest.RestConfigImpl;
@@ -34,6 +36,7 @@ import static oracle.kubernetes.operator.helpers.NamespaceHelper.getWebhookNames
 
 /** A Domain Custom Resource Conversion Webhook for WebLogic Kubernetes Operator. */
 public class ConversionWebhookMain extends BaseMain {
+  static final LoggingFacade LOGGER = LoggingFactory.getLogger("Webhook", "Operator");
 
   private final ConversionWebhookMainDelegate conversionWebhookMainDelegate;
   private boolean warnedOfCrdAbsence;

--- a/operator/src/main/java/oracle/kubernetes/operator/ConversionWebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ConversionWebhookMain.java
@@ -12,8 +12,6 @@ import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.CrdHelper;
 import oracle.kubernetes.operator.helpers.EventHelper;
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.rest.BaseRestServer;
 import oracle.kubernetes.operator.rest.RestConfig;
 import oracle.kubernetes.operator.rest.RestConfigImpl;
@@ -36,7 +34,6 @@ import static oracle.kubernetes.operator.helpers.NamespaceHelper.getWebhookNames
 
 /** A Domain Custom Resource Conversion Webhook for WebLogic Kubernetes Operator. */
 public class ConversionWebhookMain extends BaseMain {
-  static final LoggingFacade LOGGER = LoggingFactory.getLogger("Webhook", "Operator");
 
   private final ConversionWebhookMainDelegate conversionWebhookMainDelegate;
   private boolean warnedOfCrdAbsence;

--- a/operator/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/KubernetesConstants.java
@@ -20,6 +20,7 @@ public interface KubernetesConstants {
   String DOMAIN_SINGULAR = "domain";
   String DOMAIN_SHORT = "dom";
   String DOMAIN_VERSION = "v9";
+  String OLD_DOMAIN_VERSION = "v8";
 
   String API_VERSION_WEBLOGIC_ORACLE = DOMAIN_GROUP + "/" + DOMAIN_VERSION;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -385,14 +385,14 @@ public class CrdHelper {
 
       private boolean webhookIsCompatible(V1CustomResourceDefinition existingCrd) {
         return crdVersionHigherThanProductVersion(existingCrd)
-            || createConversionWebhook(getCaBundle()).equals(getWebhookClientConfig(existingCrd));
+            || createConversionWebhook(getCaBundle()).equals(getConversionWebhook(existingCrd));
       }
 
       private byte[] getCaBundle() {
         return Optional.ofNullable(getCertificateData(certificates)).map(Base64::decodeBase64).orElse(null);
       }
 
-      private V1CustomResourceConversion getWebhookClientConfig(V1CustomResourceDefinition existingCrd) {
+      private V1CustomResourceConversion getConversionWebhook(V1CustomResourceDefinition existingCrd) {
         return Optional.ofNullable(existingCrd.getSpec())
             .map(V1CustomResourceDefinitionSpec::getConversion).orElse(null);
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -117,9 +117,9 @@ public class CrdHelper {
       writer.write("\n");
       dumpYaml(writer, model);
     } catch (IOException io) {
-      throw new RuntimeException(io);
+      throw new CrdCreationException(io);
     } catch (IllegalArgumentException e) {
-      throw new RuntimeException("Bad argument: " + outputFileName, e);
+      throw new CrdCreationException("Bad argument: " + outputFileName, e);
     }
   }
 
@@ -336,8 +336,8 @@ public class CrdHelper {
 
     Step updateExistingCrd(Step next, V1CustomResourceDefinition existingCrd) {
       List<V1CustomResourceDefinitionVersion> versions = existingCrd.getSpec().getVersions();
-      for (V1CustomResourceDefinitionVersion version : versions) {
-        version.setStorage(false);
+      for (V1CustomResourceDefinitionVersion crdVersion : versions) {
+        crdVersion.setStorage(false);
       }
       versions.add(0,
           new V1CustomResourceDefinitionVersion()
@@ -565,6 +565,17 @@ public class CrdHelper {
         return true;
       }
       return version.getPrereleaseVersion() >= base.getPrereleaseVersion();
+    }
+  }
+
+  static class CrdCreationException extends RuntimeException {
+
+    public CrdCreationException(String message, Exception e) {
+      super(message, e);
+    }
+
+    public CrdCreationException(Exception e) {
+      super(e);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -80,7 +80,7 @@ public class CrdHelper {
    * Used by build to generate crd-validation.yaml
    * @param args Arguments that must be one value giving file name to create
    */
-  public static void main(String[] args) throws URISyntaxException {
+  public static void main(String... args) throws URISyntaxException {
     if (args == null || args.length != 1) {
       throw new IllegalArgumentException();
     }
@@ -400,7 +400,7 @@ public class CrdHelper {
       private boolean crdVersionHigherThanProductVersion(V1CustomResourceDefinition existingCrd) {
         if (productVersion != null) {
           SemanticVersion existingCrdVersion = KubernetesUtils.getProductVersionFromMetadata(existingCrd.getMetadata());
-          if (existingCrdVersion == null || existingCrdVersion.compareTo(productVersion) > 0) {
+          if (existingCrdVersion != null && existingCrdVersion.compareTo(productVersion) > 0) {
             return true;
           }
         }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -216,6 +217,8 @@ class CrdHelperTest {
     testSupport.defineResources(existing);
 
     testSupport.runSteps(CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_16, PRODUCT_VERSION));
+
+    assertThat(logRecords, not(containsInfo(CREATING_CRD)));
   }
 
   @Test
@@ -245,6 +248,7 @@ class CrdHelperTest {
     testSupport.defineResources(existing);
 
     testSupport.runSteps(CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_16, PRODUCT_VERSION, getCertificates()));
+    assertThat(logRecords, not(containsInfo(CREATING_CRD)));
   }
 
   @Test
@@ -270,6 +274,8 @@ class CrdHelperTest {
     testSupport.defineResources(existing);
 
     testSupport.runSteps(CrdHelper.createDomainCrdStep(KUBERNETES_VERSION_16, PRODUCT_VERSION, getCertificates()));
+
+    assertThat(logRecords, not(containsInfo(CREATING_CRD)));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -61,7 +61,7 @@ class CrdHelperTest {
   private static final SemanticVersion PRODUCT_VERSION_OLD = new SemanticVersion(2, 4, 0);
   private static final SemanticVersion PRODUCT_VERSION_FUTURE = new SemanticVersion(3, 1, 0);
   public static final String WEBHOOK_CERTIFICATE = "/deployment/webhook-identity/webhookCert";
-  private static final String HASH = "b2bbe25894b465f3da8d9b7272e7049f67e2c2b0d983859af3556acdfd591313";
+  private static final String HASH = "58a295e514ceb84ae0bb6e1609d0bd16cd68fe06de13966c964a4cb36a0cd9fd";
 
   private V1CustomResourceDefinition defaultCrd;
   private final RetryStrategyStub retryStrategy = createStrictStub(RetryStrategyStub.class);

--- a/operator/src/test/java/oracle/kubernetes/operator/utils/InMemoryFileSystem.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/utils/InMemoryFileSystem.java
@@ -55,6 +55,11 @@ public abstract class InMemoryFileSystem extends FileSystem {
     return PathStub.createPathStub(createPathString(uri.getPath(), new String[0]));
   }
 
+  @Nonnull
+  public Path getPathThrowsIllegaArgumentException(@Nonnull URI uri) {
+    throw new IllegalArgumentException("test");
+  }
+
   private String createPathString(String first, String[] more) {
     return more.length == 0 ? first : first + "/" + String.join("/", more);
   }


### PR DESCRIPTION
This PR checks if the existing CRD conversion webhook configuration is compatible with the configuration that the current webhook deployment will generate. If webhook configuration is incompatible, it updates the existing CRD webhook configuration. We decided to do this while working on documentation PR 2967 as this makes it easier to troubleshoot and debug the webhook. 

This PR also fixes a potential NPE issue in standalone DomainUpgrader tool for a particular use-case.