### PR TITLE
Create multiple secrets if BASE_IMAGES_REPO and REPO_REGISTRY are different

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -11,7 +11,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,6 @@ import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_PATCH;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_PATCH;
-import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.KIND_REPO;
@@ -97,7 +95,6 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.verifyServerCommu
 import static oracle.weblogic.kubernetes.utils.ConfigMapUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.DeployUtil.deployUsingRest;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
-import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.JobUtils.createDomainJob;
 import static oracle.weblogic.kubernetes.utils.JobUtils.getIntrospectJobName;
@@ -116,6 +113,7 @@ import static oracle.weblogic.kubernetes.utils.PodUtils.getPodCreationTime;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getPodsWithTimeStamps;
 import static oracle.weblogic.kubernetes.utils.PodUtils.setPodAntiAffinity;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretsForImageRepos;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static oracle.weblogic.kubernetes.utils.WLSTUtils.executeWLSTScript;
 import static org.apache.commons.io.FileUtils.copyDirectory;
@@ -205,10 +203,6 @@ class ItIntrospectVersion {
 
     // install operator and verify its running in ready state
     installAndVerifyOperator(opNamespace, introDomainNamespace);
-
-    // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
-    // this secret is used only for non-kind cluster
-    createSecretForBaseImages(introDomainNamespace);
 
     // build the clusterview application
     Path targetDir = Paths.get(WORK_DIR,
@@ -1026,9 +1020,6 @@ class ItIntrospectVersion {
             .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv
             .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
-            .imagePullSecrets(Arrays.asList(
-                new V1LocalObjectReference()
-                    .name(BASE_IMAGES_REPO_SECRET)))  // this secret is used only in non-kind cluster
             .webLogicCredentialsSecret(new V1SecretReference()
                 .name(wlSecretName)
                 .namespace(introDomainNamespace))
@@ -1071,6 +1062,14 @@ class ItIntrospectVersion {
                 .clusterName(cluster1Name)
                 .replicas(cluster1ReplicaCount)
                 .serverStartState("RUNNING")));
+
+    // create secrets
+    List<V1LocalObjectReference> secrets = new ArrayList<>();
+    for (String secret : createSecretsForImageRepos(introDomainNamespace)) {
+      secrets.add(new V1LocalObjectReference().name(secret));
+    }
+    domain.spec().setImagePullSecrets(secrets);
+    
     setPodAntiAffinity(domain);
     // verify the domain custom resource is created
     createDomainAndVerify(domain, introDomainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -63,6 +63,8 @@ import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_API_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.KIND_REPO;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_REGISTRY;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
@@ -710,7 +712,7 @@ class ItIntrospectVersion {
     String imageTag = CommonTestUtils.getDateAndTimeStamp();
     String imageUpdate = KIND_REPO != null ? KIND_REPO
         + (WEBLOGIC_IMAGE_NAME + ":" + imageTag).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
-        : WEBLOGIC_IMAGE_NAME + ":" + imageTag;
+        : OCIR_REGISTRY + "/" + OCIR_WEBLOGIC_IMAGE_NAME + ":" + imageTag;
     dockerTag(imageName, imageUpdate);
     dockerLoginAndPushImageToRegistry(imageUpdate);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.util.Yaml;
 import oracle.weblogic.domain.AuxiliaryImage;
 import oracle.weblogic.domain.Domain;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
@@ -288,6 +289,8 @@ class ItMiiAuxiliaryImage {
         WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, miiAuxiliaryImage1, miiAuxiliaryImage2);
+
+    logger.info(Yaml.dump(domainCR));
 
     // create domain and verify its running
     logger.info("Creating domain {0} with auxiliary images {1} {2} in namespace {3}",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -37,6 +37,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_IMAGES_REPO;
@@ -45,7 +46,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_WDT_MODEL_FILE;
-import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_TEST_VERSION;
@@ -87,6 +87,7 @@ import static oracle.weblogic.kubernetes.utils.FileUtils.copyFileFromPod;
 import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.FileUtils.unzipWDTInstallationFile;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.JobUtils.getIntrospectJobName;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_PROCESSING_FAILED;
@@ -168,6 +169,10 @@ class ItMiiAuxiliaryImage {
     assertNotNull(namespaces.get(3), "Namespace list is null");
     wdtDomainNamespace = namespaces.get(3);
 
+    // Create the repo secret to pull the image
+    // this secret is used only for non-kind cluster
+    createSecretForBaseImages(domainNamespace);
+
     // install and verify operator
     installAndVerifyOperator(opNamespace, domainNamespace, errorpathDomainNamespace, wdtDomainNamespace);
   }
@@ -191,7 +196,7 @@ class ItMiiAuxiliaryImage {
 
     // Create the repo secret to pull the image
     // this secret is used only for non-kind cluster
-    createOcirRepoSecret(domainNamespace);
+    createSecretForBaseImages(domainNamespace);
 
     // create secret for admin credentials
     logger.info("Create secret for admin credentials");
@@ -286,7 +291,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage1, miiAuxiliaryImage2);
     Domain domainCR = createDomainResource(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, BASE_IMAGES_REPO_SECRET,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, miiAuxiliaryImage1, miiAuxiliaryImage2);
 
@@ -612,7 +617,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage1);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, BASE_IMAGES_REPO_SECRET,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage1);
 
@@ -695,7 +700,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage2);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, BASE_IMAGES_REPO_SECRET,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage2);
 
@@ -785,7 +790,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage3);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, BASE_IMAGES_REPO_SECRET,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage3);
 
@@ -894,7 +899,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage4);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, BASE_IMAGES_REPO_SECRET,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage4);
 
@@ -1060,7 +1065,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage4, miiAuxiliaryImage5);
     Domain domainCR = createDomainResource(domainUid, wdtDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, BASE_IMAGES_REPO_SECRET,
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, miiAuxiliaryImage4, miiAuxiliaryImage5);
 
@@ -1256,9 +1261,6 @@ class ItMiiAuxiliaryImage {
   }
 
   private void createSecretsForDomain(String adminSecretName, String encryptionSecretName, String domainNamespace) {
-    if (!secretExists(OCIR_SECRET_NAME, domainNamespace)) {
-      createOcirRepoSecret(domainNamespace);
-    }
 
     // create secret for admin credentials
     logger.info("Create secret for admin credentials");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -8,7 +8,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,7 +36,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
-import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_IMAGES_REPO;
@@ -46,9 +44,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_WDT_MODEL_FILE;
-import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
-import static oracle.weblogic.kubernetes.TestConstants.OCR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_TEST_VERSION;
@@ -90,7 +85,6 @@ import static oracle.weblogic.kubernetes.utils.FileUtils.copyFileFromPod;
 import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.FileUtils.unzipWDTInstallationFile;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
-import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcrRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.JobUtils.getIntrospectJobName;
@@ -106,6 +100,7 @@ import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodNam
 import static oracle.weblogic.kubernetes.utils.PodUtils.getPodCreationTime;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getPodsWithTimeStamps;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretsForImageRepos;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -1278,19 +1273,6 @@ class ItMiiAuxiliaryImage {
     }
   }
 
-  private static String[] createSecretsForImageRepos(String... namespaces) {
-    List<String> secrets = new ArrayList<>();
-    for (String namespace : namespaces) {
-      //create base images repo secret and repo registry secret
-      createOcirRepoSecret(namespace);
-      secrets.add(OCIR_SECRET_NAME);
-      if (BASE_IMAGES_REPO.equals(OCR_REGISTRY)) {
-        createOcrRepoSecret(namespace);
-        secrets.add(OCR_SECRET_NAME);
-      }
-    }
-    return secrets.toArray(new String[secrets.size()]);
-  }
 
   private void checkConfiguredJMSresouce(String domainNamespace, String adminServerPodName) {
     int adminServiceNodePort

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -152,7 +152,6 @@ class ItMiiAuxiliaryImage {
   @BeforeAll
   public static void initAll(@Namespaces(4) List<String> namespaces) {
     logger = getLogger();
-    logAll();
     // get a new unique opNamespace
     logger.info("Creating unique namespace for Operator");
     assertNotNull(namespaces.get(0), "Namespace list is null");
@@ -1350,43 +1349,4 @@ class ItMiiAuxiliaryImage {
         .until(() ->
             introspectorPodLogContainsExpectedErrorMsg(domainUid, namespace, expectedErrorMsg));
   }
-
-  private static void logAll() {
-    logger.info("BASE_IMAGES_REPO:{0}", TestConstants.BASE_IMAGES_REPO);
-    logger.info("BASE_IMAGES_REPO_SECRET:{0}", TestConstants.BASE_IMAGES_REPO_SECRET);
-    logger.info("OCIR_DEFAULT:{0}", TestConstants.OCIR_DEFAULT);
-    logger.info("OCIR_EMAIL:{0}", TestConstants.OCIR_EMAIL);
-    logger.info("OCIR_FMWINFRA_IMAGE_NAME:{0}", TestConstants.OCIR_FMWINFRA_IMAGE_NAME);
-    logger.info("OCIR_FMWINFRA_IMAGE_TAG:{0}", TestConstants.OCIR_FMWINFRA_IMAGE_TAG);
-    logger.info("OCIR_PASSWORD:{0}", TestConstants.OCIR_PASSWORD);
-    logger.info("OCIR_REGISTRY:{0}", TestConstants.OCIR_REGISTRY);
-    logger.info("OCIR_SECRET_NAME:{0}", TestConstants.OCIR_SECRET_NAME);
-    logger.info("OCIR_USERNAME:{0}", TestConstants.OCIR_USERNAME);
-    logger.info("OCIR_WEBLOGIC_IMAGE_NAME:{0}", TestConstants.OCIR_WEBLOGIC_IMAGE_NAME);
-    logger.info("OCIR_WEBLOGIC_IMAGE_TAG:{0}", TestConstants.OCIR_WEBLOGIC_IMAGE_TAG);
-    logger.info("OCIR_DB_IMAGE_NAME:{0}", TestConstants.OCIR_DB_IMAGE_NAME);
-    logger.info("OCIR_DB_IMAGE_TAG:{0}", TestConstants.OCIR_DB_IMAGE_TAG);
-
-    logger.info("OCR_DB_IMAGE_NAME:{0}", TestConstants.OCR_DB_IMAGE_NAME);
-    logger.info("OCR_DB_IMAGE_TAG:{0}", TestConstants.OCR_DB_IMAGE_TAG);
-    logger.info("OCR_EMAIL:{0}", TestConstants.OCR_EMAIL);
-    logger.info("OCR_FMWINFRA_IMAGE_NAME:{0}", TestConstants.OCR_FMWINFRA_IMAGE_NAME);
-    logger.info("OCR_FMWINFRA_IMAGE_TAG:{0}", TestConstants.OCR_FMWINFRA_IMAGE_TAG);
-    logger.info("OCR_PASSWORD:{0}", TestConstants.OCR_PASSWORD);
-    logger.info("OCR_REGISTRY:{0}", TestConstants.OCR_REGISTRY);
-    logger.info("OCR_SECRET_NAME:{0}", TestConstants.OCR_SECRET_NAME);
-    logger.info("OCR_USERNAME:{0}", TestConstants.OCR_USERNAME);
-    logger.info("OCR_WEBLOGIC_IMAGE_NAME:{0}", TestConstants.OCR_WEBLOGIC_IMAGE_NAME);
-    logger.info("OCR_WEBLOGIC_IMAGE_TAG:{0}", TestConstants.OCR_WEBLOGIC_IMAGE_TAG);
-
-    logger.info("WEBLOGIC_IMAGE_NAME:{0}", TestConstants.WEBLOGIC_IMAGE_NAME);
-    logger.info("WEBLOGIC_IMAGE_TAGS:{0}", TestConstants.WEBLOGIC_IMAGE_TAGS);
-    logger.info("WEBLOGIC_IMAGE_TO_USE_IN_SPEC:{0}", TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC);
-
-    logger.info("FMWINFRA_IMAGE_NAME:{0}", TestConstants.FMWINFRA_IMAGE_NAME);
-    logger.info("DB_IMAGE_NAME:{0}", TestConstants.DB_IMAGE_NAME);
-    logger.info("DB_IMAGE_TAG:{0}", TestConstants.DB_IMAGE_TAG);
-    logger.info("DB_IMAGE_TO_USE_IN_SPEC:{0}", TestConstants.DB_IMAGE_TO_USE_IN_SPEC);
-  }
-
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -44,6 +44,8 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_WDT_MODEL_FILE;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_REGISTRY;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_TEST_VERSION;
@@ -405,7 +407,7 @@ class ItMiiAuxiliaryImage {
     String imageTag = getDateAndTimeStamp();
     String imageUpdate = KIND_REPO != null ? KIND_REPO
         + (WEBLOGIC_IMAGE_NAME + ":" + imageTag).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
-        : WEBLOGIC_IMAGE_NAME + ":" + imageTag;
+        : OCIR_REGISTRY + "/" + OCIR_WEBLOGIC_IMAGE_NAME + ":" + imageTag;
     dockerTag(imageName, imageUpdate);
     dockerLoginAndPushImageToRegistry(imageUpdate);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -85,7 +85,6 @@ import static oracle.weblogic.kubernetes.utils.FileUtils.copyFileFromPod;
 import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.FileUtils.unzipWDTInstallationFile;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
-import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseImages;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.JobUtils.getIntrospectJobName;
 import static oracle.weblogic.kubernetes.utils.K8sEvents.DOMAIN_PROCESSING_FAILED;
@@ -169,10 +168,6 @@ class ItMiiAuxiliaryImage {
     assertNotNull(namespaces.get(3), "Namespace list is null");
     wdtDomainNamespace = namespaces.get(3);
 
-    // Create the repo secret to pull the image
-    // this secret is used only for non-kind cluster
-    imageSecrets = createSecretsForImageRepos(domainNamespace, errorpathDomainNamespace);
-
     // install and verify operator
     installAndVerifyOperator(opNamespace, domainNamespace, errorpathDomainNamespace, wdtDomainNamespace);
   }
@@ -193,10 +188,6 @@ class ItMiiAuxiliaryImage {
     // admin/managed server name here should match with model yaml
     final String auxiliaryImageVolumeName = "auxiliaryImageVolume1";
     final String auxiliaryImagePath = "/auxiliary";
-
-    // Create the repo secret to pull the image
-    // this secret is used only for non-kind cluster
-    createSecretForBaseImages(domainNamespace);
 
     // create secret for admin credentials
     logger.info("Create secret for admin credentials");
@@ -291,7 +282,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage1, miiAuxiliaryImage2);
     Domain domainCR = createDomainResource(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, imageSecrets,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, miiAuxiliaryImage1, miiAuxiliaryImage2);
 
@@ -615,7 +606,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage1);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, imageSecrets,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage1);
 
@@ -698,7 +689,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage2);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, imageSecrets,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage2);
 
@@ -788,7 +779,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage3);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, imageSecrets,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage3);
 
@@ -897,7 +888,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, errorPathAuxiliaryImage4);
     Domain domainCR = createDomainResource(domainUid, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, imageSecrets,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, errorPathAuxiliaryImage4);
 
@@ -1063,7 +1054,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage4, miiAuxiliaryImage5);
     Domain domainCR = createDomainResource(domainUid, wdtDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, imageSecrets,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(wdtDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         auxiliaryImageVolumeName, miiAuxiliaryImage4, miiAuxiliaryImage5);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -149,6 +149,7 @@ class ItMiiAuxiliaryImage {
   @BeforeAll
   public static void initAll(@Namespaces(4) List<String> namespaces) {
     logger = getLogger();
+    logAll();
     // get a new unique opNamespace
     logger.info("Creating unique namespace for Operator");
     assertNotNull(namespaces.get(0), "Namespace list is null");
@@ -1352,6 +1353,44 @@ class ItMiiAuxiliaryImage {
                     condition.getRemainingTimeInMS()))
         .until(() ->
             introspectorPodLogContainsExpectedErrorMsg(domainUid, namespace, expectedErrorMsg));
+  }
+
+  private static void logAll() {
+    logger.info("BASE_IMAGES_REPO:{0}", TestConstants.BASE_IMAGES_REPO);
+    logger.info("BASE_IMAGES_REPO_SECRET:{0}", TestConstants.BASE_IMAGES_REPO_SECRET);
+    logger.info("OCIR_DEFAULT:{0}", TestConstants.OCIR_DEFAULT);
+    logger.info("OCIR_EMAIL:{0}", TestConstants.OCIR_EMAIL);
+    logger.info("OCIR_FMWINFRA_IMAGE_NAME:{0}", TestConstants.OCIR_FMWINFRA_IMAGE_NAME);
+    logger.info("OCIR_FMWINFRA_IMAGE_TAG:{0}", TestConstants.OCIR_FMWINFRA_IMAGE_TAG);
+    logger.info("OCIR_PASSWORD:{0}", TestConstants.OCIR_PASSWORD);
+    logger.info("OCIR_REGISTRY:{0}", TestConstants.OCIR_REGISTRY);
+    logger.info("OCIR_SECRET_NAME:{0}", TestConstants.OCIR_SECRET_NAME);
+    logger.info("OCIR_USERNAME:{0}", TestConstants.OCIR_USERNAME);
+    logger.info("OCIR_WEBLOGIC_IMAGE_NAME:{0}", TestConstants.OCIR_WEBLOGIC_IMAGE_NAME);
+    logger.info("OCIR_WEBLOGIC_IMAGE_TAG:{0}", TestConstants.OCIR_WEBLOGIC_IMAGE_TAG);
+    logger.info("OCIR_DB_IMAGE_NAME:{0}", TestConstants.OCIR_DB_IMAGE_NAME);
+    logger.info("OCIR_DB_IMAGE_TAG:{0}", TestConstants.OCIR_DB_IMAGE_TAG);
+
+    logger.info("OCR_DB_IMAGE_NAME:{0}", TestConstants.OCR_DB_IMAGE_NAME);
+    logger.info("OCR_DB_IMAGE_TAG:{0}", TestConstants.OCR_DB_IMAGE_TAG);
+    logger.info("OCR_EMAIL:{0}", TestConstants.OCR_EMAIL);
+    logger.info("OCR_FMWINFRA_IMAGE_NAME:{0}", TestConstants.OCR_FMWINFRA_IMAGE_NAME);
+    logger.info("OCR_FMWINFRA_IMAGE_TAG:{0}", TestConstants.OCR_FMWINFRA_IMAGE_TAG);
+    logger.info("OCR_PASSWORD:{0}", TestConstants.OCR_PASSWORD);
+    logger.info("OCR_REGISTRY:{0}", TestConstants.OCR_REGISTRY);
+    logger.info("OCR_SECRET_NAME:{0}", TestConstants.OCR_SECRET_NAME);
+    logger.info("OCR_USERNAME:{0}", TestConstants.OCR_USERNAME);
+    logger.info("OCR_WEBLOGIC_IMAGE_NAME:{0}", TestConstants.OCR_WEBLOGIC_IMAGE_NAME);
+    logger.info("OCR_WEBLOGIC_IMAGE_TAG:{0}", TestConstants.OCR_WEBLOGIC_IMAGE_TAG);
+
+    logger.info("WEBLOGIC_IMAGE_NAME:{0}", TestConstants.WEBLOGIC_IMAGE_NAME);
+    logger.info("WEBLOGIC_IMAGE_TAGS:{0}", TestConstants.WEBLOGIC_IMAGE_TAGS);
+    logger.info("WEBLOGIC_IMAGE_TO_USE_IN_SPEC:{0}", TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC);
+
+    logger.info("FMWINFRA_IMAGE_NAME:{0}", TestConstants.FMWINFRA_IMAGE_NAME);
+    logger.info("DB_IMAGE_NAME:{0}", TestConstants.DB_IMAGE_NAME);
+    logger.info("DB_IMAGE_TAG:{0}", TestConstants.DB_IMAGE_TAG);
+    logger.info("DB_IMAGE_TO_USE_IN_SPEC:{0}", TestConstants.DB_IMAGE_TO_USE_IN_SPEC);
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImageCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImageCluster.java
@@ -33,7 +33,6 @@ import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_IMAGES_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
-import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
@@ -50,6 +49,7 @@ import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretsForImageRepos;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -186,7 +186,7 @@ class ItMiiAuxiliaryImageCluster {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, auxiliaryImageDomainScopeNames.toString(), auxiliaryImageClusterScopeNames.toString());
     Domain domainCR = createDomainResourceWithAuxiliaryImageClusterScope(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, clusterName,
         Map.of(auxiliaryImagePath, List.of(auxiliaryImageVolumeName)),
         auxiliaryImageDomainScopeNames, auxiliaryImageClusterScopeNames);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImageCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImageCluster.java
@@ -372,7 +372,7 @@ class ItMiiAuxiliaryImageCluster {
     });
 
     String cmdToExecute = String.format("cd %s && docker build -f %s %s -t %s .",
-        stageDirPath, dockerDestFile,
+        stageDirPath, dockerDestFile.toString(),
         "--build-arg AUXILIARY_IMAGE_PATH=" + auxiliaryImagePath, auxiliaryImage);
     assertTrue(new Command()
         .withParams(new CommandParams()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImageCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImageCluster.java
@@ -30,6 +30,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
+import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_IMAGE;
+import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_IMAGES_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
@@ -37,6 +39,7 @@ import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
+import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResourceWithAuxiliaryImageClusterScope;
@@ -44,6 +47,7 @@ import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.patchDomainClu
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.readFilesInPod;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkSystemResourceConfiguration;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.FileUtils.unzipWDTInstallationFile;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
@@ -357,8 +361,18 @@ class ItMiiAuxiliaryImageCluster {
   }
 
   private void createAuxiliaryImage(String stageDirPath, String dockerFileLocation, String auxiliaryImage) {
+    //replace the BUSYBOX_IMAGE and BUSYBOX_TAG in Dockerfile
+    Path dockerDestFile = Paths.get(WORK_DIR, "auximagescluster", "Dockerfile");
+    assertDoesNotThrow(() -> {
+      Files.createDirectories(dockerDestFile.getParent());
+      Files.copy(Paths.get(dockerFileLocation),
+          dockerDestFile, StandardCopyOption.REPLACE_EXISTING);
+      replaceStringInFile(dockerDestFile.toString(), "BUSYBOX_IMAGE", BUSYBOX_IMAGE);
+      replaceStringInFile(dockerDestFile.toString(), "BUSYBOX_TAG", BUSYBOX_TAG);
+    });
+
     String cmdToExecute = String.format("cd %s && docker build -f %s %s -t %s .",
-        stageDirPath, dockerFileLocation,
+        stageDirPath, dockerDestFile,
         "--build-arg AUXILIARY_IMAGE_PATH=" + auxiliaryImagePath, auxiliaryImage);
     assertTrue(new Command()
         .withParams(new CommandParams()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -47,7 +47,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_PASSWORD;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_REGISTRY;
-import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_USERNAME;
 import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.OKE_CLUSTER;
@@ -83,6 +82,7 @@ import static oracle.weblogic.kubernetes.utils.PersistentVolumeUtils.createfixPV
 import static oracle.weblogic.kubernetes.utils.PodUtils.execInPod;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretsForImageRepos;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -254,7 +254,8 @@ public class ItMiiDomainModelInPV {
     logger.info("Creating domain custom resource with domainUid {0} and image {1}",
         domainUid, image);
     Domain domainCR = CommonMiiTestUtils.createDomainResource(domainUid, domainNamespace,
-        image, adminSecretName, OCIR_SECRET_NAME, encryptionSecretName, replicaCount, clusterName);
+        image, adminSecretName, createSecretsForImageRepos(domainNamespace),
+        encryptionSecretName, replicaCount, clusterName);
     domainCR.spec().configuration().model().withModelHome(modelMountPath + "/model");
     domainCR.spec().serverPod()
         .addVolumesItem(new V1Volume()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -223,11 +223,16 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String imageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName) {
 
+    // create secrets
+    List<V1LocalObjectReference> secrets = new ArrayList<>();
+    for (String secret : repoSecretName) {
+      secrets.add(secret);
+    }
     // create the domain CR
     Domain domain = new Domain()
         .apiVersion(DOMAIN_API_VERSION)
@@ -268,6 +273,7 @@ public class CommonMiiTestUtils {
                     .domainType("WLS")
                     .runtimeEncryptionSecret(encryptionSecretName))
                 .introspectorJobActiveDeadlineSeconds(300L)));
+    domain.spec().setImagePullSecrets(secrets);
 
     setPodAntiAffinity(domain);
     return domain;
@@ -296,7 +302,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -171,7 +171,7 @@ public class CommonMiiTestUtils {
         domainNamespace,
         imageName,
         adminSecretName,
-        OCIR_SECRET_NAME,
+        new String[]{OCIR_SECRET_NAME},
         encryptionSecretName,
         replicaCount,
         "cluster-1");
@@ -231,7 +231,7 @@ public class CommonMiiTestUtils {
     // create secrets
     List<V1LocalObjectReference> secrets = new ArrayList<>();
     for (String secret : repoSecretName) {
-      secrets.add(secret);
+      secrets.add(new V1LocalObjectReference().name(secret));
     }
     // create the domain CR
     Domain domain = new Domain()
@@ -244,8 +244,6 @@ public class CommonMiiTestUtils {
             .domainUid(domainResourceName)
             .domainHomeSourceType("FromModel")
             .image(imageName)
-            .addImagePullSecretsItem(new io.kubernetes.client.openapi.models.V1LocalObjectReference()
-                .name(repoSecretName))
             .webLogicCredentialsSecret(new io.kubernetes.client.openapi.models.V1SecretReference()
                 .name(adminSecretName)
                 .namespace(domNamespace))
@@ -349,7 +347,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName,
@@ -400,7 +398,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName,

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/SecretUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/SecretUtils.java
@@ -218,19 +218,22 @@ public class SecretUtils {
   /**
    * Create multiple secrets if base images repository and domain images repository are different.
    *
-   * @param namespaces list of namespaces in which to create image repository secrets
+   * @param namespace namespace in which to create image repository secrets
    * @return string array of secret names created
    */
-  public static String[] createSecretsForImageRepos(String... namespaces) {
+  public static String[] createSecretsForImageRepos(String namespace) {
     List<String> secrets = new ArrayList<>();
-    for (String namespace : namespaces) {
-      //create base images repo secret and repo registry secret
+    //create repo registry secret
+    if (!secretExists(OCIR_SECRET_NAME, namespace)) {
       createOcirRepoSecret(namespace);
-      secrets.add(OCIR_SECRET_NAME);
-      if (BASE_IMAGES_REPO.equals(OCR_REGISTRY)) {
+    }
+    secrets.add(OCIR_SECRET_NAME);
+    if (BASE_IMAGES_REPO.equals(OCR_REGISTRY)) {
+      //create base images repo secret
+      if (!secretExists(OCR_SECRET_NAME, namespace)) {
         createOcrRepoSecret(namespace);
-        secrets.add(OCR_SECRET_NAME);
       }
+      secrets.add(OCR_SECRET_NAME);
     }
     return secrets.toArray(new String[secrets.size()]);
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/SecretUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/SecretUtils.java
@@ -6,6 +6,7 @@ package oracle.weblogic.kubernetes.utils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -24,10 +25,16 @@ import org.awaitility.core.ConditionFactory;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.GEN_EXTERNAL_REST_IDENTITY_FILE;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OCR_REGISTRY;
+import static oracle.weblogic.kubernetes.TestConstants.OCR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.secretExists;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcrRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -206,5 +213,25 @@ public class SecretUtils {
           }
           return false;
         });
+  }
+
+  /**
+   * Create multiple secrets if base images repository and domain images repository are different.
+   *
+   * @param namespaces list of namespaces in which to create image repository secrets
+   * @return string array of secret names created
+   */
+  public static String[] createSecretsForImageRepos(String... namespaces) {
+    List<String> secrets = new ArrayList<>();
+    for (String namespace : namespaces) {
+      //create base images repo secret and repo registry secret
+      createOcirRepoSecret(namespace);
+      secrets.add(OCIR_SECRET_NAME);
+      if (BASE_IMAGES_REPO.equals(OCR_REGISTRY)) {
+        createOcrRepoSecret(namespace);
+        secrets.add(OCR_SECRET_NAME);
+      }
+    }
+    return secrets.toArray(new String[secrets.size()]);
   }
 }


### PR DESCRIPTION
The tests needs to pass multiple secrets if the base image and auxilary images are coming from different repos, this PR creates secrets for OCR as well as OCIR registries if they are different.

Also this PR fixes the Dockerfile used in ItMiiAuxiliaryImageCluster.java is not substituted with BUSYBOX_IMAGE:TAG locations

BUSYBOX issue fixed
-----------------------
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10355/

All tests in Kind job
---------------------
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10367/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10345/

BASE_IMAGES_REPO as OCR
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10359/

OKD
https://build.weblogick8s.org:8443/job/wko-okd-test/312/

