### PR TITLE
add multiple secrets to domain resource if ocr and ocir are used, use unique hostpath in ItKubernetesDomainEvents

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -532,13 +532,14 @@ class ItKubernetesDomainEvents {
     Map<String, OffsetDateTime> podsWithTimeStamps = getPodsWithTimeStamps(domainNamespace3,
         adminServerPodName, managedServerPodNamePrefix, replicaCount);
 
+    String newLogHome = "/shared/" + domainNamespace3 + "/domains/logHome";
     //print out the original image name
     String logHome = domain1.getSpec().getLogHome();
-    logger.info("Currently the log home used by the domain is: {0}", logHome);
+    logger.info("Changing the current log home used by the domain : {0} to {1}", logHome, newLogHome);
 
     //change logHome from /shared/logs to /shared/logs/logHome
     String patchStr = "["
-        + "{\"op\": \"replace\", \"path\": \"/spec/logHome\", \"value\": \"/shared/logs/logHome\"}"
+        + "{\"op\": \"replace\", \"path\": \"/spec/logHome\", \"value\": \"" + newLogHome + "\"}"
         + "]";
     logger.info("PatchStr for logHome: {0}", patchStr);
 
@@ -551,7 +552,7 @@ class ItKubernetesDomainEvents {
 
     //print out logHome in the new patched domain
     logger.info("In the new patched domain logHome is: {0}", domain1.getSpec().getLogHome());
-    assertEquals("/shared/logs/logHome", domain1.getSpec().getLogHome(), "logHome is not updated");
+    assertEquals(newLogHome, domain1.getSpec().getLogHome(), "logHome is not updated");
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -730,6 +731,8 @@ class ItKubernetesDomainEvents {
   private static Domain createDomain(String domainNamespace, String domainUid,
                                      String pvName, String pvcName, String serverStartupPolicy) {
 
+    String uniquePath = "/shared/" + domainNamespace + "/domains";
+
     // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
     // this secret is used only for non-kind cluster
     createSecretForBaseImages(domainNamespace);
@@ -748,7 +751,7 @@ class ItKubernetesDomainEvents {
                     -> File.createTempFile("domain", "properties"),
             "Failed to create domain properties file");
     Properties p = new Properties();
-    p.setProperty("domain_path", "/shared/domains");
+    p.setProperty("domain_path", uniquePath);
     p.setProperty("domain_name", domainUid);
     p.setProperty("cluster_name", cluster1Name);
     p.setProperty("admin_server_name", adminServerName);
@@ -760,7 +763,7 @@ class ItKubernetesDomainEvents {
     p.setProperty("admin_t3_channel_port", Integer.toString(t3ChannelPort));
     p.setProperty("number_of_ms", "2");
     p.setProperty("managed_server_name_base", managedServerNameBase);
-    p.setProperty("domain_logs", "/shared/logs");
+    p.setProperty("domain_logs", uniquePath + "/logs");
     p.setProperty("production_mode_enabled", "true");
     assertDoesNotThrow(()
                     -> p.store(new FileOutputStream(domainPropertiesFile), "domain properties file"),
@@ -783,7 +786,7 @@ class ItKubernetesDomainEvents {
                     .namespace(domainNamespace))
             .spec(new DomainSpec()
                     .domainUid(domainUid)
-                    .domainHome("/shared/domains/" + domainUid) // point to domain home in pv
+                    .domainHome(uniquePath + "/" + domainUid) // point to domain home in pv
                     .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv
                     .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
                     .imagePullPolicy(V1Container.ImagePullPolicyEnum.IFNOTPRESENT)
@@ -795,7 +798,7 @@ class ItKubernetesDomainEvents {
                             .namespace(domainNamespace))
                     .includeServerOutInPodLog(true)
                     .logHomeEnabled(Boolean.TRUE)
-                    .logHome("/shared/logs/" + domainUid)
+                    .logHome(uniquePath + "/logs/" + domainUid)
                     .dataHome("")
                     .serverStartPolicy(serverStartupPolicy)
                     .serverPod(new ServerPod() //serverpod

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -38,7 +38,8 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_WDT_MODEL_FILE;
-import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_REGISTRY;
+import static oracle.weblogic.kubernetes.TestConstants.OCIR_WEBLOGIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_TEST_VERSION;
@@ -93,6 +94,7 @@ import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodNam
 import static oracle.weblogic.kubernetes.utils.PodUtils.getPodsWithTimeStamps;
 import static oracle.weblogic.kubernetes.utils.PodUtils.verifyIntrospectorPodLogContainsExpectedErrorMsg;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretsForImageRepos;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -197,11 +199,6 @@ class ItMiiAuxiliaryImage {
         assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace),
             "Can't get operator's pod name");
 
-    // Create the repo secret to pull the image
-    // this secret is used only for non-kind cluster
-    createOcirRepoSecret(domainNamespace);
-    createOcirRepoSecret(errorpathDomainNamespace);
-
     // create secret for admin credentials
     logger.info("Create secret for admin credentials");
     createSecretWithUsernamePassword(adminSecretName, domainNamespace,
@@ -251,7 +248,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid1, miiAuxiliaryImage1, miiAuxiliaryImage2);
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domainUid1, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         miiAuxiliaryImage1,
         miiAuxiliaryImage2);
@@ -388,7 +385,7 @@ class ItMiiAuxiliaryImage {
     String imageTag = getDateAndTimeStamp();
     String imageUpdate = KIND_REPO != null ? KIND_REPO
         + (WEBLOGIC_IMAGE_NAME + ":" + imageTag).substring(TestConstants.BASE_IMAGES_REPO.length() + 1)
-        : WEBLOGIC_IMAGE_NAME + ":" + imageTag;
+        : OCIR_REGISTRY + "/" + OCIR_WEBLOGIC_IMAGE_NAME + ":" + imageTag;
     dockerTag(imageName, imageUpdate);
     dockerLoginAndPushImageToRegistry(imageUpdate);
 
@@ -461,7 +458,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage1, miiAuxiliaryImage4);
     Domain domainCR1 = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePath,
         miiAuxiliaryImage1, miiAuxiliaryImage4);
 
@@ -483,7 +480,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage1, miiAuxiliaryImage4);
     Domain domainCR2 = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domainUid + "1", domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         miiAuxiliaryImage1,
         miiAuxiliaryImage4);
@@ -539,7 +536,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domainUid, miiAuxiliaryImage5);
     Domain domainCR = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePathCustom,
         miiAuxiliaryImage5);
 
@@ -610,7 +607,7 @@ class ItMiiAuxiliaryImage {
     // create domain custom resource using auxiliary images
     String[] images = {miiAuxiliaryImage6, miiAuxiliaryImage7};
     Domain domainCR = CommonMiiTestUtils.createDomainResource(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1",
         auxiliaryImagePathCustom, miiAuxiliaryImage6,
         miiAuxiliaryImage7);
@@ -664,7 +661,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
             domainUid, miiAuxiliaryImage8);
     Domain domainCR = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
             encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePathCustom,
             miiAuxiliaryImage8);
 
@@ -731,7 +728,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
             domainUid, miiAuxiliaryImage12);
     final Domain domainCR = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
             encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePathCustom,
             miiAuxiliaryImage12);
     assertNotNull(domainCR, "failed to create domain resource");
@@ -777,7 +774,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
             domainUid, miiAuxiliaryImage12);
     Domain domainCR1 = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
             encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePathCustom,
             miiAuxiliaryImage12);
     assertNotNull(domainCR1, "failed to create domain resource");
@@ -844,7 +841,7 @@ class ItMiiAuxiliaryImage {
     createDomainUsingAuxImageWithCustomWdtModelHomeInstallHome(wdtInstallPath,
             wdtModelHomePath,domainUid,miiAuxiliaryImage14Tag);
   }
-  
+
   /**
    * Create a domain using multiple auxiliary images. One auxiliary image containing the domain configuration and
    * another auxiliary image with JMS system resource but with sourceModelHome set to none,
@@ -866,7 +863,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage1, miiAuxiliaryImage4);
     Domain domainCR1 = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePath,
         miiAuxiliaryImage1, miiAuxiliaryImage2);
 
@@ -922,7 +919,7 @@ class ItMiiAuxiliaryImage {
         domainUid2, errorPathAuxiliaryImage1);
 
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domainUid2, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         errorPathAuxiliaryImage1);
 
@@ -990,7 +987,7 @@ class ItMiiAuxiliaryImage {
         domainUid2, errorPathAuxiliaryImage2);
 
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domainUid2, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         errorPathAuxiliaryImage2);
 
@@ -1061,7 +1058,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid2, errorPathAuxiliaryImage3);
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domainUid2, errorpathDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(errorpathDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         errorPathAuxiliaryImage3);
 
@@ -1161,7 +1158,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1} {2}",
         domainUid, miiAuxiliaryImage9, miiAuxiliaryImage10);
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domainUid, wdtDomainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(wdtDomainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         miiAuxiliaryImage9,
         miiAuxiliaryImage10);
@@ -1245,7 +1242,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary images {1}",
         domainUid, aiThatDoesntExist);
     Domain domainCR = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, List.of("cluster-1"), auxiliaryImagePath,
         aiThatDoesntExist + ":" + MII_BASIC_IMAGE_TAG);
     // createDomainResource util method sets 600 for activeDeadlineSeconds which is too long to verify
@@ -1339,7 +1336,7 @@ class ItMiiAuxiliaryImage {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       List<String> clusterNames,
@@ -1365,7 +1362,7 @@ class ItMiiAuxiliaryImage {
           String domNamespace,
           String baseImageName,
           String adminSecretName,
-          String repoSecretName,
+          String[] repoSecretName,
           String encryptionSecretName,
           int replicaCount,
           String sourceWDTInstallHome,
@@ -1420,7 +1417,7 @@ class ItMiiAuxiliaryImage {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
             domainUid, imageName);
     Domain domainCR = createDomainResourceWithAuxiliaryImage(domainUid, domainNamespace,
-            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+            WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
             encryptionSecretName, replicaCount, wdtInstallPath, wdtModelHomePath,
             List.of("cluster-1"),
             imageName);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCreateAuxImageWithImageTool.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCreateAuxImageWithImageTool.java
@@ -35,7 +35,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_AUXILIARY_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_WDT_MODEL_FILE;
-import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.ORACLELINUX_TEST_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.SKIP_CLEANUP;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_TEST_VERSION;
@@ -55,12 +54,12 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.verifyConfiguredS
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.verifyConfiguredSystemResource;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withStandardRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
-import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
 import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
+import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretsForImageRepos;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -106,10 +105,6 @@ class ItMiiCreateAuxImageWithImageTool {
     // install and verify operator
     installAndVerifyOperator(opNamespace, domainNamespace);
 
-    // Create the repo secret to pull the image
-    // this secret is used only for non-kind cluster
-    createOcirRepoSecret(domainNamespace);
-
     // create secret for admin credentials
     logger.info("Create secret for admin credentials");
     adminSecretName = "weblogic-credentials";
@@ -154,7 +149,7 @@ class ItMiiCreateAuxImageWithImageTool {
         createAuxiliaryImage(MII_AUXILIARY_IMAGE_NAME, miiAuxiliaryImageTag, modelList, archiveList),
         logger,
         "createAuxImage to be successful");
-   
+
 
     // push auxiliary image to repo for multi node cluster
     logger.info("docker push image {0} to registry {2}", miiAuxiliaryImage,
@@ -165,7 +160,7 @@ class ItMiiCreateAuxImageWithImageTool {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domain1Uid, miiAuxiliaryImage);
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domain1Uid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath,
         miiAuxiliaryImage);
 
@@ -238,7 +233,7 @@ class ItMiiCreateAuxImageWithImageTool {
         createAuxiliaryImage(witParams),
         logger,
         "createAuxImage to be successful");
-    
+
 
     // push image1 to repo for multi node cluster
     logger.info("docker push image {0} to registry {1}", miiAuxiliaryImage,
@@ -249,7 +244,7 @@ class ItMiiCreateAuxImageWithImageTool {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
         domain2Uid, miiAuxiliaryImage);
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domain2Uid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1", auxiliaryImagePath2,
         miiAuxiliaryImage);
 
@@ -321,7 +316,7 @@ class ItMiiCreateAuxImageWithImageTool {
     logger.info("Creating domain custom resource with domainUid {0} and auxiliary image {1}",
             domain3Uid, miiAuxiliaryImage);
     Domain domainCR = CommonMiiTestUtils.createDomainResourceWithAuxiliaryImage(domain3Uid, domainNamespace,
-        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, OCIR_SECRET_NAME,
+        WEBLOGIC_IMAGE_TO_USE_IN_SPEC, adminSecretName, createSecretsForImageRepos(domainNamespace),
         encryptionSecretName, replicaCount, "cluster-1");
     domainCR.spec().configuration().model()
         .withAuxiliaryImage(new AuxiliaryImage()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -170,7 +170,7 @@ public class CommonMiiTestUtils {
         domainNamespace,
         imageName,
         adminSecretName,
-        OCIR_SECRET_NAME,
+        new String[]{OCIR_SECRET_NAME},
         encryptionSecretName,
         replicaCount,
         "cluster-1");
@@ -222,7 +222,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String imageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName) {
@@ -255,10 +255,16 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String imageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       List<String> clusterNames) {
+
+    // create secrets
+    List<V1LocalObjectReference> secrets = new ArrayList<>();
+    for (String secret : repoSecretName) {
+      secrets.add(new V1LocalObjectReference().name(secret));
+    }
 
     // create the domain CR
     Domain domain = new Domain()
@@ -271,8 +277,6 @@ public class CommonMiiTestUtils {
             .domainUid(domainResourceName)
             .domainHomeSourceType("FromModel")
             .image(imageName)
-            .addImagePullSecretsItem(new io.kubernetes.client.openapi.models.V1LocalObjectReference()
-                .name(repoSecretName))
             .webLogicCredentialsSecret(new io.kubernetes.client.openapi.models.V1SecretReference()
                 .name(adminSecretName)
                 .namespace(domNamespace))
@@ -304,6 +308,7 @@ public class CommonMiiTestUtils {
               .serverStartState("RUNNING"));
     }
 
+    domain.spec().setImagePullSecrets(secrets);
     setPodAntiAffinity(domain);
     return domain;
   }
@@ -331,7 +336,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName,
@@ -369,7 +374,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       List<String> clusterNames,
@@ -418,7 +423,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName,
@@ -464,7 +469,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String imageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName) {
@@ -497,11 +502,16 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String imageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       List<String> clusterNames) {
 
+    // create secrets
+    List<V1LocalObjectReference> secrets = new ArrayList<>();
+    for (String secret : repoSecretName) {
+      secrets.add(new V1LocalObjectReference().name(secret));
+    }
     // create the domain CR
     Domain domain = new Domain()
             .apiVersion(DOMAIN_API_VERSION)
@@ -513,8 +523,6 @@ public class CommonMiiTestUtils {
                     .domainUid(domainResourceName)
                     .domainHomeSourceType("FromModel")
                     .image(imageName)
-                    .addImagePullSecretsItem(new io.kubernetes.client.openapi.models.V1LocalObjectReference()
-                            .name(repoSecretName))
                     .webLogicCredentialsSecret(new io.kubernetes.client.openapi.models.V1SecretReference()
                             .name(adminSecretName)
                             .namespace(domNamespace))
@@ -546,6 +554,7 @@ public class CommonMiiTestUtils {
                       .serverStartState("RUNNING"));
     }
 
+    domain.spec().setImagePullSecrets(secrets);
     setPodAntiAffinity(domain);
     return domain;
   }
@@ -572,7 +581,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       String clusterName,
@@ -608,7 +617,7 @@ public class CommonMiiTestUtils {
       String domNamespace,
       String baseImageName,
       String adminSecretName,
-      String repoSecretName,
+      String[] repoSecretName,
       String encryptionSecretName,
       int replicaCount,
       List<String> clusterNames,


### PR DESCRIPTION
This PR forward ports the below fixes made in release/3.4 

- Add multiple secrets to domain resource if ocr is used as BASE_IMAGES_REPO and ocir is used as REPO_REGISTRY
- Use unique hostpath in ItKubernetesDomainEvents

Kind
-----
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10403/