### PR TITLE
Add domain condition reasons upgrade

### DIFF
--- a/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
+++ b/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
@@ -7,9 +7,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -17,26 +18,45 @@ import com.meterware.simplestub.Memento;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static oracle.kubernetes.common.CommonConstants.API_VERSION_V9;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 class SchemaConversionUtilsTest {
 
-  public static final String DOMAIN_V8_AUX_IMAGE30_YAML = "aux-image-30-sample.yaml";
-  public static final String DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML = "converted-domain-sample.yaml";
-  public static final String DOMAIN_V8_SERVER_SCOPED_AUX_IMAGE30_YAML = "aux-image-30-sample-2.yaml";
-  public static final String DOMAIN_V9_CONVERTED_SERVER_SCOPED_LEGACY_AUX_IMAGE_YAML = "converted-domain-sample-2.yaml";
+  private static final String DOMAIN_V8_AUX_IMAGE30_YAML = "aux-image-30-sample.yaml";
+  private static final String DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML = "converted-domain-sample.yaml";
+  private static final String DOMAIN_V8_SERVER_SCOPED_AUX_IMAGE30_YAML = "aux-image-30-sample-2.yaml";
+  private static final String DOMAIN_V9_CONVERTED_SERVER_SCOPED_AUX_IMAGE_YAML = "converted-domain-sample-2.yaml";
 
   private final List<Memento> mementos = new ArrayList<>();
+  private final ConversionAdapter converter = new ConversionAdapter();
+  private Map<String, Object> v8Domain;
 
   @BeforeEach
   public void setUp() throws Exception {
     mementos.add(CommonTestUtils.silenceLogger());
+    mementos.add(BaseTestUtils.silenceJsonPathLogger());
+    
+    v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> readAsYaml(String fileName) throws IOException {
+    InputStream yamlStream = inputStreamFromClasspath(fileName);
+    ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+    return ((Map<String, Object>) yamlReader.readValue(yamlStream, Map.class));
+  }
+
+  private static InputStream inputStreamFromClasspath(String path) {
+    return SchemaConversionUtilsTest.class.getResourceAsStream(path);
   }
 
   @AfterEach
@@ -44,83 +64,130 @@ class SchemaConversionUtilsTest {
     mementos.forEach(Memento::revert);
   }
 
+  static class ConversionAdapter {
+    private final SchemaConversionUtils utils = SchemaConversionUtils.create();
+    private Map<String, Object> convertedDomain;
+
+    void convert(Map<String, Object> yaml) {
+      convertedDomain = utils.convertDomainSchema(yaml);
+    }
+
+    Map<String, Object> getDomain() {
+      return convertedDomain;
+    }
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private static Map<String, Object> getMapAtPath(Map<String, Object> parent, String jsonPath) {
+    Map<String, Object> result = parent;
+    for (String key : jsonPath.split("\\.")) {
+      result = getSubMap(result, key);
+    }
+
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> getSubMap(Map<String, Object> parentMap, String key) {
+    assertThat(parentMap, hasKey(key));
+    return (Map<String, Object>) parentMap.get(key);
+  }
+
   @Test
   void testV8DomainUpgradeWithLegacyAuxImagesToV9DomainWithInitContainers() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+    final Object expectedDomain = readAsYaml(DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML);
 
-    Object convertedDomain = schemaConversionUtils.convertDomainSchema(
-            readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML), API_VERSION_V9);
-    Object expectedDomain = readAsYaml(DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML);
-    assertThat(convertedDomain, equalTo(expectedDomain));
+    converter.convert(readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML));
+
+    assertThat(converter.getDomain(), equalTo(expectedDomain));
   }
 
   @Test
   void testV8DomainUpgradeWithServerScopedLegacyAuxImagesToV9DomainWithInitContainers() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+    final Object expectedDomain = readAsYaml(DOMAIN_V9_CONVERTED_SERVER_SCOPED_AUX_IMAGE_YAML);
 
-    Object convertedDomain = schemaConversionUtils.convertDomainSchema(
-            readAsYaml(DOMAIN_V8_SERVER_SCOPED_AUX_IMAGE30_YAML), API_VERSION_V9);
-    Object expectedDomain = readAsYaml(DOMAIN_V9_CONVERTED_SERVER_SCOPED_LEGACY_AUX_IMAGE_YAML);
-    assertThat(convertedDomain, equalTo(expectedDomain));
+    converter.convert(readAsYaml(DOMAIN_V8_SERVER_SCOPED_AUX_IMAGE30_YAML));
+
+    assertThat(converter.getDomain(), equalTo(expectedDomain));
   }
 
   @Test
-  void testV8DomainWithDomainHomeInImageTrue_convertedToDomainHomeSourceType() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+  void whenOldDomainHasProgressingCondition_removeIt() {
+    addStatusCondition("Progressing", null, "in progress");
 
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
-    setDomainHomeInImage(v8Domain, true);
-    setDomainHomeSourceType(v8Domain, null);
+    converter.convert(v8Domain);
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-            v8Domain, API_VERSION_V9);
+    assertThat(converter.getDomain(), hasJsonPath("$.status.conditions[?(@.type=='Progressing')]", empty()));
+  }
 
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasEntry("domainHomeSourceType", "Image"));
-    assertThat(spec, not(hasKey("domainHomeInImage")));
+  private void addStatusCondition(String type, String reason, String message) {
+    final Map<String, String> condition = new HashMap<>();
+    condition.put("type", type);
+    Optional.ofNullable(reason).ifPresent(r -> condition.put("reason", r));
+    Optional.ofNullable(message).ifPresent(m -> condition.put("message", m));
+    getStatusConditions().add(condition);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> getStatusConditions() {
+    return (List<Object>) getStatus().computeIfAbsent("conditions", k -> new ArrayList<>());
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String,Object> getStatus() {
+    return (Map<String, Object>) v8Domain.computeIfAbsent("status", k -> new HashMap<>());
   }
 
   @Test
-  void testV8DomainWithDomainHomeInImageFalse_convertedToDomainHomeSourceType() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+  void whenOldDomainHasUnsupportedConditionReasons_removeThem() {
+    addStatusCondition("Completed", "Nothing else to do", "Too bad");
+    addStatusCondition("Failed", "Internal", "whoops");
 
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
-    setDomainHomeInImage(v8Domain, false);
-    setDomainHomeSourceType(v8Domain, null);
+    converter.convert(v8Domain);
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-            v8Domain, API_VERSION_V9);
-
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasEntry("domainHomeSourceType", "PersistentVolume"));
-    assertThat(spec, not(hasKey("domainHomeInImage")));
+    assertThat(converter.getDomain(),
+          hasJsonPath("$.status.conditions[?(@.type=='Completed')].reason", empty()));
+    assertThat(converter.getDomain(),
+          hasJsonPath("$.status.conditions[?(@.type=='Completed')].message", contains("Too bad")));
   }
 
   @Test
-  void testV8DomainWithDomainHomeInImage_dontReplaceExistingDomainHomeSourceType() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+  void whenOldDomainHasSupportedConditionReasons_dontRemoveThem() {
+    addStatusCondition("Completed", "Nothing else to do", "Too bad");
+    addStatusCondition("Failed", "Internal", "whoops");
 
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
-    setDomainHomeInImage(v8Domain, true);
-    setDomainHomeSourceType(v8Domain, "FromModel");
+    converter.convert(v8Domain);
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-            v8Domain, API_VERSION_V9);
+    assertThat(converter.getDomain(),
+          hasJsonPath("$.status.conditions[?(@.type=='Failed')].reason", contains("Internal")));
+    assertThat(converter.getDomain(),
+          hasJsonPath("$.status.conditions[?(@.type=='Failed')].message", contains("whoops")));
+  }
 
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasEntry("domainHomeSourceType", "FromModel"));
-    assertThat(spec, not(hasKey("domainHomeInImage")));
+  @ParameterizedTest
+  @CsvSource({"true,, Image", "false,, PersistentVolume", "true, FromModel, FromModel"})
+  void whenOldDomainHasDomainHomeInImageBoolean_convertToDomainSourceType(
+        boolean isImage, String oldSourceType, String newSourceType) {
+
+    setDomainHomeInImage(v8Domain, isImage);
+    setDomainHomeSourceType(v8Domain, oldSourceType);
+
+    converter.convert(v8Domain);
+
+    assertThat(converter.getDomain(), hasJsonPath("$.spec.domainHomeSourceType", equalTo(newSourceType)));
+    assertThat(converter.getDomain(), hasNoJsonPath("$.spec.domainHomeInImage"));
+  }
+
+  private Map<String, Object> getDomainSpec(Map<String, Object> domainMap) {
+    return getSubMap(domainMap, "spec");
   }
 
   private void setDomainHomeInImage(Map<String, Object> v8Domain, boolean domainHomeInImage) {
-    ((Map<String, Object>) v8Domain.get("spec")).put("domainHomeInImage", String.valueOf(domainHomeInImage));
+    getDomainSpec(v8Domain).put("domainHomeInImage", String.valueOf(domainHomeInImage));
   }
 
   private void setDomainHomeSourceType(Map<String, Object> v8Domain, String domainHomeSourceType) {
-    Map<String, Object> spec = (Map<String, Object>) v8Domain.get("spec");
+    Map<String, Object> spec = getDomainSpec(v8Domain);
     if (domainHomeSourceType == null) {
       spec.remove("domainHomeSourceType");
     } else {
@@ -129,86 +196,55 @@ class SchemaConversionUtilsTest {
   }
 
   @Test
-  void testV8DomainWithConfigOverrides_moveToOverridesConfigMap() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
-
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
+  void testV8DomainWithConfigOverrides_moveToOverridesConfigMap() {
     setConfigOverrides(v8Domain, "someMap");
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-        v8Domain, API_VERSION_V9);
+    converter.convert(v8Domain);
 
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasKey("configuration"));
-    Map<String, Object> configuration = (Map<String, Object>) spec.get("configuration");
-    assertThat(configuration, hasEntry("overridesConfigMap", "someMap"));
-    assertThat(spec, not(hasKey("configOverrides")));
+    assertThat(converter.getDomain(), hasJsonPath("$.spec.configuration.overridesConfigMap", equalTo("someMap")));
+    assertThat(converter.getDomain(), hasNoJsonPath("$.spec.configOverrides"));
   }
 
   @Test
-  void testV8DomainWithConfigOverrides_dontReplaceExistingOverridesConfigMap() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
-
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
+  void testV8DomainWithConfigOverrides_dontReplaceExistingOverridesConfigMap() {
     setConfigOverrides(v8Domain, "someMap");
     setOverridesConfigMap(v8Domain, "existingMap");
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-        v8Domain, API_VERSION_V9);
+    converter.convert(v8Domain);
 
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasKey("configuration"));
-    Map<String, Object> configuration = (Map<String, Object>) spec.get("configuration");
-    assertThat(configuration, hasEntry("overridesConfigMap", "existingMap"));
-    assertThat(spec, not(hasKey("configOverrides")));
+    assertThat(converter.getDomain(), hasJsonPath("$.spec.configuration.overridesConfigMap", equalTo("existingMap")));
+    assertThat(converter.getDomain(), hasNoJsonPath("$.spec.configOverrides"));
   }
 
+  @SuppressWarnings("SameParameterValue")
   private void setConfigOverrides(Map<String, Object> v8Domain, String configMap) {
-    ((Map<String, Object>) v8Domain.get("spec")).put("configOverrides", configMap);
+    getDomainSpec(v8Domain).put("configOverrides", configMap);
   }
 
+  @SuppressWarnings("SameParameterValue")
   private void setOverridesConfigMap(Map<String, Object> v8Domain, String configMap) {
-    ((Map<String, Object>) ((Map<String, Object>) v8Domain.get("spec"))
-        .computeIfAbsent("configuration", k -> new LinkedHashMap<>())).put("overridesConfigMap", configMap);
+    getMapAtPath(v8Domain, "spec.configuration").put("overridesConfigMap", configMap);
   }
 
   @Test
-  void testV8DomainWithConfigOverrideSecrets_moveToConfigurationSecrets() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
-
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
+  void testV8DomainWithConfigOverrideSecrets_moveToConfigurationSecrets() {
     setConfigOverrideSecrets(v8Domain, Collections.singletonList("someSecret"));
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-        v8Domain, API_VERSION_V9);
+    converter.convert(v8Domain);
 
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasKey("configuration"));
-    Map<String, Object> configuration = (Map<String, Object>) spec.get("configuration");
-    assertThat(configuration, hasEntry("secrets", Collections.singletonList("someSecret")));
-    assertThat(spec, not(hasKey("configOverrideSecrets")));
+    assertThat(converter.getDomain(), hasJsonPath("$.spec.configuration.secrets", contains("someSecret")));
+    assertThat(converter.getDomain(), hasNoJsonPath("$.spec.configOverrideSecrets"));
   }
 
   @Test
-  void testV8DomainWithConfigOverrideSecrets_dontReplaceExistingSecrets() throws IOException {
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
-
-    Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
+  void testV8DomainWithConfigOverrideSecrets_dontReplaceExistingSecrets() {
     setConfigOverrideSecrets(v8Domain, Collections.singletonList("someSecret"));
     setConfigurationSecrets(v8Domain, Collections.singletonList("configSecret"));
 
-    Map<String, Object> convertedDomain = (Map<String, Object>) schemaConversionUtils.convertDomainSchema(
-        v8Domain, API_VERSION_V9);
+    converter.convert(v8Domain);
 
-    assertThat(convertedDomain, hasKey("spec"));
-    Map<String, Object> spec = (Map<String, Object>) convertedDomain.get("spec");
-    assertThat(spec, hasKey("configuration"));
-    Map<String, Object> configuration = (Map<String, Object>) spec.get("configuration");
-    assertThat(configuration, hasEntry("secrets", Collections.singletonList("configSecret")));
-    assertThat(spec, not(hasKey("configOverrideSecrets")));
+    assertThat(converter.getDomain(), hasJsonPath("$.spec.configuration.secrets", contains("configSecret")));
+    assertThat(converter.getDomain(), hasNoJsonPath("$.spec.configOverrideSecrets"));
   }
 
   @SuppressWarnings("unchecked")
@@ -217,17 +253,7 @@ class SchemaConversionUtilsTest {
   }
 
   private void setConfigurationSecrets(Map<String, Object> v8Domain, List<String> secrets) {
-    ((Map<String, Object>) ((Map<String, Object>) v8Domain.get("spec"))
-        .computeIfAbsent("configuration", k -> new LinkedHashMap<>())).put("secrets", secrets);
+    getMapAtPath(v8Domain, "spec.configuration").put("secrets", secrets);
   }
 
-  private Map<String, Object> readAsYaml(String fileName) throws IOException {
-    InputStream yamlStream = inputStreamFromClasspath(fileName);
-    ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
-    return ((Map<String, Object>) yamlReader.readValue(yamlStream, Map.class));
-  }
-
-  public static InputStream inputStreamFromClasspath(String path) {
-    return SchemaConversionUtilsTest.class.getResourceAsStream(path);
-  }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/model/ConversionRequest.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/model/ConversionRequest.java
@@ -14,9 +14,12 @@ public class ConversionRequest {
 
   @Expose
   private String uid;
+
   @Expose
   private String desiredAPIVersion;
+
   @Expose
+  // The domains to be converted. Note that the field name 'objects' is required by the conversion API.
   private List<Map<String,Object>> objects = new ArrayList<>();
 
   public String getUid() {
@@ -31,16 +34,11 @@ public class ConversionRequest {
     return desiredAPIVersion;
   }
 
-  public void setDesiredAPIVersion(String desiredAPIVersion) {
-    this.desiredAPIVersion = desiredAPIVersion;
-  }
-
-  public List<Map<String,Object>> getObjects() {
+  /**
+   * Returns a list domains to be converted by the webhook.
+   */
+  public List<Map<String,Object>> getDomains() {
     return objects;
-  }
-
-  public void setObjects(List<Map<String,Object>> objects) {
-    this.objects = objects;
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/model/ConversionRequest.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/model/ConversionRequest.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.rest.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.google.gson.annotations.Expose;
@@ -16,7 +17,7 @@ public class ConversionRequest {
   @Expose
   private String desiredAPIVersion;
   @Expose
-  private List<Object> objects = new ArrayList<>();
+  private List<Map<String,Object>> objects = new ArrayList<>();
 
   public String getUid() {
     return uid;
@@ -34,11 +35,11 @@ public class ConversionRequest {
     this.desiredAPIVersion = desiredAPIVersion;
   }
 
-  public List<Object> getObjects() {
+  public List<Map<String,Object>> getObjects() {
     return objects;
   }
 
-  public void setObjects(List<Object> objects) {
+  public void setObjects(List<Map<String,Object>> objects) {
     this.objects = objects;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ConversionWebhookResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ConversionWebhookResource.java
@@ -4,9 +4,9 @@
 package oracle.kubernetes.operator.rest.resource;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -102,11 +102,11 @@ public class ConversionWebhookResource extends BaseResource {
    * @return ConversionResponse The response to the conversion request.
    */
   private ConversionResponse createConversionResponse(ConversionRequest conversionRequest) {
-    List<Object> convertedDomains = new ArrayList<>();
     SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils(conversionRequest.getDesiredAPIVersion());
 
-    conversionRequest.getObjects()
-            .forEach(domain -> convertedDomains.add(schemaConversionUtils.convertDomainSchema(domain)));
+    List<Object> convertedDomains = conversionRequest.getDomains().stream()
+          .map(schemaConversionUtils::convertDomainSchema)
+          .collect(Collectors.toList());
 
     return new ConversionResponse()
             .uid(conversionRequest.getUid())

--- a/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ConversionWebhookResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/rest/resource/ConversionWebhookResource.java
@@ -6,7 +6,6 @@ package oracle.kubernetes.operator.rest.resource;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import com.google.gson.Gson;
@@ -67,9 +66,7 @@ public class ConversionWebhookResource extends BaseResource {
     } catch (Exception e) {
       LOGGER.severe(DOMAIN_CONVERSION_FAILED, e.getMessage(), getConversionRequest(conversionReview));
       conversionResponse = new ConversionResponse()
-          .uid(getUid(conversionReview))
-          .result(new Result().status(FAILED_STATUS)
-              .message("Exception: " + e.toString()));
+          .uid(getUid(conversionReview)).result(new Result().status(FAILED_STATUS).message("Exception: " + e));
       generateFailedEvent(e, getConversionRequest(conversionReview));
     }
     LOGGER.exiting(conversionResponse);
@@ -106,12 +103,10 @@ public class ConversionWebhookResource extends BaseResource {
    */
   private ConversionResponse createConversionResponse(ConversionRequest conversionRequest) {
     List<Object> convertedDomains = new ArrayList<>();
-    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils();
+    SchemaConversionUtils schemaConversionUtils = new SchemaConversionUtils(conversionRequest.getDesiredAPIVersion());
 
     conversionRequest.getObjects()
-            .forEach(domain -> convertedDomains.add(
-                    schemaConversionUtils.convertDomainSchema(
-                            (Map<String,Object>) domain, conversionRequest.getDesiredAPIVersion())));
+            .forEach(domain -> convertedDomains.add(schemaConversionUtils.convertDomainSchema(domain)));
 
     return new ConversionResponse()
             .uid(conversionRequest.getUid())

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -1238,10 +1238,10 @@ abstract class DomainStatusUpdateTestBase {
     updateDomainStatus();
 
     assertThat(getEvents().stream().sorted(this::compareEventTimes).collect(Collectors.toList()),
-        containsInRelativeOrder(
+        containsInRelativeOrder(List.of(
               eventWithReason(DOMAIN_AVAILABLE_EVENT),
               eventWithReason(DOMAIN_ROLL_COMPLETED_EVENT),
-              eventWithReason(DOMAIN_COMPLETED_EVENT)));
+              eventWithReason(DOMAIN_COMPLETED_EVENT))));
   }
 
   private void setUniqueCreationTimestamp(Object event) {

--- a/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
@@ -161,7 +161,7 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase implements A
 
     createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
 
-    assertThat(callBacks, contains(addEvent(object1), modifyEvent(object2)));
+    assertThat(callBacks, contains(List.of(addEvent(object1), modifyEvent(object2))));
   }
 
   @SuppressWarnings({"rawtypes"})

--- a/operator/src/test/java/oracle/kubernetes/operator/builders/WatchBuilderTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/builders/WatchBuilderTest.java
@@ -142,9 +142,7 @@ class WatchBuilderTest {
   @Test
   void afterWatchError_closeDoesNotReturnClientToPool() throws ApiException {
     Watchable<Domain> domainWatch = new WatchBuilder().createDomainWatch(NAMESPACE);
-    assertThrows(NoSuchElementException.class, () -> {
-      domainWatch.next();
-    });
+    assertThrows(NoSuchElementException.class, domainWatch::next);
 
     assertThat(ClientPoolStub.getPooledClients(), is(empty()));
   }
@@ -166,7 +164,7 @@ class WatchBuilderTest {
 
     Watchable<Domain> domainWatch = new WatchBuilder().createDomainWatch(NAMESPACE);
 
-    assertThat(domainWatch, contains(modifyEvent(domain1), deleteEvent(domain2)));
+    assertThat(domainWatch, contains(List.of(modifyEvent(domain1), deleteEvent(domain2))));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
@@ -16,7 +16,6 @@ import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
-import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -295,6 +294,7 @@ class RollingHelperTest {
     assertThat(serversMarkedForRoll(testSupport.getPacket()), anEmptyMap());
   }
 
+  @SuppressWarnings("unchecked")
   private Map<String, Step.StepAndPacket> serversMarkedForRoll(Packet packet) {
     return DomainPresenceInfo.fromPacket(packet)
         .map(DomainPresenceInfo::getServersToRoll)
@@ -371,10 +371,6 @@ class RollingHelperTest {
 
   private <T> T getFirst(List<T> list) {
     return list.get(0);
-  }
-
-  private List<CoreV1Event> getEvents() {
-    return testSupport.getResources(KubernetesTestSupport.EVENT);
   }
 
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/AdminServerTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/AdminServerTest.java
@@ -1,7 +1,9 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.weblogic.domain.model;
+
+import java.util.List;
 
 import oracle.kubernetes.weblogic.domain.AdminServerConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
@@ -104,7 +106,7 @@ class AdminServerTest extends BaseConfigurationTestBase {
 
     assertThat(
         domain.getAdminServerSpec().getAdminService().getChannels(),
-        containsInAnyOrder(channelWith(CHANNEL1, PORT1), channelWith(CHANNEL2, PORT2)));
+        containsInAnyOrder(List.of(channelWith(CHANNEL1, PORT1), channelWith(CHANNEL2, PORT2))));
   }
 
   @Test
@@ -191,6 +193,7 @@ class AdminServerTest extends BaseConfigurationTestBase {
     assertThat(server1, not(equalTo(server2)));
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void callingGetAdminService_doesNotChangeTheObject() {
     server1.getAdminService();

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainUpgradeConsistencyTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainUpgradeConsistencyTest.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.weblogic.domain.model;
+
+import java.util.Arrays;
+
+import oracle.kubernetes.common.utils.SchemaConversionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+class DomainUpgradeConsistencyTest {
+
+  @Test
+  void upgradeUsesActualObsoleteConditions() {
+    assertThat(SchemaConversionUtils.OBSOLETE_CONDITION_TYPES, containsInAnyOrder(getObsoleteConditionTypes()));
+  }
+
+  private String[] getObsoleteConditionTypes() {
+    return Arrays.stream(DomainConditionType.values())
+          .filter(DomainConditionType::isObsolete)
+          .map(DomainConditionType::toString)
+          .toArray(String[]::new);
+  }
+
+  @Test
+  void upgradeUsesActualSupportedFailureReasons() {
+    assertThat(SchemaConversionUtils.SUPPORTED_FAILURE_REASONS, containsInAnyOrder(getSupportedConditionReasons()));
+  }
+
+  private String[] getSupportedConditionReasons() {
+    return Arrays.stream(DomainFailureReason.values())
+          .map(DomainFailureReason::toString)
+          .toArray(String[]::new);
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
@@ -906,9 +906,8 @@ class DomainV2Test extends DomainTestBase {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML);
     AdminService adminService = domain.getAdminServerSpec().getAdminService();
 
-    assertThat(
-        adminService.getChannels(),
-        containsInAnyOrder(channelWith("default", 7001), channelWith("extra", 7011)));
+    assertThat(adminService.getChannels(), containsInAnyOrder(
+          List.of(channelWith("default", 7001), channelWith("extra", 7011))));
     assertThat(
         adminService.getLabels(), both(hasEntry("red", "maroon")).and(hasEntry("blue", "azure")));
     assertThat(


### PR DESCRIPTION
The primary intent of this change is to add support to the domain upgrade for the new behavior of condition reasons: since only values from DomainFailureReason are supported, the field was changed from a string to an enum. 

I have also done a bit of code cleanup, especially in the unit tests. This addresses warnings in the build and improves the readability of the domain conversion unit test.

I note some concerns that I did not address:
1.  The class `SchemaConversionUtils` is misleadingly named. It is not, as the name suggests, a set of utilities for doing schema conversion. It is, rather, the set of rules for upgrading an old domain. It should really be renamed and moved to a more appropriate package.
2. There are still some behaviors of the conversion that are not unit-tested. I added a test for removing the `Progressing` condition, but it is not the only gap.
3. I do not see a unit test for loading a domain resource into the `ConversionRequest` class. I modified the base type of the `objects` field because of a build warning. That should be safe because of the way Java handles generics, but the presence of a unit test would be reassuring, at the least.