### PR TITLE
OWLS-97729 - Enable ItMultiDomainModelsWithLoadBalancer#testMiiMultiClustersRollingRestart test 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
@@ -36,7 +36,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.DomainUtils;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -665,7 +664,6 @@ class ItMultiDomainModelsWithLoadBalancer {
    * Verify domain changed event is logged.
    * Disabled for now due to bug.
    */
-  @Disabled
   @Test
   @DisplayName("Verify server pods are restarted only once by changing the imagePullPolicy in multi-cluster domain")
   void testMiiMultiClustersRollingRestart() {


### PR DESCRIPTION
OWLS-97729 - Enable ItMultiDomainModelsWithLoadBalancer#testMiiMultiClustersRollingRestart test. I ran the test 10 times after enabling the test and it's always passing.
Build - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10457/