### PR TITLE
Provide operatorOnly helm config value to only install the operator and skip the webhook installation

### DIFF
--- a/documentation/staging/content/userguide/managing-operators/conversion-webhook.md
+++ b/documentation/staging/content/userguide/managing-operators/conversion-webhook.md
@@ -36,7 +36,7 @@ Beginning with  operator version 4.0, when you [install the operator]({{<relref 
 
 {{% notice note %}}
 **Security Considerations:**
-The `helm install` step requires cluster-level permissions for listing and reading all Namespaces and Deployments to search for existing conversion webhook deployments. In addition, the webhook uses a service account that is usually the same service account as an operator running in the same namespace. This service account requires permissions to create and read events in the conversion webhook namespace. For more information, see [RBAC]({{<relref "/userguide/managing-operators/rbac.md" >}}).
+The `helm install` step requires cluster-level permissions for listing and reading all Namespaces and Deployments to search for existing conversion webhook deployments. If you cannot grant the cluster-level permissions and have multiple operators deployed, then install the conversion webhook separately and set the Helm configuration value `operatorOnly` to `true` in the `helm install` command to prevent multiple conversion webhook deployments. In addition, the webhook uses a service account that is usually the same service account as an operator running in the same namespace. This service account requires permissions to create and read events in the conversion webhook namespace. For more information, see [RBAC]({{<relref "/userguide/managing-operators/rbac.md" >}}).
 {{% /notice %}}
 
 
@@ -64,12 +64,13 @@ The following table describes the behavior of different operator `Helm` chart co
 | --- | --- | --- |
 | Helm install | None specified | Operator and conversion webhook installed. |
 | Helm install | `webhookOnly=true` | Only conversion webhook installed. |
+| Helm install | `operatorOnly=true` | Only operator installed. |
 | Helm install | `preserveWebhook=true` | Operator and webhook installed and a future uninstall will not remove the webhook. |
 | Helm uninstall | | Operator and webhook deployment uninstalled. |
 | Helm uninstall with `preserveWebhook=true` set during `helm install` | | Operator deployment uninstalled and webhook deployment preserved. |
 
 **Note:**
-A webhook install is skipped if there's already a webhook deployment at the same or newer version.
+A webhook install is skipped if there's already a webhook deployment at the same or newer version. The `helm install` step requires cluster-level permissions to search for existing conversion webhook deployments in all namespaces. 
 
 ### Uninstall the conversion webhook
 

--- a/documentation/staging/content/userguide/managing-operators/installation.md
+++ b/documentation/staging/content/userguide/managing-operators/installation.md
@@ -34,6 +34,8 @@ See [Prepare for installation]({{<relref "/userguide/managing-operators/preparat
 By default, installing the operator also configures a deployment and supporting resources for the
 [conversion webhook]({{<relref "/userguide/managing-operators/conversion-webhook">}})
 and deploys the conversion webhook.
+To skip the conversion webhook installation, set helm configuration value `operatorOnly` to `true` 
+in the `helm install` command.
 For more details, see [install the conversion webhook]({{<relref "/userguide/managing-operators/conversion-webhook#install-the-conversion-webhook">}}).
 {{% /notice %}}
 

--- a/documentation/staging/content/userguide/managing-operators/using-helm.md
+++ b/documentation/staging/content/userguide/managing-operators/using-helm.md
@@ -689,8 +689,14 @@ If set to `true`, the `helm install` will install _only_ the conversion webhook 
 
 Defaults to `false`.
 
+##### `operatorOnly`
+Specifies whether only the operator should be installed during the `helm install` and that the conversion webhook installation should be skipped. By default, the `helm install` command installs both the operator and the conversion webhook.
+If set to `true`, the `helm install` will install _only_ the operator (and not the conversion webhook).
+
+Defaults to `false`.
+
 ##### `preserveWebhook`
 Specifies whether the existing conversion webhook deployment should be preserved (not removed) when the release is uninstalled using `helm uninstall`. By default, the `helm uninstall` removes both the webhook and the operator installation.
-If set to `true`, the `helm uninstall` command will not remove the webhook installation. Ignored when `webhookOnly` is set to `true`.
+If set to `true` in the `helm install` command, then the `helm uninstall` command will not remove the webhook installation. Ignored when `webhookOnly` is set to `true` in the `helm install` command.
 
 Defaults to `false`.

--- a/documentation/staging/content/userguide/managing-operators/using-helm.md
+++ b/documentation/staging/content/userguide/managing-operators/using-helm.md
@@ -22,6 +22,10 @@ description: "An operator runtime is installed and configured using Helm. Here a
     - [`labels`](#labels)
     - [`nodeSelector`](#nodeselector)
     - [`affinity`](#affinity)
+  - [WebLogic domain conversion webhook](#weblogic-domain-conversion-webhook)
+    - [`webhookOnly`](#webhookonly)
+    - [`operatorOnly`](#operatoronly)
+    - [`preserveWebhook`](#preservewebhook)
   - [WebLogic domain management](#weblogic-domain-management)
     - [`domainNamespaceSelectionStrategy`](#domainnamespaceselectionstrategy)
     - [`domainNamespaces`](#domainnamespaces)
@@ -49,9 +53,6 @@ description: "An operator runtime is installed and configured using Helm. Here a
     - [`remoteDebugNodePortEnabled`](#remotedebugnodeportenabled)
     - [`internalDebugHttpPort`](#internaldebughttpport)
     - [`externalDebugHttpPort`](#externaldebughttpport)
-  - [WebLogic Domain conversion webhook Helm configuration values](#weblogic-domain-conversion-webhook-helm-configuration-values)
-    - [`webhookOnly`](#webhookonly)
-    - [`preserveWebhook`](#preservewebhook)
 
 ### Introduction
 
@@ -291,6 +292,30 @@ affinity:
           values:
           - another-node-label-value
 ```
+
+#### WebLogic domain conversion webhook
+
+The WebLogic domain conversion webhook is automatically installed by default when an operator is installed and uninstalled when an operator is uninstalled. You can optionally install and uninstall it independently by using the operator's Helm chart. For details, see [Install the conversion webhook]({{<relref "/userguide/managing-operators/conversion-webhook#install-the-conversion-webhook" >}}) and [Uninstall the conversion webhook]({{<relref "/userguide/managing-operators/conversion-webhook#uninstall-the-conversion-webhook" >}}).
+
+**Note:** By default, the conversion webhook installation uses the same [`serviceAccount`](#serviceaccount), [Elastic Stack integration](#elastic-stack-integration), and [Debugging options](#debugging-options) configuration values that are used by the operator installation. If you want to use different `serviceAccount` or `Elastic Stack integration` or `Debugging options` for the conversion webhook, then install the conversion webhook independently by using the following `webhookOnly` configuration value and provide the new value during webhook installation.
+
+##### `webhookOnly`
+Specifies whether only the conversion webhook should be installed during the `helm install` and that the operator installation should be skipped. By default, the `helm install` command installs both the operator and the conversion webhook.
+If set to `true`, the `helm install` will install _only_ the conversion webhook (and not the operator).
+
+Defaults to `false`.
+
+##### `operatorOnly`
+Specifies whether only the operator should be installed during the `helm install` and that the conversion webhook installation should be skipped. By default, the `helm install` command installs both the operator and the conversion webhook.
+If set to `true`, the `helm install` will install _only_ the operator (and not the conversion webhook).
+
+Defaults to `false`.
+
+##### `preserveWebhook`
+Specifies whether the existing conversion webhook deployment should be preserved (not removed) when the release is uninstalled using `helm uninstall`. By default, the `helm uninstall` removes both the webhook and the operator installation.
+If set to `true` in the `helm install` command, then the `helm uninstall` command will not remove the webhook installation. Ignored when `webhookOnly` is set to `true` in the `helm install` command.
+
+Defaults to `false`.
 
 #### WebLogic domain management
 
@@ -676,27 +701,3 @@ externalDebugHttpPort:  30777
 ```
 
 **Note**: A node port is a security risk because the port may be publicly exposed to the internet in some environments. If you need external access to the debug port, then consider using Kubernetes port forwarding instead.
-
-### WebLogic Domain conversion webhook Helm configuration values
-
-The WebLogic Domain conversion webhook is automatically installed by default when an operator is installed and uninstalled when an operator is uninstalled. You can optionally install and uninstall it independently by using the operator's Helm chart. For details, see [Install the conversion webhook]({{<relref "/userguide/managing-operators/conversion-webhook#install-the-conversion-webhook" >}}) and [Uninstall the conversion webhook]({{<relref "/userguide/managing-operators/conversion-webhook#uninstall-the-conversion-webhook" >}}).
-
-**Note:** By default, the conversion webhook installation uses the same [`serviceAccount`](#serviceaccount), [Elastic Stack integration](#elastic-stack-integration), and [Debugging options](#debugging-options) configuration values that are used by the operator installation. If you want to use different `serviceAccount` or `Elastic Stack integration` or `Debugging options` for the conversion webhook, then install the conversion webhook independently by using the following `webhookOnly` configuration value and provide the new value during webhook installation.
-
-##### `webhookOnly`
-Specifies whether only the conversion webhook should be installed during the `helm install` and that the operator installation should be skipped. By default, the `helm install` command installs both the operator and the conversion webhook.
-If set to `true`, the `helm install` will install _only_ the conversion webhook (and not the operator).
-
-Defaults to `false`.
-
-##### `operatorOnly`
-Specifies whether only the operator should be installed during the `helm install` and that the conversion webhook installation should be skipped. By default, the `helm install` command installs both the operator and the conversion webhook.
-If set to `true`, the `helm install` will install _only_ the operator (and not the conversion webhook).
-
-Defaults to `false`.
-
-##### `preserveWebhook`
-Specifies whether the existing conversion webhook deployment should be preserved (not removed) when the release is uninstalled using `helm uninstall`. By default, the `helm uninstall` removes both the webhook and the operator installation.
-If set to `true` in the `helm install` command, then the `helm uninstall` command will not remove the webhook installation. Ignored when `webhookOnly` is set to `true` in the `helm install` command.
-
-Defaults to `false`.

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -172,7 +172,7 @@ spec:
 ---
   {{ $chartVersion := .Chart.Version }}
   {{ $webhookExists := include "utils.verifyExistingWebhookDeployment" (list $chartVersion) | trim }}
-  {{- if or (ne $webhookExists "true") (.recreateWebhook) }}
+  {{- if and (ne $webhookExists "true") (not .operatorOnly) }}
     # webhook does not exist or chart version is newer, create a new webhook
     apiVersion: "v1"
     kind: "ConfigMap"
@@ -193,7 +193,7 @@ spec:
       labels:
         weblogic.webhookName: {{ .Release.Namespace | quote }}
         weblogic.webhookVersion: {{ .Chart.Version }}
-      {{- if .preserveWebhook }}
+      {{- if and (.preserveWebhook) (not .webhookOnly) }}
       annotations:
         "helm.sh/hook": pre-install
         "helm.sh/resource-policy": keep

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # serviceAccount specifies the name of the ServiceAccount in the operator's namespace that the
 # operator will use to make requests to the Kubernetes API server.
 # The customer is responsible for creating the ServiceAccount in the same namespace as this Helm release.
-# If not specified, the operator will use the Helm release namespace's 'default' ServiceAccount.
+# If not specified, the the operator will use the Helm release namespace's 'default' ServiceAccount.
 serviceAccount: "default"
 
 # domainNamespaceSelectionStrategy specifies how the operator will select the set of namespaces
@@ -18,6 +18,13 @@ serviceAccount: "default"
 # If set to 'Dedicated', then operator will manage WebLogic Domains only in the same namespace
 # where the operator itself is deployed, which is the namespace of the Helm release.
 domainNamespaceSelectionStrategy: List
+
+# This value is deprecated. Please use 'domainNamespaceSelectionStrategy: Dedicated'.
+# dedicated specifies if this operator will manage WebLogic Domains only in the same namespace in
+# which the operator itself is deployed.  If set to 'true', then the 'domainNamespaces' value below
+# is ignored. This value is ignored if 'domainNamespaceSelectionStrategy' is set to a value other
+# than 'List'.
+# dedicated: false
 
 # domainNamespaces specifies list of WebLogic Domain namespaces that this operator manages. This value
 # is ignored if 'domainNamespaceSelectionStrategy' is not 'List'. The customer is responsible for creating these
@@ -153,12 +160,19 @@ javaLoggingFileCount: 10
 # for more information on node selectors.
 #nodeSelector:
  
-# webhookOnly specifies whether only the webhook deployment named weblogic-operator-webhook
-# should be created during helm install and if the creation of the operator deployment should be skipped.
-# By default, the helm install will create both the webhook deployment and the operator deployment.
-# If set to true, the helm install will only create the webhook deployment.
+# webhookOnly specifies whether only the conversion webhook should be installed during the helm install
+# and that the operator installation should be skipped.
+# By default, the helm install command installs both the operator and the conversion webhook.
+# If set to true, the helm install will install only the conversion webhook (and not the operator).
 # The default value is false.
 webhookOnly: false
+
+# operatorOnly specifies whether only the operator should be installed during the helm install and that 
+# the conversion webhook installation should be skipped.
+# By default, the helm install command installs both the operator and the conversion webhook.
+# If set to true, the helm install will install only the operator (and not the conversion webhook).
+# The default value is false.
+operatorOnly: false
  
 # preserveWebhook specifies whether the previous webhook deployment should be preserved
 # when the chart is uninstalled using helm uninstall.
@@ -254,3 +268,6 @@ clusterSizePaddingValidationEnabled: true
 # Defaults to 5 retries and 10 seconds between each retry.
 # domainPresenceFailureRetryMaxCount: 5
 # domainPresenceFailureRetrySeconds: 10
+#
+
+operatorOnly: false

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -1,10 +1,10 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # serviceAccount specifies the name of the ServiceAccount in the operator's namespace that the
 # operator will use to make requests to the Kubernetes API server.
 # The customer is responsible for creating the ServiceAccount in the same namespace as this Helm release.
-# If not specified, the the operator will use the Helm release namespace's 'default' ServiceAccount.
+# If not specified, the operator will use the Helm release namespace's 'default' ServiceAccount.
 serviceAccount: "default"
 
 # domainNamespaceSelectionStrategy specifies how the operator will select the set of namespaces
@@ -18,13 +18,6 @@ serviceAccount: "default"
 # If set to 'Dedicated', then operator will manage WebLogic Domains only in the same namespace
 # where the operator itself is deployed, which is the namespace of the Helm release.
 domainNamespaceSelectionStrategy: List
-
-# This value is deprecated. Please use 'domainNamespaceSelectionStrategy: Dedicated'.
-# dedicated specifies if this operator will manage WebLogic Domains only in the same namespace in
-# which the operator itself is deployed.  If set to 'true', then the 'domainNamespaces' value below
-# is ignored. This value is ignored if 'domainNamespaceSelectionStrategy' is set to a value other
-# than 'List'.
-# dedicated: false
 
 # domainNamespaces specifies list of WebLogic Domain namespaces that this operator manages. This value
 # is ignored if 'domainNamespaceSelectionStrategy' is not 'List'. The customer is responsible for creating these
@@ -78,7 +71,7 @@ imagePullPolicy: IfNotPresent
 # imagePullSecrets:
 # - name: "my-operator-secret"
 
-# externalRestEnabled specifies whether the the operator's REST interface is exposed
+# externalRestEnabled specifies whether the operator's REST interface is exposed
 # outside of the Kubernetes cluster on the port specified by the 'externalRestHttpsPort'
 # property.
 #
@@ -253,7 +246,7 @@ externalServiceNameSuffix: "-ext"
 # The default value is true.
 clusterSizePaddingValidationEnabled: true
 
-# tokenReviewAuthentication, if set to true, specifies whether the the operator's REST API should use
+# tokenReviewAuthentication, if set to true, specifies whether the operator's REST API should use
 #   1. Kubernetes token review API for authenticating users, and
 #   2. Kubernetes subject access review API for authorizing a user's operation (get, list,
 #      patch, etc) on a resource.
@@ -268,6 +261,3 @@ clusterSizePaddingValidationEnabled: true
 # Defaults to 5 retries and 10 seconds between each retry.
 # domainPresenceFailureRetryMaxCount: 5
 # domainPresenceFailureRetrySeconds: 10
-#
-
-operatorOnly: false


### PR DESCRIPTION
This change provides `operatorOnly` helm configuration value to only install the operator and skip the webhook installation. This might be needed in multiple operators use-case where cluster-level permissions can't be granted or all operators are deployed concurrently. This also includes a minor change to ignore the `preserveWebhook`  helm config value when `webhookOnly` is set to true.