### PR TITLE
Use time rather than number of retries to determine timeouts

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -145,6 +145,7 @@ public class MessageKeys {
   public static final String LOG_WAITING_COUNT = "WLSKO-0193";
   public static final String INTERNAL_IDENTITY_INITIALIZATION_FAILED = "WLSKO-0194";
   public static final String DOMAIN_FATAL_ERROR = "WLSKO-0195";
+  public static final String INTROSPECTOR_FATAL_ERROR = "WLSKO-0196";
   public static final String INTROSPECTOR_MAX_ERRORS_EXCEEDED = "WLSKO-0196";
   public static final String NON_FATAL_INTROSPECTOR_ERROR = "WLSKO-0197";
   public static final String DUMP_BREADCRUMBS = "WLSKO-0198";
@@ -193,7 +194,6 @@ public class MessageKeys {
   public static final String NO_MANAGED_SERVER_IN_DOMAIN = "WLSDO-0012";
   public static final String CANNOT_EXPOSE_DEFAULT_CHANNEL_ISTIO = "WLSDO-0013";
   public static final String INTROSPECT_JOB_FAILED = "WLSDO-0014";
-  public static final String INTROSPECT_JOB_FAILED_RETRY_COUNT = "WLSDO-0015";
   public static final String ILLEGAL_INTROSPECTOR_JOB_NAME_LENGTH = "WLSDO-0016";
   public static final String ILLEGAL_CLUSTER_SERVICE_NAME_LENGTH = "WLSDO-0017";
   public static final String ILLEGAL_SERVER_SERVICE_NAME_LENGTH = "WLSDO-0018";

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -145,12 +145,11 @@ WLSKO-0191=Rolling restart of WebLogic domain {0} completed
 WLSKO-0192=Executing make right domain operation, recheck count for server {0} is {1}.
 WLSKO-0193=Waiting for server {0} to start, recheck count is {1}.
 WLSKO-0194=Internal identity initialization step failed with exception {0}.
-WLSKO-0195=The operator encountered a fatal error: ''{0}'' and will not retry automatically. \
+WLSKO-0195=The operator failed after retrying for {0,number,#} minutes. \
+  This time limit may be specified in spec.failureRetryLimitMinutes. \
+  Please resolve the error and then update 'domain.spec.introspectVersion' to force another retry.
+WLSKO-0196=Introspection encountered a fatal error: ''{0}'' and will not retry automatically. \
   Please resolve the error and then update 'domain.spec.introspectVersion' to force a retry.
-WLSKO-0196=Introspection failed: ''{0}'' after {1} attempt(s) and will not retry. \
-  Please correct the error and force the operator to try again by updating 'domain.spec.introspectVersion'. \
-  The number of retries is controlled by the operator tuning parameter 'domainPresenceFailureRetryMaxCount', \
-  which may be specified in the weblogic-operator-cm configmap.
 WLSKO-0197=Introspection failed: ''{0}'' and will retry. Attempt {1} of {2}.
 WLSKO-0198={0} Fiber {1}
 WLSKO-0199=WL pod shutdown: Initiating shutdown of WebLogic server {0} via REST interface.
@@ -207,7 +206,6 @@ default-admin, default-secure are internal to the WebLogic Kubernetes Operator. 
 exposing it.
 WLSDO-0014=The domain {0} introspect job failed, it will automatically retry in {1} seconds. Current number of  \
   retries = {2}
-WLSDO-0015="Retrying failed domain {0} introspect job, retry {1} of a maximum {2}."
 WLSDO-0016=DomainUID ''{0}'' introspector job name ''{1}'' exceeds maximum allowed length ''{2}''.
 WLSDO-0017=The combination of UID ''{0}'' and cluster name ''{1}'' exceeds maximum allowed length ''{2}''.
 WLSDO-0018=The combination of UID ''{0}'' and server name ''{1}'' exceeds maximum allowed length ''{2}''.

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -846,10 +846,6 @@ public class DomainProcessorImpl implements DomainProcessor {
         LOGGER.fine("Cached domain info is newer than the live info from the watch event .");
         return false;  // we have already cached this
       } else if (shouldRecheck(cachedInfo)) {
-
-        if (getCurrentIntrospectFailureRetryCount(liveInfo) > 0) {
-          logRetryCount(cachedInfo);
-        }
         LOGGER.fine("Continue the make-right domain presence, explicitRecheck -> " + explicitRecheck);
         return true;
       }
@@ -857,21 +853,8 @@ public class DomainProcessorImpl implements DomainProcessor {
       return false;
     }
 
-    private Integer getCurrentIntrospectFailureRetryCount(DomainPresenceInfo info) {
-      return Optional.ofNullable(info)
-              .map(DomainPresenceInfo::getDomain)
-              .map(Domain::getStatus)
-              .map(DomainStatus::getIntrospectJobFailureCount)
-              .orElse(0);
-    }
-
     private int getFailureRetryMaxCount() {
       return DomainPresence.getFailureRetryMaxCount();
-    }
-
-    private void logRetryCount(DomainPresenceInfo cachedInfo) {
-      LOGGER.info(MessageKeys.INTROSPECT_JOB_FAILED_RETRY_COUNT, cachedInfo.getDomain().getDomainUid(),
-          getCurrentIntrospectFailureRetryCount(liveInfo), getFailureRetryMaxCount());
     }
 
     private boolean shouldRecheck(DomainPresenceInfo cachedInfo) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -64,6 +64,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_FATAL_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_ROLL_START;
 import static oracle.kubernetes.common.logging.MessageKeys.INTROSPECTOR_MAX_ERRORS_EXCEEDED;
 import static oracle.kubernetes.common.logging.MessageKeys.PODS_FAILED;
@@ -98,6 +99,7 @@ import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.KUBERN
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.REPLICAS_TOO_HIGH;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.SERVER_POD;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.TOPOLOGY_MISMATCH;
+import static oracle.kubernetes.weblogic.domain.model.DomainFailureSeverity.SEVERE;
 
 /**
  * Updates for status of Domain. This class has two modes: 1) Watching for Pod state changes by
@@ -505,8 +507,24 @@ public class DomainStatusUpdater {
     }
 
     void addFailure(DomainStatus status, DomainCondition condition) {
+      addFailureCondition(status, condition);
+      if (hasReachedRetryLimit(status, condition)) {
+        addFailureCondition(status, new DomainCondition(FAILED).withReason(ABORTED).withMessage(getFatalMessage()));
+      }
+    }
+
+    private void addFailureCondition(DomainStatus status, DomainCondition condition) {
       status.addCondition(condition);
       addDomainEvent(condition);
+    }
+
+    private boolean hasReachedRetryLimit(DomainStatus status, DomainCondition condition) {
+      return condition.getSeverity() == SEVERE
+          && status.getMinutesFromInitialToLastFailure() > getDomain().getFailureRetryLimitMinutes();
+    }
+
+    private String getFatalMessage() {
+      return LOGGER.formatMessage(DOMAIN_FATAL_ERROR, getDomain().getFailureRetryLimitMinutes());
     }
 
     void addDomainEvent(DomainCondition condition) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -721,6 +721,10 @@ public class DomainPresenceInfo implements PacketComponent {
     return result;
   }
 
+  long getNumDeadlineIncreases() {
+    return getDomain().getOrCreateStatus().getNumDeadlineIncreases(getDomain().getFailureRetryIntervalSeconds());
+  }
+
   @Nonnull
   private Set<String> getExpectedRunningManagedServers() {
     return getServerStartupInfo().stream().map(ServerStartupInfo::getServerName).collect(Collectors.toSet());

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/Domain.java
@@ -834,14 +834,14 @@ public class Domain implements KubernetesObject {
   /**
    * Returns the interval in seconds at which Severe failures will be retried.
    */
-  public int getFailureRetryIntervalSeconds() {
+  public long getFailureRetryIntervalSeconds() {
     return spec.getFailureRetryIntervalSeconds();
   }
 
   /**
    * Returns the time in minutes after the first severe failure when the operator will stop retrying Severe failures.
    */
-  public int getFailureRetryLimitMinutes() {
+  public long getFailureRetryLimitMinutes() {
     return spec.getFailureRetryLimitMinutes();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -44,11 +45,8 @@ import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_WDT_MODEL_HO
 @Description("The specification of the operation of the WebLogic domain. Required.")
 public class DomainSpec extends BaseConfiguration {
 
-  private static final int SECONDS_PER_MINUTE = 60;
-  private static final int MINUTES_PER_HOUR = 60;
-  private static final int HOURS_PER_DAY = 24;
-  private static final int DEFAULT_RETRY_INTERVAL_SECONDS = 2 * SECONDS_PER_MINUTE;
-  private static final int DEFAULT_RETRY_LIMIT_MINUTES = HOURS_PER_DAY * MINUTES_PER_HOUR;
+  private static final long DEFAULT_RETRY_INTERVAL_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+  private static final long DEFAULT_RETRY_LIMIT_MINUTES = TimeUnit.HOURS.toMinutes(24);
 
   /** Domain unique identifier. Must be unique across the Kubernetes cluster. */
   @Description(
@@ -259,11 +257,11 @@ public class DomainSpec extends BaseConfiguration {
 
   @Description("The wait time in seconds before the start of the next retry after a Severe failure. Defaults to 120.")
   @Range(minimum = 0)
-  private Integer failureRetryIntervalSeconds;
+  private Long failureRetryIntervalSeconds;
 
   @Description("The time in minutes before the operator will stop retrying Severe failures. Defaults to 1440.")
   @Range(minimum = 0)
-  private Integer failureRetryLimitMinutes;
+  private Long failureRetryLimitMinutes;
 
   /**
    * Whether the domain home is part of the image.
@@ -1141,19 +1139,19 @@ public class DomainSpec extends BaseConfiguration {
     return clusters;
   }
 
-  void setFailureRetryIntervalSeconds(Integer retryIntervalSeconds) {
+  void setFailureRetryIntervalSeconds(Long retryIntervalSeconds) {
     this.failureRetryIntervalSeconds = retryIntervalSeconds;
   }
 
-  int getFailureRetryIntervalSeconds() {
+  long getFailureRetryIntervalSeconds() {
     return Optional.ofNullable(failureRetryIntervalSeconds).orElse(DEFAULT_RETRY_INTERVAL_SECONDS);
   }
 
-  void setFailureRetryLimitMinutes(Integer retryLimitMinutes) {
+  void setFailureRetryLimitMinutes(Long retryLimitMinutes) {
     this.failureRetryLimitMinutes = retryLimitMinutes;
   }
 
-  int getFailureRetryLimitMinutes() {
+  long getFailureRetryLimitMinutes() {
     return Optional.ofNullable(failureRetryLimitMinutes).orElse(DEFAULT_RETRY_LIMIT_MINUTES);
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
@@ -17,6 +18,8 @@ import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.TuningParametersStub;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.utils.RandomStringGenerator;
 import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.SystemClockTestSupport;
@@ -28,11 +31,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_FATAL_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_ROLL_START;
 import static oracle.kubernetes.common.utils.LogMatcher.containsInfo;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createInternalFailureSteps;
+import static oracle.kubernetes.operator.DomainStatusUpdater.createTopologyMismatchFailureSteps;
 import static oracle.kubernetes.operator.EventConstants.ABORTED_ERROR;
 import static oracle.kubernetes.operator.EventConstants.DOMAIN_FAILED_EVENT;
 import static oracle.kubernetes.operator.EventConstants.DOMAIN_ROLL_STARTING_EVENT;
@@ -44,6 +49,7 @@ import static oracle.kubernetes.weblogic.domain.model.DomainCondition.TRUE;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionMatcher.hasCondition;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.FAILED;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.ROLLING;
+import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.ABORTED;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.INTERNAL;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.KUBERNETES;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -56,6 +62,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
  * tested by DomainStatusUpdateTestBase and its subclasses.
  */
 class DomainStatusUpdaterTest {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final String NAME = UID;
   private static final String ADMIN = "admin";
   public static final String CLUSTER = "cluster1";
@@ -216,10 +223,29 @@ class DomainStatusUpdaterTest {
   }
 
   @Test
-  void whenDomainLacksFailedCondition_failedStepUpdatesDomainWithFailedTrueAndException() {
+  void onFailedStep_emitEvent() {
     testSupport.runSteps(createInternalFailureSteps(failure));
 
     assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(INTERNAL_ERROR));
+  }
+
+  @Test
+  void whenDomainLacksFailedCondition_failedStepUpdatesDomainWithFailedCondition() {
+    testSupport.runSteps(createInternalFailureSteps(failure));
+
+    assertThat(getRecordedDomain(), hasCondition(FAILED).withStatus("True").withReason(INTERNAL));
+  }
+
+  @Test
+  void whenFailedStepCalledAndFailureLimitReached_statusHasAbortedFailureCondition() {
+    testSupport.runSteps(createTopologyMismatchFailureSteps("in unit test", null));
+
+    SystemClockTestSupport.increment(TimeUnit.MINUTES.toSeconds(domain.getFailureRetryLimitMinutes() + 1));
+    testSupport.runSteps(createInternalFailureSteps(failure));
+
+    assertThat(getRecordedDomain(),
+        hasCondition(FAILED).withReason(ABORTED)
+            .withMessageContaining(LOGGER.formatMessage(DOMAIN_FATAL_ERROR, domain.getFailureRetryLimitMinutes())));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -633,12 +633,12 @@ public abstract class DomainConfigurator {
    * @param retrySeconds the new value
    * @return this object
    */
-  public abstract DomainConfigurator withFailureRetryIntervalSeconds(int retrySeconds);
+  public abstract DomainConfigurator withFailureRetryIntervalSeconds(long retrySeconds);
 
   /**
    * Specify the Severe error retry limit in minutes.
    * @param limitMinutes the new value
    * @return this object
    */
-  public abstract DomainConfigurator withFailureRetryLimitMinutes(int limitMinutes);
+  public abstract DomainConfigurator withFailureRetryLimitMinutes(long limitMinutes);
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
@@ -431,13 +431,13 @@ public class DomainCommonConfigurator extends DomainConfigurator {
   }
 
   @Override
-  public DomainConfigurator withFailureRetryIntervalSeconds(int retrySeconds) {
+  public DomainConfigurator withFailureRetryIntervalSeconds(long retrySeconds) {
     getDomainSpec().setFailureRetryIntervalSeconds(retrySeconds);
     return this;
   }
 
   @Override
-  public DomainConfigurator withFailureRetryLimitMinutes(int limitMinutes) {
+  public DomainConfigurator withFailureRetryLimitMinutes(long limitMinutes) {
     getDomainSpec().setFailureRetryLimitMinutes(limitMinutes);
     return this;
   }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainRetryTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainRetryTest.java
@@ -42,8 +42,8 @@ class DomainRetryTest extends DomainTestBase {
 
   @Test
   void failureRetryParameters_haveDefaultValues() {
-    assertThat(domain.getFailureRetryIntervalSeconds(), equalTo(120));
-    assertThat(domain.getFailureRetryLimitMinutes(), equalTo(1440));
+    assertThat(domain.getFailureRetryIntervalSeconds(), equalTo(120L));
+    assertThat(domain.getFailureRetryLimitMinutes(), equalTo(1440L));
   }
 
   @Test
@@ -52,16 +52,16 @@ class DomainRetryTest extends DomainTestBase {
           .withFailureRetryIntervalSeconds(73)
           .withFailureRetryLimitMinutes(103);
 
-    assertThat(domain.getFailureRetryIntervalSeconds(), equalTo(73));
-    assertThat(domain.getFailureRetryLimitMinutes(), equalTo(103));
+    assertThat(domain.getFailureRetryIntervalSeconds(), equalTo(73L));
+    assertThat(domain.getFailureRetryLimitMinutes(), equalTo(103L));
   }
 
   @Test
   void readFailureRetryParametersFromYaml() throws IOException {
     Domain domain = readDomain(DOMAIN_V2_SAMPLE_YAML_3);
 
-    assertThat(domain.getFailureRetryIntervalSeconds(), equalTo(90));
-    assertThat(domain.getFailureRetryLimitMinutes(), equalTo(1000));
+    assertThat(domain.getFailureRetryIntervalSeconds(), equalTo(90L));
+    assertThat(domain.getFailureRetryLimitMinutes(), equalTo(1000L));
   }
 
   @Test


### PR DESCRIPTION
Next part of the changes to retries for severe errors.

This includes using time to determine both the retry limit and the increases in the instrospector job timeout.

Currently, two values (the maximum number of increases and size of each increase) are hard-coded. The next change will make them tuning parameters. It will also remove the rest of the retry count functions, and add removing those fields to the domain upgrade.