### PR TITLE
move domain debugging doc

### DIFF
--- a/documentation/staging/content/samples/azure-kubernetes-service/troubleshooting.md
+++ b/documentation/staging/content/samples/azure-kubernetes-service/troubleshooting.md
@@ -135,7 +135,7 @@ Status:
 
 #### Domain debugging
 
-For some suggestions for debugging problems with Model in Image after your Domain YAML file is deployed, see [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}).
+For some suggestions for debugging problems with Model in Image after your Domain YAML file is deployed, see [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 #### WSL2 bad timestamp
 

--- a/documentation/staging/content/samples/domains/model-in-image/initial.md
+++ b/documentation/staging/content/samples/domains/model-in-image/initial.md
@@ -884,7 +884,7 @@ Alternatively, you can run `/tmp/mii-sample/utils/wl-pod-wait.sh -p 3`. This is 
   {{% /expand %}}
 
 
-If you see an error, then consult [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+If you see an error, then consult [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 #### Invoke the web application
 

--- a/documentation/staging/content/samples/domains/model-in-image/update1.md
+++ b/documentation/staging/content/samples/domains/model-in-image/update1.md
@@ -10,7 +10,7 @@ This use case demonstrates dynamically adding a data source to your running doma
 - A domain's model can be updated dynamically by supplying a model update in a file in a Kubernetes ConfigMap.
 - Model updates can be as simple as changing the value of a single attribute, or more complex, such as adding a JMS Server.
 
-For a detailed description of model updates, see [Runtime Updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) in the Model in Image user guide.
+For a detailed description of model updates, see [Runtime Updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}).
 
 {{% notice warning %}}
 The operator does not support all possible dynamic model updates. For model update limitations, consult [Runtime Updates]({{< relref "/userguide/managing-domains/model-in-image/runtime-updates.md" >}}) in the Model in Image user docs, and carefully test any model update before attempting a dynamic update in production.
@@ -486,7 +486,7 @@ Here are the steps:
 
 A `TestPool Failure` is expected because we will demonstrate dynamically correcting the data source attributes in [Update 4]({{< relref "/samples/domains/model-in-image/update4.md" >}}).
 
-If you see an error other than the expected `TestPool Failure`, then consult [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+If you see an error other than the expected `TestPool Failure`, then consult [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 If you plan to run the [Update 3]({{< relref "/samples/domains/model-in-image/update3.md" >}}) or [Update 4]({{< relref "/samples/domains/model-in-image/update4.md" >}}) use case, then leave your domain running.
 

--- a/documentation/staging/content/samples/domains/model-in-image/update2.md
+++ b/documentation/staging/content/samples/domains/model-in-image/update2.md
@@ -505,7 +505,7 @@ Here are the steps for this use case:
 
 A `TestPool Failure` is expected because we will demonstrate dynamically correcting the data source attributes for `sample-domain1` in [Update 4]({{< relref "/samples/domains/model-in-image/update4.md" >}}).
 
-If you see an error other than the expected `TestPool Failure`, then consult [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+If you see an error other than the expected `TestPool Failure`, then consult [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 You will not be using the `sample-domain2` domain again in this sample; if you wish, you can shut it down now by calling `kubectl -n sample-domain1-ns delete domain sample-domain2`.
 

--- a/documentation/staging/content/samples/domains/model-in-image/update3.md
+++ b/documentation/staging/content/samples/domains/model-in-image/update3.md
@@ -443,7 +443,7 @@ Here are the steps for this use case:
 
 A `TestPool Failure` is expected because we will demonstrate dynamically correcting the data source attributes in [Update 4]({{< relref "/samples/domains/model-in-image/update4.md" >}}).
 
-If you see an error other than the expected `TestPool Failure`, then consult [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+If you see an error other than the expected `TestPool Failure`, then consult [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 If you plan to run the [Update 4]({{< relref "/samples/domains/model-in-image/update4.md" >}}) use case, then leave your domain running.
 

--- a/documentation/staging/content/samples/domains/model-in-image/update4.md
+++ b/documentation/staging/content/samples/domains/model-in-image/update4.md
@@ -261,7 +261,7 @@ Here are the steps:
    ```
      {{% /expand %}}
 
-   - If the introspector job fails, then consult [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+   - If the introspector job fails, then consult [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 1. Call the sample web application to:
 
@@ -314,7 +314,7 @@ The `testPool='Passed'` for `mynewdatasource` verifies that your update to the d
 
 If you see a `testPool='Failed'` error, then it is likely you did not deploy the database or your database is not deployed correctly.
 
-If you see any other error, then consult [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+If you see any other error, then consult [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 This completes the sample scenarios.
 

--- a/documentation/staging/content/userguide/managing-domains/debugging.md
+++ b/documentation/staging/content/userguide/managing-domains/debugging.md
@@ -1,7 +1,7 @@
 +++
 title = "Domain debugging"
 date = 2020-03-11T16:45:16-05:00
-weight = 60
+weight = 11
 pre = "<b> </b>"
 description = "Debugging a deployed domain."
 +++
@@ -14,7 +14,6 @@ Here are some suggestions for debugging problems with a domain after your Domain
  - [Check the Domain events](#check-the-domain-events)
  - [Check the introspector job](#check-the-introspector-job)
  - [Check the WebLogic Server pods](#check-the-weblogic-server-pods)
- - [Check the operator log](#check-the-operator-log)
  - [Check the docs](#check-the-docs)
  - [Check the operator](#check-the-operator)
 
@@ -77,7 +76,7 @@ Here we see a failed introspector job pod among the domain's pods:
 - Here's an alternative log command that will have same output as shown in the previous command.
   `$ kubectl -n sample-domain1-ns logs pod/sample-domain1-introspector-v2l7k`
 
-A common reason for the introspector job to fail is because of an error in a model file. Here's some sample log output from an introspector job that shows such a failure:
+A common reason for the introspector job to fail in a Model in Image domain is because of an error in a model file. Here's some sample log output from an introspector job that shows such a failure:
  ```
   ...
 
@@ -103,37 +102,6 @@ If `kubectl -n MY_NAMESPACE get pods` reveals that your WebLogic Server pods hav
 If you are performing an online update to a running domain's WebLogic configuration,
 then see [Online update status and labels]({{<relref "/userguide/managing-domains/model-in-image/runtime-updates#online-update-status-and-labels">}}).
 
-### Check the operator log
-
-Look for `SEVERE` and `ERROR` level messages in your operator logs. For example:
-
-
-- Find your operator.
-  ```shell
-  $ kubectl get deployment --all-namespaces=true -l weblogic.operatorName
-  ```
-  ```
-  NAMESPACE                     NAME                DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-  sample-weblogic-operator-ns   weblogic-operator   1         1         1            1           20h
-
-  ```
-- Use `grep` on the operator log; look for `SEVERE` and `WARNING` level messages.
-
-  ```shell
-  $ kubectl logs deployment/weblogic-operator -n sample-weblogic-operator-ns  \
-    | egrep -e "level...(SEVERE|WARNING)"
-  ```
-  ```json
-  {"timestamp":"03-18-2020T20:42:21.702+0000","thread":11,"fiber":"","domainUID":"","level":"WARNING","class":"oracle.kubernetes.operator.helpers.HealthCheckHelper","method":"createAndValidateKubernetesVersion","timeInMillis":1584564141702,"message":"Kubernetes minimum version check failed. Supported versions are 1.13.5+,1.14.8+,1.15.7+, but found version v1.12.3","exception":"","code":"","headers":{},"body":""}
-  ```
-
-- You can filter out operator log messages specific to your `domainUID` by piping the previous logs command through `grep "domainUID...MY_DOMAINUID"`. For example, assuming your operator is running in namespace `sample-weblogic-operator-ns` and your domain UID is `sample-domain1`:
-
-  ```shell
-  $ kubectl logs deployment/weblogic-operator -n sample-weblogic-operator-ns  \
-    | egrep -e "level...(SEVERE|WARNING)" \
-    | grep "domainUID...sample-domain1"
-  ```
 
 ### Check the docs
 

--- a/documentation/staging/content/userguide/managing-domains/domain-lifecycle/introspection.md
+++ b/documentation/staging/content/userguide/managing-domains/domain-lifecycle/introspection.md
@@ -76,7 +76,7 @@ When introspection fails, the operator will not start any WebLogic Server instan
 
 The introspection will be periodically retried and then will eventually timeout with the Domain `status` indicating the processing failed. To recover from a failed state, correct the underlying problem and update the `introspectVersion`.
 
-Please review the details for diagnosing introspection failures related to [configuration overrides]({{<relref "/userguide/managing-domains/configoverrides/_index.md#debugging">}}) or [Model in Image domain home generation]({{<relref "/userguide/managing-domains/model-in-image/debugging.md">}}).
+Please review the details for diagnosing introspection failures related to [configuration overrides]({{<relref "/userguide/managing-domains/configoverrides/_index.md#debugging">}}) or [Model in Image domain home generation]({{<relref "/userguide/managing-domains/debugging.md">}}).
 
 {{% notice tip %}}
 The introspector log is mirrored to the Domain resource `spec.logHome` directory

--- a/documentation/staging/content/userguide/managing-domains/model-in-image/auxiliary-images.md
+++ b/documentation/staging/content/userguide/managing-domains/model-in-image/auxiliary-images.md
@@ -793,7 +793,7 @@ their corresponding values in their domain resource.
   ```
   {{% /expand %}}
 
-If you see an error, then consult [Domain debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) in the Model in Image user guide.
+If you see an error, then consult [Domain debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 #### Step 4: Invoke the web application
 

--- a/documentation/staging/content/userguide/managing-domains/model-in-image/runtime-updates.md
+++ b/documentation/staging/content/userguide/managing-domains/model-in-image/runtime-updates.md
@@ -178,7 +178,7 @@ A domain roll begins by restarting the domain's Administration Server and
 then proceeds to restart each Managed Server in the domain.
 
 If the job reports a failure, see
-[Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}})
+[Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}})
 for advice.
 
 #### Offline update sample
@@ -236,7 +236,7 @@ and runs WebLogic Deploy Tooling to process the differences:
 
 
 If the introspector job reports a failure or any other failure occurs, then
-see [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}) for advice.
+see [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}) for advice.
 When recovering from a failure, please keep the following points in mind:
 
  - The operator cannot automatically revert changes to resources that are under
@@ -328,7 +328,7 @@ spec:
      * The expected behavior is often undefined, but in some cases there will be helpful error in the introspector job, events, and/or domain status, and the job will periodically retry until the error is corrected or its maximum error count exceeded.
    * Actions required:
      * Use offline updates if they are supported, or, if not, shutdown the entire domain and restart it.
-     * See [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}).
+     * See [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
 
 1. Errors in the model; for example, a syntax error.
    * Expected outcome after the introspector job completes:
@@ -345,7 +345,7 @@ spec:
      * The domain status `Failed` condition will have a `Status` of `True`.
      * If there's a failed introspector job, the job will retry periodically until the error is corrected or until it exceeds its maximum error count. Other types of errors will also usually incur periodic retries.
    * Actions required:
-     * See [Debugging]({{< relref "/userguide/managing-domains/model-in-image/debugging.md" >}}).
+     * See [Debugging]({{< relref "/userguide/managing-domains/debugging.md" >}}).
      * Make corrections to the domain resource and/or model.
      * If retries have halted, then alter the `spec.introspectVersion`.
 


### PR DESCRIPTION
Moved Domain Debugging doc as per advice in JIRA [OWLS-99150](https://jira.oraclecorp.com/jira/browse/OWLS-99150). However, I chose **not** to rename the document from Domain Debugging to Domain Troubleshooting to avoid confusion with the Manage Operators > Troubleshooting document.