### PR TITLE
create crio-pipeline profile and use unique namespace in ItTwoDomainsManagedByTwoOperators

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -587,12 +587,15 @@
             <id>wls-srg</id>
             <properties>
                 <skipITs>false</skipITs>
+                <groups>gate,samples-gate</groups>
+                <!--
                 <includes-failsafe>
                     **/ItKubernetesDomainEvents,
                     **/ItMiiAuxiliaryImage,
                     **/ItMultiDomainModels,
                     **/ItPodsRestart
                 </includes-failsafe>
+                -->
             </properties>
         </profile>
         <profile>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -594,7 +594,7 @@
             <id>crio-pipeline</id>
             <properties>
                 <skipITs>false</skipITs>
-                <groups>gate</groups>
+                <groups>crio</groups>
             </properties>
         </profile>
         <profile>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -591,6 +591,13 @@
             </properties>
         </profile>
         <profile>
+            <id>crio-pipeline</id>
+            <properties>
+                <skipITs>false</skipITs>
+                <groups>gate</groups>
+            </properties>
+        </profile>
+        <profile>
             <id>toolkits-srg</id>
             <properties>
                 <skipITs>false</skipITs>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -588,14 +588,6 @@
             <properties>
                 <skipITs>false</skipITs>
                 <groups>gate,samples-gate</groups>
-                <!--
-                <includes-failsafe>
-                    **/ItKubernetesDomainEvents,
-                    **/ItMiiAuxiliaryImage,
-                    **/ItMultiDomainModels,
-                    **/ItPodsRestart
-                </includes-failsafe>
-                -->
             </properties>
         </profile>
         <profile>

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItInitContainers.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItInitContainers.java
@@ -267,6 +267,7 @@ class ItInitContainers {
   @Test
   @DisplayName("Add initContainers to cluster1 and verify all managed server pods go through Init state ")
   @Tag("gate")
+  @Tag("crio")
   void testClusterInitContainer() {
     assertTrue(createVerifyDomain(domain3Namespace, domain3Uid, "clusters"),
         "can't start or verify domain in namespace " + domain3Namespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -230,6 +230,7 @@ class ItIntrospectVersion {
   @Test
   @DisplayName("Test introSpectVersion starting a introspector and updating domain status")
   @Tag("gate")
+  @Tag("crio")
   void testDomainIntrospectVersionNotRolling() {
 
     // get the pod creation time stamps

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
@@ -147,6 +147,7 @@ class ItIstioMiiDomain {
   @Order(1)
   @DisplayName("Create WebLogic Domain with mii model with istio")
   @Tag("gate")
+  @Tag("crio")
   void testIstioModelInImage() {
 
     // Create the repo secret to pull the image

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -234,6 +234,7 @@ class ItKubernetesDomainEvents {
   @Test
   @DisplayName("Test domain events for various successful domain life cycle changes")
   @Tag("gate")
+  @Tag("crio")
   void testDomainK8SEventsSuccess() {
     try {
       OffsetDateTime timestamp = now();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItLivenessProbeCustomization.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItLivenessProbeCustomization.java
@@ -135,6 +135,7 @@ class ItLivenessProbeCustomization {
   @Test
   @DisplayName("Test customization of the liveness probe")
   @Tag("gate")
+  @Tag("crio")
   void testCustomLivenessProbeTriggered() {
     Domain domain1 = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
         String.format("getDomainCustomResource failed with ApiException when tried to get domain %s in namespace %s",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManageNameSpace.java
@@ -200,6 +200,7 @@ class ItManageNameSpace {
   @DisplayName("install operator helm chart and domain, "
       + " using expression namespace management")
   @Tag("gate")
+  @Tag("crio")
   void testNameSpaceManageByRegularExpression() {
     //create domain namespace
     String manageByExp1NS = "test-" +  domainNamespaces[0];

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -245,6 +245,7 @@ public class ItMiiDomainModelInPV {
   @MethodSource("paramProvider")
   @DisplayName("Create MII domain with model and application file from PV and custon wdtModelHome")
   @Tag("gate")
+  @Tag("crio")
   void testMiiDomainWithModelAndApplicationInPV(Entry<String, String> params) {
 
     String domainUid = params.getKey();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
@@ -138,6 +138,7 @@ class ItMiiDynamicUpdatePart1 {
   @Order(1)
   @DisplayName("Add a work manager to a model-in-image domain using dynamic update")
   @Tag("gate")
+  @Tag("crio")
   void testMiiAddWorkManager() {
 
     // This test uses the WebLogic domain created in BeforeAll method

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart2.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart2.java
@@ -111,6 +111,7 @@ class ItMiiDynamicUpdatePart2 {
   @DisplayName("Changing Weblogic datasource URL and deleting application with CommitUpdateAndRoll "
       + "using mii dynamic update")
   @Tag("gate")
+  @Tag("crio")
   void testMiiDeleteAppChangeDBUrlWithCommitUpdateAndRoll() {
 
     // This test uses the WebLogic domain created in BeforeAll method

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
@@ -321,6 +321,7 @@ class ItMiiMultiModel {
   @Test
   @DisplayName("Create a model-in-image domain with two model files in both the image and the ConfigMap")
   @Tag("gate")
+  @Tag("crio")
   void testMiiWithMultiModelImageAndCM() {
     final String adminServerPodName = String.format("%s-%s", domainUid3, ADMIN_SERVER_NAME_BASE);
     final String managedServerPrefix = String.format("%s-%s", domainUid3, MANAGED_SERVER_NAME_BASE);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiMultiModel.java
@@ -321,7 +321,6 @@ class ItMiiMultiModel {
   @Test
   @DisplayName("Create a model-in-image domain with two model files in both the image and the ConfigMap")
   @Tag("gate")
-  @Tag("crio")
   void testMiiWithMultiModelImageAndCM() {
     final String adminServerPodName = String.format("%s-%s", domainUid3, ADMIN_SERVER_NAME_BASE);
     final String managedServerPrefix = String.format("%s-%s", domainUid3, MANAGED_SERVER_NAME_BASE);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -111,7 +111,7 @@ class ItMultiDomainModels {
       + "verify admin console login using admin node port.")
   @ValueSource(strings = {"modelInImage", "domainInImage", "domainOnPV"})
   @Tag("gate")
-  @Tag("ocir")
+  @Tag("crio")
   void testScaleClustersAndAdminConsoleLogin(String domainType) {
 
     assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -111,6 +111,7 @@ class ItMultiDomainModels {
       + "verify admin console login using admin node port.")
   @ValueSource(strings = {"modelInImage", "domainInImage", "domainOnPV"})
   @Tag("gate")
+  @Tag("ocir")
   void testScaleClustersAndAdminConsoleLogin(String domainType) {
 
     assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsRestart.java
@@ -627,6 +627,7 @@ class ItPodsRestart {
   @Test
   @DisplayName("Restart pods using restartVersion flag")
   @Tag("gate")
+  @Tag("crio")
   void testRestartVersion() {
     // get the original domain resource before update
     Domain domain1 = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
@@ -693,6 +694,7 @@ class ItPodsRestart {
   @Test
   @DisplayName("Check restart of pods after image change")
   @Tag("gate")
+  @Tag("crio")
   void testRestartWithImageChange() {
 
     String tag = getDateAndTimeStamp();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
@@ -308,12 +308,11 @@ class ItPodsShutdownOption {
                 .serverStartState("RUNNING")
                 )
             .configuration(new Configuration()
-                .introspectorJobActiveDeadlineSeconds(300L)
                 .model(new Model()
                     .configMap(cmName)
                     .domainType(WLS_DOMAIN_TYPE)
                     .runtimeEncryptionSecret(encryptionSecretName))
-                .introspectorJobActiveDeadlineSeconds(300L))
+                .introspectorJobActiveDeadlineSeconds(600L))
             .addManagedServersItem(new ManagedServer()
                 .serverStartState("RUNNING")
                 .serverStartPolicy("ALWAYS")
@@ -346,7 +345,7 @@ class ItPodsShutdownOption {
         adminServerPodName, domainNamespace);
     checkPodReadyAndServiceExists(with().pollDelay(2, SECONDS)
         .and().with().pollInterval(10, SECONDS)
-        .atMost(10, MINUTES).await(), adminServerPodName, domainUid, domainNamespace);
+        .atMost(20, MINUTES).await(), adminServerPodName, domainUid, domainNamespace);
 
     for (int i = 1; i <= replicaCount; i++) {
       String managedServerPodName = managedServerPodNamePrefix + i;
@@ -356,7 +355,7 @@ class ItPodsShutdownOption {
           managedServerPodName, domainNamespace);
       checkPodReadyAndServiceExists(with().pollDelay(2, SECONDS)
           .and().with().pollInterval(10, SECONDS)
-          .atMost(10, MINUTES).await(), managedServerPodName, domainUid, domainNamespace);
+          .atMost(20, MINUTES).await(), managedServerPodName, domainUid, domainNamespace);
     }
 
     // check for independent managed server pods existence in the domain namespace
@@ -366,7 +365,7 @@ class ItPodsShutdownOption {
           podName, domainNamespace);
       checkPodReadyAndServiceExists(with().pollDelay(2, SECONDS)
           .and().with().pollInterval(10, SECONDS)
-          .atMost(10, MINUTES).await(), podName, domainUid, domainNamespace);
+          .atMost(20, MINUTES).await(), podName, domainUid, domainNamespace);
     }
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
@@ -176,6 +176,7 @@ class ItPodsShutdownOption {
   @Test
   @DisplayName("Verify shutdown rules when shutdown properties are defined at different levels ")
   @Tag("gate")
+  @Tag("crio")
   void testShutdownPropsAllLevels() {
 
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsManagedByTwoOperators.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItTwoDomainsManagedByTwoOperators.java
@@ -235,6 +235,7 @@ class ItTwoDomainsManagedByTwoOperators {
    */
   @Test
   @Tag("gate")
+  @Tag("crio")
   void testTwoDomainsManagedByOneOperatorSharingPV() {
     // create two domains sharing one PV in default namespace
     createMultipleDomainsSharingPVUsingWlstAndVerify(

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -576,11 +576,19 @@ class ItWlsSamples {
       createOcirRepoSecret(domainNamespace);
     }
 
+    // wait until domain.yaml file exits
+    String domainYamlFileString = Paths.get(sampleBase.toString(), "weblogic-domains/"
+        + domainName + "/domain.yaml").toString();
+    File domainYamlFile = new File(domainYamlFileString);
+    testUntil(() -> domainYamlFile.exists(),
+        logger,
+        "domain yaml file {0} exists",
+        domainYamlFileString);
+
     // run kubectl to create the domain
     logger.info("Run kubectl to create the domain");
     params = new CommandParams().defaults();
-    params.command("kubectl apply -f "
-            + Paths.get(sampleBase.toString(), "weblogic-domains/" + domainName + "/domain.yaml").toString());
+    params.command("kubectl apply -f " + domainYamlFileString);
 
     result = Command.withParams(params).execute();
     assertTrue(result, "Failed to create domain custom resource");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -3,6 +3,7 @@
 
 package oracle.weblogic.kubernetes;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,6 +52,7 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.secretExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkClusterReplicaCountMatches;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getDateAndTimeStamp;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.FileUtils.replaceStringInFile;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createOcirRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createSecretForBaseImages;
@@ -633,6 +635,15 @@ class ItWlsSamples {
     boolean result = Command.withParams(params).execute();
     assertTrue(result, "Failed to create domain.yaml");
 
+    // wait until domain.yaml file exits
+    String domainYamlFileString = Paths.get(sampleBase.toString(), "weblogic-domains/"
+        + domainName + "/domain.yaml").toString();
+    File domainYamlFile = new File(domainYamlFileString);
+    testUntil(() -> domainYamlFile.exists(),
+        logger,
+        "domain yaml file {0} exists",
+        domainYamlFileString);
+
     // For the domain created by WLST, we have to apply domain.yaml created by update-domain.sh
     // before initiating introspection of the domain to start the second cluster that was just added
     // otherwise the newly added Cluster 'cluster-2' is not added to the domain1.
@@ -640,10 +651,7 @@ class ItWlsSamples {
       // run kubectl to update the domain
       logger.info("Run kubectl to create the domain");
       params = new CommandParams().defaults();
-      params.command("kubectl apply -f "
-          + Paths.get(sampleBase.toString(), "weblogic-domains/"
-          + domainName
-          + "/domain.yaml").toString());
+      params.command("kubectl apply -f " + domainYamlFileString);
 
       result = Command.withParams(params).execute();
       assertTrue(result, "Failed to create domain custom resource");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -77,6 +77,8 @@ import static oracle.weblogic.kubernetes.actions.impl.ConfigMap.doesCMExist;
 import static oracle.weblogic.kubernetes.actions.impl.Operator.start;
 import static oracle.weblogic.kubernetes.actions.impl.Operator.stop;
 import static oracle.weblogic.kubernetes.actions.impl.Prometheus.uninstall;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -839,6 +841,13 @@ public class TestActions {
     String cmNamespace = configMap.getMetadata().getNamespace();
     if (doesCMExist(cmName, cmNamespace)) {
       deleteConfigMap(cmName, cmNamespace);
+      // wait until the cm is deleted
+      testUntil(withLongRetryPolicy,
+          () -> !doesCMExist(cmName, cmNamespace),
+          getLogger(),
+          "configmap {0} in namespace {1} is deleted",
+          cmName,
+          cmNamespace);
     }
 
     return ConfigMap.create(configMap);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonLBTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonLBTestUtils.java
@@ -124,8 +124,8 @@ public class CommonLBTestUtils {
     createSecretWithUsernamePassword(wlSecretName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
     Path pvHostPath = get(PV_ROOT, testClassName, "sharing-persistentVolume");
 
-    String sharingPvName = getUniqueName(domainNamespace + "-sharing-pv");
-    String sharingPvcName = getUniqueName(domainNamespace + "-sharing-pvc");
+    String sharingPvName = getUniqueName("sharing-pv-");
+    String sharingPvcName = getUniqueName("sharing-pvc-");
 
     V1PersistentVolume v1pv = new V1PersistentVolume()
         .spec(new V1PersistentVolumeSpec()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -199,7 +199,7 @@ public class CommonTestUtils {
    */
   public static void checkServiceExists(String serviceName, String namespace) {
     LoggingFacade logger = getLogger();
-    withStandardRetryPolicy
+    withLongRetryPolicy
         .conditionEvaluationListener(
             condition -> logger.info("Waiting for service {0} to exist in namespace {1} "
                     + "(elapsed time {2}ms, remaining time {3}ms)",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ConfigMapUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ConfigMapUtils.java
@@ -21,7 +21,10 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 
 import static java.nio.file.Files.readString;
+import static oracle.weblogic.kubernetes.actions.impl.ConfigMap.doesCMExist;
 import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -99,6 +102,14 @@ public class ConfigMapUtils {
     assertTrue(assertDoesNotThrow(() -> createConfigMap(configMap),
         String.format("Create ConfigMap %s failed due to Kubernetes client  ApiException", configMapName)),
         String.format("Failed to create ConfigMap %s", configMapName));
+
+    // wait until the CM is created
+    testUntil(withLongRetryPolicy,
+        () -> doesCMExist(configMapName, namespace),
+        logger,
+        "configmap {0} is created in namespace {1}",
+        configMapName,
+        namespace);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ConfigMapUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ConfigMapUtils.java
@@ -21,8 +21,8 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 
 import static java.nio.file.Files.readString;
-import static oracle.weblogic.kubernetes.actions.impl.ConfigMap.doesCMExist;
 import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
+import static oracle.weblogic.kubernetes.actions.impl.ConfigMap.doesCMExist;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ImageUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ImageUtils.java
@@ -59,6 +59,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.dockerPush;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listSecrets;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.doesImageExist;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getDateAndTimeStamp;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.FileUtils.checkDirectory;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -536,7 +537,10 @@ public class ImageUtils {
       // docker login, if necessary
       if (!OCIR_USERNAME.equals(REPO_DUMMY_VALUE)) {
         logger.info("docker login");
-        assertTrue(dockerLogin(OCIR_REGISTRY, OCIR_USERNAME, OCIR_PASSWORD), "docker login failed");
+        testUntil(() -> dockerLogin(OCIR_REGISTRY, OCIR_USERNAME, OCIR_PASSWORD),
+            logger,
+            "docker login to repo {0} succeeds",
+            OCIR_REGISTRY);
       }
 
       logger.info("docker push image {0} to {1}", dockerImage, DOMAIN_IMAGES_REPO);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ImageUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ImageUtils.java
@@ -544,7 +544,11 @@ public class ImageUtils {
       }
 
       logger.info("docker push image {0} to {1}", dockerImage, DOMAIN_IMAGES_REPO);
-      assertTrue(dockerPush(dockerImage), String.format("docker push failed for image %s", dockerImage));
+      testUntil(() -> dockerPush(dockerImage),
+          logger,
+          "docker push succeeds for image {0} to repo {1}",
+          dockerImage,
+          DOMAIN_IMAGES_REPO);
     }
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PodUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PodUtils.java
@@ -32,6 +32,7 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.podExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podInitialized;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withStandardRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.JobUtils.getIntrospectJobName;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -96,7 +97,7 @@ public class PodUtils {
    */
   public static void checkPodReady(String podName, String domainUid, String domainNamespace) {
     LoggingFacade logger = getLogger();
-    withStandardRetryPolicy
+    withLongRetryPolicy
         .conditionEvaluationListener(
             condition -> logger.info("Waiting for pod {0} to be ready in namespace {1} "
                     + "(elapsed time {2}ms, remaining time {3}ms)",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ServerStartPolicyUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ServerStartPolicyUtils.java
@@ -294,7 +294,7 @@ public class ServerStartPolicyUtils {
                                     .domainType("WLS")
                                     .configMap(configmapName)
                                     .runtimeEncryptionSecret(encryptionSecretName))
-                            .introspectorJobActiveDeadlineSeconds(300L)));
+                            .introspectorJobActiveDeadlineSeconds(600L)));
 
     setPodAntiAffinity(domain);
 


### PR DESCRIPTION
Create crio-pipeline profile using tag annotation. Also use unique namespace instead of default namespace in ItTwoDomainsManagedByTwoOperators.java. 

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10670/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10664/
https://ci-cloud.us.oracle.com/jenkins/fmwk8s/job/wko-crio-job/167/

Make sure OKD tests are clean
https://build.weblogick8s.org:8443/job/wko-okd-test/340/ ( 10 failure )
