### PR TITLE
Make the domain home path unique for domain on pv usecases

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -457,7 +457,6 @@
                   **/ItIntrospectVersion,
                   **/ItLiftAndShiftFromOnPremDomain,
                   **/ItLivenessProbeCustomization,
-                  **/ItManageNameSpace,
                   **/ItManagedCoherence,
                   **/ItMiiDynamicUpdate*,
                   **/ItMiiCustomSslStore,
@@ -476,8 +475,7 @@
                   **/ItSystemResOverrides,
                   **/ItMonitoringExporterWebApp,
                   **/ItMonitoringExporterSideCar,
-                  **/ItMonitoringExporterSamples,
-                  **/ItUsabilityOperatorHelmChart
+                  **/ItMonitoringExporterSamples
                 </includes-failsafe>
             </properties>
         </profile>
@@ -520,7 +518,6 @@
                   **/ItIntrospectVersion,
                   **/ItLiftAndShiftFromOnPremDomain,
                   **/ItLivenessProbeCustomization,
-                  **/ItManageNameSpace,
                   **/ItManagedCoherence,
                   **/ItMiiDynamicUpdate*,
                   **/ItMiiCustomSslStore,
@@ -539,8 +536,7 @@
                   **/ItSystemResOverrides,
                   **/ItMonitoringExporterWebApp,
                   **/ItMonitoringExporterSideCar,
-                  **/ItMonitoringExporterSamples,
-                  **/ItUsabilityOperatorHelmChart            
+                  **/ItMonitoringExporterSamples
                 </includes-failsafe>
           </properties>
         </profile>

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItConfigDistributionStrategy.java
@@ -825,6 +825,8 @@ class ItConfigDistributionStrategy {
 
   //create a standard WebLogic domain.
   private void createDomain() {
+    
+    String uniquePath = "/shared/" + domainNamespace + "/domains";
 
     // create WebLogic domain credential secret
     createSecretWithUsernamePassword(wlSecretName, domainNamespace,
@@ -840,7 +842,7 @@ class ItConfigDistributionStrategy {
         -> File.createTempFile("domain", ".properties"),
         "Failed to create domain properties file");
     Properties p = new Properties();
-    p.setProperty("domain_path", "/shared/domains");
+    p.setProperty("domain_path", uniquePath);
     p.setProperty("domain_name", domainUid);
     p.setProperty("cluster_name", clusterName);
     p.setProperty("admin_server_name", adminServerName);
@@ -852,7 +854,7 @@ class ItConfigDistributionStrategy {
     p.setProperty("admin_t3_channel_port", Integer.toString(t3ChannelPort));
     p.setProperty("number_of_ms", "2");
     p.setProperty("managed_server_name_base", managedServerNameBase);
-    p.setProperty("domain_logs", "/shared/logs");
+    p.setProperty("domain_logs", uniquePath + "/logs");
     p.setProperty("production_mode_enabled", "true");
     assertDoesNotThrow(()
         -> p.store(new FileOutputStream(domainPropertiesFile), "domain properties file"),
@@ -878,7 +880,7 @@ class ItConfigDistributionStrategy {
                 .overrideDistributionStrategy("DYNAMIC")
                 .introspectorJobActiveDeadlineSeconds(300L))
             .domainUid(domainUid)
-            .domainHome("/shared/domains/" + domainUid) // point to domain home in pv
+            .domainHome(uniquePath + "/" + domainUid) // point to domain home in pv
             .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv
             .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
@@ -890,7 +892,7 @@ class ItConfigDistributionStrategy {
                 .namespace(domainNamespace))
             .includeServerOutInPodLog(true)
             .logHomeEnabled(Boolean.TRUE)
-            .logHome("/shared/logs/" + domainUid)
+            .logHome(uniquePath + "/logs/" + domainUid)
             .dataHome("")
             .serverStartPolicy("IF_NEEDED")
             .serverPod(new ServerPod() //serverpod

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWDT.java
@@ -79,7 +79,7 @@ class ItFmwDomainInPVUsingWDT {
   private static final String RCUSCHEMAUSERNAME = "myrcuuser";
   private static final String RCUSCHEMAPASSWORD = "Oradoc_db1";
 
-  private static final String DOMAINHOMEPREFIX = "/shared/domains/";
+  private static final String DOMAINHOMEPREFIX = "/shared/" + domainNamespace + "/domains/";
 
   private static String dbUrl = null;
   private static LoggingFacade logger = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItFmwDomainInPVUsingWLST.java
@@ -195,10 +195,11 @@ class ItFmwDomainInPVUsingWLST {
     java_home = getImageEnvVar(FMWINFRA_IMAGE_TO_USE_IN_SPEC, "JAVA_HOME");
     logger.info("JAVA_HOME in image {0} is: {1}", FMWINFRA_IMAGE_TO_USE_IN_SPEC, java_home);
 
+    String uniquePath = "/shared/" + jrfDomainNamespace + "/domains/";
     Properties p = new Properties();
     p.setProperty("oracleHome", oracle_home); //default $ORACLE_HOME
     p.setProperty("javaHome", java_home); //default $JAVA_HOME
-    p.setProperty("domainParentDir", "/shared/domains/");
+    p.setProperty("domainParentDir", uniquePath);
     p.setProperty("domainName", domainUid);
     p.setProperty("domainUser", ADMIN_USERNAME_DEFAULT);
     p.setProperty("domainPassword", ADMIN_PASSWORD_DEFAULT);
@@ -237,7 +238,7 @@ class ItFmwDomainInPVUsingWLST {
             .namespace(jrfDomainNamespace))
         .spec(new DomainSpec()
             .domainUid(domainUid)
-            .domainHome("/shared/domains/" + domainUid)  // point to domain home in pv
+            .domainHome(uniquePath + domainUid)  // point to domain home in pv
             .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv
             .image(FMWINFRA_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
@@ -249,7 +250,7 @@ class ItFmwDomainInPVUsingWLST {
                 .namespace(jrfDomainNamespace))
             .includeServerOutInPodLog(true)
             .logHomeEnabled(Boolean.TRUE)
-            .logHome("/shared/logs/" + domainUid)
+            .logHome(uniquePath + "logs/" + domainUid)
             .dataHome("")
             .serverStartPolicy("IF_NEEDED")
             .serverPod(new ServerPod() //serverpod
@@ -351,4 +352,3 @@ class ItFmwDomainInPVUsingWLST {
   }
 
 }
-

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -969,6 +969,7 @@ class ItIntrospectVersion {
   }
 
   private static void createDomain() {
+    String uniquePath = "/shared/" + introDomainNamespace + "/domains";
 
     // create WebLogic domain credential secret
     createSecretWithUsernamePassword(wlSecretName, introDomainNamespace,
@@ -981,7 +982,7 @@ class ItIntrospectVersion {
             File.createTempFile("domain", "properties"),
         "Failed to create domain properties file");
     Properties p = new Properties();
-    p.setProperty("domain_path", "/shared/domains");
+    p.setProperty("domain_path", uniquePath);
     p.setProperty("domain_name", domainUid);
     p.setProperty("cluster_name", cluster1Name);
     p.setProperty("admin_server_name", adminServerName);
@@ -993,7 +994,7 @@ class ItIntrospectVersion {
     p.setProperty("admin_t3_channel_port", Integer.toString(t3ChannelPort));
     p.setProperty("number_of_ms", "2"); // maximum number of servers in cluster
     p.setProperty("managed_server_name_base", cluster1ManagedServerNameBase);
-    p.setProperty("domain_logs", "/shared/logs");
+    p.setProperty("domain_logs", uniquePath + "/logs");
     p.setProperty("production_mode_enabled", "true");
     assertDoesNotThrow(() ->
             p.store(new FileOutputStream(domainPropertiesFile), "domain properties file"),
@@ -1016,7 +1017,7 @@ class ItIntrospectVersion {
             .namespace(introDomainNamespace))
         .spec(new DomainSpec()
             .domainUid(domainUid)
-            .domainHome("/shared/domains/" + domainUid)  // point to domain home in pv
+            .domainHome(uniquePath + "/" + domainUid) // point to domain home in pv
             .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv
             .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
@@ -1025,7 +1026,7 @@ class ItIntrospectVersion {
                 .namespace(introDomainNamespace))
             .includeServerOutInPodLog(true)
             .logHomeEnabled(Boolean.TRUE)
-            .logHome("/shared/logs/" + domainUid)
+            .logHome(uniquePath + "/logs/" + domainUid)
             .dataHome("")
             .serverStartPolicy("IF_NEEDED")
             .serverPod(new ServerPod() //serverpod

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -546,7 +546,7 @@ class ItKubernetesDomainEvents {
     Map<String, OffsetDateTime> podsWithTimeStamps = getPodsWithTimeStamps(domainNamespace3,
         adminServerPodName, managedServerPodNamePrefix, replicaCount);
 
-    String newLogHome = "/shared/" + domainNamespace3 + "/domains/logHome";
+    String newLogHome = "/shared/" + domainNamespace3 + "/domains/logHome/" + domainUid;
     //print out the original image name
     String logHome = domain1.getSpec().getLogHome();
     logger.info("Changing the current log home used by the domain : {0} to {1}", logHome, newLogHome);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItSystemResOverrides.java
@@ -306,7 +306,8 @@ class ItSystemResOverrides {
   }
 
   //create a standard WebLogic domain.
-  private void createDomain() {
+  private void createDomain() {    
+    String uniquePath = "/shared/" + domainNamespace + "/domains";
 
     // create WebLogic domain credential secret
     createSecretWithUsernamePassword(wlSecretName, domainNamespace,
@@ -322,7 +323,7 @@ class ItSystemResOverrides {
         -> File.createTempFile("domain", ".properties"),
         "Failed to create domain properties file");
     Properties p = new Properties();
-    p.setProperty("domain_path", "/shared/domains");
+    p.setProperty("domain_path", uniquePath);
     p.setProperty("domain_name", domainUid);
     p.setProperty("cluster_name", clusterName);
     p.setProperty("admin_server_name", adminServerName);
@@ -334,7 +335,7 @@ class ItSystemResOverrides {
     p.setProperty("admin_t3_channel_port", Integer.toString(t3ChannelPort));
     p.setProperty("number_of_ms", "2");
     p.setProperty("managed_server_name_base", managedServerNameBase);
-    p.setProperty("domain_logs", "/shared/logs");
+    p.setProperty("domain_logs", uniquePath + "/logs");
     p.setProperty("production_mode_enabled", "true");
     assertDoesNotThrow(()
         -> p.store(new FileOutputStream(domainPropertiesFile), "domain properties file"),
@@ -359,7 +360,7 @@ class ItSystemResOverrides {
             .configuration(new Configuration()
                 .overrideDistributionStrategy("DYNAMIC"))
             .domainUid(domainUid)
-            .domainHome("/shared/domains/" + domainUid) // point to domain home in pv
+            .domainHome(uniquePath + "/" + domainUid) // point to domain home in pv
             .domainHomeSourceType("PersistentVolume") // set the domain home source type as pv
             .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
@@ -371,7 +372,7 @@ class ItSystemResOverrides {
                 .namespace(domainNamespace))
             .includeServerOutInPodLog(true)
             .logHomeEnabled(Boolean.TRUE)
-            .logHome("/shared/logs/" + domainUid)
+            .logHome(uniquePath + "/logs/" + domainUid)
             .dataHome("")
             .serverStartPolicy("IF_NEEDED")
             .serverPod(new ServerPod() //serverpod

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/WebLogicRemoteConsole.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/WebLogicRemoteConsole.java
@@ -13,6 +13,7 @@ import static oracle.weblogic.kubernetes.actions.ActionConstants.REMOTECONSOLE_F
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Installer.defaultInstallRemoteconsoleParams;
 import static oracle.weblogic.kubernetes.utils.ApplicationUtils.callWebAppAndWaitTillReady;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.FileUtils.copyFileFromPod;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
@@ -103,7 +104,11 @@ public class WebLogicRemoteConsole {
         + " --write-out %{http_code} -o /dev/null";
     logger.info("Executing curl command {0}", curlCmd);
 
-    return callWebAppAndWaitTillReady(curlCmd, 10);
+    testUntil((() -> {
+      return callWebAppAndWaitTillReady(curlCmd, 1);
+    }), logger, "Waiting for remote console access to return 200 status code");
+
+    return true;
 
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -533,6 +533,7 @@ public class CommonMiiTestUtils {
       securityList.add(dbSecretName);
     }
 
+    String uniquePath = "/shared/" + domNamespace + "/" + domainResourceName;
     DomainSpec domainSpec = new DomainSpec()
         .domainUid(domainResourceName)
         .domainHomeSourceType("FromModel")
@@ -545,7 +546,7 @@ public class CommonMiiTestUtils {
             .namespace(domNamespace))
         .includeServerOutInPodLog(true)
         .logHomeEnabled(Boolean.TRUE)
-        .logHome("/shared/logs")
+        .logHome(uniquePath + "/logs")
         .serverStartPolicy("IF_NEEDED")
         .serverPod(new ServerPod()
             .addEnvItem(new V1EnvVar()
@@ -582,7 +583,7 @@ public class CommonMiiTestUtils {
             .introspectorJobActiveDeadlineSeconds(300L));
 
     if (setDataHome) {
-      domainSpec.dataHome("/shared/data");
+      domainSpec.dataHome(uniquePath + "/data");
     }
     // create the domain CR
     Domain domain = new Domain()

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -346,6 +346,8 @@ public class DomainUtils {
                                                          String pvcName,
                                                          String clusterName,
                                                          int replicaCount) {
+    
+    String uniquePath = "/u01/shared/" + domainNamespace + "/domains/" + domainUid;
     // create the domain custom resource
     getLogger().info("Creating domain custom resource");
     Domain domain = new Domain()
@@ -356,7 +358,7 @@ public class DomainUtils {
             .namespace(domainNamespace))
         .spec(new DomainSpec()
             .domainUid(domainUid)
-            .domainHome("/u01/shared/domains/" + domainUid)
+            .domainHome(uniquePath)
             .domainHomeSourceType("PersistentVolume")
             .image(WEBLOGIC_IMAGE_TO_USE_IN_SPEC)
             .imagePullPolicy("IfNotPresent")
@@ -368,7 +370,7 @@ public class DomainUtils {
                 .namespace(domainNamespace))
             .includeServerOutInPodLog(true)
             .logHomeEnabled(Boolean.TRUE)
-            .logHome("/u01/shared/logs/" + domainUid)
+            .logHome(uniquePath + "/logs")
             .dataHome("")
             .serverStartPolicy("IF_NEEDED")
             .serverPod(new ServerPod()
@@ -428,6 +430,8 @@ public class DomainUtils {
     domainScriptFiles.add(domainCreationScriptFile);
     domainScriptFiles.add(domainPropertiesFile);
     domainScriptFiles.add(modelFile);
+    
+    String uniquePath = "/u01/shared/" + namespace + "/domains/" + domainUid;
 
     getLogger().info("Creating a config map to hold domain creation scripts");
     String domainScriptConfigMapName = "create-domain-scripts-cm-" + testClassName.toLowerCase();
@@ -459,7 +463,7 @@ public class DomainUtils {
             .value(System.getenv("http_proxy")))
         .addEnvItem(new V1EnvVar()
             .name("DOMAIN_HOME_DIR")
-            .value("/u01/shared/domains/" + domainUid))
+            .value(uniquePath))
         .addEnvItem(new V1EnvVar()
             .name("https_proxy")
             .value(HTTPS_PROXY));


### PR DESCRIPTION
- Make the domain home path unique for domain on pv usecases
- Wait until remotr console access returns 200 status code
- Remove ItUsabilityOperatorHelmChart and ItManageNameSpace from okd profiles because of intermittent issues

kind
-----
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10565/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10572/

okd
-----
https://build.weblogick8s.org:8443/job/wko-okd-test/326/
https://build.weblogick8s.org:8443/job/wko-okd-test/327/