### PR TITLE
remove integration test failure counter

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
+++ b/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
@@ -81,6 +81,7 @@ public class SchemaConversionUtils {
     adjustAdminPortForwardingDefault(spec, apiVersion);
     convertLegacyAuxiliaryImages(spec);
     removeObsoleteConditionsFromDomainStatus(domain);
+    removeObsoleteFieldsFromDomainStatus(domain);
     removeUnsupportedDomainStatusConditionReasons(domain);
     convertDomainHomeInImageToDomainHomeSourceType(domain);
     moveConfigOverrides(domain);
@@ -145,6 +146,15 @@ public class SchemaConversionUtils {
 
   private void removeUnsupportedDomainStatusConditionReasons(Map<String, Object> domain) {
     getStatusConditions(domain).forEach(this::removeReasonIfUnsupported);
+  }
+
+  private void removeObsoleteFieldsFromDomainStatus(Map<String, Object> domain) {
+    Optional.ofNullable(domain.get("status")).ifPresent(this::removeObsoleteStatusFields);
+  }
+
+  private void removeObsoleteStatusFields(@Nonnull Object domainStatus) {
+    Map<String,Object> statusMap = (Map<String, Object>) domainStatus;
+    statusMap.remove("introspectJobFailureCount");
   }
 
   private void removeReasonIfUnsupported(Map<String, String> condition) {

--- a/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
+++ b/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
@@ -164,6 +164,15 @@ class SchemaConversionUtilsTest {
           hasJsonPath("$.status.conditions[?(@.type=='Failed')].message", contains("whoops")));
   }
 
+  @Test
+  void whenOldDomainHasIntrospectionFailureCount_removeIt() {
+    getStatus().put("introspectJobFailureCount", "3");
+
+    converter.convert(v8Domain);
+
+    assertThat(converter.getDomain(), hasNoJsonPath("$.status.introspectJobFailureCount"));
+  }
+
   @ParameterizedTest
   @CsvSource({"true,, Image", "false,, PersistentVolume", "true, FromModel, FromModel"})
   void whenOldDomainHasDomainHomeInImageBoolean_convertToDomainSourceType(

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -527,11 +527,6 @@
             "$ref": "#/definitions/ServerStatus"
           }
         },
-        "introspectJobFailureCount": {
-          "description": "Non-zero if the introspector job fails for any reason. You can configure an introspector job retry limit for jobs that log script failures using the Operator tuning parameter \u0027domainPresenceFailureRetryMaxCount\u0027 (default 5). You cannot configure a limit for other types of failures, such as a Domain resource reference to an unknown secret name; in which case, the retries are unlimited.",
-          "type": "number",
-          "minimum": 0
-        },
         "replicas": {
           "description": "The number of running cluster member Managed Servers in the WebLogic cluster if there is exactly one cluster defined in the domain configuration and where the `replicas` field is set at the `spec` level rather than for the specific cluster under `clusters`. This field is provided to support use of Kubernetes scaling for this limited use case.",
           "type": "number",

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -57,7 +57,6 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `conditions` | Array of [Domain Condition](#domain-condition) | Current service state of the domain. |
 | `failedIntrospectionUid` | string | Unique ID of the last failed introspection job. |
 | `initialFailureTime` | DateTime | RFC 3339 date and time at which a currently failing domain started automatic retries. |
-| `introspectJobFailureCount` | number | Non-zero if the introspector job fails for any reason. You can configure an introspector job retry limit for jobs that log script failures using the Operator tuning parameter 'domainPresenceFailureRetryMaxCount' (default 5). You cannot configure a limit for other types of failures, such as a Domain resource reference to an unknown secret name; in which case, the retries are unlimited. |
 | `lastFailureTime` | DateTime | RFC 3339 date and time at which a currently failing domain last experienced a Severe failure. |
 | `message` | string | A human readable message indicating details about why the domain is in this condition. |
 | `reason` | string | A brief CamelCase message indicating details about why the domain is in this state. |

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1448,11 +1448,6 @@ window.onload = function() {
             "$ref": "#/definitions/ServerStatus"
           }
         },
-        "introspectJobFailureCount": {
-          "description": "Non-zero if the introspector job fails for any reason. You can configure an introspector job retry limit for jobs that log script failures using the Operator tuning parameter \u0027domainPresenceFailureRetryMaxCount\u0027 (default 5). You cannot configure a limit for other types of failures, such as a Domain resource reference to an unknown secret name; in which case, the retries are unlimited.",
-          "type": "number",
-          "minimum": 0.0
-        },
         "replicas": {
           "description": "The number of running cluster member Managed Servers in the WebLogic cluster if there is exactly one cluster defined in the domain configuration and where the `replicas` field is set at the `spec` level rather than for the specific cluster under `clusters`. This field is provided to support use of Kubernetes scaling for this limited use case.",
           "type": "number",

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 4424293c3c408cb5c457be82ec8e36d1d2c0b2b1b4eb85dce435435af3ed121f
+    weblogic.sha256: f0dca33a101d04ac261a8734a5e3fa543871e6970b7ae91f1513d156caf6e4e5
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -12613,15 +12613,6 @@ spec:
                       description: Current state of this WebLogic Server instance.
                       type: string
                 type: array
-              introspectJobFailureCount:
-                description: Non-zero if the introspector job fails for any reason.
-                  You can configure an introspector job retry limit for jobs that
-                  log script failures using the Operator tuning parameter 'domainPresenceFailureRetryMaxCount'
-                  (default 5). You cannot configure a limit for other types of failures,
-                  such as a Domain resource reference to an unknown secret name; in
-                  which case, the retries are unlimited.
-                minimum: 0.0
-                type: number
               replicas:
                 description: The number of running cluster member Managed Servers
                   in the WebLogic cluster if there is exactly one cluster defined

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -74,10 +74,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import org.jetbrains.annotations.NotNull;
 
-import static oracle.kubernetes.common.logging.MessageKeys.CANNOT_START_DOMAIN_AFTER_MAX_RETRIES;
 import static oracle.kubernetes.operator.DomainPresence.getDomainPresenceFailureRetrySeconds;
-import static oracle.kubernetes.operator.DomainPresence.getFailureRetryMaxCount;
-import static oracle.kubernetes.operator.DomainStatusUpdater.createAbortedFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createInternalFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createIntrospectionFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createStatusInitializationStep;
@@ -826,18 +823,12 @@ public class DomainProcessorImpl implements DomainProcessor {
       return inspectionRun;
     }
 
-    @Override
-    public boolean isExplicitRecheck() {
-      return explicitRecheck;
-    }
-
     private boolean shouldContinue() {
       DomainPresenceInfo cachedInfo = getExistingDomainPresenceInfo(getNamespace(), getDomainUid());
 
       if (isNewDomain(cachedInfo)) {
         return true;
-      } else if (hasReachedMaximumFailureCount(liveInfo) && !isImgRestartIntrospectVerChanged(liveInfo, cachedInfo)) {
-        LOGGER.severe(MessageKeys.INTROSPECTOR_MAX_ERRORS_EXCEEDED, getFailureRetryMaxCount());
+      } else if (isDomainProcessingAborted(liveInfo) && !isImgRestartIntrospectVerChanged(liveInfo, cachedInfo)) {
         return false;
       } else if (isFatalIntrospectorError()) {
         LOGGER.fine(ProcessingConstants.FATAL_INTROSPECTOR_ERROR_MSG);
@@ -853,8 +844,12 @@ public class DomainProcessorImpl implements DomainProcessor {
       return false;
     }
 
-    private int getFailureRetryMaxCount() {
-      return DomainPresence.getFailureRetryMaxCount();
+    private boolean isDomainProcessingAborted(DomainPresenceInfo info) {
+      return Optional.ofNullable(info)
+              .map(DomainPresenceInfo::getDomain)
+              .map(Domain::getStatus)
+              .map(DomainStatus::isAborted)
+              .orElse(false);
     }
 
     private boolean shouldRecheck(DomainPresenceInfo cachedInfo) {
@@ -1006,14 +1001,6 @@ public class DomainProcessorImpl implements DomainProcessor {
         .orElse(null);
   }
 
-  private boolean hasReachedMaximumFailureCount(DomainPresenceInfo info) {
-    return Optional.ofNullable(info)
-            .map(DomainPresenceInfo::getDomain)
-            .map(Domain::getStatus)
-            .map(DomainStatus::hasReachedMaximumFailureCount)
-            .orElse(false);
-  }
-
   private static boolean isCachedInfoNewer(DomainPresenceInfo liveInfo, DomainPresenceInfo cachedInfo) {
     return liveInfo.getDomain() != null
         && KubernetesUtils.isFirstNewer(cachedInfo.getDomain().getMetadata(), liveInfo.getDomain().getMetadata());
@@ -1064,7 +1051,7 @@ public class DomainProcessorImpl implements DomainProcessor {
       @Override
       public void onThrowable(Packet packet, Throwable throwable) {
         reportFailure(throwable);
-        scheduleRetry(throwable);
+        scheduleRetry();
       }
 
       private void reportFailure(Throwable throwable) {
@@ -1082,18 +1069,12 @@ public class DomainProcessorImpl implements DomainProcessor {
       }
 
       private Step getFailureSteps(Throwable throwable) {
-        if (hasReachedMaximumFailureCount()) {
-          return createAbortedFailureSteps();
-        } else if (throwable instanceof IntrospectionJobHolder) {
+        if (throwable instanceof IntrospectionJobHolder) {
           return createIntrospectionFailureSteps(throwable, ((IntrospectionJobHolder) throwable).getIntrospectionJob());
         } else {
           return createInternalFailureSteps(throwable);
         }
       }
-    }
-
-    private boolean hasReachedMaximumFailureCount() {
-      return DomainProcessorImpl.this.hasReachedMaximumFailureCount(getExistingDomainPresenceInfo());
     }
 
     class FailureReportCompletionCallback extends ThrowableCallback {
@@ -1103,12 +1084,8 @@ public class DomainProcessorImpl implements DomainProcessor {
       }
     }
 
-    public void scheduleRetry(Throwable throwable) {
-      if (hasReachedMaximumFailureCount()) {
-        reportTooManyRetries(throwable);
-      } else {
-        Optional.ofNullable(getExistingDomainPresenceInfo()).ifPresent(this::scheduleRetry);
-      }
+    public void scheduleRetry() {
+      Optional.ofNullable(getExistingDomainPresenceInfo()).ifPresent(this::scheduleRetry);
     }
 
     private void scheduleRetry(@Nonnull DomainPresenceInfo domainPresenceInfo) {
@@ -1116,10 +1093,6 @@ public class DomainProcessorImpl implements DomainProcessor {
         MakeRightRetry retry = new MakeRightRetry(domainPresenceInfo);
         gate.getExecutor().schedule(retry::execute, getDomainPresenceFailureRetrySeconds(), TimeUnit.SECONDS);
       }
-    }
-
-    private void reportTooManyRetries(Throwable throwable) {
-      LOGGER.severe(CANNOT_START_DOMAIN_AFTER_MAX_RETRIES, domainUid, ns, getFailureRetryMaxCount(), throwable);
     }
 
     private DomainPresenceInfo getExistingDomainPresenceInfo() {
@@ -1156,11 +1129,6 @@ public class DomainProcessorImpl implements DomainProcessor {
             new DomainStatusStep(info, null),
             bringAdminServerUp(info, delegate.getPodAwaiterStepFactory(info.getNamespace())),
             managedServerStrategy);
-
-    if (hasReachedMaximumFailureCount(info) && isImgRestartIntrospectVerChanged(info,
-            getExistingDomainPresenceInfo(info.getNamespace(), info.getDomainUid()))) {
-      domainUpStrategy = Step.chain(DomainStatusUpdater.createResetFailureCountStep(), domainUpStrategy);
-    }
 
     return Step.chain(
           createDomainUpInitialStep(info),
@@ -1208,7 +1176,7 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     @Override
     public NextAction apply(Packet packet) {
-      return doNext(DomainStatusUpdater.createResetFailureCountStep(), packet);
+      return doNext(packet);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -306,18 +306,6 @@ public class DomainStatusUpdater {
     return new FailureStep(INTROSPECTION, message);
   }
 
-  static class ResetFailureCountStep extends DomainStatusUpdaterStep {
-
-    @Override
-    void modifyStatus(DomainStatus domainStatus) {
-      domainStatus.resetIntrospectJobFailureCount();
-    }
-  }
-
-  public static Step createResetFailureCountStep() {
-    return new ResetFailureCountStep();
-  }
-
   abstract static class DomainStatusUpdaterStep extends Step {
 
     DomainStatusUpdaterStep() {
@@ -1309,7 +1297,8 @@ public class DomainStatusUpdater {
       @Override
       void modifyStatus(DomainStatus status) {
         removingReasons.forEach(status::markFailuresForRemoval);
-        addFailure(status, status.createAdjustedFailedCondition(reason, message, jobUid));
+        addFailure(status, status.createAdjustedFailedCondition(reason, message));
+        Optional.ofNullable(jobUid).ifPresent(status::setFailedIntrospectionUid);
         status.removeMarkedFailures();
       }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -57,12 +57,6 @@ public interface MakeRightDomainOperation {
     return domainRequiresIntrospectionInCurrentMakeRight(packet) && !wasInspectionRun(packet);
   }
 
-  boolean isExplicitRecheck();
-
-  static boolean isExplicitRecheck(Packet packet) {
-    return fromPacket(packet).map(MakeRightDomainOperation::isExplicitRecheck).orElse(false);
-  }
-
   /**
    * Returns true if the packet contains info about a domain that requires introspection in a sequences of steps
    * before server pods are created or modified.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -68,7 +68,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.AuxiliaryImage;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
 import oracle.kubernetes.weblogic.domain.model.MonitoringExporterSpecification;
 import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
@@ -1248,11 +1247,6 @@ public abstract class PodStepContext extends BasePodStepContext {
     @Override
     public NextAction apply(Packet packet) {
       V1Pod currentPod = info.getServerPod(getServerName());
-      // reset introspect failure job count - if any
-      Optional.ofNullable(packet.getSpi(DomainPresenceInfo.class))
-          .map(DomainPresenceInfo::getDomain)
-          .map(Domain::getStatus)
-          .ifPresent(DomainStatus::resetIntrospectJobFailureCount);
 
       if (currentPod == null) {
         return doNext(createNewPod(getNext()), packet);

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -34,7 +34,6 @@ import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_FATAL_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.INTROSPECTOR_MAX_ERRORS_EXCEEDED;
 import static oracle.kubernetes.common.logging.MessageKeys.NON_FATAL_INTROSPECTOR_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.NO_FORMATTING;
-import static oracle.kubernetes.operator.DomainPresence.getFailureRetryMaxCount;
 import static oracle.kubernetes.operator.ProcessingConstants.FATAL_INTROSPECTOR_ERROR;
 import static oracle.kubernetes.operator.ProcessingConstants.FATAL_INTROSPECTOR_ERROR_MSG;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
@@ -66,17 +65,8 @@ public class DomainStatus {
       "A brief CamelCase message indicating details about why the domain is in this state.")
   private String reason;
 
-  @Description(
-      "Non-zero if the introspector job fails for any reason. "
-          + "You can configure an introspector job retry limit for jobs that log script failures using "
-          + "the Operator tuning parameter 'domainPresenceFailureRetryMaxCount' (default 5). "
-          + "You cannot configure a limit for other types of failures, such as a Domain resource reference "
-          + "to an unknown secret name; in which case, the retries are unlimited.")
-  @Range(minimum = 0)
-  private Integer introspectJobFailureCount = 0;  //todo remove this field
-
   @Description("Unique ID of the last failed introspection job.")
-  private String failedIntrospectionUid;  //todo remove this field
+  private String failedIntrospectionUid;
 
   @Description("Status of WebLogic Servers in this domain.")
   @Valid
@@ -126,7 +116,6 @@ public class DomainStatus {
     initialFailureTime = that.initialFailureTime;
     lastFailureTime = that.lastFailureTime;
     replicas = that.replicas;
-    introspectJobFailureCount = that.introspectJobFailureCount;
     failedIntrospectionUid = that.failedIntrospectionUid;
   }
 
@@ -377,50 +366,20 @@ public class DomainStatus {
     return this;
   }
 
-  /**
-   * The number of times the introspect job failed.
-   *
-   * @return introspectJobFailureRetryCount
-   */
-  public Integer getIntrospectJobFailureCount() {
-    return this.introspectJobFailureCount;
-  }
-
-  /**
-   * Increment the number of introspect job failure count.
-   *
-   * @param uid the Kubernetes-assigned UID of the job which discovered the introspection failure
-   */
-  public void incrementIntrospectJobFailureCount(String uid) {
-    if (fiberException(uid) || failedIntrospectionNotRecorded(uid)) {
-      introspectJobFailureCount = introspectJobFailureCount + 1;
-    }
-    failedIntrospectionUid = uid;
-  }
-
-  private boolean fiberException(String uid) {
-    return uid == null;
-  }
-
-  private boolean failedIntrospectionNotRecorded(String uid) {
-    return !uid.equals(failedIntrospectionUid);
-  }
-
-  /**
-   * Reset the number of introspect job failure to default.
-   *
-   * @return this
-   */
-  public DomainStatus resetIntrospectJobFailureCount() {
-    this.introspectJobFailureCount = 0;
-    return this;
-  }
 
   /**
    * Returns the UID of the last failed introspection job.
    */
   public String getFailedIntrospectionUid() {
     return failedIntrospectionUid;
+  }
+
+  /**
+   * Records the UID of a failed introspection job.
+   * @param failedIntrospectionUid  the Kubernetes-assigned UID of the job which discovered the introspection failure
+   */
+  public void setFailedIntrospectionUid(String failedIntrospectionUid) {
+    this.failedIntrospectionUid = failedIntrospectionUid;
   }
 
   /**
@@ -635,7 +594,6 @@ public class DomainStatus {
         .append("startTime", startTime)
         .append("initialFailureTime", initialFailureTime)
         .append("lastFailureTime", lastFailureTime)
-        .append("introspectJobFailureCount", introspectJobFailureCount)
         .append("failedIntrospectionUid", failedIntrospectionUid)
         .toString();
   }
@@ -651,7 +609,6 @@ public class DomainStatus {
         .append(Domain.sortOrNull(clusters))
         .append(Domain.sortOrNull(conditions))
         .append(message)
-        .append(introspectJobFailureCount)
         .append(failedIntrospectionUid)
         .toHashCode();
   }
@@ -674,7 +631,6 @@ public class DomainStatus {
         .append(Domain.sortOrNull(clusters), Domain.sortOrNull(rhs.clusters))
         .append(Domain.sortOrNull(conditions), Domain.sortOrNull(rhs.conditions))
         .append(message, rhs.message)
-        .append(introspectJobFailureCount, rhs.introspectJobFailureCount)
         .append(failedIntrospectionUid, rhs.failedIntrospectionUid)
         .isEquals();
   }
@@ -685,7 +641,6 @@ public class DomainStatus {
         .withStringField("reason", DomainStatus::getReason)
         .withBooleanField("rolling", DomainStatus::isRolling)
         .withStringField("failedIntrospectionUid", DomainStatus::getFailedIntrospectionUid)
-        .withIntegerField("introspectJobFailureCount", DomainStatus::getIntrospectJobFailureCount)
         .withIntegerField("replicas", DomainStatus::getReplicas)
         .withListField("conditions", DomainCondition.getObjectPatch(), DomainStatus::getConditions)
         .withListField("clusters", ClusterStatus.getObjectPatch(), DomainStatus::getClusters)
@@ -695,14 +650,8 @@ public class DomainStatus {
     statusPatch.createPatch(builder, "/status", oldStatus, this);
   }
 
-  public DomainStatus withIntrospectJobFailureCount(int failureCount) {
-    this.introspectJobFailureCount = failureCount;
-    return this;
-  }
-
   public String createDomainStatusMessage(String message) {
-    return LOGGER.formatMessage(getMessageKey(failedIntrospectionUid, message),
-          message, getIntrospectJobFailureCount(), getFailureRetryMaxCount());
+    return LOGGER.formatMessage(getMessageKey(failedIntrospectionUid, message), message);
   }
 
   @NotNull
@@ -714,7 +663,7 @@ public class DomainStatus {
   private FailureLevel getFailureLevel(String jobUid, String message) {
     if (jobUid == null) {
       return FailureLevel.NON_INTROSPECTION;
-    } else if (hasReachedMaximumFailureCount()) {
+    } else if (isAborted()) {
       return FailureLevel.RETRIES_EXCEEDED;
     } else if (isFatalError(message)) {
       return FailureLevel.FATAL;
@@ -730,24 +679,25 @@ public class DomainStatus {
   /**
    * Returns true if the failure count in the status is equal to or greater than the configured maximum.
    */
-  public boolean hasReachedMaximumFailureCount() {
-    return getIntrospectJobFailureCount() >= getFailureRetryMaxCount();
+  public boolean isAborted() {
+    return Optional.ofNullable(conditions).orElse(Collections.emptyList()).stream().anyMatch(this::isAbortedFailure);
+  }
+
+  private boolean isAbortedFailure(DomainCondition domainCondition) {
+    return ABORTED == domainCondition.getReason();
   }
 
   /**
    * Computes a failure condition that accounts for retries and failed inspection messages.
    * @param reason the underlying reason
    * @param message the underlying message
-   * @param jobUid the uid of the failed introspection job. May be null.
    */
-  public DomainCondition createAdjustedFailedCondition(DomainFailureReason reason, String message, String jobUid) {
+  public DomainCondition createAdjustedFailedCondition(DomainFailureReason reason, String message) {
     DomainFailureReason effectiveReason = reason;
     String effectiveMessage = message;
     if (hasJustGotFatalIntrospectorError(effectiveMessage)) {
       effectiveReason = ABORTED;
       effectiveMessage = FATAL_INTROSPECTOR_ERROR_MSG + effectiveMessage;
-    } else if (hasJustExceededMaxRetryCount(jobUid)) {
-      effectiveReason = ABORTED;
     }
     return new DomainCondition(FAILED).withReason(effectiveReason).withMessage(effectiveMessage);
   }
@@ -762,20 +712,6 @@ public class DomainStatus {
 
   private boolean isFatalIntrospectorMessage(String statusMessage) {
     return statusMessage != null && statusMessage.contains(FATAL_INTROSPECTOR_ERROR);
-  }
-
-  /**
-   * Increments the failure count associated with the specified introspection job and returns true
-   * if doing so results in the count reaching its maximum value.
-   * @param jobUid the UID of a failed introspection job
-   */
-  private boolean hasJustExceededMaxRetryCount(String jobUid) {
-    if (jobUid == null || hasReachedMaximumFailureCount()) {
-      return false;
-    } else {
-      incrementIntrospectJobFailureCount(jobUid);
-      return hasReachedMaximumFailureCount();
-    }
   }
 
   private enum FailureLevel {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -67,7 +67,6 @@ import oracle.kubernetes.weblogic.domain.model.Configuration;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
-import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainTestUtils;
 import oracle.kubernetes.weblogic.domain.model.Model;
 import org.jetbrains.annotations.NotNull;
@@ -128,6 +127,7 @@ import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.ABORTE
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.INTROSPECTION;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.KUBERNETES;
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_AUXILIARY_IMAGE_MOUNT_PATH;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.empty;
@@ -611,13 +611,11 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
   }
 
   @Test
-  void whenJobCreatedWithFluentdTerminatedDuringIntropsection_checkExpectedMessage() {
+  void whenJobCreatedWithFluentdTerminatedDuringIntrospection_checkExpectedMessage() {
     String jobName = UID + "-introspector";
-    DomainConfiguratorFactory.forDomain(domain)
-            .withFluentdConfiguration(true, "elastic-cred", null);
+    DomainConfiguratorFactory.forDomain(domain).withFluentdConfiguration(true, "elastic-cred", null);
     V1Pod jobPod = new V1Pod().metadata(new V1ObjectMeta().name(jobName).namespace(NS));
-    testSupport.defineFluentdJobContainersCompleteStatus(jobPod, jobName,
-            true, true);
+    testSupport.defineFluentdJobContainersCompleteStatus(jobPod, jobName, true, true);
     testSupport.defineResources(jobPod);
     defineFailedFluentdContainerInIntrospection();
 
@@ -627,7 +625,7 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
             jobPod.getMetadata().getName(),
             jobPod.getMetadata().getNamespace(), 1, null, null);
 
-    assertThat(getUpdatedDomain().getStatus().getMessage(), equalTo(formatIntrospectionError(expectedDetail)));
+    assertThat(getUpdatedDomain().getStatus().getMessage(), containsString(expectedDetail));
   }
 
   private String formatIntrospectionError(String failure) {
@@ -768,12 +766,12 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
 
   private void definePreviousFailedIntrospection() {
     defineFailedIntrospection();
-    getDomain().getOrCreateStatus().incrementIntrospectJobFailureCount(JOB_UID);
+    getDomain().getOrCreateStatus().setFailedIntrospectionUid(JOB_UID);
   }
 
   private void definePreviousFailedIntrospectionWithoutPodLog() {
     testSupport.defineResources(asFailedJob(createIntrospectorJob()));
-    getDomain().getOrCreateStatus().incrementIntrospectJobFailureCount(JOB_UID);
+    getDomain().getOrCreateStatus().setFailedIntrospectionUid(JOB_UID);
   }
 
   @Test
@@ -1207,52 +1205,8 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
     logRecords.clear();
   }
 
-  @Test
-  void whenJobLogContainsSevereError_incrementFailureCount() {
-    createFailedIntrospectionLog();
-
-    testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
-
-    assertThat(getUpdatedDomain().getStatus().getIntrospectJobFailureCount(), equalTo(1));
-  }
-
   private Domain getUpdatedDomain() {
     return testSupport.<Domain>getResources(DOMAIN).get(0);
-  }
-
-  @Test
-  void whenJobLogContainsSevereError_recordJobUid() {
-    createFailedIntrospectionLog();
-
-    testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
-
-    assertThat(getUpdatedDomain().getStatus().getFailedIntrospectionUid(), equalTo(JOB_UID));
-  }
-
-  @Test
-  void whenJobLogContainsSevereErrorAndStatusHasCurrentJobUID_dontIncrementFailureCount() {
-    createFailedIntrospectionLog();
-    getUpdatedDomain().setStatus(createDomainStatusAfterOneFailure(JOB_UID));
-
-    testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
-
-    assertThat(getUpdatedDomain().getStatus().getIntrospectJobFailureCount(), equalTo(1));
-  }
-
-  private DomainStatus createDomainStatusAfterOneFailure(String jobUid) {
-    final DomainStatus status = new DomainStatus();
-    status.incrementIntrospectJobFailureCount(jobUid);
-    return status;
-  }
-
-  @Test
-  void whenJobLogContainsSevereErrorAndStatusHasDifferentJobUID_incrementFailureCount() {
-    createFailedIntrospectionLog();
-    getUpdatedDomain().setStatus(createDomainStatusAfterOneFailure("zzzz"));
-
-    testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
-
-    assertThat(getUpdatedDomain().getStatus().getIntrospectJobFailureCount(), equalTo(2));
   }
 
   @Test
@@ -1261,7 +1215,7 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
 
     testSupport.runSteps(JobHelper.readDomainIntrospectorPodLog(terminalStep));
 
-    assertThat(getUpdatedDomain().getStatus().getMessage(), equalTo(formatIntrospectionError(SEVERE_PROBLEM)));
+    assertThat(getUpdatedDomain().getStatus().getMessage(), containsString(SEVERE_PROBLEM));
   }
 
   @Test
@@ -1485,11 +1439,6 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
             hasItem(new V1VolumeMount().name(getLegacyAuxiliaryImageVolumeName())
                     .mountPath(DEFAULT_LEGACY_AUXILIARY_IMAGE_MOUNT_PATH)));
   }
-
-  // create job
-  // add job uid to status
-  // do NOT create pod log
-  // run successfully
 
   private Cluster getCluster(String clusterName) {
     return domain.getSpec().getClusters().stream()

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
@@ -37,6 +37,7 @@ import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
 import static oracle.kubernetes.operator.helpers.TuningParametersStub.MAX_RETRY_COUNT;
 import static oracle.kubernetes.utils.OperatorUtils.onSeparateLines;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.INTROSPECTION;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -111,7 +112,7 @@ class IntrospectionLoggingTest {
 
     Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
     assertThat(updatedDomain.getStatus().getReason(), equalTo(INTROSPECTION.toString()));
-    assertThat(updatedDomain.getStatus().getMessage(), equalTo(formatIntrospectionError(SEVERE_PROBLEM_1)));
+    assertThat(updatedDomain.getStatus().getMessage(), containsString(SEVERE_PROBLEM_1));
   }
 
   private String formatIntrospectionError(String problem) {
@@ -157,6 +158,6 @@ class IntrospectionLoggingTest {
     assertThat(updatedDomain.getStatus().getReason(), equalTo(INTROSPECTION.toString()));
     assertThat(
         updatedDomain.getStatus().getMessage(),
-        equalTo(formatIntrospectionError(onSeparateLines(SEVERE_PROBLEM_1, SEVERE_PROBLEM_2))));
+        containsString(onSeparateLines(SEVERE_PROBLEM_1, SEVERE_PROBLEM_2)));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TopologyValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TopologyValidationStepTest.java
@@ -12,10 +12,8 @@ import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
-import com.meterware.simplestub.Stub;
 import oracle.kubernetes.operator.DomainProcessorImpl;
 import oracle.kubernetes.operator.DomainProcessorTestSetup;
-import oracle.kubernetes.operator.MakeRightDomainOperation;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
@@ -51,7 +49,6 @@ import static oracle.kubernetes.operator.EventConstants.DOMAIN_FAILED_EVENT;
 import static oracle.kubernetes.operator.EventConstants.TOPOLOGY_MISMATCH_ERROR;
 import static oracle.kubernetes.operator.EventMatcher.hasEvent;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
-import static oracle.kubernetes.operator.ProcessingConstants.MAKE_RIGHT_DOMAIN_OPERATION;
 import static oracle.kubernetes.operator.ServerStartPolicy.IF_NEEDED;
 import static oracle.kubernetes.operator.helpers.LegalNames.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX;
 import static oracle.kubernetes.operator.helpers.LegalNames.EXTERNAL_SERVICE_NAME_SUFFIX_PARAM;
@@ -929,19 +926,6 @@ class TopologyValidationStepTest {
                       getFormattedMessage(NO_MANAGED_SERVER_IN_DOMAIN, "no-such-server")));
   }
 
-  @Test
-  void whenIsExplicitRecheck_createEvent() {
-    consoleControl.ignoreMessage(NO_CLUSTER_IN_DOMAIN);
-    setExplicitRecheck();
-    defineScenario(TopologyCase.CONFIGURATION)
-          .withClusterConfiguration("no-such-cluster")
-          .build();
-
-    runTopologyValidationStep();
-
-    assertThat(testSupport, hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(TOPOLOGY_MISMATCH_ERROR));
-  }
-
 
   // todo compute ReplicasTooHigh
   // todo remove ReplicasTooHigh
@@ -951,17 +935,4 @@ class TopologyValidationStepTest {
     return logger.formatMessage(msgId, params);
   }
 
-  private void setExplicitRecheck() {
-    testSupport.addToPacket(MAKE_RIGHT_DOMAIN_OPERATION,
-        Stub.createStub(ExplicitRecheckMakeRightDomainOperationStub.class));
-  }
-
-  abstract static class ExplicitRecheckMakeRightDomainOperationStub implements
-        MakeRightDomainOperation {
-
-    @Override
-    public boolean isExplicitRecheck() {
-      return true;
-    }
-  }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -407,6 +408,29 @@ class DomainStatusTest {
     assertThat(domainStatus.getClusters(), hasItem(clusterStatus("cluster1").withMinimumReplicas(2)));
     assertThat(domainStatus.getClusters(), not(hasItem(clusterStatus("cluster1").withReplicas(3))));
     assertThat(domainStatus.getClusters(), not(hasItem(clusterStatus("cluster1").withReplicasGoal(5))));
+  }
+
+  @Test
+  void statusEqualsItself() {
+    assertThat(domainStatus, equalTo(domainStatus));
+  }
+
+  @Test
+  void status_doesNotEqualsChangedClone() {
+    DomainStatus clone = new DomainStatus(this.domainStatus);
+    clone.addCondition(new DomainCondition(COMPLETED).withStatus("True"));
+
+    assertThat(domainStatus, not(equalTo(clone)));
+  }
+
+  @Test
+  void hashCodeForStatus_equalsCloneHashCode() {
+    assertThat(domainStatus.hashCode(), equalTo(new DomainStatus(domainStatus).hashCode()));
+  }
+
+  @Test
+  void status_toStringResultsInAString() {
+    assertThat(domainStatus.toString(), isA(String.class));
   }
 
   @Test


### PR DESCRIPTION
Next phase of the severe error handling work. The main part of this is to remove the failure counter and ensure that all logic that depended on it still works.