### PR TITLE
Owls 98836 - Changes for intermittent failure in ItElasticLoggingFluentd due to image pull and API exception

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -206,7 +206,7 @@ public interface TestConstants {
   public static final String APACHE_SAMPLE_CHART_DIR = "../kubernetes/samples/charts/apache-webtier";
 
   // ELK Stack and WebLogic logging exporter constants
-  public static final String ELASTICSEARCH_NAME = "elasticsearch";
+  public static final String ELASTICSEARCH_NAME = "phx.ocir.io/weblogick8s/test-images/docker/elasticsearch";
   public static final String ELK_STACK_VERSION = "7.8.1";
   public static final String FLUENTD_IMAGE_VERSION =
       getNonEmptySystemProperty("wko.it.fluentd.image.version", "v1.14.5-debian-elasticsearch7-1.1");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -206,11 +206,12 @@ public interface TestConstants {
   public static final String APACHE_SAMPLE_CHART_DIR = "../kubernetes/samples/charts/apache-webtier";
 
   // ELK Stack and WebLogic logging exporter constants
-  public static final String ELASTICSEARCH_NAME = "phx.ocir.io/weblogick8s/test-images/docker/elasticsearch";
+  public static final String ELASTICSEARCH_NAME = "elasticsearch";
+  public static final String ELASTICSEARCH_IMAGE_NAME = "phx.ocir.io/weblogick8s/test-images/docker/elasticsearch";
   public static final String ELK_STACK_VERSION = "7.8.1";
   public static final String FLUENTD_IMAGE_VERSION =
       getNonEmptySystemProperty("wko.it.fluentd.image.version", "v1.14.5-debian-elasticsearch7-1.1");
-  public static final String ELASTICSEARCH_IMAGE = ELASTICSEARCH_NAME + ":" + ELK_STACK_VERSION;
+  public static final String ELASTICSEARCH_IMAGE = ELASTICSEARCH_IMAGE_NAME + ":" + ELK_STACK_VERSION;
   public static final String ELASTICSEARCH_HOST = "elasticsearch.default.svc.cluster.local";
   public static final int DEFAULT_LISTEN_PORT = 7100;
   public static final int ELASTICSEARCH_HTTP_PORT = 9200;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -504,8 +504,8 @@ public class Kubernetes {
    * @param serviceName name of the service to check for
    * @param label the key value pair with which the service is decorated with
    * @param namespace the namespace in which to check for the service
-   * @return true if the service is found, otherwise false. If there is
-   *              an error in querying the cluster, it returns false.
+   * @return true if the service is found, otherwise false.
+   * @throws ApiException when there is error in querying the cluster
    */
   public static boolean doesServiceExist(
       String serviceName, Map<String, String> label, String namespace)

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -504,18 +504,18 @@ public class Kubernetes {
    * @param serviceName name of the service to check for
    * @param label the key value pair with which the service is decorated with
    * @param namespace the namespace in which to check for the service
-   * @return true if the service is found otherwise false
-   * @throws ApiException when there is error in querying the cluster
+   * @return true if the service is found, otherwise false. If there is
+   *              an error in querying the cluster, it returns false.
    */
-  public static boolean doesServiceExist(
-      String serviceName, Map<String, String> label, String namespace)
-      throws ApiException {
-    boolean exist = false;
-    V1Service service = getService(serviceName, label, namespace);
-    if (service != null) {
-      exist = true;
+  public static boolean doesServiceExist(String serviceName, Map<String, String> label, String namespace) {
+    try {
+      if (getService(serviceName, label, namespace) != null) {
+        return true;
+      }
+    } catch (ApiException aie) {
+      //ignore
     }
-    return exist;
+    return false;
   }
 
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -507,15 +507,10 @@ public class Kubernetes {
    * @return true if the service is found, otherwise false. If there is
    *              an error in querying the cluster, it returns false.
    */
-  public static boolean doesServiceExist(String serviceName, Map<String, String> label, String namespace) {
-    try {
-      if (getService(serviceName, label, namespace) != null) {
-        return true;
-      }
-    } catch (ApiException aie) {
-      //ignore
-    }
-    return false;
+  public static boolean doesServiceExist(
+      String serviceName, Map<String, String> label, String namespace)
+      throws ApiException {
+    return getService(serviceName, label, namespace) != null ? true : false;
   }
 
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -510,7 +510,7 @@ public class Kubernetes {
   public static boolean doesServiceExist(
       String serviceName, Map<String, String> label, String namespace)
       throws ApiException {
-    return getService(serviceName, label, namespace) != null ? true : false;
+    return getService(serviceName, label, namespace) != null;
   }
 
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -94,6 +94,8 @@ public class CommonTestUtils {
   }
 
   public static ConditionFactory withStandardRetryPolicy = createStandardRetryPolicyWithAtMost(5);
+  public static ConditionFactory withStandardRetryPolicyIgnoringExceptions =
+      createStandardRetryPolicyWithAtMost(5).ignoreExceptions();
   public static ConditionFactory withLongRetryPolicy = createStandardRetryPolicyWithAtMost(15);
 
   /**
@@ -208,6 +210,7 @@ public class CommonTestUtils {
   public static void checkServiceExists(String serviceName, String namespace) {
     LoggingFacade logger = getLogger();
     testUntil(
+        withStandardRetryPolicyIgnoringExceptions,
         assertDoesNotThrow(() -> serviceExists(serviceName, null, namespace),
           String.format("serviceExists failed with ApiException for service %s in namespace %s",
             serviceName, namespace)),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
@@ -23,6 +23,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.uninstallElasticsea
 import static oracle.weblogic.kubernetes.actions.TestActions.uninstallKibana;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isElkStackPodReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -89,6 +90,7 @@ public class LoggingExporterUtils {
 
     // wait until the Elasticsearch pod is ready.
     testUntil(
+        withLongRetryPolicy,
         assertDoesNotThrow(() -> isElkStackPodReady(namespace, elasticsearchPodNamePrefix),
           "isElkStackPodReady failed with ApiException"),
         logger,


### PR DESCRIPTION
Owls 98836 - Changes for intermittent failure in ItElasticLoggingFluentd due to image pull and API exception. 
  - Use the elasticsearch image from OCIR instead of docker hub to reduce image pull latency.
  - Increased the wait time for the ELK stack pod to be ready.
  - Ignore an intermittent APIException from the Kubernetes API server when verifying service existence.

Jenkins results - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10583/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10575/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10569/