### PR TITLE
Stop use of introspectJobFailureCount field

### DIFF
--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -528,6 +528,7 @@
           }
         },
         "introspectJobFailureCount": {
+          "deprecated": "true",
           "description": "Non-zero if the introspector job fails for any reason. You can configure an introspector job retry limit for jobs that log script failures using the Operator tuning parameter \u0027domainPresenceFailureRetryMaxCount\u0027 (default 5). You cannot configure a limit for other types of failures, such as a Domain resource reference to an unknown secret name; in which case, the retries are unlimited.",
           "type": "number",
           "minimum": 0

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -74,10 +74,7 @@ import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import org.jetbrains.annotations.NotNull;
 
-import static oracle.kubernetes.common.logging.MessageKeys.CANNOT_START_DOMAIN_AFTER_MAX_RETRIES;
 import static oracle.kubernetes.operator.DomainPresence.getDomainPresenceFailureRetrySeconds;
-import static oracle.kubernetes.operator.DomainPresence.getFailureRetryMaxCount;
-import static oracle.kubernetes.operator.DomainStatusUpdater.createAbortedFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createInternalFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createIntrospectionFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createStatusInitializationStep;
@@ -826,18 +823,12 @@ public class DomainProcessorImpl implements DomainProcessor {
       return inspectionRun;
     }
 
-    @Override
-    public boolean isExplicitRecheck() {
-      return explicitRecheck;
-    }
-
     private boolean shouldContinue() {
       DomainPresenceInfo cachedInfo = getExistingDomainPresenceInfo(getNamespace(), getDomainUid());
 
       if (isNewDomain(cachedInfo)) {
         return true;
-      } else if (hasReachedMaximumFailureCount(liveInfo) && !isImgRestartIntrospectVerChanged(liveInfo, cachedInfo)) {
-        LOGGER.severe(MessageKeys.INTROSPECTOR_MAX_ERRORS_EXCEEDED, getFailureRetryMaxCount());
+      } else if (isDomainProcessingAborted(liveInfo) && !isImgRestartIntrospectVerChanged(liveInfo, cachedInfo)) {
         return false;
       } else if (isFatalIntrospectorError()) {
         LOGGER.fine(ProcessingConstants.FATAL_INTROSPECTOR_ERROR_MSG);
@@ -853,8 +844,12 @@ public class DomainProcessorImpl implements DomainProcessor {
       return false;
     }
 
-    private int getFailureRetryMaxCount() {
-      return DomainPresence.getFailureRetryMaxCount();
+    private boolean isDomainProcessingAborted(DomainPresenceInfo info) {
+      return Optional.ofNullable(info)
+              .map(DomainPresenceInfo::getDomain)
+              .map(Domain::getStatus)
+              .map(DomainStatus::isAborted)
+              .orElse(false);
     }
 
     private boolean shouldRecheck(DomainPresenceInfo cachedInfo) {
@@ -1006,14 +1001,6 @@ public class DomainProcessorImpl implements DomainProcessor {
         .orElse(null);
   }
 
-  private boolean hasReachedMaximumFailureCount(DomainPresenceInfo info) {
-    return Optional.ofNullable(info)
-            .map(DomainPresenceInfo::getDomain)
-            .map(Domain::getStatus)
-            .map(DomainStatus::hasReachedMaximumFailureCount)
-            .orElse(false);
-  }
-
   private static boolean isCachedInfoNewer(DomainPresenceInfo liveInfo, DomainPresenceInfo cachedInfo) {
     return liveInfo.getDomain() != null
         && KubernetesUtils.isFirstNewer(cachedInfo.getDomain().getMetadata(), liveInfo.getDomain().getMetadata());
@@ -1064,7 +1051,7 @@ public class DomainProcessorImpl implements DomainProcessor {
       @Override
       public void onThrowable(Packet packet, Throwable throwable) {
         reportFailure(throwable);
-        scheduleRetry(throwable);
+        scheduleRetry();
       }
 
       private void reportFailure(Throwable throwable) {
@@ -1082,18 +1069,12 @@ public class DomainProcessorImpl implements DomainProcessor {
       }
 
       private Step getFailureSteps(Throwable throwable) {
-        if (hasReachedMaximumFailureCount()) {
-          return createAbortedFailureSteps();
-        } else if (throwable instanceof IntrospectionJobHolder) {
+        if (throwable instanceof IntrospectionJobHolder) {
           return createIntrospectionFailureSteps(throwable, ((IntrospectionJobHolder) throwable).getIntrospectionJob());
         } else {
           return createInternalFailureSteps(throwable);
         }
       }
-    }
-
-    private boolean hasReachedMaximumFailureCount() {
-      return DomainProcessorImpl.this.hasReachedMaximumFailureCount(getExistingDomainPresenceInfo());
     }
 
     class FailureReportCompletionCallback extends ThrowableCallback {
@@ -1103,12 +1084,8 @@ public class DomainProcessorImpl implements DomainProcessor {
       }
     }
 
-    public void scheduleRetry(Throwable throwable) {
-      if (hasReachedMaximumFailureCount()) {
-        reportTooManyRetries(throwable);
-      } else {
-        Optional.ofNullable(getExistingDomainPresenceInfo()).ifPresent(this::scheduleRetry);
-      }
+    public void scheduleRetry() {
+      Optional.ofNullable(getExistingDomainPresenceInfo()).ifPresent(this::scheduleRetry);
     }
 
     private void scheduleRetry(@Nonnull DomainPresenceInfo domainPresenceInfo) {
@@ -1116,10 +1093,6 @@ public class DomainProcessorImpl implements DomainProcessor {
         MakeRightRetry retry = new MakeRightRetry(domainPresenceInfo);
         gate.getExecutor().schedule(retry::execute, getDomainPresenceFailureRetrySeconds(), TimeUnit.SECONDS);
       }
-    }
-
-    private void reportTooManyRetries(Throwable throwable) {
-      LOGGER.severe(CANNOT_START_DOMAIN_AFTER_MAX_RETRIES, domainUid, ns, getFailureRetryMaxCount(), throwable);
     }
 
     private DomainPresenceInfo getExistingDomainPresenceInfo() {
@@ -1156,11 +1129,6 @@ public class DomainProcessorImpl implements DomainProcessor {
             new DomainStatusStep(info, null),
             bringAdminServerUp(info, delegate.getPodAwaiterStepFactory(info.getNamespace())),
             managedServerStrategy);
-
-    if (hasReachedMaximumFailureCount(info) && isImgRestartIntrospectVerChanged(info,
-            getExistingDomainPresenceInfo(info.getNamespace(), info.getDomainUid()))) {
-      domainUpStrategy = Step.chain(DomainStatusUpdater.createResetFailureCountStep(), domainUpStrategy);
-    }
 
     return Step.chain(
           createDomainUpInitialStep(info),
@@ -1208,7 +1176,7 @@ public class DomainProcessorImpl implements DomainProcessor {
 
     @Override
     public NextAction apply(Packet packet) {
-      return doNext(DomainStatusUpdater.createResetFailureCountStep(), packet);
+      return doNext(packet);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -306,18 +306,6 @@ public class DomainStatusUpdater {
     return new FailureStep(INTROSPECTION, message);
   }
 
-  static class ResetFailureCountStep extends DomainStatusUpdaterStep {
-
-    @Override
-    void modifyStatus(DomainStatus domainStatus) {
-      domainStatus.resetIntrospectJobFailureCount();
-    }
-  }
-
-  public static Step createResetFailureCountStep() {
-    return new ResetFailureCountStep();
-  }
-
   abstract static class DomainStatusUpdaterStep extends Step {
 
     DomainStatusUpdaterStep() {
@@ -1309,7 +1297,8 @@ public class DomainStatusUpdater {
       @Override
       void modifyStatus(DomainStatus status) {
         removingReasons.forEach(status::markFailuresForRemoval);
-        addFailure(status, status.createAdjustedFailedCondition(reason, message, jobUid));
+        addFailure(status, status.createAdjustedFailedCondition(reason, message));
+        Optional.ofNullable(jobUid).ifPresent(status::setFailedIntrospectionUid);
         status.removeMarkedFailures();
       }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -57,12 +57,6 @@ public interface MakeRightDomainOperation {
     return domainRequiresIntrospectionInCurrentMakeRight(packet) && !wasInspectionRun(packet);
   }
 
-  boolean isExplicitRecheck();
-
-  static boolean isExplicitRecheck(Packet packet) {
-    return fromPacket(packet).map(MakeRightDomainOperation::isExplicitRecheck).orElse(false);
-  }
-
   /**
    * Returns true if the packet contains info about a domain that requires introspection in a sequences of steps
    * before server pods are created or modified.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -68,7 +68,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.AuxiliaryImage;
 import oracle.kubernetes.weblogic.domain.model.Domain;
-import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
 import oracle.kubernetes.weblogic.domain.model.MonitoringExporterSpecification;
 import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
@@ -1248,11 +1247,6 @@ public abstract class PodStepContext extends BasePodStepContext {
     @Override
     public NextAction apply(Packet packet) {
       V1Pod currentPod = info.getServerPod(getServerName());
-      // reset introspect failure job count - if any
-      Optional.ofNullable(packet.getSpi(DomainPresenceInfo.class))
-          .map(DomainPresenceInfo::getDomain)
-          .map(Domain::getStatus)
-          .ifPresent(DomainStatus::resetIntrospectJobFailureCount);
 
       if (currentPod == null) {
         return doNext(createNewPod(getNext()), packet);

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -35,6 +35,7 @@ import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1HTTPGetAction;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobCondition;
+import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -91,7 +92,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStub;
-import static oracle.kubernetes.common.logging.MessageKeys.ABORTED_EVENT_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.NOT_STARTING_DOMAINUID_THREAD;
 import static oracle.kubernetes.common.utils.LogMatcher.containsFine;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
@@ -100,9 +100,6 @@ import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.DomainSourceType.FROM_MODEL;
 import static oracle.kubernetes.operator.DomainSourceType.IMAGE;
 import static oracle.kubernetes.operator.DomainSourceType.PERSISTENT_VOLUME;
-import static oracle.kubernetes.operator.EventConstants.DOMAIN_FAILED_EVENT;
-import static oracle.kubernetes.operator.EventMatcher.hasEvent;
-import static oracle.kubernetes.operator.EventTestUtils.getLocalizedString;
 import static oracle.kubernetes.operator.IntrospectorConfigMapConstants.INTROSPECTOR_CONFIG_MAP_NAME_SUFFIX;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_OK;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
@@ -289,12 +286,42 @@ class DomainProcessorTest {
   private String getResourceVersion(Domain domain) {
     return Optional.of(domain).map(Domain::getMetadata).map(V1ObjectMeta::getResourceVersion).orElse("");
   }
-
+  
   @Test
   void whenDomainExplicitSet_runUpdateThread() {
     DomainProcessorImpl.registerDomainPresenceInfo(new DomainPresenceInfo(domain));
 
     processor.createMakeRightOperation(new DomainPresenceInfo(domain)).withExplicitRecheck().execute();
+
+    assertThat(logRecords, not(containsFine(NOT_STARTING_DOMAINUID_THREAD)));
+  }
+
+  @Test
+  void whenDomainChangedSpec_runUpdateThread() {
+    DomainProcessorImpl.registerDomainPresenceInfo(new DomainPresenceInfo(domain));
+
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
+
+    assertThat(logRecords, not(containsFine(NOT_STARTING_DOMAINUID_THREAD)));
+  }
+
+  @Test
+  void whenDomainChangedSpecButProcessingAborted_dontRunUpdateThread() {
+    DomainProcessorImpl.registerDomainPresenceInfo(new DomainPresenceInfo(domain));
+    newDomain.getOrCreateStatus().addCondition(new DomainCondition(FAILED).withReason(ABORTED).withMessage("ugh"));
+
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
+
+    assertThat(logRecords, containsFine(NOT_STARTING_DOMAINUID_THREAD));
+  }
+
+  @Test
+  void whenDomainChangedSpecAndProcessingAbortedButInspectionVersionChanged_runUpdateThread() {
+    DomainProcessorImpl.registerDomainPresenceInfo(new DomainPresenceInfo(domain));
+    newDomain.getOrCreateStatus().addCondition(new DomainCondition(FAILED).withReason(ABORTED).withMessage("ugh"));
+    domainConfigurator.withIntrospectVersion("17");
+
+    processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
 
     assertThat(logRecords, not(containsFine(NOT_STARTING_DOMAINUID_THREAD)));
   }
@@ -923,14 +950,6 @@ class DomainProcessorTest {
     assertThat(processorDelegate.waitedForIntrospection(), is(true));
   }
 
-
-  @Test
-  void whenIntrospectionJobTimedOut_failureCountIncremented() throws Exception {
-    runMakeRight_withIntrospectionTimeout();
-
-    assertThat(newDomain.getStatus().getIntrospectJobFailureCount(), is(1));
-  }
-
   private void runMakeRight_withIntrospectionTimeout() throws JsonProcessingException {
     consoleHandlerMemento.ignoringLoggedExceptions(JobWatcher.DeadlineExceededException.class);
     consoleHandlerMemento.ignoreMessage(MessageKeys.NOT_STARTING_DOMAINUID_THREAD);
@@ -949,31 +968,13 @@ class DomainProcessorTest {
   }
 
   @Test
-  void whenIntrospectionJobTimedOut_createAbortedEvent() throws Exception {
+  void whenIntrospectionJobTimedOut_activeDeadlineIncreased() throws Exception {
     runMakeRight_withIntrospectionTimeout();
 
     executeScheduledRetry();
 
-    assertThat(testSupport,
-        hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(getLocalizedString(ABORTED_EVENT_ERROR)));
-  }
-
-  @Test
-  void whenIntrospectionJobTimedOut_createFailureWithAbortedReason() throws Exception {
-    runMakeRight_withIntrospectionTimeout();
-
-    executeScheduledRetry();
-
-    assertThat(getRecordedDomain(), hasCondition(FAILED).withReason(ABORTED));
-  }
-
-  @Test
-  void whenIntrospectionJobTimedOut_activeDeadlineIncremented() throws Exception {
-    runMakeRight_withIntrospectionTimeout();
-
-    executeScheduledRetry();
-
-    assertThat(getJob().getSpec().getActiveDeadlineSeconds(), is(240L));
+    assertThat(
+        Optional.ofNullable(getJob().getSpec()).map(V1JobSpec::getActiveDeadlineSeconds).orElse(0L), is(240L));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdaterTest.java
@@ -55,6 +55,7 @@ import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.INTERN
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.KUBERNETES;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
@@ -67,6 +68,7 @@ class DomainStatusUpdaterTest {
   private static final String NAME = UID;
   private static final String ADMIN = "admin";
   public static final String CLUSTER = "cluster1";
+  private static final String JOB_UID = "JOB";
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final List<Memento> mementos = new ArrayList<>();
   private final Domain domain = DomainProcessorTestSetup.createTestDomain();
@@ -75,7 +77,7 @@ class DomainStatusUpdaterTest {
   private final String message = generator.getUniqueString();
   private final RuntimeException failure = new RuntimeException(message);
   private final String validationWarning = generator.getUniqueString();
-  private final V1Job job = createIntrospectorJob("JOB");
+  private final V1Job job = createIntrospectorJob(JOB_UID);
   private final Collection<LogRecord> logRecords = new ArrayList<>();
   private TestUtils.ConsoleHandlerMemento consoleHandlerMemento;
 
@@ -258,6 +260,13 @@ class DomainStatusUpdaterTest {
 
     assertThat(testSupport,
         hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(getLocalizedString(ABORTED_EVENT_ERROR)));
+  }
+
+  @Test
+  void afterIntrospectionFailure_statusIncludesFailedJobUid() {
+    testSupport.runSteps(DomainStatusUpdater.createIntrospectionFailureSteps(FATAL_INTROSPECTOR_ERROR, job));
+
+    assertThat(getRecordedDomain().getOrCreateStatus().getFailedIntrospectionUid(), equalTo(JOB_UID));
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionLoggingTest.java
@@ -38,6 +38,7 @@ import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
 import static oracle.kubernetes.operator.helpers.TuningParametersStub.MAX_RETRY_COUNT;
 import static oracle.kubernetes.utils.OperatorUtils.onSeparateLines;
 import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.INTROSPECTION;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -112,7 +113,7 @@ class IntrospectionLoggingTest {
 
     Domain updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
     assertThat(updatedDomain.getStatus().getReason(), equalTo(INTROSPECTION.toString()));
-    assertThat(updatedDomain.getStatus().getMessage(), equalTo(formatIntrospectionError(SEVERE_PROBLEM_1)));
+    assertThat(updatedDomain.getStatus().getMessage(), containsString(SEVERE_PROBLEM_1));
   }
 
   private String formatIntrospectionError(String problem) {
@@ -158,6 +159,6 @@ class IntrospectionLoggingTest {
     assertThat(updatedDomain.getStatus().getReason(), equalTo(INTROSPECTION.toString()));
     assertThat(
         updatedDomain.getStatus().getMessage(),
-        equalTo(formatIntrospectionError(onSeparateLines(SEVERE_PROBLEM_1, SEVERE_PROBLEM_2))));
+        containsString(onSeparateLines(SEVERE_PROBLEM_1, SEVERE_PROBLEM_2)));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TopologyValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TopologyValidationStepTest.java
@@ -12,10 +12,8 @@ import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
-import com.meterware.simplestub.Stub;
 import oracle.kubernetes.operator.DomainProcessorImpl;
 import oracle.kubernetes.operator.DomainProcessorTestSetup;
-import oracle.kubernetes.operator.MakeRightDomainOperation;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
@@ -52,7 +50,6 @@ import static oracle.kubernetes.operator.EventConstants.DOMAIN_FAILED_EVENT;
 import static oracle.kubernetes.operator.EventMatcher.hasEvent;
 import static oracle.kubernetes.operator.EventTestUtils.getLocalizedString;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
-import static oracle.kubernetes.operator.ProcessingConstants.MAKE_RIGHT_DOMAIN_OPERATION;
 import static oracle.kubernetes.operator.ServerStartPolicy.IF_NEEDED;
 import static oracle.kubernetes.operator.helpers.LegalNames.DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX;
 import static oracle.kubernetes.operator.helpers.LegalNames.EXTERNAL_SERVICE_NAME_SUFFIX_PARAM;
@@ -932,21 +929,6 @@ class TopologyValidationStepTest {
                       getFormattedMessage(NO_MANAGED_SERVER_IN_DOMAIN, "no-such-server")));
   }
 
-  @Test
-  void whenIsExplicitRecheck_createEvent() {
-    consoleControl.ignoreMessage(NO_CLUSTER_IN_DOMAIN);
-    setExplicitRecheck();
-    defineScenario(TopologyCase.CONFIGURATION)
-          .withClusterConfiguration("no-such-cluster")
-          .build();
-
-    runTopologyValidationStep();
-
-    assertThat(testSupport,
-        hasEvent(DOMAIN_FAILED_EVENT).withMessageContaining(getLocalizedString(TOPOLOGY_MISMATCH_EVENT_ERROR)));
-  }
-
-
   // todo compute ReplicasTooHigh
   // todo remove ReplicasTooHigh
 
@@ -955,17 +937,4 @@ class TopologyValidationStepTest {
     return logger.formatMessage(msgId, params);
   }
 
-  private void setExplicitRecheck() {
-    testSupport.addToPacket(MAKE_RIGHT_DOMAIN_OPERATION,
-        Stub.createStub(ExplicitRecheckMakeRightDomainOperationStub.class));
-  }
-
-  abstract static class ExplicitRecheckMakeRightDomainOperationStub implements
-        MakeRightDomainOperation {
-
-    @Override
-    public boolean isExplicitRecheck() {
-      return true;
-    }
-  }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -407,6 +408,29 @@ class DomainStatusTest {
     assertThat(domainStatus.getClusters(), hasItem(clusterStatus("cluster1").withMinimumReplicas(2)));
     assertThat(domainStatus.getClusters(), not(hasItem(clusterStatus("cluster1").withReplicas(3))));
     assertThat(domainStatus.getClusters(), not(hasItem(clusterStatus("cluster1").withReplicasGoal(5))));
+  }
+
+  @Test
+  void statusEqualsItself() {
+    assertThat(domainStatus, equalTo(domainStatus));
+  }
+
+  @Test
+  void status_doesNotEqualsChangedClone() {
+    DomainStatus clone = new DomainStatus(this.domainStatus);
+    clone.addCondition(new DomainCondition(COMPLETED).withStatus("True"));
+
+    assertThat(domainStatus, not(equalTo(clone)));
+  }
+
+  @Test
+  void hashCodeForStatus_equalsCloneHashCode() {
+    assertThat(domainStatus.hashCode(), equalTo(new DomainStatus(domainStatus).hashCode()));
+  }
+
+  @Test
+  void status_toStringResultsInAString() {
+    assertThat(domainStatus.toString(), isA(String.class));
   }
 
   @Test


### PR DESCRIPTION
This change removes the logic that uses the number of introspection job failures, and deprecates the field itself. The corresponding logic is migrating to the total retry timeout