### PR TITLE
Fix for slim image and domain path

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -285,7 +285,7 @@ class ItMiiDomain {
       logger.info("WebLogic console is accessible thru default service");
     } else {
       logger.info("Checking Rest API management console in WebLogic slim image");
-      verifyCredentials(adminServerPodName, domainNamespace,
+      verifyCredentials(adminSvcExtHost, adminServerPodName, domainNamespace,
             ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT, true);
     }
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -13,7 +13,7 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -24,6 +24,7 @@ import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomainAndVerify;
@@ -76,6 +77,7 @@ class ItMultiDomainModels {
   @BeforeAll
   public static void initAll(@Namespaces(4) List<String> namespaces) {
     logger = getLogger();
+    System.setProperty("WEBLOGIC_SLIM", Boolean.toString(WEBLOGIC_SLIM));
 
     // get a unique operator namespace
     logger.info("Getting a unique namespace for operator");
@@ -110,7 +112,7 @@ class ItMultiDomainModels {
       + "verify admin console login using admin node port.")
   @ValueSource(strings = {"modelInImage", "domainInImage", "domainOnPV"})
   @Tag("gate")
-  @DisabledIf("java.lang.String.valueOf(WEBLOGIC_SLIM)")
+  @DisabledIfEnvironmentVariable(named = "WEBLOGIC_SLIM", matches = "true")
   void testScaleClustersAndAdminConsoleLogin(String domainType) {
     Domain domain = createDomainBasedOnDomainType(domainType);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -7,13 +7,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import oracle.weblogic.domain.Domain;
+import oracle.weblogic.kubernetes.annotations.DisabledOnSlimImage;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -24,7 +24,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
-import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomainAndVerify;
@@ -77,7 +76,6 @@ class ItMultiDomainModels {
   @BeforeAll
   public static void initAll(@Namespaces(4) List<String> namespaces) {
     logger = getLogger();
-    System.setProperty("WEBLOGIC_SLIM", Boolean.toString(WEBLOGIC_SLIM));
 
     // get a unique operator namespace
     logger.info("Getting a unique namespace for operator");
@@ -112,7 +110,7 @@ class ItMultiDomainModels {
       + "verify admin console login using admin node port.")
   @ValueSource(strings = {"modelInImage", "domainInImage", "domainOnPV"})
   @Tag("gate")
-  @DisabledIfEnvironmentVariable(named = "WEBLOGIC_SLIM", matches = "true")
+  @DisabledOnSlimImage
   void testScaleClustersAndAdminConsoleLogin(String domainType) {
     Domain domain = createDomainBasedOnDomainType(domainType);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -13,6 +13,7 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -23,7 +24,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
-import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomainAndVerify;
@@ -38,7 +38,6 @@ import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodNam
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * The test class creates WebLogic domains with three models.
@@ -111,9 +110,8 @@ class ItMultiDomainModels {
       + "verify admin console login using admin node port.")
   @ValueSource(strings = {"modelInImage", "domainInImage", "domainOnPV"})
   @Tag("gate")
+  @DisabledIf("java.lang.String.valueOf(WEBLOGIC_SLIM)")
   void testScaleClustersAndAdminConsoleLogin(String domainType) {
-
-    assumeFalse(WEBLOGIC_SLIM, "Skipping the Console Test for slim image");
     Domain domain = createDomainBasedOnDomainType(domainType);
 
     // get the domain properties

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
@@ -610,6 +610,8 @@ class ItMultiDomainModelsWithLoadBalancer {
     Domain domainOnPV = createOrStartDomainBasedOnDomainType("domainOnPV");
     String domainUid = domainOnPV.getSpec().getDomainUid();
     String domainNamespace = domainOnPV.getMetadata().getNamespace();
+    
+    String uniquePath = "/u01/shared/" + domainNamespace + "/domains/" + domainUid;
 
     // check in admin server pod, there is a data file for JMS server created in /u01/oracle/customFileStore
     String dataFileToCheck = "/u01/oracle/customFileStore/FILESTORE-0000000.DAT";
@@ -618,7 +620,7 @@ class ItMultiDomainModelsWithLoadBalancer {
 
     // check in admin server pod, the default admin server data file is in default data store
     String defaultAdminDataFile =
-        "/u01/shared/domains/" + domainUid + "/servers/admin-server/data/store/default/_WLS_ADMIN-SERVER000000.DAT";
+        uniquePath + "/servers/admin-server/data/store/default/_WLS_ADMIN-SERVER000000.DAT";
     waitForFileExistsInPod(domainNamespace, adminServerPodName, defaultAdminDataFile);
 
     // check in managed server pod, there is no custom data file for JMS is created
@@ -632,7 +634,7 @@ class ItMultiDomainModelsWithLoadBalancer {
           String.format("found file %s in pod %s in namespace %s, expect not exist",
               customDataFile, managedServerPodName, domainNamespace));
 
-      String defaultMSDataFile = "/u01/shared/domains/" + domainUid + "/servers/managed-server" + i
+      String defaultMSDataFile = uniquePath + "/servers/managed-server" + i
           + "/data/store/default/_WLS_MANAGED-SERVER" + i + "000000.DAT";
       waitForFileExistsInPod(domainNamespace, managedServerPodName, defaultMSDataFile);
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/annotations/DisabledOnSlimImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/annotations/DisabledOnSlimImage.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import oracle.weblogic.kubernetes.extensions.DisabledOnSlimImageCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnSlimImageCondition.class)
+public @interface DisabledOnSlimImage {
+
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/DisabledOnSlimImageCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/DisabledOnSlimImageCondition.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.extensions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
+
+public class DisabledOnSlimImageCondition implements ExecutionCondition {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (WEBLOGIC_SLIM) {
+      return ConditionEvaluationResult.disabled("Test disabled on WebLogic slim image");
+    } else {
+      return ConditionEvaluationResult.enabled("Test enabled on full WebLogic image");
+    }
+  }
+}


### PR DESCRIPTION
- When tests are running with WebLogic slim image the verifyCredentials method has to be passed with adminSvcExtHost parameter if the platform is OKD in integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
- The integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java had assumeFalse in the test method causing the test to show as Failed when running with slim image. The fix is to skip the test if the test is running with WebLogic  slim image.
- Fix the domain path in the testDataHomeOverrideDomainOnPV() since the domain resource is changed to use a uniquePath


KIND
-----
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10599/  (testDataHomeOverrideDomainOnPV)

OKD
-----
https://build.weblogick8s.org:8443/job/wko-okd-test/331/  (if image is slim - ItMultiDomainModels)
https://build.weblogick8s.org:8443/job/wko-okd-test/332/ (if image is full - ItMultiDomainModels)

https://build.weblogick8s.org:8443/job/wko-okd-test/334/ (ItMiiDomain with slim image)
https://build.weblogick8s.org:8443/job/wko-okd-test/334/ (ItMiiDomain with full image)