### PR TITLE
Add webhookOnly operator installation before integration tests starts

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -72,7 +72,7 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WebLogicImageTool;
 import oracle.weblogic.kubernetes.actions.impl.primitive.WitParams;
-import oracle.weblogic.kubernetes.extensions.ImageBuilders;
+import oracle.weblogic.kubernetes.extensions.InitializationTasks;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 
@@ -1168,7 +1168,7 @@ public class TestActions {
   public static boolean dockerPush(String image) {
     boolean result = Docker.push(image);
     if (result) {
-      ImageBuilders.registerPushedImage(image);
+      InitializationTasks.registerPushedImage(image);
     }
     return result;
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/OperatorParams.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/OperatorParams.java
@@ -38,6 +38,7 @@ public class OperatorParams {
   private static final String FEATURE_GATES = "featureGates";
   private static final String KUBERNETES_PLATFORM = "kubernetesPlatform";
   private static final String CREATE_LOGSTASH_CONFIGMAP = "createLogStashConfigMap";
+  private static final String WEBHOOK_ONLY = "webhookOnly";
 
   // Adding some of the most commonly used params for now
   private List<String> domainNamespaces;
@@ -63,6 +64,7 @@ public class OperatorParams {
   private String featureGates;
   private String kubernetesPlatform;
   private boolean createLogStashConfigMap = true;
+  private boolean webhookOnly;
 
   public OperatorParams domainNamespaces(List<String> domainNamespaces) {
     this.domainNamespaces = domainNamespaces;
@@ -194,6 +196,11 @@ public class OperatorParams {
   public String getKubernetesPlatform() {
     return kubernetesPlatform;
   }
+  
+  public OperatorParams webHookOnly(boolean webhookOnly) {
+    this.webhookOnly = webhookOnly;
+    return this;
+  }
 
   /**
    * Loads Helm values into a value map.
@@ -249,6 +256,9 @@ public class OperatorParams {
     if (kubernetesPlatform != null) {
       values.put(KUBERNETES_PLATFORM, kubernetesPlatform);
     }
+    if (webhookOnly) {
+      values.put(WEBHOOK_ONLY, webhookOnly);
+    }    
 
     values.put(CREATE_LOGSTASH_CONFIGMAP, createLogStashConfigMap);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/annotations/IntegrationTest.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/annotations/IntegrationTest.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import oracle.weblogic.kubernetes.extensions.ImageBuilders;
+import oracle.weblogic.kubernetes.extensions.InitializationTasks;
 import oracle.weblogic.kubernetes.extensions.IntegrationTestWatcher;
 import oracle.weblogic.kubernetes.extensions.LoggingExtension;
 import org.junit.jupiter.api.Tag;
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Retention(RetentionPolicy.RUNTIME)
 @Tag("integration")
 @ExtendWith(LoggingExtension.class)
-@ExtendWith(ImageBuilders.class)
+@ExtendWith(InitializationTasks.class)
 @ExtendWith(IntegrationTestWatcher.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public @interface IntegrationTest {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -60,9 +60,9 @@ public class TestAssertions {
   }
   
   /**
-   * Check if Operator is running.
+   * Check if Operator WebHook pod is running.
    *
-   * @param namespace in which is operator is running
+   * @param namespace in which is operator webhook pod is running
    * @return true if running false otherwise
    */
   public static Callable<Boolean> operatorWebhookIsReady(String namespace) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -58,6 +58,16 @@ public class TestAssertions {
   public static Callable<Boolean> operatorIsReady(String namespace) {
     return Operator.isReady(namespace);
   }
+  
+  /**
+   * Check if Operator is running.
+   *
+   * @param namespace in which is operator is running
+   * @return true if running false otherwise
+   */
+  public static Callable<Boolean> operatorWebhookIsReady(String namespace) {
+    return Operator.isWebhookReady(namespace);
+  }  
 
   /**
    * Check if NGINX is running.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -394,7 +394,7 @@ public class Kubernetes {
    * starts with weblogic-operator-webhook and decorated with label weblogic.webhookName:namespace.
    *
    * @param namespace in which to check for the pod existence
-   * @return true if pod exists and running otherwise false
+   * @return true if pod exists, running and ready otherwise false
    * @throws ApiException when there is error in querying the cluster
    */
   public static boolean isWebhookPodReady(String namespace) throws ApiException {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -385,8 +385,23 @@ public class Kubernetes {
       }
     } else {
       getLogger().info("Pod doesn't exist");
-    }
+    }    
     return status;
+  }
+  
+  /**
+   * Checks if the webhook pod is running and ready in a given namespace. The method assumes the webhook pod name to
+   * starts with weblogic-operator-webhook and decorated with label weblogic.webhookName:namespace.
+   *
+   * @param namespace in which to check for the pod existence
+   * @return true if pod exists and running otherwise false
+   * @throws ApiException when there is error in querying the cluster
+   */
+  public static boolean isWebhookPodReady(String namespace) throws ApiException {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("weblogic.webhookName", namespace);
+    String podName = "weblogic-operator-webhook";
+    return isPodReady(namespace, labels, podName);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Operator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Operator.java
@@ -24,9 +24,9 @@ public class Operator {
   }
   
   /**
-   * Check if the operator pod is running in a given namespace.
-   * @param namespace in which to check for the operator pod
-   * @return true if found and running otherwise false
+   * Check if the operator webhook pod is running in a given namespace.
+   * @param namespace in which to check for the operator webhook pod
+   * @return true if found running and ready otherwise false
    */
   public static Callable<Boolean> isWebhookReady(String namespace) {
     return () -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Operator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Operator.java
@@ -22,6 +22,17 @@ public class Operator {
       return Kubernetes.isOperatorPodReady(namespace);
     };
   }
+  
+  /**
+   * Check if the operator pod is running in a given namespace.
+   * @param namespace in which to check for the operator pod
+   * @return true if found and running otherwise false
+   */
+  public static Callable<Boolean> isWebhookReady(String namespace) {
+    return () -> {
+      return Kubernetes.isWebhookPodReady(namespace);
+    };
+  }  
 
   /**
    * Checks if the operator external service exists.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -609,7 +609,7 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
             .namespace(webhookNamespace)
             .chartDir(OPERATOR_CHART_DIR);
     return installAndVerifyOperator(webhookNamespace, webhookSa, false, 0, opHelmParams, null,
-        false, false, null, null, false, "INFO", -1, -1, false, true, "default");
+        false, false, null, null, false, "INFO", -1, -1, true, "default");
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -604,7 +604,7 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
             .chartDir(OPERATOR_CHART_DIR);
 
     return installAndVerifyOperator(opNamespace, opNamespace + "-sa", false,
-        0, opHelmParams, null, false, false, null, null, false, "INFO", -1, -1, true);
+        0, opHelmParams, null, false, false, null, null, false, "INFO", -1, -1, true, "default");
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -609,7 +609,7 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
             .namespace(webhookNamespace)
             .chartDir(OPERATOR_CHART_DIR);
     return installAndVerifyOperator(webhookNamespace, webhookSa, false, 0, opHelmParams, null,
-        false, false, null, null, false, "INFO", -1, -1, true, "default");
+        false, false, null, null, false, "INFO", -1, -1, false, true, "default");
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -609,9 +609,8 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
         = new HelmParams().releaseName(OPERATOR_RELEASE_NAME)
             .namespace(opNamespace)
             .chartDir(OPERATOR_CHART_DIR);
-
-    return installAndVerifyOperator(webhookNamespace, webhookSa + "-sa", false,
-        0, opHelmParams, null, false, false, null, null, false, "INFO", -1, -1, true, "default");
+    return installAndVerifyOperator(webhookNamespace, webhookSa, false, 0, opHelmParams, null,
+        false, false, null, null, false, "INFO", -1, -1, true, "default");
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -609,7 +609,7 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
             .namespace(webhookNamespace)
             .chartDir(OPERATOR_CHART_DIR);
     return installAndVerifyOperator(webhookNamespace, webhookSa, false, 0, opHelmParams, null,
-        false, false, null, null, false, "INFO", -1, -1, true, "default");
+        false, false, null, null, false, "INFO", -1, -1, true, "null");
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/ImageBuilders.java
@@ -604,10 +604,9 @@ public class ImageBuilders implements BeforeAllCallback, ExtensionContext.Store.
   private OperatorParams installWebHookOnlyOperator() {
     webhookNamespace = assertDoesNotThrow(() -> createUniqueNamespace());
     String webhookSa = webhookNamespace + "-sa";
-    String opNamespace = "default";
     opHelmParams
         = new HelmParams().releaseName(OPERATOR_RELEASE_NAME)
-            .namespace(opNamespace)
+            .namespace(webhookNamespace)
             .chartDir(OPERATOR_CHART_DIR);
     return installAndVerifyOperator(webhookNamespace, webhookSa, false, 0, opHelmParams, null,
         false, false, null, null, false, "INFO", -1, -1, true, "default");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
@@ -294,7 +294,6 @@ public class OperatorUtils {
         -1,
         -1,
         false,
-        false,
         domainNamespace);
   }
 
@@ -390,7 +389,6 @@ public class OperatorUtils {
         domainPresenceFailureRetryMaxCount,
         domainPresenceFailureRetrySeconds,
         false,
-        false,
         domainNamespace);
   }
 
@@ -412,7 +410,6 @@ public class OperatorUtils {
    * @param loggingLevel logging level of operator
    * @param domainPresenceFailureRetryMaxCount the number of introspector job retries for a Domain
    * @param domainPresenceFailureRetrySeconds the interval in seconds between these retries
-   * @param operatorOnly install operator only
    * @param webhookOnly boolean indicating install webHookOnly operator 
    * @param domainNamespace the list of the domain namespaces which will be managed by the operator
    * @return the operator Helm installation parameters
@@ -431,13 +428,9 @@ public class OperatorUtils {
                                                         String loggingLevel,
                                                         int domainPresenceFailureRetryMaxCount,
                                                         int domainPresenceFailureRetrySeconds,
-                                                        boolean operatorOnly,
                                                         boolean webhookOnly,
                                                         String... domainNamespace) {
     LoggingFacade logger = getLogger();
-    assertFalse(operatorOnly && webhookOnly, "Both operatorOnly and webhookOnly cannot be true, "
-        + "both can be false to install operator and webhook or it can be mutually exclusive "
-        + "to install operator only or webhook only");
 
     // Create a service account for the unique opNamespace
     logger.info("Creating service account");
@@ -556,21 +549,7 @@ public class OperatorUtils {
           logger,
           "operator webhook to be running in namespace {0}",
           opNamespace);
-    } else if (operatorOnly) {
-      logger.info("Wait for the operator pod is ready in namespace {0}", opNamespace);
-      testUntil(
-          assertDoesNotThrow(() -> operatorIsReady(opNamespace),
-              "operatorIsReady failed with ApiException"),
-          logger,
-          "operator to be running in namespace {0}",
-          opNamespace);
     } else {
-      testUntil(
-          assertDoesNotThrow(() -> operatorWebhookIsReady(opNamespace),
-              "operatorWebhookIsReady failed with ApiException"),
-          logger,
-          "operator webhook to be running in namespace {0}",
-          opNamespace);
       logger.info("Wait for the operator pod is ready in namespace {0}", opNamespace);
       testUntil(
           assertDoesNotThrow(() -> operatorIsReady(opNamespace),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
@@ -292,6 +292,7 @@ public class OperatorUtils {
         "INFO",
         -1,
         -1,
+        false,
         domainNamespace);
   }
 
@@ -386,6 +387,7 @@ public class OperatorUtils {
         loggingLevel,
         domainPresenceFailureRetryMaxCount,
         domainPresenceFailureRetrySeconds,
+        false,
         domainNamespace);
   }
 
@@ -397,7 +399,9 @@ public class OperatorUtils {
    * @param withRestAPI whether to use REST API
    * @param externalRestHttpsPort the node port allocated for the external operator REST HTTPS interface
    * @param opHelmParams the Helm parameters to install operator
+   * @param elasticSearchHost Elasticsearchhost 
    * @param elkIntegrationEnabled true to enable ELK Stack, false otherwise
+   * @param createLogStashConfigMap boolean indicating creating logstash
    * @param domainNamespaceSelectionStrategy SelectLabel, RegExp or List, value to tell the operator
    *                                  how to select the set of namespaces that it will manage
    * @param domainNamespaceSelector the label or expression value to manage namespaces
@@ -405,6 +409,7 @@ public class OperatorUtils {
    * @param loggingLevel logging level of operator
    * @param domainPresenceFailureRetryMaxCount the number of introspector job retries for a Domain
    * @param domainPresenceFailureRetrySeconds the interval in seconds between these retries
+   * @param webhookOnly boolean indicating install webHookOnly operator 
    * @param domainNamespace the list of the domain namespaces which will be managed by the operator
    * @return the operator Helm installation parameters
    */
@@ -422,6 +427,7 @@ public class OperatorUtils {
                                                         String loggingLevel,
                                                         int domainPresenceFailureRetryMaxCount,
                                                         int domainPresenceFailureRetrySeconds,
+                                                        boolean webhookOnly,
                                                         String... domainNamespace) {
     LoggingFacade logger = getLogger();
 
@@ -455,6 +461,10 @@ public class OperatorUtils {
         .domainNamespaces(Arrays.asList(domainNamespace))
         .javaLoggingLevel(loggingLevel)
         .serviceAccount(opServiceAccount);
+    
+    if (webhookOnly) {
+      opParams.webHookOnly(webhookOnly);
+    }
 
     if (domainNamespaceSelectionStrategy != null) {
       opParams.domainNamespaceSelectionStrategy(domainNamespaceSelectionStrategy);


### PR DESCRIPTION
Add webhookOnly operator installation before integration tests starts in ImageBuilders beforeAll method and delete the installation in close method.

Kind
-----
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10602/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10603/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10608/