### PR TITLE
Disable ItRemoteConsole tests on slim image

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart3.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart3.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static oracle.weblogic.kubernetes.TestConstants.MII_DYNAMIC_UPDATE_EXPECTED_ERROR_MSG;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_VERSION;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
@@ -258,7 +259,9 @@ class ItMiiDynamicUpdatePart3 {
     String operatorPodLog = assertDoesNotThrow(() -> getPodLog(operatorPodName, helper.opNamespace));
     logger.info("operator pod log: {0}", operatorPodLog);
     assertTrue(operatorPodLog.contains("Introspector Job Log"));
-    assertTrue(operatorPodLog.contains("WebLogic version='" + WEBLOGIC_VERSION + "'"));
+    if (!WEBLOGIC_SLIM) {
+      assertTrue(operatorPodLog.contains("WebLogic version='" + WEBLOGIC_VERSION + "'"));
+    }
     assertTrue(operatorPodLog.contains("Job " + domainUid + "-introspector has failed"));
     assertTrue(operatorPodLog.contains(MII_DYNAMIC_UPDATE_EXPECTED_ERROR_MSG));
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRemoteConsole.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRemoteConsole.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.openapi.models.V1IngressServiceBackend;
 import io.kubernetes.client.openapi.models.V1ServiceBackendPort;
 import oracle.weblogic.kubernetes.actions.impl.NginxParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
+import oracle.weblogic.kubernetes.annotations.DisabledOnSlimImage;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -73,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Test WebLogic remote console connecting to mii domain")
 @IntegrationTest
+@DisabledOnSlimImage
 class ItRemoteConsole {
 
   private static String domainNamespace = null;


### PR DESCRIPTION
- Disable ItRemoteConsole tests on slim image
- Check the `WebLogic version=` message in introspector log only on full image runs, not slim image

Kind
------
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10615/

In the above results the test [oracle.weblogic.kubernetes.ItMiiSampleWlsMain.testCheckMiiSampleSource] will fail since the image version is hard coded in the sample script below. It can be ignored when running tests against 14.1.1.0

https://github.com/oracle/weblogic-kubernetes-operator/blob/release/3.4/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/domain-resources/JRF-AI/mii-initial-d1-JRF-AI-v1.yaml