### PR TITLE
skip ItExternalLbTunneling ItExternalNodePortService for slim image

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItExternalLbTunneling.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItExternalLbTunneling.java
@@ -28,6 +28,7 @@ import oracle.weblogic.kubernetes.actions.impl.NginxParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
+import oracle.weblogic.kubernetes.annotations.DisabledOnSlimImage;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -54,7 +55,6 @@ import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.SKIP_CLEANUP;
 import static oracle.weblogic.kubernetes.TestConstants.TRAEFIK_RELEASE_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
@@ -86,7 +86,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * The use case described in this class verifies that an external RMI client
@@ -108,6 +107,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("Test external RMI access through loadbalncer tunneling")
 @IntegrationTest
+@DisabledOnSlimImage
 class ItExternalLbTunneling {
 
   private static String opNamespace = null;
@@ -252,7 +252,6 @@ class ItExternalLbTunneling {
   @DisplayName("Verify RMI access to WLS through Traefik LoadBalancer")
   void testExternalRmiAccessThruTraefik() {
 
-    assumeFalse(WEBLOGIC_SLIM, "Skipping RMI Tunnelling Test for slim image");
     // Build the standalone JMS Client to send and receive messages
     buildClient();
     buildClientOnPod();
@@ -311,8 +310,6 @@ class ItExternalLbTunneling {
   @DisplayName("Verify tls RMI access WLS through Traefik loadBalancer")
   void testExternalRmiAccessThruTraefikHttpsTunneling() {
 
-    assumeFalse(WEBLOGIC_SLIM, "Skipping RMI Tunnelling Test for slim image");
-
     // Build the standalone JMS Client to send and receive messages
     buildClient();
 
@@ -361,9 +358,6 @@ class ItExternalLbTunneling {
   @DisplayName("Verify RMI access WLS through Route in OKD ")
   void testExternalRmiAccessThruRouteHttpTunneling() {
 
-    assumeFalse(WEBLOGIC_SLIM, "Skipping RMI Tunnelling Test for slim image");
-    logger.info("Installing Nginx controller using helm");
-
     // Build the standalone JMS Client to send and receive messages
     buildClient();
     buildClientOnPod();
@@ -392,8 +386,6 @@ class ItExternalLbTunneling {
   @Test
   @DisplayName("Verify tls RMI access WLS through Route in OKD ")
   void testExternalRmiAccessThruRouteHttpsTunneling() {
-
-    assumeFalse(WEBLOGIC_SLIM, "Skipping RMI Tunnelling Test for slim image");
 
     // Build the standalone JMS Client to send and receive messages
     buildClient();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItExternalNodePortService.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItExternalNodePortService.java
@@ -24,6 +24,7 @@ import oracle.weblogic.domain.Domain;
 import oracle.weblogic.domain.DomainSpec;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.annotations.DisabledOnSlimImage;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -47,7 +48,6 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.OCIR_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.RESULTS_ROOT;
 import static oracle.weblogic.kubernetes.TestConstants.SKIP_CLEANUP;
-import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_SLIM;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
@@ -73,7 +73,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * The use case verifies external RMI client access to WebLogic cluster.
@@ -92,6 +91,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("Test external RMI access through NodePort tunneling")
 @IntegrationTest
+@DisabledOnSlimImage
 class ItExternalNodePortService {
 
   private static String opNamespace = null;
@@ -207,7 +207,6 @@ class ItExternalNodePortService {
   @DisplayName("Verify RMI access to WLS through NodePort Service")
   void testExternalRmiAccessThruNodePortService() {
 
-    assumeFalse(WEBLOGIC_SLIM, "Skipping RMI Tunnelling Test for slim image");
     // Build the standalone JMS Client to send and receive messages
     buildClient();
     buildClientOnPod();


### PR DESCRIPTION
Kind new:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10630/ passed  (full image)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10631/ (slim image)  --just to confirm no test got run

OKD:
https://build.weblogick8s.org:8443/job/wko-okd-test/336 (full image) passed 
https://build.weblogick8s.org:8443/job/wko-okd-test/336 (slim image)  skipped 