### PR TITLE
Clean up event helper unit tests

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
-class NamespaceTest {
+public class NamespaceTest {
   public static final VersionInfo TEST_VERSION_INFO = new VersionInfo().major("1").minor("18").gitVersion("0");
   public static final KubernetesVersion TEST_VERSION = new KubernetesVersion(TEST_VERSION_INFO);
 
@@ -62,7 +62,13 @@ class NamespaceTest {
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final List<Memento> mementos = new ArrayList<>();
   private final Set<String> currentNamespaces = new HashSet<>();
-  private final DomainNamespaces domainNamespaces = new DomainNamespaces(null);
+  private final DomainNamespaces domainNamespaces = createDomainNamespaces();
+
+  @NotNull
+  public static DomainNamespaces createDomainNamespaces() {
+    return new DomainNamespaces(null);
+  }
+
   private final DomainProcessorStub dp = Stub.createNiceStub(DomainProcessorStub.class);
   private final MainDelegateStub delegate = createStrictStub(MainDelegateStub.class, dp, domainNamespaces);
   private final Collection<LogRecord> logRecords = new ArrayList<>();


### PR DESCRIPTION
When a NAMESPACE_WATCHING_STARTED event is generated, onSuccess() method expects a DomainNamespaces object. Some unit test cases in EventHelperTest do not use the right constructor to pass in a DomainNamespaces object, which causes a NPE that is not noticeable unless one runs the test with debugging and steps through the line that causes NPE.  This does not impact the test results because the test only checks if the event was generated and the NPE happened after the event was generated.

This PR changed the unit tests in question to use the constructor that takes a DomainNamespaces object.