### PR TITLE
Use authenticated pull for istio images

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/IstioUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/IstioUtils.java
@@ -51,7 +51,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class IstioUtils {
   private static SemanticVersion installedIstioVersion = new SemanticVersion(ISTIO_VERSION);
-  private static String namespace = "istio-system";
 
   /**
    * Install istio.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/IstioUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/IstioUtils.java
@@ -25,6 +25,7 @@ import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.MonitoringExporterSpecification;
 import oracle.weblogic.domain.OnlineUpdate;
 import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.actions.impl.Namespace;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.SemanticVersion.Compatibility;
@@ -51,12 +52,19 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class IstioUtils {
   private static SemanticVersion installedIstioVersion = new SemanticVersion(ISTIO_VERSION);
+  private static String namespace = "istio-system";
 
   /**
    * Install istio.
    */
   public static void installIstio() {
     LoggingFacade logger = getLogger();
+    try {
+      boolean create = new Namespace().name(namespace).create();
+    } catch (ApiException ex) {
+      logger.warning(ex.getResponseBody());
+    }
+    //ImageUtils.createDockerRegistrySecret(namespace, namespace, namespace, namespace, namespace, namespace);
     Path istioInstallPath =
         Paths.get(RESOURCE_DIR, "bash-scripts", "install-istio.sh");
     String installScript = istioInstallPath.toString();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/IstioUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/IstioUtils.java
@@ -25,7 +25,6 @@ import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.MonitoringExporterSpecification;
 import oracle.weblogic.domain.OnlineUpdate;
 import oracle.weblogic.domain.ServerPod;
-import oracle.weblogic.kubernetes.actions.impl.Namespace;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.SemanticVersion.Compatibility;
@@ -59,12 +58,6 @@ public class IstioUtils {
    */
   public static void installIstio() {
     LoggingFacade logger = getLogger();
-    try {
-      boolean create = new Namespace().name(namespace).create();
-    } catch (ApiException ex) {
-      logger.warning(ex.getResponseBody());
-    }
-    //ImageUtils.createDockerRegistrySecret(namespace, namespace, namespace, namespace, namespace, namespace);
     Path istioInstallPath =
         Paths.get(RESOURCE_DIR, "bash-scripts", "install-istio.sh");
     String installScript = istioInstallPath.toString();

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -35,9 +35,13 @@ kubectl delete namespace istio-system --ignore-not-found
   tar zxf istio.tar.gz
 )
 
+( kubectl create secret generic docker-secret --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=/home/opc/.docker/config.json -n istio-system
+  kubectl get secrets -n istio-system -o yaml
+)
+
 ( cd ${istiodir}
   bin/istioctl x precheck
-  bin/istioctl install --set profile=demo --set hub=gcr.io/istio-release --set meshConfig.enablePrometheusMerge=false -y
+  bin/istioctl install --set profile=demo --set values.global.imagePullSecrets[0]=docker-secret --set meshConfig.enablePrometheusMerge=false -y
   bin/istioctl verify-install
   bin/istioctl version
 )

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 # Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
@@ -35,13 +35,11 @@ kubectl create namespace istio-system
   tar zxf istio.tar.gz
 )
 
-( kubectl create secret generic docker-secret --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=/home/opc/.docker/config.json -n istio-system
-  kubectl get secrets -n istio-system -o yaml
-)
+( kubectl create secret generic docker-istio-secret --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=$HOME/.docker/config.json -n istio-system )
 
 ( cd ${istiodir}
   bin/istioctl x precheck
-  bin/istioctl install --set profile=demo --set values.global.imagePullSecrets[0]=docker-secret --set meshConfig.enablePrometheusMerge=false -y
+  bin/istioctl install --set profile=demo --set values.global.imagePullSecrets[0]=docker-istio-secret --set meshConfig.enablePrometheusMerge=false -y
   bin/istioctl verify-install
   bin/istioctl version
 )

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -27,7 +27,7 @@ istiodir=${workdir}/istio-${version}
 echo "Installing Istio version [${version}] in location [${istiodir}]"
 
 kubectl delete namespace istio-system --ignore-not-found
-# istio installation will create the namespace 'istio-system' 
+# create the namespace 'istio-system' 
 kubectl create namespace istio-system
 
 ( cd $workdir;

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -28,7 +28,7 @@ echo "Installing Istio version [${version}] in location [${istiodir}]"
 
 kubectl delete namespace istio-system --ignore-not-found
 # istio installation will create the namespace 'istio-system' 
-# kubectl create namespace istio-system
+kubectl create namespace istio-system
 
 ( cd $workdir;
   curl -Lo "istio.tar.gz" "https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/istio%2Fistio-${version}-linux-amd64.tar.gz";


### PR DESCRIPTION
The test infra was pulling istio images from google container registry and at times the pull was failing because of registry issues. The fix is to use authenticated pulls from dockerhub, this should not hit the pull limit issue as seen with unauthenticated pulls.

The change from this PR creates a generic secret from file $HOME/.docker/config.json to use for pulling for the images.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10652/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10653/