### PR TITLE
Owls 99380 - Part 2 of the fix for pod roll issue when domain upgraded from 3.4 to 4.0 and conversion webhook pre-created

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -36,12 +36,17 @@ import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.utils.ChecksumUtils;
+import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.AuxiliaryImage;
+import oracle.kubernetes.weblogic.domain.model.AuxiliaryImageEnvVars;
 import oracle.kubernetes.weblogic.domain.model.Domain;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
+import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
+import oracle.kubernetes.weblogic.domain.model.Istio;
+import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 import oracle.kubernetes.weblogic.domain.model.ServerSpec;
 
 import static oracle.kubernetes.operator.ProcessingConstants.COMPATIBILITY_MODE;
@@ -56,10 +61,12 @@ public abstract class JobStepContext extends BasePodStepContext {
   private static final String VOLUME_NAME_SUFFIX = "-volume";
   private static final String CONFIGMAP_TYPE = "cm";
   private static final String SECRET_TYPE = "st";
+  private final WlsDomainConfig domainTopology;
   private V1Job jobModel;
 
   JobStepContext(Packet packet) {
     super(packet.getSpi(DomainPresenceInfo.class));
+    domainTopology = packet.getValue(ProcessingConstants.DOMAIN_TOPOLOGY);
   }
 
   Step getConflictStep(Step next) {
@@ -238,6 +245,130 @@ public abstract class JobStepContext extends BasePodStepContext {
 
   private String getConfigOverrides() {
     return emptyToNull(getDomain().getConfigOverrides());
+  }
+
+  @Override
+  List<V1EnvVar> getConfiguredEnvVars() {
+    // Pod for introspector job would use same environment variables as for admin server
+    List<V1EnvVar> vars =
+        PodHelper.createCopy(getDomain().getAdminServerSpec().getEnvironmentVariables());
+
+    addEnvVar(vars, ServerEnvVars.DOMAIN_UID, getDomainUid());
+    addEnvVar(vars, ServerEnvVars.DOMAIN_HOME, getDomainHome());
+    addEnvVar(vars, ServerEnvVars.NODEMGR_HOME, getNodeManagerHome());
+    addEnvVar(vars, ServerEnvVars.LOG_HOME, getEffectiveLogHome());
+    addEnvVar(vars, ServerEnvVars.SERVER_OUT_IN_POD_LOG, getIncludeServerOutInPodLog());
+    addEnvVar(vars, ServerEnvVars.ACCESS_LOG_IN_LOG_HOME, getHttpAccessLogInLogHome());
+    addEnvVar(vars, IntrospectorJobEnvVars.NAMESPACE, getNamespace());
+    addEnvVar(vars, IntrospectorJobEnvVars.INTROSPECT_HOME, getIntrospectHome());
+    addEnvVar(vars, IntrospectorJobEnvVars.CREDENTIALS_SECRET_NAME, getWebLogicCredentialsSecretName());
+    addEnvVar(vars, IntrospectorJobEnvVars.OPSS_KEY_SECRET_NAME, getOpssWalletPasswordSecretName());
+    addEnvVar(vars, IntrospectorJobEnvVars.OPSS_WALLETFILE_SECRET_NAME, getOpssWalletFileSecretName());
+    addEnvVar(vars, IntrospectorJobEnvVars.RUNTIME_ENCRYPTION_SECRET_NAME, getRuntimeEncryptionSecretName());
+    addEnvVar(vars, IntrospectorJobEnvVars.WDT_DOMAIN_TYPE, getWdtDomainType());
+    addEnvVar(vars, IntrospectorJobEnvVars.DOMAIN_SOURCE_TYPE, getDomainHomeSourceType().toString());
+    addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_ENABLED, Boolean.toString(isIstioEnabled()));
+    addEnvVar(vars, IntrospectorJobEnvVars.ADMIN_CHANNEL_PORT_FORWARDING_ENABLED,
+        Boolean.toString(isAdminChannelPortForwardingEnabled(getDomain().getSpec())));
+    Optional.ofNullable(getKubernetesPlatform())
+        .ifPresent(v -> addEnvVar(vars, ServerEnvVars.KUBERNETES_PLATFORM, v));
+
+    addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_READINESS_PORT, Integer.toString(getIstioReadinessPort()));
+    addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_POD_NAMESPACE, getNamespace());
+    if (isIstioEnabled()) {
+      // Only add the following Istio configuration environment variables when explicitly configured
+      // otherwise the introspection job will needlessly run, after operator upgrade, based on generated
+      // hash code of the set of environment variables.
+      if (!isLocalhostBindingsEnabled()) {
+        addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_USE_LOCALHOST_BINDINGS, "false");
+      }
+
+      if (getIstioReplicationPort() != Istio.DEFAULT_REPLICATION_PORT) {
+        addEnvVar(vars, IntrospectorJobEnvVars.ISTIO_REPLICATION_PORT, Integer.toString(getIstioReplicationPort()));
+      }
+    }
+    if (isUseOnlineUpdate()) {
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_USE_ONLINE_UPDATE, "true");
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_ACTIVATE_TIMEOUT,
+          Long.toString(getDomain().getWDTActivateTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_CONNECT_TIMEOUT,
+          Long.toString(getDomain().getWDTConnectTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_DEPLOY_TIMEOUT,
+          Long.toString(getDomain().getWDTDeployTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_REDEPLOY_TIMEOUT,
+          Long.toString(getDomain().getWDTReDeployTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_UNDEPLOY_TIMEOUT,
+          Long.toString(getDomain().getWDTUnDeployTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_START_APPLICATION_TIMEOUT,
+          Long.toString(getDomain().getWDTStartApplicationTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_STOP_APPLICAITON_TIMEOUT,
+          Long.toString(getDomain().getWDTStopApplicationTimeoutMillis()));
+      addEnvVar(vars, IntrospectorJobEnvVars.MII_WDT_SET_SERVERGROUPS_TIMEOUT,
+          Long.toString(getDomain().getWDTSetServerGroupsTimeoutMillis()));
+    }
+
+    String dataHome = getDataHome();
+    if (dataHome != null && !dataHome.isEmpty()) {
+      addEnvVar(vars, ServerEnvVars.DATA_HOME, dataHome);
+    }
+
+    // Populate env var list used by the MII introspector job's 'short circuit' MD5
+    // check. To prevent a false trip of the circuit breaker, the list must be the
+    // same regardless of whether domainTopology == null.
+    StringBuilder sb = new StringBuilder(vars.size() * 32);
+    for (V1EnvVar var : vars) {
+      sb.append(var.getName()).append(',');
+    }
+    sb.deleteCharAt(sb.length() - 1);
+    addEnvVar(vars, "OPERATOR_ENVVAR_NAMES", sb.toString());
+
+    if (domainTopology != null) {
+      // The domainTopology != null when the job is rerun for the same domain. In which
+      // case we should now know how to contact the admin server, the admin server may
+      // already be running, and the job may want to contact the admin server.
+
+      addEnvVar(vars, "ADMIN_NAME", getAsName());
+      addEnvVar(vars, "ADMIN_PORT", getAsPort().toString());
+      if (isLocalAdminProtocolChannelSecure()) {
+        addEnvVar(vars, "ADMIN_PORT_SECURE", "true");
+      }
+      addEnvVar(vars, "AS_SERVICE_NAME", getAsServiceName());
+    }
+
+    String modelHome = getModelHome();
+    if (modelHome != null && !modelHome.isEmpty()) {
+      addEnvVar(vars, IntrospectorJobEnvVars.WDT_MODEL_HOME, modelHome);
+    }
+
+    String wdtInstallHome = getWdtInstallHome();
+    if (wdtInstallHome != null && !wdtInstallHome.isEmpty()) {
+      addEnvVar(vars, IntrospectorJobEnvVars.WDT_INSTALL_HOME, wdtInstallHome);
+    }
+
+    Optional.ofNullable(getAuxiliaryImagePaths(getServerSpec().getAuxiliaryImages(),
+        getDomain().getAuxiliaryImageVolumes()))
+        .ifPresent(c -> addEnvVar(vars, AuxiliaryImageEnvVars.AUXILIARY_IMAGE_PATHS, c));
+    return vars;
+  }
+
+  private boolean isLocalAdminProtocolChannelSecure() {
+    return domainTopology
+        .getServerConfig(getAsName())
+        .isLocalAdminProtocolChannelSecure();
+  }
+
+  private String getAsServiceName() {
+    return LegalNames.toServerServiceName(getDomainUid(), getAsName());
+  }
+
+  private Integer getAsPort() {
+    return domainTopology
+        .getServerConfig(getAsName())
+        .getLocalAdminProtocolChannelPort();
+  }
+
+  private String getAsName() {
+    return domainTopology.getAdminServerName();
   }
 
   private long getIntrospectorJobActiveDeadlineSeconds(TuningParameters.PodTuning podTuning) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -415,9 +415,9 @@ public class PodHelper {
     }
 
     @Override
-    List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
+    List<V1EnvVar> getConfiguredEnvVars() {
       List<V1EnvVar> vars = createCopy(getServerSpec().getEnvironmentVariables());
-      addStartupEnvVars(vars, tuningParameters);
+      addStartupEnvVars(vars);
       return vars;
     }
 
@@ -574,11 +574,11 @@ public class PodHelper {
 
     @Override
     @SuppressWarnings("unchecked")
-    List<V1EnvVar> getConfiguredEnvVars(TuningParameters tuningParameters) {
+    List<V1EnvVar> getConfiguredEnvVars() {
       List<V1EnvVar> envVars = createCopy((List<V1EnvVar>) packet.get(ProcessingConstants.ENVVARS));
 
       List<V1EnvVar> vars = new ArrayList<>(envVars);
-      addStartupEnvVars(vars, tuningParameters);
+      addStartupEnvVars(vars);
       return vars;
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -889,10 +889,10 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   private List<V1Volume> getVolumes(String domainUid) {
     List<V1Volume> volumes = PodDefaults.getStandardVolumes(domainUid, getNumIntrospectorConfigMaps());
-    volumes.addAll(getServerSpec().getAdditionalVolumes());
     if (getDomainHomeSourceType() == DomainSourceType.FromModel) {
       volumes.add(createRuntimeEncryptionSecretVolume());
     }
+    volumes.addAll(getServerSpec().getAdditionalVolumes());
 
     return volumes;
   }
@@ -947,10 +947,10 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   private List<V1VolumeMount> getVolumeMounts() {
     List<V1VolumeMount> mounts = PodDefaults.getStandardVolumeMounts(getDomainUid(), getNumIntrospectorConfigMaps());
-    mounts.addAll(getServerSpec().getAdditionalVolumeMounts());
     if (getDomainHomeSourceType() == DomainSourceType.FromModel) {
       mounts.add(createRuntimeEncryptionSecretVolumeMount());
     }
+    mounts.addAll(getServerSpec().getAdditionalVolumeMounts());
     return mounts;
   }
 
@@ -968,7 +968,7 @@ public abstract class PodStepContext extends BasePodStepContext {
    * Sets the environment variables used by operator/src/main/resources/scripts/startServer.sh
    * @param vars a list to which new variables are to be added
    */
-  void addStartupEnvVars(List<V1EnvVar> vars, TuningParameters tuningParameters) {
+  void addStartupEnvVars(List<V1EnvVar> vars) {
     addEnvVar(vars, ServerEnvVars.DOMAIN_NAME, getDomainName());
     addEnvVar(vars, ServerEnvVars.DOMAIN_HOME, getDomainHome());
     addEnvVar(vars, ServerEnvVars.ADMIN_NAME, getAsName());
@@ -993,7 +993,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     }
     Optional.ofNullable(getServerSpec().getAuxiliaryImages()).ifPresent(cm -> addAuxiliaryImageEnv(cm, vars));
     addEnvVarIfTrue(mockWls(), vars, "MOCK_WLS");
-    Optional.ofNullable(getKubernetesPlatform(tuningParameters)).ifPresent(v ->
+    Optional.ofNullable(getKubernetesPlatform()).ifPresent(v ->
             addEnvVar(vars, ServerEnvVars.KUBERNETES_PLATFORM, v));
   }
 
@@ -1141,10 +1141,6 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   private boolean mockWls() {
     return Boolean.getBoolean("mockWLS");
-  }
-
-  private String getKubernetesPlatform(TuningParameters tuningParameters) {
-    return tuningParameters.getKubernetesPlatform();
   }
 
   private abstract class BaseStep extends Step {


### PR DESCRIPTION
OWLS-99380 - This is part 2 of the fix for pod roll issue when domain is upgraded from 3.4 to 4.0 and conversion webhook is pre-created using webhookOnly option. See PR https://github.com/oracle/weblogic-kubernetes-operator/pull/3085 for part 1.

This PR backports some of the changes from 4.0 release and creates the volume, volume mounts and some environment variables in a specific order after the auxiliary images are converted to raw init-containers, volume and mounts by the pre-created conversion webhook.

Integration test results -
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10674/
