### PR TITLE
Always replace existing validating webhook configuration

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/WebhookHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/WebhookHelper.java
@@ -5,7 +5,6 @@ package oracle.kubernetes.operator.helpers;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -84,11 +83,9 @@ public class WebhookHelper {
   static class ValidatingWebhookConfigurationContext {
     private final Step conflictStep;
     private final V1ValidatingWebhookConfiguration model;
-    private final Certificates certificates;
 
     ValidatingWebhookConfigurationContext(Step conflictStep, Certificates certificates) {
       this.conflictStep = conflictStep;
-      this.certificates = certificates;
       this.model = createModel(certificates);
     }
 
@@ -177,26 +174,9 @@ public class WebhookHelper {
         V1ValidatingWebhookConfiguration existingWebhookConfig = callResponse.getResult();
         if (existingWebhookConfig == null) {
           return doNext(createValidatingWebhookConfiguration(getNext()), packet);
-        } else if (shouldUpdate(existingWebhookConfig, model)) {
-          return doNext(replaceValidatingWebhookConfiguration(getNext(), existingWebhookConfig), packet);
         } else {
-          return doNext(packet);
+          return doNext(replaceValidatingWebhookConfiguration(getNext(), existingWebhookConfig), packet);
         }
-      }
-
-      private boolean shouldUpdate(V1ValidatingWebhookConfiguration existingWebhookConfig,
-                                   V1ValidatingWebhookConfiguration model) {
-        return !getServiceNamespaceFromConfig(existingWebhookConfig).equals(getServiceNamespaceFromConfig(model));
-      }
-
-      private Object getServiceNamespaceFromConfig(V1ValidatingWebhookConfiguration webhookConfig) {
-        return getServiceNamespace(getFirstWebhook(webhookConfig));
-      }
-
-      private String getServiceNamespace(V1ValidatingWebhook webhook) {
-        return Optional.ofNullable(webhook).map(V1ValidatingWebhook::getClientConfig)
-            .map(AdmissionregistrationV1WebhookClientConfig::getService)
-            .map(AdmissionregistrationV1ServiceReference::getNamespace).orElse("");
       }
 
       private Step createValidatingWebhookConfiguration(Step next) {
@@ -214,42 +194,8 @@ public class WebhookHelper {
       }
 
       private V1ValidatingWebhookConfiguration updateModel(V1ValidatingWebhookConfiguration existing) {
-        setServiceNamespace(existing);
-        setCaBundle(existing);
-        return existing;
-      }
-
-      private void setServiceNamespace(V1ValidatingWebhookConfiguration existing) {
-        Optional.ofNullable(getServiceFromConfig(existing)).ifPresent(s -> s.namespace(getWebhookNamespace()));
-      }
-
-      private void setCaBundle(V1ValidatingWebhookConfiguration existing) {
-        Optional.ofNullable(getClientConfig(existing)).ifPresent(s -> s.caBundle(getCaBundle(certificates)));
-      }
-
-      private AdmissionregistrationV1ServiceReference getServiceFromConfig(
-          V1ValidatingWebhookConfiguration webhookConfig) {
-        return Optional.ofNullable(getClientConfig(webhookConfig))
-            .map(AdmissionregistrationV1WebhookClientConfig::getService)
-            .orElse(null);
-      }
-
-      private AdmissionregistrationV1WebhookClientConfig getClientConfig(
-          V1ValidatingWebhookConfiguration webhookConfig) {
-        return Optional.ofNullable(getFirstWebhook(webhookConfig))
-            .map(V1ValidatingWebhook::getClientConfig)
-            .orElse(null);
-      }
-
-      private V1ValidatingWebhook getFirstWebhook(V1ValidatingWebhookConfiguration webhookConfig) {
-        return Optional.of(webhookConfig)
-            .map(V1ValidatingWebhookConfiguration::getWebhooks)
-            .map(this::getFirstWebhook)
-            .orElse(null);
-      }
-
-      private V1ValidatingWebhook getFirstWebhook(List<V1ValidatingWebhook> l) {
-        return l.isEmpty() ? null : l.get(0);
+        model.setMetadata(existing.getMetadata());
+        return model;
       }
 
       @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
@@ -9,6 +9,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,8 +33,6 @@ import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
 import oracle.kubernetes.operator.helpers.OnConflictRetryStrategyStub;
 import oracle.kubernetes.operator.helpers.SemanticVersion;
-import oracle.kubernetes.operator.rest.RestConfig;
-import oracle.kubernetes.operator.rest.backend.RestBackend;
 import oracle.kubernetes.operator.steps.InitializeWebhookIdentityStep;
 import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.operator.utils.Certificates;
@@ -110,6 +109,27 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"})
   private static Function<String, Path> getInMemoryPath = inMemoryFileSystem::getPath;
   private final OnConflictRetryStrategyStub retryStrategy = createStrictStub(OnConflictRetryStrategyStub.class);
+
+  private final byte[] testCaBundle = new byte[] { (byte)0xe0, 0x4f, (byte)0xd0,
+      0x20, (byte)0xea, 0x3a, 0x69, 0x10, (byte)0xa2, (byte)0xd8, 0x08, 0x00, 0x2b,
+      0x30, 0x30, (byte)0x9d };
+
+  private final V1ValidatingWebhookConfiguration testValidatingWebhookConfig
+      = new V1ValidatingWebhookConfiguration()
+      .metadata(createNameOnlyMetadata())
+      .addWebhooksItem(createValidatingWebhook());
+
+  private V1ValidatingWebhook createValidatingWebhook() {
+    return new V1ValidatingWebhook().clientConfig(createWebhookClientConfig());
+  }
+
+  private AdmissionregistrationV1WebhookClientConfig createWebhookClientConfig() {
+    return new AdmissionregistrationV1WebhookClientConfig().service(createServiceReference()).caBundle(testCaBundle);
+  }
+
+  private AdmissionregistrationV1ServiceReference createServiceReference() {
+    return new AdmissionregistrationV1ServiceReference().namespace("ns1");
+  }
 
   static {
     buildProperties = new PropertiesBuilder()
@@ -237,8 +257,7 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   void whenValidatingWebhookCreated_logStartupMessage() {
     loggerControl.withLogLevel(Level.INFO).collectLogMessages(logRecords, VALIDATING_WEBHOOK_CONFIGURATION_CREATED);
 
-    WebhookMain main = new WebhookMain(delegate);
-    main.startDeployment(null);
+    testSupport.runSteps(main.createStartupSteps());
 
     assertThat(testSupport.getResources(VALIDATING_WEBHOOK_CONFIGURATION), notNullValue());
     assertThat(logRecords,
@@ -247,9 +266,7 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
 
   @Test
   void whenValidatingWebhookCreated_foundExpectedContents() {
-    WebhookMain main = new WebhookMain(delegate);
-
-    main.startDeployment(null);
+    testSupport.runSteps(main.createStartupSteps());
 
     logRecords.clear();
     V1ValidatingWebhookConfiguration generatedConfiguration = getCreatedValidatingWebhookConfiguration();
@@ -264,16 +281,10 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenValidatingWebhookCreatedWithClientServiceDifferentNamespace_replaceIt() {
-    V1ValidatingWebhookConfiguration resource
-        = new V1ValidatingWebhookConfiguration().metadata(createNameOnlyMetadata(VALIDATING_WEBHOOK_NAME))
-        .addWebhooksItem(new V1ValidatingWebhook().clientConfig(new AdmissionregistrationV1WebhookClientConfig()
-            .service(new AdmissionregistrationV1ServiceReference().namespace("ns1"))));
-    testSupport.defineResources(resource);
+  void whenValidatingWebhookCreatedAgainWithDifferentNamespace_replaceIt() {
+    testSupport.defineResources(testValidatingWebhookConfig);
 
-    WebhookMain main = new WebhookMain(delegate);
-
-    main.startDeployment(null);
+    testSupport.runSteps(main.createStartupSteps());
 
     logRecords.clear();
     V1ValidatingWebhookConfiguration generatedConfiguration = getCreatedValidatingWebhookConfiguration();
@@ -283,12 +294,27 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   }
 
   @Test
+  void whenValidatingWebhookCreatedAgainWithSameNamespaceDifferentCABundle_replaceIt() {
+    testSupport.defineResources(testValidatingWebhookConfig);
+
+    testSupport.runSteps(main.createStartupSteps());
+
+    logRecords.clear();
+    V1ValidatingWebhookConfiguration generatedConfiguration = getCreatedValidatingWebhookConfiguration();
+
+    assertThat(getName(generatedConfiguration), equalTo(VALIDATING_WEBHOOK_NAME));
+    assertThat(getCaBundle(generatedConfiguration), not(equalTo(testCaBundle)));
+    assertThat(getCreatedValidatingWebhookConfigurationCount(), equalTo(1));
+  }
+
+  @Test
   void whenValidatingWebhookCreatedAfterFailure401_logStartupMessage() {
+    testSupport.addRetryStrategy(retryStrategy);
     loggerControl.withLogLevel(Level.INFO).collectLogMessages(logRecords, VALIDATING_WEBHOOK_CONFIGURATION_CREATED);
 
-    testSupport.failOnCreate(VALIDATING_WEBHOOK_CONFIGURATION, VALIDATING_WEBHOOK_NAME, 401);
-    WebhookMain main = new WebhookMain(delegate);
-    main.startDeployment(null);
+    testSupport.failOnCreate(VALIDATING_WEBHOOK_CONFIGURATION, null, 401);
+
+    testSupport.runSteps(main.createStartupSteps());
 
     assertThat(testSupport.getResources(VALIDATING_WEBHOOK_CONFIGURATION), notNullValue());
     assertThat(logRecords,
@@ -296,28 +322,21 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenValidatingWebhookCreatedWithClientServiceDifferentNamespaceAfterFailure401_replaceIt() {
-    byte[] caBundle = new byte[] { (byte)0xe0, 0x4f, (byte)0xd0,
-        0x20, (byte)0xea, 0x3a, 0x69, 0x10, (byte)0xa2, (byte)0xd8, 0x08, 0x00, 0x2b,
-        0x30, 0x30, (byte)0x9d };
-    V1ValidatingWebhookConfiguration resource
-        = new V1ValidatingWebhookConfiguration().metadata(createNameOnlyMetadata(VALIDATING_WEBHOOK_NAME))
-        .addWebhooksItem(new V1ValidatingWebhook().clientConfig(new AdmissionregistrationV1WebhookClientConfig()
-            .caBundle(caBundle)
-            .service(new AdmissionregistrationV1ServiceReference().namespace("ns1"))));
-    testSupport.defineResources(resource);
+  void whenValidatingWebhookCreatedAgainAfterFailure401onReplace_replaceItOnRetry() {
+    testSupport.addRetryStrategy(retryStrategy);
+
+    testSupport.defineResources(testValidatingWebhookConfig);
     testSupport.failOnReplace(VALIDATING_WEBHOOK_CONFIGURATION, VALIDATING_WEBHOOK_NAME, null, 401);
 
-    WebhookMain main = new WebhookMain(delegate);
-
-    main.startDeployment(null);
+    testSupport.runSteps(main.createStartupSteps());
 
     logRecords.clear();
     V1ValidatingWebhookConfiguration generatedConfiguration = getCreatedValidatingWebhookConfiguration();
 
     assertThat(getName(generatedConfiguration), equalTo(VALIDATING_WEBHOOK_NAME));
-    assertThat(getCaBundle(generatedConfiguration), not(equalTo(caBundle)));
+    assertThat(getCaBundle(generatedConfiguration), not(equalTo(testCaBundle)));
     assertThat(getServiceNamespace(generatedConfiguration), equalTo(getWebhookNamespace()));
+    assertThat(getCreatedValidatingWebhookConfigurationCount(), equalTo(1));
   }
 
   @Test
@@ -327,7 +346,6 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
 
     testSupport.failOnCreate(VALIDATING_WEBHOOK_CONFIGURATION, null, 400);
 
-    WebhookMain main = new WebhookMain(delegate);
     testSupport.runSteps(main.createStartupSteps());
 
     assertThat(testSupport.getResources(VALIDATING_WEBHOOK_CONFIGURATION), notNullValue());
@@ -338,14 +356,10 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   @Test
   void whenValidatingWebhookCreatedWithClientServiceDifferentNamespaceAfterFailure404_replaceIt() {
     testSupport.addRetryStrategy(retryStrategy);
-    V1ValidatingWebhookConfiguration resource
-        = new V1ValidatingWebhookConfiguration().metadata(createNameOnlyMetadata(VALIDATING_WEBHOOK_NAME))
-        .addWebhooksItem(new V1ValidatingWebhook().clientConfig(new AdmissionregistrationV1WebhookClientConfig()
-            .service(new AdmissionregistrationV1ServiceReference().namespace("ns1"))));
-    testSupport.defineResources(resource);
+
+    testSupport.defineResources(testValidatingWebhookConfig);
     testSupport.failOnReplace(VALIDATING_WEBHOOK_CONFIGURATION, VALIDATING_WEBHOOK_NAME, null, 404);
 
-    WebhookMain main = new WebhookMain(delegate);
     testSupport.runSteps(main.createStartupSteps());
 
     logRecords.clear();
@@ -355,39 +369,40 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
     assertThat(getServiceNamespace(generatedConfiguration), equalTo(getWebhookNamespace()));
   }
 
-  private V1ObjectMeta createNameOnlyMetadata(String name) {
-    return new V1ObjectMeta().name(name);
+  private V1ObjectMeta createNameOnlyMetadata() {
+    return new V1ObjectMeta().name(VALIDATING_WEBHOOK_NAME);
   }
 
-  @Nullable
   private String getName(V1ValidatingWebhookConfiguration configuration) {
-    return configuration.getMetadata().getName();
+    return Optional.ofNullable(configuration)
+        .map(V1ValidatingWebhookConfiguration::getMetadata)
+        .map(V1ObjectMeta::getName)
+        .orElse("");
   }
 
-  @Nullable
   private Map<String, String> getLabels(V1ValidatingWebhookConfiguration configuration) {
-    return configuration.getMetadata().getLabels();
+    return Optional.ofNullable(configuration)
+        .map(V1ValidatingWebhookConfiguration::getMetadata)
+        .map(V1ObjectMeta::getLabels)
+        .orElse(new HashMap<>());
   }
 
-  @Nullable
   private String getServiceNamespace(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
+    return Optional.ofNullable(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
         .map(AdmissionregistrationV1WebhookClientConfig::getService)
         .map(AdmissionregistrationV1ServiceReference::getNamespace)
         .orElse("");
   }
 
-  @Nullable
   private Integer getServicePort(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
+    return Optional.ofNullable(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
         .map(AdmissionregistrationV1WebhookClientConfig::getService)
         .map(AdmissionregistrationV1ServiceReference::getPort)
         .orElse(0);
   }
 
-  @Nullable
   private String getServicePath(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
+    return Optional.ofNullable(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
         .map(AdmissionregistrationV1WebhookClientConfig::getService)
         .map(AdmissionregistrationV1ServiceReference::getPath)
         .orElse("");
@@ -395,22 +410,31 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
 
   @Nullable
   private V1ValidatingWebhook getFirstWebhook(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(configuration).map(V1ValidatingWebhookConfiguration::getWebhooks).get().get(0);
+    return (V1ValidatingWebhook) Optional.of(configuration)
+        .map(V1ValidatingWebhookConfiguration::getWebhooks)
+        .map(this::getFirstElement)
+        .orElse(null);
   }
 
   @Nullable
   private V1RuleWithOperations getFirstRule(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getRules).get().get(0);
+    return (V1RuleWithOperations) Optional.ofNullable(getFirstWebhook(configuration))
+        .map(V1ValidatingWebhook::getRules)
+        .map(this::getFirstElement)
+        .orElse(null);
   }
 
-  @Nullable
   private String getRuleOperation(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstRule(configuration)).map(V1RuleWithOperations::getOperations).get().get(0);
+    return (String) Optional.ofNullable(getFirstRule(configuration))
+        .map(V1RuleWithOperations::getOperations).map(this::getFirstElement).orElse(null);
   }
 
-  @Nullable
+  private <T> Object getFirstElement(List<T> l) {
+    return l.isEmpty() ? null : l.get(0);
+  }
+
   private String getServiceName(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
+    return Optional.ofNullable(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
         .map(AdmissionregistrationV1WebhookClientConfig::getService)
         .map(AdmissionregistrationV1ServiceReference::getName)
         .orElse("");
@@ -418,7 +442,7 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
 
   @Nullable
   private byte[] getCaBundle(V1ValidatingWebhookConfiguration configuration) {
-    return Optional.of(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
+    return Optional.ofNullable(getFirstWebhook(configuration)).map(V1ValidatingWebhook::getClientConfig)
         .map(AdmissionregistrationV1WebhookClientConfig::getCaBundle)
         .orElse(null);
   }
@@ -426,6 +450,10 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   V1ValidatingWebhookConfiguration getCreatedValidatingWebhookConfiguration() {
     return (V1ValidatingWebhookConfiguration)
         testSupport.getResources(VALIDATING_WEBHOOK_CONFIGURATION).get(0);
+  }
+
+  int getCreatedValidatingWebhookConfigurationCount() {
+    return testSupport.getResources(VALIDATING_WEBHOOK_CONFIGURATION).size();
   }
 
   public abstract static class WebhookMainDelegateStub implements WebhookMainDelegate {
@@ -485,99 +513,5 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
 
   public static Certificates getCertificates() {
     return new Certificates(new CoreDelegateImpl(buildProperties, null));
-  }
-
-  static class RestConfigStub implements RestConfig {
-    private final Certificates certificates;
-
-    RestConfigStub(Certificates certificates) {
-      this.certificates = certificates;
-    }
-
-    @Override
-    public String getHost() {
-      return null;
-    }
-
-    @Override
-    public int getExternalHttpsPort() {
-      return 0;
-    }
-
-    @Override
-    public int getInternalHttpsPort() {
-      return 0;
-    }
-
-    @Override
-    public int getWebhookHttpsPort() {
-      return 0;
-    }
-
-    @Override
-    public String getOperatorExternalCertificateData() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorInternalCertificateData() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorExternalCertificateFile() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorInternalCertificateFile() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorExternalKeyData() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorInternalKeyData() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorExternalKeyFile() {
-      return null;
-    }
-
-    @Override
-    public String getOperatorInternalKeyFile() {
-      return null;
-    }
-
-    @Override
-    public RestBackend getBackend(String accessToken) {
-      return null;
-    }
-
-    @Override
-    public String getWebhookCertificateData() {
-      return certificates.getWebhookCertificateData();
-    }
-
-    @Override
-    public String getWebhookCertificateFile() {
-      return null;
-    }
-
-    @Override
-    public String getWebhookKeyData() {
-      return null;
-    }
-
-    @Override
-    public String getWebhookKeyFile() {
-      return certificates.getWebhookKeyFilePath();
-    }
-
   }
 }


### PR DESCRIPTION
Currently, WebhookHelper only replaces an existing ValidatingWebhookConfiguration when the namespaces do not match. It turned out that we need to update the configuration even when namespaces are the same because the caBundle may become stale if the certificates are recreated upon a restart of the webhook. While I was adding a new test case for the condition that the change is fixing, I did some refactoring plus cleanup in WebhookMainTest.