### PR TITLE
Owls 99654 - Expand the WDT custom folder from the archive before calling update or create domain

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -894,15 +894,7 @@ function wdtCreatePrimordialDomain() {
 
   trace "About to call '${WDT_BINDIR}/createDomain.sh ${wdtArgs}'."
 
-  trace "DEBUG: WLSDEPLOY_PROPERTIES is ${WLSDEPLOY_PROPERTIES}"
-
-  cd ${DOMAIN_HOME} || exitOrLoop
-  for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
-    do
-        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
-    done
-
-  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
+  expandWdtArchiveCustomDir
 
   if [ -z "${OPSS_FLAGS}" ]; then
 
@@ -992,15 +984,8 @@ function wdtUpdateModelDomain() {
   wdtArgs+=" ${UPDATE_RCUPWD_FLAG}"
 
   trace "About to call '${WDT_BINDIR}/updateDomain.sh ${wdtArgs}'."
-  trace "DEBUG: WLSDEPLOY_PROPERTIES is ${WLSDEPLOY_PROPERTIES}"
 
-  cd ${DOMAIN_HOME} || exitOrLoop
-  for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
-    do
-        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
-    done
-
-  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
+  expandWdtArchiveCustomDir
 
   ${WDT_BINDIR}/updateDomain.sh ${wdtArgs} > ${WDT_OUTPUT} 2>&1
   ret=$?
@@ -1394,4 +1379,15 @@ function wdtRotateAndCopyLogFile() {
   logFileRotate "${WDT_OUTPUT_DIR}/${logFileName}" "${WDT_LOG_FILE_MAX:-11}"
 
   cp ${WDT_ROOT}/logs/${logFileName} ${WDT_OUTPUT_DIR}/
+}
+
+# Function to expand the WDT custom folder from the archive before calling update or create domain.
+function expandWdtArchiveCustomDir() {
+  cd ${DOMAIN_HOME} || exitOrLoop
+  for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
+    do
+        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
+    done
+
+  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
 }

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -894,6 +894,16 @@ function wdtCreatePrimordialDomain() {
 
   trace "About to call '${WDT_BINDIR}/createDomain.sh ${wdtArgs}'."
 
+  trace "Operator DEBUG: WLSDEPLOY_PROPERTIES is ${WLSDEPLOY_PROPERTIES}"
+
+  cd ${DOMAIN_HOME} || exitOrLoop
+  for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
+    do
+        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
+    done
+
+  traceDirs before $IMG_ARCHIVES_ROOTDIR
+
   if [ -z "${OPSS_FLAGS}" ]; then
 
     # We get here for WLS domains, and for the JRF 'first time' case
@@ -982,6 +992,15 @@ function wdtUpdateModelDomain() {
   wdtArgs+=" ${UPDATE_RCUPWD_FLAG}"
 
   trace "About to call '${WDT_BINDIR}/updateDomain.sh ${wdtArgs}'."
+  trace "DEBUG: WLSDEPLOY_PROPERTIES is ${WLSDEPLOY_PROPERTIES}"
+
+  cd ${DOMAIN_HOME} || exitOrLoop
+  for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
+    do
+        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
+    done
+
+  traceDirs before ${DOMAIN_HOME}/wlsdeploy
 
   ${WDT_BINDIR}/updateDomain.sh ${wdtArgs} > ${WDT_OUTPUT} 2>&1
   ret=$?

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -894,7 +894,7 @@ function wdtCreatePrimordialDomain() {
 
   trace "About to call '${WDT_BINDIR}/createDomain.sh ${wdtArgs}'."
 
-  trace "Operator DEBUG: WLSDEPLOY_PROPERTIES is ${WLSDEPLOY_PROPERTIES}"
+  trace "DEBUG: WLSDEPLOY_PROPERTIES is ${WLSDEPLOY_PROPERTIES}"
 
   cd ${DOMAIN_HOME} || exitOrLoop
   for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
@@ -902,7 +902,7 @@ function wdtCreatePrimordialDomain() {
         ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
     done
 
-  traceDirs before $IMG_ARCHIVES_ROOTDIR
+  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
 
   if [ -z "${OPSS_FLAGS}" ]; then
 
@@ -1000,7 +1000,7 @@ function wdtUpdateModelDomain() {
         ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
     done
 
-  traceDirs before ${DOMAIN_HOME}/wlsdeploy
+  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
 
   ${WDT_BINDIR}/updateDomain.sh ${wdtArgs} > ${WDT_OUTPUT} 2>&1
   ret=$?

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -101,6 +101,7 @@ function traceEnv() {
     INTROSPECT_HOME \
     PATH \
     TRACE_TIMING \
+    WLSDEPLOY_PROPERTIES \
     OPERATOR_ENVVAR_NAMES
   do
     echo "    ${env_var}='${!env_var}'"


### PR DESCRIPTION
Creating this draft PR for Owls 99654. This change expands the custom folder from the WDT archive in the domain dir before calling updateDomain.sh or createDomain.sh. Once we find out the correct operator version, I will create and push a debug image based on this change to OCIR or provide a tar file to verify the fix.