### PR TITLE
Backport fix for OWLS-96080 to 3.4 branch

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -408,14 +408,15 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
     }
   }
 
-  static class DeadlineExceededException extends Exception {
+  public static class DeadlineExceededException extends Exception {
     final V1Job job;
 
-    DeadlineExceededException(V1Job job) {
+    public DeadlineExceededException(V1Job job) {
       super();
       this.job = job;
     }
 
+    @Override
     public String toString() {
       return LOGGER.formatMessage(
           MessageKeys.JOB_DEADLINE_EXCEEDED_MESSAGE,

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -192,7 +192,18 @@ public abstract class ResponseStep<T> extends Step {
   }
 
   protected NextAction onFailureNoRetry(Packet packet, CallResponse<T> callResponse) {
-    return doTerminate(UnrecoverableErrorBuilder.createExceptionFromFailedCall(callResponse), packet);
+    return doTerminate(createTerminationException(packet, callResponse), packet);
+  }
+
+  /**
+   * Create an exception to be passed to the doTerminate call.
+   *
+   * @param packet Packet for creating the exception
+   * @param callResponse CallResponse for creating the exception
+   * @return An Exception to be passed to the doTerminate call
+   */
+  protected Throwable createTerminationException(Packet packet, CallResponse<T> callResponse) {
+    return UnrecoverableErrorBuilder.createExceptionFromFailedCall(callResponse);
   }
 
   protected boolean isNotAuthorizedOrForbidden(CallResponse<T> callResponse) {

--- a/operator/src/main/java/oracle/kubernetes/operator/work/FiberGate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/FiberGate.java
@@ -109,14 +109,20 @@ public class FiberGate {
         new CompletionCallback() {
           @Override
           public void onCompletion(Packet packet) {
-            gateMap.remove(key, f);
-            callback.onCompletion(packet);
+            try {
+              callback.onCompletion(packet);
+            } finally {
+              gateMap.remove(key, f);
+            }
           }
 
           @Override
           public void onThrowable(Packet packet, Throwable throwable) {
-            gateMap.remove(key, f);
-            callback.onThrowable(packet, throwable);
+            try {
+              callback.onThrowable(packet, throwable);
+            } finally {
+              gateMap.remove(key, f);
+            }
           }
         });
     return f;


### PR DESCRIPTION
Backport to 3.4 branch the fix for OWLS-96080 - Updated handling of introspector job pod that has failed with `DeadlineExceeded` reason to be the same as that for failed introspector job with the same reason, ie, terminate fiber with `JobWatcher.DeadlineExceeded` exception. (see[ PR 3066](https://github.com/oracle/weblogic-kubernetes-operator/pull/3066/))

This includes backport of fixes to FiberGate.java from [PR 2613](https://github.com/oracle/weblogic-kubernetes-operator/pull/2613).

jenkins:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10758/

test results from release/3.4 branch for comparison:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10759/