### PR TITLE
Owls 99654 - Expand the WDT custom folder from the archive before calling update or create domain

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -894,6 +894,8 @@ function wdtCreatePrimordialDomain() {
 
   trace "About to call '${WDT_BINDIR}/createDomain.sh ${wdtArgs}'."
 
+  expandWdtArchiveCustomDir
+
   if [ -z "${OPSS_FLAGS}" ]; then
 
     # We get here for WLS domains, and for the JRF 'first time' case
@@ -982,6 +984,8 @@ function wdtUpdateModelDomain() {
   wdtArgs+=" ${UPDATE_RCUPWD_FLAG}"
 
   trace "About to call '${WDT_BINDIR}/updateDomain.sh ${wdtArgs}'."
+
+  expandWdtArchiveCustomDir
 
   ${WDT_BINDIR}/updateDomain.sh ${wdtArgs} > ${WDT_OUTPUT} 2>&1
   ret=$?
@@ -1377,4 +1381,15 @@ function wdtRotateAndCopyLogFile() {
   logFileRotate "${WDT_OUTPUT_DIR}/${logFileName}" "${WDT_LOG_FILE_MAX:-11}"
 
   cp ${WDT_ROOT}/logs/${logFileName} ${WDT_OUTPUT_DIR}/
+}
+
+# Function to expand the WDT custom folder from the archive before calling update or create domain.
+function expandWdtArchiveCustomDir() {
+  cd ${DOMAIN_HOME} || exitOrLoop
+  for file in $(sort_files ${IMG_ARCHIVES_ROOTDIR} "*.zip")
+    do
+        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
+    done
+
+  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
 }

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -101,6 +101,7 @@ function traceEnv() {
     INTROSPECT_HOME \
     PATH \
     TRACE_TIMING \
+    WLSDEPLOY_PROPERTIES \
     OPERATOR_ENVVAR_NAMES
   do
     echo "    ${env_var}='${!env_var}'"


### PR DESCRIPTION
Owls 99654 fix - This change expands the custom folder from the WDT archive in the domain dir before calling updateDomain.sh or createDomain.sh. This PR replaces PR #3108 which has 3.3 as the base release.