### PR TITLE
Metrics2

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -20,9 +20,9 @@ spec:
   replicas: 1
   template:
     metadata:
-      {{- with .annotations }}
       annotations:
-      {{- end }}
+        prometheus.io/port: 8083
+        prometheus.io/scrape: 'true'
       {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
@@ -208,9 +208,9 @@ spec:
       replicas: 1
       template:
         metadata:
-          {{- with .annotations }}
           annotations:
-          {{- end }}
+            prometheus.io/port: '8083'
+            prometheus.io/scrape: 'true'
           {{- range $key, $value := .annotations }}
             {{ $key }}: {{ $value | quote }}
           {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: 8083
+        prometheus.io/port: '8083'
         prometheus.io/scrape: 'true'
       {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-internal-svc.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-internal-svc.tpl
@@ -18,6 +18,9 @@ spec:
     - port: 8082
       name: "rest"
       appProtocol: https
+    - port: 8083
+      name: "metrics"
+      appProtocol: http
 ---
 apiVersion: "v1"
 kind: "Service"
@@ -31,6 +34,9 @@ spec:
   selector:
     app: "weblogic-operator-webhook"
   ports:
+    - port: 8083
+      name: "metrics"
+      appProtocol: http
     - port: 8084
       name: "restwebhook"
       appProtocol: https

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -99,7 +99,7 @@
             <configuration>
               <includeScope>runtime</includeScope>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
-              <excludeGroupIds>io.prometheus,com.google.protobuf</excludeGroupIds>
+              <excludeGroupIds>com.google.protobuf</excludeGroupIds>
               <excludeArtifactIds>kotlin-stdlib-jdk7,kotlin-stdlib-jdk8</excludeArtifactIds>
             </configuration>
           </execution>
@@ -306,6 +306,18 @@
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.grizzly</groupId>
+      <artifactId>grizzly-http-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet_jakarta</artifactId>
     </dependency>
 
     <dependency>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -319,6 +319,10 @@
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet_jakarta</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/operator/src/main/java/oracle/kubernetes/operator/OperatorMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/OperatorMain.java
@@ -179,8 +179,8 @@ public class OperatorMain extends BaseMain {
       // now we just wait until the pod is terminated
       operatorMain.waitForDeath();
 
-      // stop the REST server
       operatorMain.stopRestServer();
+      operatorMain.stopMetricsServer();
     } finally {
       LOGGER.info(MessageKeys.OPERATOR_SHUTTING_DOWN);
     }
@@ -277,7 +277,7 @@ public class OperatorMain extends BaseMain {
 
   private void completeBegin() {
     try {
-      // start the REST server
+      startMetricsServer(container);
       startRestServer(container);
 
       // start periodic retry and recheck

--- a/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
@@ -81,8 +81,8 @@ public class WebhookMain extends BaseMain {
       // now we just wait until the pod is terminated
       main.waitForDeath();
 
-      // stop the webhook REST server
       main.stopRestServer();
+      main.stopMetricsServer();
     } finally {
       LOGGER.info(MessageKeys.WEBHOOK_SHUTTING_DOWN);
     }
@@ -117,7 +117,7 @@ public class WebhookMain extends BaseMain {
 
   void completeBegin() {
     try {
-      // start the conversion webhook REST server
+      startMetricsServer(container);
       startRestServer(container);
 
       // start periodic recheck of CRD

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/AnnotationHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -38,7 +38,7 @@ public class AnnotationHelper {
    */
   static void annotateForPrometheus(V1ObjectMeta meta, String applicationContext, int httpPort) {
     meta.putAnnotationsItem(
-        "prometheus.io/port", "" + httpPort); // should be the ListenPort of the server in the pod
+        "prometheus.io/port", String.valueOf(httpPort)); // should be the ListenPort of the server in the pod
     meta.putAnnotationsItem("prometheus.io/path", applicationContext + "/metrics");
     meta.putAnnotationsItem("prometheus.io/scrape", "true");
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ClientPool.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ClientPool.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.kubernetes.client.monitoring.Monitoring;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.util.ClientBuilder;
@@ -32,7 +33,7 @@ public class ClientPool extends Pool<ApiClient> {
   private static ThreadFactory threadFactory;
   private final AtomicBoolean isFirst = new AtomicBoolean(true);
 
-  // With OKHttp3, each client has it's own connection pool, so instance will be shared
+  // With OKHttp3, each client has its own connection pool, so instance will be shared
   private final AtomicReference<ApiClient> instance = new AtomicReference<>();
 
   public static void initialize(ThreadFactory threadFactory) {
@@ -132,6 +133,8 @@ public class ClientPool extends Pool<ApiClient> {
               client.getHttpClient().newBuilder().dispatcher(new Dispatcher(exec)).build();
           client.setHttpClient(httpClient);
         }
+
+        Monitoring.installMetrics(client);
 
         return client;
       } catch (IOException e) {

--- a/operator/src/main/java/oracle/kubernetes/operator/http/BaseServer.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/BaseServer.java
@@ -1,0 +1,176 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.http;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.security.SecureRandom;
+import java.util.Collection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+
+import io.kubernetes.client.util.SSLUtils;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.work.Container;
+import oracle.kubernetes.operator.work.ContainerResolver;
+import org.apache.commons.codec.binary.Base64;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
+import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
+import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+
+public abstract class BaseServer {
+  static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  static final int CORE_POOL_SIZE = 3;
+  protected static final String SSL_PROTOCOL = "TLSv1.2";
+  protected static final String[] SSL_PROTOCOLS = {
+      SSL_PROTOCOL
+  }; // ONLY support TLSv1.2 (by default, we would get TLSv1 and TLSv1.1 too)
+
+  private static byte[] readFromDataOrFile(String data, String file) throws IOException {
+    if (data != null && data.length() > 0) {
+      return Base64.decodeBase64(data);
+    }
+    return Files.readAllBytes(new File(file).toPath());
+  }
+
+  /**
+   * Starts WebLogic operator's or conversion webhook's REST api.
+   *
+   * @param container Container
+   * @throws Exception if the REST api could not be started for reasons other than a port was not
+   *                   configured. When an exception is thrown, then none of the ports will be left running,
+   *                   however it is still OK to call stop (which will be a no-op).
+   */
+  public abstract void start(Container container) throws Exception;
+
+  /**
+   * Stops WebLogic operator's or conversion webhook's REST api.
+   *
+   * <p>Since it only stops ports that are running, it is safe to call this even if start threw an
+   * exception or didn't start any ports because none were configured.
+   */
+  public abstract void stop();
+
+  protected abstract ResourceConfig createResourceConfig();
+
+  protected HttpServer createHttpsServer(Container container, SSLContext ssl, String uri) throws Exception {
+    HttpServer h =
+        GrizzlyHttpServerFactory.createHttpServer(
+            URI.create(uri),
+            createResourceConfig(),
+            true, // used for call
+            // org.glassfish.jersey.grizzly2.httpserver.NetworkListener#setSecure(boolean)}.
+            new SSLEngineConfigurator(ssl)
+                .setClientMode(false)
+                .setNeedClientAuth(false)
+                .setEnabledProtocols(SSL_PROTOCOLS),
+            false);
+
+    // We discovered the default thread pool configuration was generating hundreds of
+    // threads.  Tune it down to something more modest.  Note: these are core
+    // pool sizes, so they can still grow if there is sufficient load.
+    Collection<NetworkListener> nlc = h.getListeners();
+    if (nlc != null) {
+      for (NetworkListener nl : nlc) {
+        TCPNIOTransport transport = nl.getTransport();
+        ThreadPoolConfig t = transport.getWorkerThreadPoolConfig();
+        if (t == null) {
+          t = ThreadPoolConfig.defaultConfig();
+          transport.setWorkerThreadPoolConfig(t);
+        }
+        updateThreadPoolConfig(t, container);
+
+        t = transport.getKernelThreadPoolConfig();
+        if (t == null) {
+          t = ThreadPoolConfig.defaultConfig();
+          transport.setKernelThreadPoolConfig(t);
+        }
+        updateThreadPoolConfig(t, container);
+        transport.setSelectorRunnersCount(CORE_POOL_SIZE);
+      }
+    }
+
+    h.start();
+    return h;
+  }
+
+  private void updateThreadPoolConfig(ThreadPoolConfig threadPoolConfig, Container container) {
+    threadPoolConfig.setCorePoolSize(CORE_POOL_SIZE);
+    ThreadFactory x = threadPoolConfig.getThreadFactory();
+    ThreadFactory tf = x != null ? x : Executors.defaultThreadFactory();
+    threadPoolConfig.setThreadFactory(
+        r -> {
+          Thread n =
+              tf.newThread(
+                  () -> {
+                    ContainerResolver.getDefault().enterContainer(container);
+                    r.run();
+                  });
+          if (!n.isDaemon()) {
+            n.setDaemon(true);
+          }
+          return n;
+        });
+  }
+
+  protected boolean isSslConfigured(
+      String certificateData, String certificateFile, String keyData, String keyFile) {
+    // don't log keyData since it can contain sensitive data
+    LOGGER.entering(certificateData, certificateFile, keyFile);
+    boolean certConfigured = isPemConfigured(certificateData, certificateFile);
+    boolean keyConfigured = isPemConfigured(keyData, keyFile);
+    LOGGER.finer("certConfigured=" + certConfigured);
+    LOGGER.finer("keyConfigured=" + keyConfigured);
+    boolean result = (certConfigured && keyConfigured);
+    LOGGER.exiting(result);
+    return result;
+  }
+
+  protected boolean isPemConfigured(String data, String path) {
+    boolean result = false;
+    if (data != null && data.length() > 0) {
+      result = true;
+    } else if (path != null) {
+      File f = new File(path);
+      if (f.exists() && f.isFile()) {
+        result = true;
+      }
+    }
+    return result;
+  }
+
+  protected SSLContext createSslContext(KeyManager[] kms) throws Exception {
+    SSLContext ssl = SSLContext.getInstance(SSL_PROTOCOL);
+    ssl.init(kms, null, new SecureRandom());
+    return ssl;
+  }
+
+  protected KeyManager[] createKeyManagers(
+      String certificateData, String certificateFile, String keyData, String keyFile)
+      throws Exception {
+    LOGGER.entering(certificateData, certificateFile);
+    KeyManager[] result =
+        SSLUtils.keyManagers(
+            BaseServer.readFromDataOrFile(certificateData, certificateFile),
+            BaseServer.readFromDataOrFile(keyData, keyFile),
+            "", // Let utility figure it out, "RSA", // key algorithm
+            "", // operator key passphrase in the temp keystore that gets created to hold the
+            // keypair
+            null, // file name of the temp keystore
+            null // pass phrase of the temp keystore
+            );
+    LOGGER.exiting(result);
+    return result;
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/http/metrics/MetricsServer.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/metrics/MetricsServer.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.http.metrics;
+
+import io.prometheus.client.servlet.jakarta.exporter.MetricsServlet;
+import oracle.kubernetes.operator.http.BaseServer;
+import oracle.kubernetes.operator.work.Container;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.servlet.WebappContext;
+import org.glassfish.jersey.server.ResourceConfig;
+
+public class MetricsServer extends BaseServer {
+
+  private HttpServer metricsServer = null;
+
+  @Override
+  public void start(Container container) throws Exception {
+    metricsServer = createHttpServer(container, "http://0.0.0.0:8083");
+  }
+
+  @Override
+  public void stop() {
+    metricsServer.shutdownNow();
+    metricsServer = null;
+  }
+
+  @Override
+  protected void configureServer(HttpServer h) {
+    WebappContext webappContext = new WebappContext("metricscontex");
+    webappContext.addServlet("MetricsServlet", new MetricsServlet()).addMapping("/metrics");
+    webappContext.deploy(h);
+  }
+
+  @Override
+  protected ResourceConfig createResourceConfig() {
+    return new ResourceConfig();
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/http/metrics/MetricsServer.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/metrics/MetricsServer.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator.http.metrics;
 
+import io.prometheus.client.hotspot.DefaultExports;
 import io.prometheus.client.servlet.jakarta.exporter.MetricsServlet;
 import oracle.kubernetes.operator.http.BaseServer;
 import oracle.kubernetes.operator.work.Container;
@@ -16,6 +17,7 @@ public class MetricsServer extends BaseServer {
 
   @Override
   public void start(Container container) throws Exception {
+    DefaultExports.initialize();
     metricsServer = createHttpServer(container, "http://0.0.0.0:8083");
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/BaseRestServer.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/BaseRestServer.java
@@ -3,42 +3,17 @@
 
 package oracle.kubernetes.operator.http.rest;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.security.SecureRandom;
-import java.util.Collection;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-
-import io.kubernetes.client.util.SSLUtils;
+import oracle.kubernetes.operator.http.BaseServer;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
-import oracle.kubernetes.operator.work.Container;
-import oracle.kubernetes.operator.work.ContainerResolver;
-import org.apache.commons.codec.binary.Base64;
-import org.glassfish.grizzly.http.server.HttpServer;
-import org.glassfish.grizzly.http.server.NetworkListener;
-import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
-import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
-import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
-import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 
 /**
  * The base class for the RestServer that runs the WebLogic operator's REST api and
  * WebhookRestServer that runs domain custom resource conversion webhook's REST api.
  */
-public abstract class BaseRestServer {
+public abstract class BaseRestServer extends BaseServer {
   static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-  static final int CORE_POOL_SIZE = 3;
-  static final String SSL_PROTOCOL = "TLSv1.2";
-  static final String[] SSL_PROTOCOLS = {
-    SSL_PROTOCOL
-  }; // ONLY support TLSv1.2 (by default, we would get TLSv1 and TLSv1.1 too)
   final RestConfig config;
 
   /**
@@ -60,7 +35,7 @@ public abstract class BaseRestServer {
    */
   abstract ResourceConfig createResourceConfig(RestConfig restConfig);
 
-  ResourceConfig createResourceConfig() {
+  protected ResourceConfig createResourceConfig() {
     LOGGER.entering();
 
     ResourceConfig rc = createResourceConfig(config);
@@ -69,150 +44,4 @@ public abstract class BaseRestServer {
     return rc;
   }
 
-  private static byte[] readFromDataOrFile(String data, String file) throws IOException {
-    if (data != null && data.length() > 0) {
-      return Base64.decodeBase64(data);
-    }
-    return Files.readAllBytes(new File(file).toPath());
-  }
-
-  /**
-   * Starts WebLogic operator's or conversion webhook's REST api.
-   *
-   * @param container Container
-   * @throws Exception if the REST api could not be started for reasons other than a port was not
-   *     configured. When an exception is thrown, then none of the ports will be left running,
-   *     however it is still OK to call stop (which will be a no-op).
-   */
-  public abstract void start(Container container) throws Exception;
-
-  /**
-   * Stops WebLogic operator's or conversion webhook's REST api.
-   *
-   * <p>Since it only stops ports that are running, it is safe to call this even if start threw an
-   * exception or didn't start any ports because none were configured.
-   */
-  public abstract void stop();
-
-  HttpServer createHttpsServer(Container container, SSLContext ssl, String uri)
-      throws Exception {
-    HttpServer h =
-        GrizzlyHttpServerFactory.createHttpServer(
-            URI.create(uri),
-            createResourceConfig(),
-            true, // used for call
-            // org.glassfish.jersey.grizzly2.httpserver.NetworkListener#setSecure(boolean)}.
-            new SSLEngineConfigurator(ssl)
-                .setClientMode(false)
-                .setNeedClientAuth(false)
-                .setEnabledProtocols(SSL_PROTOCOLS),
-            false);
-
-    // We discovered the default thread pool configuration was generating hundreds of
-    // threads.  Tune it down to something more modest.  Note: these are core
-    // pool sizes, so they can still grow if there is sufficient load.
-    Collection<NetworkListener> nlc = h.getListeners();
-    if (nlc != null) {
-      for (NetworkListener nl : nlc) {
-        TCPNIOTransport transport = nl.getTransport();
-        ThreadPoolConfig t = transport.getWorkerThreadPoolConfig();
-        if (t == null) {
-          t = ThreadPoolConfig.defaultConfig();
-          transport.setWorkerThreadPoolConfig(t);
-        }
-        t.setCorePoolSize(CORE_POOL_SIZE);
-        ThreadFactory x = t.getThreadFactory();
-        ThreadFactory tf = x != null ? x : Executors.defaultThreadFactory();
-        t.setThreadFactory(
-            r -> {
-              Thread n =
-                  tf.newThread(
-                      () -> {
-                        ContainerResolver.getDefault().enterContainer(container);
-                        r.run();
-                      });
-              if (!n.isDaemon()) {
-                n.setDaemon(true);
-              }
-              return n;
-            });
-
-        t = transport.getKernelThreadPoolConfig();
-        if (t == null) {
-          t = ThreadPoolConfig.defaultConfig();
-          transport.setKernelThreadPoolConfig(t);
-        }
-        t.setCorePoolSize(CORE_POOL_SIZE);
-        x = t.getThreadFactory();
-        ThreadFactory tf2 = x != null ? x : Executors.defaultThreadFactory();
-        t.setThreadFactory(
-            r -> {
-              Thread n =
-                  tf2.newThread(
-                      () -> {
-                        ContainerResolver.getDefault().enterContainer(container);
-                        r.run();
-                      });
-              if (!n.isDaemon()) {
-                n.setDaemon(true);
-              }
-              return n;
-            });
-        transport.setSelectorRunnersCount(CORE_POOL_SIZE);
-      }
-    }
-
-    h.start();
-    return h;
-  }
-
-  SSLContext createSslContext(KeyManager[] kms) throws Exception {
-    SSLContext ssl = SSLContext.getInstance(SSL_PROTOCOL);
-    ssl.init(kms, null, new SecureRandom());
-    return ssl;
-  }
-
-  KeyManager[] createKeyManagers(
-      String certificateData, String certificateFile, String keyData, String keyFile)
-      throws Exception {
-    LOGGER.entering(certificateData, certificateFile);
-    KeyManager[] result =
-        SSLUtils.keyManagers(
-            readFromDataOrFile(certificateData, certificateFile),
-            readFromDataOrFile(keyData, keyFile),
-            "", // Let utility figure it out, "RSA", // key algorithm
-            "", // operator key passphrase in the temp keystore that gets created to hold the
-            // keypair
-            null, // file name of the temp keystore
-            null // pass phrase of the temp keystore
-            );
-    LOGGER.exiting(result);
-    return result;
-  }
-
-  boolean isSslConfigured(
-      String certificateData, String certificateFile, String keyData, String keyFile) {
-    // don't log keyData since it can contain sensitive data
-    LOGGER.entering(certificateData, certificateFile, keyFile);
-    boolean certConfigured = isPemConfigured(certificateData, certificateFile);
-    boolean keyConfigured = isPemConfigured(keyData, keyFile);
-    LOGGER.finer("certConfigured=" + certConfigured);
-    LOGGER.finer("keyConfigured=" + keyConfigured);
-    boolean result = (certConfigured && keyConfigured);
-    LOGGER.exiting(result);
-    return result;
-  }
-
-  boolean isPemConfigured(String data, String path) {
-    boolean result = false;
-    if (data != null && data.length() > 0) {
-      result = true;
-    } else if (path != null) {
-      File f = new File(path);
-      if (f.exists() && f.isFile()) {
-        result = true;
-      }
-    }
-    return result;
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,21 @@
         <version>${jersey-version}</version>
       </dependency>
       <dependency>
+        <groupId>org.glassfish.grizzly</groupId>
+        <artifactId>grizzly-http-servlet</artifactId>
+        <version>${grizzly-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${jakarta-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_servlet_jakarta</artifactId>
+        <version>${prometheus-version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml-version}</version>
@@ -610,6 +625,9 @@
     <junit.platform.surefire.version>1.3.2</junit.platform.surefire.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jersey-version>3.0.4</jersey-version>
+    <grizzly-version>3.0.1</grizzly-version>
+    <jakarta-version>5.0.0</jakarta-version>
+    <prometheus-version>0.15.0</prometheus-version>
     <jackson-version>2.13.3</jackson-version>
     <jackson-databind-version>2.13.3</jackson-databind-version>
     <snakeyaml-version>1.30</snakeyaml-version>

--- a/pom.xml
+++ b/pom.xml
@@ -485,6 +485,11 @@
         <version>${prometheus-version}</version>
       </dependency>
       <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_hotspot</artifactId>
+        <version>${prometheus-version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml-version}</version>


### PR DESCRIPTION
This change enables a metrics endpoint for the operator and webhook. Presently, I've enabled the standard collectors for Java (CPU, memory, threads, etc.) and the collectors for the Kubernetes Java Client.

You get output like this (truncated for length):
```
bash-4.4$ curl http://localhost:8083/metrics
# HELP jvm_buffer_pool_used_bytes Used bytes of a given JVM buffer pool.
# TYPE jvm_buffer_pool_used_bytes gauge
jvm_buffer_pool_used_bytes{pool="mapped",} 0.0
jvm_buffer_pool_used_bytes{pool="direct",} 1031682.0
jvm_buffer_pool_used_bytes{pool="mapped - 'non-volatile memory'",} 0.0
# HELP jvm_buffer_pool_capacity_bytes Bytes capacity of a given JVM buffer pool.
# TYPE jvm_buffer_pool_capacity_bytes gauge
jvm_buffer_pool_capacity_bytes{pool="mapped",} 0.0
jvm_buffer_pool_capacity_bytes{pool="direct",} 1031682.0
jvm_buffer_pool_capacity_bytes{pool="mapped - 'non-volatile memory'",} 0.0
# HELP jvm_buffer_pool_used_buffers Used buffers of a given JVM buffer pool.
# TYPE jvm_buffer_pool_used_buffers gauge
jvm_buffer_pool_used_buffers{pool="mapped",} 0.0
jvm_buffer_pool_used_buffers{pool="direct",} 28.0
jvm_buffer_pool_used_buffers{pool="mapped - 'non-volatile memory'",} 0.0
# HELP jvm_threads_current Current thread count of a JVM
# TYPE jvm_threads_current gauge
jvm_threads_current 44.0
# HELP jvm_threads_daemon Daemon thread count of a JVM
# TYPE jvm_threads_daemon gauge
jvm_threads_daemon 43.0
# HELP jvm_threads_peak Peak thread count of a JVM
# TYPE jvm_threads_peak gauge
jvm_threads_peak 50.0
# HELP jvm_threads_started_total Started thread count of a JVM
# TYPE jvm_threads_started_total counter
jvm_threads_started_total 54.0
# HELP jvm_threads_deadlocked Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers
# TYPE jvm_threads_deadlocked gauge
jvm_threads_deadlocked 0.0
# HELP jvm_threads_deadlocked_monitor Cycles of JVM-threads that are in deadlock waiting to acquire object monitors
# TYPE jvm_threads_deadlocked_monitor gauge
jvm_threads_deadlocked_monitor 0.0
# HELP jvm_threads_state Current count of threads by state
# TYPE jvm_threads_state gauge
jvm_threads_state{state="NEW",} 0.0
jvm_threads_state{state="WAITING",} 24.0
jvm_threads_state{state="RUNNABLE",} 11.0
jvm_threads_state{state="BLOCKED",} 0.0
jvm_threads_state{state="TIMED_WAITING",} 9.0
jvm_threads_state{state="TERMINATED",} 0.0
# HELP k8s_java_resource_request_latency_seconds Kubernetes resource request latency (seconds)
# TYPE k8s_java_resource_request_latency_seconds histogram
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="policy",version="v1",resource="poddisruptionbudgets",subresource="",api_verb="list",namespace="weblogic-operator",le="0.005",} 0.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",le="2.5",} 120.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",le="5.0",} 120.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",le="7.5",} 120.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",le="10.0",} 120.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",le="+Inf",} 120.0
k8s_java_resource_request_latency_seconds_count{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",} 120.0
k8s_java_resource_request_latency_seconds_sum{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",} 1.4309750360000006
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",group="",version="v1",resource="configmaps",subresource="",api_verb="list",namespace="weblogic-operator",le="0.005",} 0.0
# HELP k8s_java_response_code_total Response code total
# TYPE k8s_java_response_code_total counter
k8s_java_response_code_total{code="200",} 179.0
k8s_java_response_code_total{code="201",} 4.0
k8s_java_response_code_total{code="403",} 120.0
k8s_java_response_code_total{code="404",} 5.0
# HELP jvm_gc_collection_seconds Time spent in a given JVM garbage collector in seconds.
# TYPE jvm_gc_collection_seconds summary
jvm_gc_collection_seconds_count{gc="Copy",} 7.0
jvm_gc_collection_seconds_sum{gc="Copy",} 0.077
jvm_gc_collection_seconds_count{gc="MarkSweepCompact",} 1.0
jvm_gc_collection_seconds_sum{gc="MarkSweepCompact",} 0.03
# HELP k8s_java_non_resource_request_latency_seconds Kubernetes non-resource request latency (seconds)
# TYPE k8s_java_non_resource_request_latency_seconds histogram
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.005",} 0.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.01",} 0.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.025",} 0.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.05",} 0.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.075",} 0.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.1",} 0.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.25",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.5",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="0.75",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="1.0",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="2.5",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="5.0",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="7.5",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="10.0",} 1.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="200",non_resource_url_path="/version/",le="+Inf",} 1.0
k8s_java_non_resource_request_latency_seconds_count{http_response_code="200",non_resource_url_path="/version/",} 1.0
k8s_java_non_resource_request_latency_seconds_sum{http_response_code="200",non_resource_url_path="/version/",} 0.233116281
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.005",} 43.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.01",} 107.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.025",} 119.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.05",} 119.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.075",} 119.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.1",} 119.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.25",} 119.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.5",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="0.75",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="1.0",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="2.5",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="5.0",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="7.5",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="10.0",} 120.0
k8s_java_non_resource_request_latency_seconds_bucket{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",le="+Inf",} 120.0
k8s_java_non_resource_request_latency_seconds_count{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",} 120.0
k8s_java_non_resource_request_latency_seconds_sum{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",} 1.2089185870000003
# HELP k8s_java_requests_total Total requests
# TYPE k8s_java_requests_total counter
k8s_java_requests_total 308.0
# HELP jvm_info VM version info
# TYPE jvm_info gauge
jvm_info{runtime="OpenJDK Runtime Environment",vendor="Oracle Corporation",version="18.0.1.1+2-6",} 1.0
# HELP jvm_memory_pool_allocated_bytes_total Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously.
# TYPE jvm_memory_pool_allocated_bytes_total counter
# HELP jvm_classes_currently_loaded The number of classes that are currently loaded in the JVM
# TYPE jvm_classes_currently_loaded gauge
jvm_classes_currently_loaded 7361.0
# HELP jvm_classes_loaded_total The total number of classes that have been loaded since the JVM has started execution
# TYPE jvm_classes_loaded_total counter
jvm_classes_loaded_total 7361.0
# HELP jvm_classes_unloaded_total The total number of classes that have been unloaded since the JVM has started execution
# TYPE jvm_classes_unloaded_total counter
jvm_classes_unloaded_total 0.0
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.653678191887E9
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 6.672236544E9
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 2.33787392E8
# HELP k8s_java_non_resource_request_latency_seconds_created Kubernetes non-resource request latency (seconds)
# TYPE k8s_java_non_resource_request_latency_seconds_created gauge
k8s_java_non_resource_request_latency_seconds_created{http_response_code="200",non_resource_url_path="/version/",} 1.653678193553E9
k8s_java_non_resource_request_latency_seconds_created{http_response_code="403",non_resource_url_path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions/domains.weblogic.oracle",} 1.653678193842E9
# HELP k8s_java_requests_created Total requests
# TYPE k8s_java_requests_created gauge
k8s_java_requests_created 1.653678193283E9
# HELP k8s_java_resource_request_latency_seconds_created Kubernetes resource request latency (seconds)
# TYPE k8s_java_resource_request_latency_seconds_created gauge
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="policy",version="v1",resource="poddisruptionbudgets",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678239427E9
k8s_java_resource_request_latency_seconds_created{http_response_code="404",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678193866E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="services",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678239391E9
k8s_java_resource_request_latency_seconds_created{http_response_code="201",group="authorization.k8s.io",version="v1",resource="selfsubjectrulesreviews",subresource="",api_verb="create",namespace="",} 1.653678193819E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="batch",version="v1",resource="jobs",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678239344E9
k8s_java_resource_request_latency_seconds_created{http_response_code="201",group="",version="v1",resource="configmaps",subresource="",api_verb="create",namespace="weblogic-operator",} 1.653678239225E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="batch",version="v1",resource="jobs",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239376E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="pods",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678239373E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="configmaps",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239321E9
k8s_java_resource_request_latency_seconds_created{http_response_code="201",group="",version="v1",resource="events",subresource="",api_verb="create",namespace="weblogic-operator",} 1.65367823881E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="services",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239421E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="events",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239332E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239444E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="configmaps",subresource="",api_verb="get",namespace="weblogic-operator",} 1.653678313719E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="weblogic.oracle",version="v9",resource="domains",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678234573E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="configmaps",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678239273E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="policy",version="v1",resource="poddisruptionbudgets",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239441E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="events",subresource="",api_verb="list",namespace="weblogic-operator",} 1.653678239317E9
k8s_java_resource_request_latency_seconds_created{http_response_code="404",group="",version="v1",resource="configmaps",subresource="",api_verb="get",namespace="weblogic-operator",} 1.65367823884E9
k8s_java_resource_request_latency_seconds_created{http_response_code="200",group="",version="v1",resource="pods",subresource="",api_verb="watch",namespace="weblogic-operator",} 1.653678239393E9
# HELP k8s_java_response_code_created Response code total
# TYPE k8s_java_response_code_created gauge
k8s_java_response_code_created{code="200",} 1.653678193553E9
k8s_java_response_code_created{code="201",} 1.653678193819E9
k8s_java_response_code_created{code="403",} 1.653678193842E9
k8s_java_response_code_created{code="404",} 1.653678193866E9
```