### PR TITLE
Fix NullPointerException in oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isDeploymentReady in release/3.4

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -661,7 +661,7 @@ public class Kubernetes {
                                           String namespace) throws ApiException {
     boolean status = false;
     V1Deployment deployment = getDeployment(deploymentName, label, namespace);
-    if (deployment != null) {
+    if (deployment != null && deployment.getStatus() != null && deployment.getStatus().getConditions() != null) {
       // get the deploymentCondition with the 'Available' type field
       V1DeploymentCondition v1DeploymentRunningCondition = deployment.getStatus().getConditions().stream()
           .filter(v1DeploymentCondition -> "Available".equals(v1DeploymentCondition.getType()))


### PR DESCRIPTION
Fix NullPointerException in oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isDeploymentReady in release/3.4

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10774/
