### PR TITLE
Backport - Fix NullPointerException in oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isDeploymentReady to main

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -674,9 +674,12 @@ public class Kubernetes {
     boolean status = false;
     V1Deployment deployment = getDeployment(deploymentName, label, namespace);
 
-    List<V1DeploymentCondition> deplList = Optional.ofNullable(deployment)
-        .map(V1Deployment::getStatus).map(V1DeploymentStatus::getConditions)
-        .orElse(null);
+    V1DeploymentStatus deploymentStatus = Optional.ofNullable(deployment)
+        .map(V1Deployment::getStatus).orElse(null);
+
+    List<V1DeploymentCondition> deplList = Optional.ofNullable(deploymentStatus)
+        .map(V1DeploymentStatus::getConditions).orElse(null);
+
     if (deplList != null) {
       V1DeploymentCondition v1DeploymentRunningCondition = deplList.stream()
           .filter(v1DeploymentCondition -> "Available".equals(v1DeploymentCondition.getType()))


### PR DESCRIPTION
Backport - Fix NullPointerException in oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isDeploymentReady to main

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10807/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/10804/