### PR TITLE
Correct protocol designation for metrics port

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -1489,7 +1489,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     }
 
     private String getMetricsPortName() {
-      return getDomain().isIstioEnabled() ? "tcp-metrics" : "metrics";
+      return getDomain().isIstioEnabled() ? "http-metrics" : "metrics";
     }
 
     private String createJavaOptions() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -421,7 +421,7 @@ public class ServiceHelper {
     }
 
     private String getMetricsPortName() {
-      return getDomain().isIstioEnabled() ? "tcp-metrics" : "metrics";
+      return getDomain().isIstioEnabled() ? "http-metrics" : "metrics";
     }
 
     List<NetworkAccessPoint> getNetworkAccessPoints(@Nonnull WlsServerConfig config) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/MonitoringExporterSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/MonitoringExporterSteps.java
@@ -282,7 +282,7 @@ public class MonitoringExporterSteps {
     }
 
     private String getMetricsPortName() {
-      return getDomain().isIstioEnabled() ? "tcp-metrics" : "metrics";
+      return getDomain().isIstioEnabled() ? "http-metrics" : "metrics";
     }
 
     private HttpRequest createConfigurationQueryRequest() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagerServerServiceHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagerServerServiceHelperTest.java
@@ -83,6 +83,6 @@ class ManagerServerServiceHelperTest extends ServiceHelperTest {
 
     V1Service service = createService();
 
-    assertThat(service, containsPort("tcp-metrics", DEFAULT_EXPORTER_SIDECAR_PORT));
+    assertThat(service, containsPort("http-metrics", DEFAULT_EXPORTER_SIDECAR_PORT));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -579,7 +579,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
   void whenExporterContainerCreatedAndIstioEnabled_hasMetricsPortsItem() {
     defineExporterConfiguration().withIstio();
 
-    V1ContainerPort metricsPort = getExporterContainerPort("tcp-metrics");
+    V1ContainerPort metricsPort = getExporterContainerPort("http-metrics");
     assertThat(metricsPort, notNullValue());
     assertThat(metricsPort.getProtocol(), equalTo(V1ContainerPort.ProtocolEnum.TCP));
     assertThat(metricsPort.getContainerPort(), equalTo(DEFAULT_EXPORTER_SIDECAR_PORT));


### PR DESCRIPTION
The Verrazzano team has let us know that they need the protocol prefix to be `http-`. I don't remember why we originally used `tcp-`.

So, this is a very simple change but I'm concerned that we'll cause a pod roll on upgrade...

@ankedia or @russgold, what can I do if anything so that this change doesn't cause a pod roll on upgrade? I'm planning to backport this to 3.4.1.