### PR TITLE
Change webhook messages to use prefix WLSWH

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -153,38 +153,20 @@ public class MessageKeys {
   public static final String SERVER_SHUTDOWN_REST_TIMEOUT = "WLSKO-0202";
   public static final String SERVER_SHUTDOWN_REST_THROWABLE = "WLSKO-0203";
   public static final String SERVER_SHUTDOWN_REST_RETRY = "WLSKO-0204";
-  public static final String CONVERSION_WEBHOOK_STARTED = "WLSKO-0205";
-  public static final String COULD_NOT_CREATE_WEBHOOK_LIVENESS_FILE = "WLSKO-0206";
-  public static final String NO_WEBHOOK_CERTIFICATE = "WLSKO-0207";
-  public static final String WEBHOOK_CONFIG_NAMESPACE = "WLSKO-0208";
-  public static final String WAIT_FOR_CRD_INSTALLATION = "WLSKO-0209";
-  public static final String WEBHOOK_SHUTTING_DOWN = "WLSKO-0210";
-  public static final String STARTING_WEBHOOK_LIVENESS_THREAD = "WLSKO-0211";
-  public static final String WEBHOOK_IDENTITY_INITIALIZATION_FAILED = "WLSKO-0212";
-  public static final String INPUT_FILE_NON_EXISTENT = "WLSKO-0213";
-  public static final String OUTPUT_FILE_NON_EXISTENT = "WLSKO-0214";
-  public static final String OUTPUT_FILE_EXISTS = "WLSKO-0215";
-  public static final String PRINT_HELP = "WLSKO-0216";
-  public static final String OUTPUT_DIRECTORY = "WLSKO-0217";
-  public static final String OUTPUT_FILE_NAME = "WLSKO-0218";
-  public static final String OVERWRITE_EXISTING_OUTPUT_FILE = "WLSKO-0219";
-  public static final String DOMAIN_UPGRADE_SUCCESS = "WLSKO-0220";
-  public static final String DOMAIN_CONVERSION_FAILED = "WLSKO-0221";
-  public static final String INTROSPECTOR_FLUENTD_CONTAINER_TERMINATED = "WLSKO-0222";
-  public static final String MISSING_ELASTIC_SEARCH_SECRET = "WLSKO-0223";
+  public static final String INPUT_FILE_NON_EXISTENT = "WLSKO-0205";
+  public static final String OUTPUT_FILE_NON_EXISTENT = "WLSKO-0206";
+  public static final String OUTPUT_FILE_EXISTS = "WLSKO-0207";
+  public static final String PRINT_HELP = "WLSKO-0208";
+  public static final String OUTPUT_DIRECTORY = "WLSKO-0209";
+  public static final String OUTPUT_FILE_NAME = "WLSKO-0210";
+  public static final String OVERWRITE_EXISTING_OUTPUT_FILE = "WLSKO-0211";
+  public static final String DOMAIN_UPGRADE_SUCCESS = "WLSKO-0212";
+  public static final String INTROSPECTOR_FLUENTD_CONTAINER_TERMINATED = "WLSKO-0213";
+  public static final String MISSING_ELASTIC_SEARCH_SECRET = "WLSKO-0214";
   public static final String FLUENTD_CONFIGMAP_CREATED = "WLSKO-0224";
   public static final String FLUENTD_CONFIGMAP_REPLACED = "WLSKO-0225";
-  public static final String POD_EVICTED = "WLSKO-0226";
-  public static final String POD_EVICTED_NO_RESTART = "WLSKO-0227";
-  public static final String VALIDATING_WEBHOOK_CONFIGURATION_CREATED = "WLSKO-0228";
-  public static final String CREATE_VALIDATING_WEBHOOK_CONFIGURATION_FAILED = "WLSKO-0229";
-  public static final String VALIDATION_FAILED = "WLSKO-0230";
-  public static final String VALIDATING_WEBHOOK_CONFIGURATION_REPLACED = "WLSKO-0231";
-  public static final String REPLACE_VALIDATING_WEBHOOK_CONFIGURATION_FAILED = "WLSKO-0232";
-  public static final String READ_VALIDATING_WEBHOOK_CONFIGURATION_FAILED = "WLSKO-0233";
-  public static final String CLUSTER_REPLICAS_CANNOT_BE_HONORED = "WLSKO-0234";
-  public static final String CLUSTER_REPLICAS_TOO_HIGH = "WLSKO-0235";
-  public static final String DOMAIN_INTROSPECTION_TRIGGER_CHANGED = "WLSKO-0236";
+  public static final String POD_EVICTED = "WLSKO-0215";
+  public static final String POD_EVICTED_NO_RESTART = "WLSKO-0216";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";
@@ -256,6 +238,25 @@ public class MessageKeys {
   public static final String DOMAIN_INVALID_ERROR_EVENT_SUGGESTION = "WLSEO-0028";
   public static final String TOPOLOGY_MISMATCH_ERROR_EVENT_SUGGESTION = "WLSEO-0029";
   public static final String REPLICAS_TOO_HIGH_ERROR_EVENT_SUGGESTION = "WLSEO-0030";
+
+  // Webhook messages
+  public static final String CONVERSION_WEBHOOK_STARTED = "WLSWH-0001";
+  public static final String NO_WEBHOOK_CERTIFICATE = "WLSWH-0002";
+  public static final String WEBHOOK_CONFIG_NAMESPACE = "WLSWH-0003";
+  public static final String WAIT_FOR_CRD_INSTALLATION = "WLSWH-0004";
+  public static final String WEBHOOK_SHUTTING_DOWN = "WLSWH-0005";
+  public static final String STARTING_WEBHOOK_LIVENESS_THREAD = "WLSWH-0006";
+  public static final String WEBHOOK_IDENTITY_INITIALIZATION_FAILED = "WLSWH-0007";
+  public static final String DOMAIN_CONVERSION_FAILED = "WLSWH-0008";
+  public static final String VALIDATING_WEBHOOK_CONFIGURATION_CREATED = "WLSWH-0009";
+  public static final String CREATE_VALIDATING_WEBHOOK_CONFIGURATION_FAILED = "WLSWH-0010";
+  public static final String VALIDATION_FAILED = "WLSWH-0011";
+  public static final String VALIDATING_WEBHOOK_CONFIGURATION_REPLACED = "WLSWH-0012";
+  public static final String REPLACE_VALIDATING_WEBHOOK_CONFIGURATION_FAILED = "WLSWH-0013";
+  public static final String READ_VALIDATING_WEBHOOK_CONFIGURATION_FAILED = "WLSWH-0014";
+  public static final String CLUSTER_REPLICAS_CANNOT_BE_HONORED = "WLSWH-0015";
+  public static final String CLUSTER_REPLICAS_TOO_HIGH = "WLSWH-0016";
+  public static final String DOMAIN_INTROSPECTION_TRIGGER_CHANGED = "WLSWH-0017";
 
   private MessageKeys() {
   }

--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -153,20 +153,20 @@ public class MessageKeys {
   public static final String SERVER_SHUTDOWN_REST_TIMEOUT = "WLSKO-0202";
   public static final String SERVER_SHUTDOWN_REST_THROWABLE = "WLSKO-0203";
   public static final String SERVER_SHUTDOWN_REST_RETRY = "WLSKO-0204";
-  public static final String INPUT_FILE_NON_EXISTENT = "WLSKO-0205";
-  public static final String OUTPUT_FILE_NON_EXISTENT = "WLSKO-0206";
-  public static final String OUTPUT_FILE_EXISTS = "WLSKO-0207";
-  public static final String PRINT_HELP = "WLSKO-0208";
-  public static final String OUTPUT_DIRECTORY = "WLSKO-0209";
-  public static final String OUTPUT_FILE_NAME = "WLSKO-0210";
-  public static final String OVERWRITE_EXISTING_OUTPUT_FILE = "WLSKO-0211";
-  public static final String DOMAIN_UPGRADE_SUCCESS = "WLSKO-0212";
-  public static final String INTROSPECTOR_FLUENTD_CONTAINER_TERMINATED = "WLSKO-0213";
-  public static final String MISSING_ELASTIC_SEARCH_SECRET = "WLSKO-0214";
+  public static final String INPUT_FILE_NON_EXISTENT = "WLSKO-0213";
+  public static final String OUTPUT_FILE_NON_EXISTENT = "WLSKO-0214";
+  public static final String OUTPUT_FILE_EXISTS = "WLSKO-0215";
+  public static final String PRINT_HELP = "WLSKO-0216";
+  public static final String OUTPUT_DIRECTORY = "WLSKO-0217";
+  public static final String OUTPUT_FILE_NAME = "WLSKO-0218";
+  public static final String OVERWRITE_EXISTING_OUTPUT_FILE = "WLSKO-0219";
+  public static final String DOMAIN_UPGRADE_SUCCESS = "WLSKO-0220";
+  public static final String INTROSPECTOR_FLUENTD_CONTAINER_TERMINATED = "WLSKO-0222";
+  public static final String MISSING_ELASTIC_SEARCH_SECRET = "WLSKO-0223";
   public static final String FLUENTD_CONFIGMAP_CREATED = "WLSKO-0224";
   public static final String FLUENTD_CONFIGMAP_REPLACED = "WLSKO-0225";
-  public static final String POD_EVICTED = "WLSKO-0215";
-  public static final String POD_EVICTED_NO_RESTART = "WLSKO-0216";
+  public static final String POD_EVICTED = "WLSKO-0226";
+  public static final String POD_EVICTED_NO_RESTART = "WLSKO-0227";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -157,44 +157,23 @@ WLSKO-0201=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST inte
 WLSKO-0202=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface due to HTTP request timeout after {1} seconds.
 WLSKO-0203=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface due to exception: {1}.
 WLSKO-0204=WL pod shutdown: Retry shutdown of WebLogic server {0} via REST interface.
-WLSKO-0205=WebLogic Domain custom resource conversion webhook, version: {0}, implementation: {1}, build time: {2}
-WLSKO-0206=Could not create WebLogic Domain custom resource conversion webhook liveness file /operator/.webhook_alive
-WLSKO-0207=Unable to read WebLogic Domain custom resource conversion webhook certificate at path {0}
-WLSKO-0208=WebLogic Domain custom resource conversion webhook namespace is: {0}
-WLSKO-0209=The Custom Resource Definition for 'domains.weblogic.oracle' is not installed, waiting for {0} seconds for the CRD to be installed.
-WLSKO-0210=The WebLogic Domain custom resource conversion webhook is shutting down
-WLSKO-0211=Starting WebLogic Domain custom resource conversion webhook liveness thread
-WLSKO-0212=WebLogic Domain custom resource conversion webhook identity initialization step failed with exception {0}.
-WLSKO-0213=InputFile: {0} does not exist or could not be read.
-WLSKO-0214=The output dir {0} specified by ''-d'' does not exist or could not be read.
-WLSKO-0215=The output file {0} already exists, remove it and try again. \
+WLSKO-0205=InputFile: {0} does not exist or could not be read.
+WLSKO-0206=The output dir {0} specified by ''-d'' does not exist or could not be read.
+WLSKO-0207=The output file {0} already exists, remove it and try again. \
   Use ''-o'' option to overwrite the existing file.
-WLSKO-0216=Print this help message.
-WLSKO-0217=The directory where the tool will place the converted file. If not specified, \
+WLSKO-0208=Print this help message.
+WLSKO-0209=The directory where the tool will place the converted file. If not specified, \
   it defaults to the directory of the input file.
-WLSKO-0218=Domain custom resource converter: Name of the converted file. If not specified, it generates the \
+WLSKO-0210=Domain custom resource converter: Name of the converted file. If not specified, it generates the \
   file name by appending "__converted." and the input file extension to the base name of the input file name.
-WLSKO-0219=Enable overwriting the existing output file, if any.
-WLSKO-0220=Successfully generated upgraded domain custom resource file ''{0}''.
-WLSKO-0221=WebLogic Domain custom resource conversion webhook failed due to ''{0}''. Conversion Request is {1}.
-WLSKO-0222=Introspection job fluentd container in the introspector pod {0} namespace {1} has been terminated. \
+WLSKO-0211=Enable overwriting the existing output file, if any.
+WLSKO-0212=Successfully generated upgraded domain custom resource file ''{0}''.
+WLSKO-0213=Introspection job fluentd container in the introspector pod {0} namespace {1} has been terminated. \
   Exit Code: {2} Reason: {3} Message {4}. Check the pod's fluentd container log for details
-WLSKO-0223=When fluentdSpecification is specified in the domain spec, a secret containing elastic search credentials \
+WLSKO-0214=When fluentdSpecification is specified in the domain spec, a secret containing elastic search credentials \
   must be specified in {0}
-WLSKO-0226=Pod {0} was evicted due to {1}; validating domain
-WLSKO-0227=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
-WLSKO-0228=Validating Webhook configuration ''{0}'' has been created
-WLSKO-0229=Validating Webhook configuration ''{0}'' has not been created due to ''{1}''
-WLSKO-0230=Validating webhook failed to perform validation due to ''{0}''
-WLSKO-0231=Validating Webhook configuration ''{0}'' has been updated
-WLSKO-0232=Validating Webhook configuration ''{0}'' has not been updated due to ''{1}''
-WLSKO-0233=Cannot read validating Webhook configuration ''{0}'' due to ''{1}''
-WLSKO-0234=Change request to domain resource ''{0}'' cannot be honored because the replica count for cluster ''{1}'' \
-  would exceed the cluster size ''{2}''.
-WLSKO-0235=Change request to domain resource ''{0}'' causes the replica count of cluster ''{1}'' to exceed the cluster \
-  size ''{2}''.
-WLSKO-0236=The request is allowed because ''{0}'' also changed, which will lead to a re-introspection of the domain. \
-  If the WebLogic domain still cannot honor the replica count, the domain update will eventually fail.
+WLSKO-0215=Pod {0} was evicted due to {1}; validating domain
+WLSKO-0216=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
 
 # Domain status messages
 
@@ -292,3 +271,25 @@ WLSEO-0028=Update the domain resource to correct the validation error
 WLSEO-0029=Update the domain resource or change the WebLogic domain configuration to correct the error
 WLSEO-0030=Lower replicas in the domain resource, or increase the number of WebLogic servers in \
   the WebLogic domain configuration for the cluster
+
+# Webhook messages
+WLSWH-0001=WebLogic Domain custom resource conversion webhook, version: {0}, implementation: {1}, build time: {2}
+WLSWH-0002=Unable to read WebLogic Domain custom resource conversion webhook certificate at path {0}
+WLSWH-0003=WebLogic Domain custom resource conversion webhook namespace is: {0}
+WLSWH-0004=The Custom Resource Definition for 'domains.weblogic.oracle' is not installed, waiting for {0} seconds for the CRD to be installed.
+WLSWH-0005=The WebLogic Domain custom resource conversion webhook is shutting down
+WLSWH-0006=Starting WebLogic Domain custom resource conversion webhook liveness thread
+WLSWH-0007=WebLogic Domain custom resource conversion webhook identity initialization step failed with exception {0}.
+WLSWH-0008=WebLogic Domain custom resource conversion webhook failed due to ''{0}''. Conversion Request is {1}.
+WLSWH-0009=Validating Webhook configuration ''{0}'' has been created
+WLSWH-0010=Validating Webhook configuration ''{0}'' has not been created due to ''{1}''
+WLSWH-0011=Validating webhook failed to perform validation due to ''{0}''
+WLSWH-0012=Validating Webhook configuration ''{0}'' has been updated
+WLSWH-0013=Validating Webhook configuration ''{0}'' has not been updated due to ''{1}''
+WLSWH-0014=Cannot read validating Webhook configuration ''{0}'' due to ''{1}''
+WLSWH-0015=Change request to domain resource ''{0}'' cannot be honored because the replica count for cluster ''{1}'' \
+  would exceed the cluster size ''{2}''.
+WLSWH-0016=Change request to domain resource ''{0}'' causes the replica count of cluster ''{1}'' to exceed the cluster \
+  size ''{2}''.
+WLSWH-0017=The request is allowed because ''{0}'' also changed, which will lead to a re-introspection of the domain. \
+  If the WebLogic domain still cannot honor the replica count, the domain update will eventually fail.

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -172,6 +172,8 @@ WLSKO-0222=Introspection job fluentd container in the introspector pod {0} names
   Exit Code: {2} Reason: {3} Message {4}. Check the pod's fluentd container log for details
 WLSKO-0223=When fluentdSpecification is specified in the domain spec, a secret containing elastic search credentials \
   must be specified in {0}
+WLSKO-0224=Fluentd configmap created.
+WLSKO-0225=Fluentd configmap replaced.
 WLSKO-0226=Pod {0} was evicted due to {1}; validating domain
 WLSKO-0227=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
 

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -157,23 +157,23 @@ WLSKO-0201=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST inte
 WLSKO-0202=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface due to HTTP request timeout after {1} seconds.
 WLSKO-0203=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface due to exception: {1}.
 WLSKO-0204=WL pod shutdown: Retry shutdown of WebLogic server {0} via REST interface.
-WLSKO-0205=InputFile: {0} does not exist or could not be read.
-WLSKO-0206=The output dir {0} specified by ''-d'' does not exist or could not be read.
-WLSKO-0207=The output file {0} already exists, remove it and try again. \
+WLSKO-0213=InputFile: {0} does not exist or could not be read.
+WLSKO-0214=The output dir {0} specified by ''-d'' does not exist or could not be read.
+WLSKO-0215=The output file {0} already exists, remove it and try again. \
   Use ''-o'' option to overwrite the existing file.
-WLSKO-0208=Print this help message.
-WLSKO-0209=The directory where the tool will place the converted file. If not specified, \
+WLSKO-0216=Print this help message.
+WLSKO-0217=The directory where the tool will place the converted file. If not specified, \
   it defaults to the directory of the input file.
-WLSKO-0210=Domain custom resource converter: Name of the converted file. If not specified, it generates the \
+WLSKO-0218=Domain custom resource converter: Name of the converted file. If not specified, it generates the \
   file name by appending "__converted." and the input file extension to the base name of the input file name.
-WLSKO-0211=Enable overwriting the existing output file, if any.
-WLSKO-0212=Successfully generated upgraded domain custom resource file ''{0}''.
-WLSKO-0213=Introspection job fluentd container in the introspector pod {0} namespace {1} has been terminated. \
+WLSKO-0219=Enable overwriting the existing output file, if any.
+WLSKO-0220=Successfully generated upgraded domain custom resource file ''{0}''.
+WLSKO-0222=Introspection job fluentd container in the introspector pod {0} namespace {1} has been terminated. \
   Exit Code: {2} Reason: {3} Message {4}. Check the pod's fluentd container log for details
-WLSKO-0214=When fluentdSpecification is specified in the domain spec, a secret containing elastic search credentials \
+WLSKO-0223=When fluentdSpecification is specified in the domain spec, a secret containing elastic search credentials \
   must be specified in {0}
-WLSKO-0215=Pod {0} was evicted due to {1}; validating domain
-WLSKO-0216=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
+WLSKO-0226=Pod {0} was evicted due to {1}; validating domain
+WLSKO-0227=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
 
 # Domain status messages
 

--- a/operator/src/test/java/oracle/kubernetes/operator/logging/MessageIntegrityTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/logging/MessageIntegrityTest.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.logging;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import oracle.kubernetes.common.logging.MessageKeys;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+class MessageIntegrityTest {
+
+  private static final DuplicateFindingProperties properties = new DuplicateFindingProperties();
+
+  @BeforeAll
+  static void setUpClass() throws IOException {
+    properties.load(MessageIntegrityTest.class.getClassLoader().getResourceAsStream("Operator.properties"));
+  }
+
+  @Test
+  void operatorPropertiesHasNoDuplications() throws IOException {
+    assertThat(properties.duplicateProperties, empty());
+  }
+
+  @Test
+  void messageKeysAllHaveProperties() throws IllegalAccessException {
+    List<String> missingProperties = new ArrayList<>();
+    for (Field field : MessageKeys.class.getDeclaredFields()) {
+      if (field.getType().equals(String.class) && !(properties.containsKey(field.get(null)))) {
+        missingProperties.add(field.getName());
+      }
+    }
+    assertThat("MessageKey entries with no properties", missingProperties, empty());
+  }
+
+  static class DuplicateFindingProperties extends Properties {
+    private final List<Object> duplicateProperties = new ArrayList<>();
+
+    @Override
+    public synchronized Object put(Object key, Object value) {
+      if (containsKey(key)) {
+        return duplicateProperties.add(key);
+      } else {
+        return super.put(key, value);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR includes two changes:

- Change all webhook messages to use prefix "WLSWH-"; leaving all non-webhook messages unchanged.
- Remove an unused message WLSKO-0206.
- Add back WLSKO-0224 and WLSKO-0225 in Operator.properties, which were removed in PR#3043 because there was a spelling error.
- Add Russ' message integrity unit test