### PR TITLE
Correct message property names

### DIFF
--- a/operator/src/main/resources/Operator.properties
+++ b/operator/src/main/resources/Operator.properties
@@ -149,8 +149,8 @@ WLSKO-0222=Introspection job fluentd container in the introspector pod {0} names
   Exit Code: {2} Reason: {3} Message {4}. Check the pod's fluentd container log for details
 WLSKO-0223=When fluentdSpecification is specified in the domain spec, a secret containing elastic search credentials \
   must be specified in {0}
-WKSKO-0224=Fluentd configmap created.
-WKSKO-0225=Fluentd configmap replaced.
+WLSKO-0224=Fluentd configmap created.
+WLSKO-0225=Fluentd configmap replaced.
 WLSKO-0226=Pod {0} was evicted due to {1}; validating domain
 WLSKO-0227=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
 

--- a/operator/src/test/java/oracle/kubernetes/operator/logging/MessageIntegrityTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/logging/MessageIntegrityTest.java
@@ -1,0 +1,55 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.logging;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+class MessageIntegrityTest {
+
+  private static final DuplicateFindingProperties properties = new DuplicateFindingProperties();
+
+  @BeforeAll
+  static void setUpClass() throws IOException {
+    properties.load(MessageIntegrityTest.class.getClassLoader().getResourceAsStream("Operator.properties"));
+  }
+
+  @Test
+  void operatorPropertiesHasNoDuplications() throws IOException {
+    assertThat(properties.duplicateProperties, empty());
+  }
+
+  @Test
+  void messageKeysAllHaveProperties() throws IllegalAccessException {
+    List<String> missingProperties = new ArrayList<>();
+    for (Field field : MessageKeys.class.getDeclaredFields()) {
+      if (field.getType().equals(String.class) && !(properties.containsKey(field.get(null)))) {
+        missingProperties.add(field.getName());
+      }
+    }
+    assertThat("MessageKey entries with no properties", missingProperties, empty());
+  }
+
+  static class DuplicateFindingProperties extends Properties {
+    private final List<Object> duplicateProperties = new ArrayList<>();
+
+    @Override
+    public synchronized Object put(Object key, Object value) {
+      if (containsKey(key)) {
+        return duplicateProperties.add(key);
+      } else {
+        return super.put(key, value);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added a unit test to detect missing or misnamed message property entries - and corrected the incorrect ones.