### PR TITLE
Fix the getPodNameOfDb() method to check the pod name prefix

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsFailedCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsFailedCondition.java
@@ -627,7 +627,7 @@ class ItDiagnosticsFailedCondition {
       String patchStr
           = "[{\"op\": \"add\", \"path\": \"/spec/clusters/0/serverStartPolicy\", \"value\": \"NEVER\"}]";
 
-      logger.info("Shutting down cluster using patch string: {1}", patchStr);
+      logger.info("Shutting down cluster using patch string: {0}", patchStr);
       V1Patch patch = new V1Patch(patchStr);
       assertTrue(patchDomainCustomResource(domainName, domainNamespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
           "Failed to patch domain");
@@ -650,7 +650,7 @@ class ItDiagnosticsFailedCondition {
       patchStr
           = "[{\"op\": \"replace\", \"path\": \"/spec/clusters/0/serverStartPolicy\", \"value\": \"IF_NEEDED\"}]";
 
-      logger.info("Starting cluster using patch string: {1}", patchStr);
+      logger.info("Starting cluster using patch string: {0}", patchStr);
       patch = new V1Patch(patchStr);
       assertTrue(patchDomainCustomResource(domainName, domainNamespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
           "Failed to patch domain");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DbUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DbUtils.java
@@ -461,15 +461,16 @@ public class DbUtils {
    * @throws ApiException if Kubernetes client API call fails
    */
   public static String getPodNameOfDb(String dbNamespace, String podPrefix) throws ApiException {
-
-    V1PodList pod = null;
-    pod = Kubernetes.listPods(dbNamespace, null);
-
     String podName = null;
-
-    //There is only one pod in the given DB namespace
-    if (pod != null && pod.getItems().get(0).getMetadata().getName().startsWith(podPrefix)) {
-      podName = pod.getItems().get(0).getMetadata().getName();
+    V1PodList pods = null;
+    pods = Kubernetes.listPods(dbNamespace, null);    
+    if (pods.getItems().size() != 0) {
+      for (V1Pod pod : pods.getItems()) {
+        if (pod != null && pod.getMetadata().getName().startsWith(podPrefix)) {
+          podName = pod.getMetadata().getName();
+          break;
+        }
+      }
     }
     return podName;
   }


### PR DESCRIPTION
The method assumed there was only one pod in the namespace and it returned a wls pod name when this method was called. This fix will check the pod name prefix and see if that is the right and then return its name.

