### PR TITLE
add overwrite option when unzipping wdt files

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
@@ -380,7 +380,7 @@ public class FileUtils {
           installWdtParams(locationURL))
           .download(downloadDir), "WDT download failed");
     }
-    String cmdToExecute = String.format("unzip %s -d %s", wlDeployZipFile, unzipLocation);
+    String cmdToExecute = String.format("unzip -o %s -d %s", wlDeployZipFile, unzipLocation);
     assertTrue(new Command()
         .withParams(new CommandParams()
             .command(cmdToExecute))


### PR DESCRIPTION
Without overwrite option if the wdt files exist the unzip command is waiting for an answer to prompt.