### PR TITLE
owls-99772 - Github issue # 3122 - Provide ablility to specify the UID for the container in helm chart

### DIFF
--- a/documentation/3.4/content/userguide/managing-operators/using-helm.md
+++ b/documentation/3.4/content/userguide/managing-operators/using-helm.md
@@ -22,6 +22,7 @@ description: "An operator runtime is installed and configured using Helm. Here a
     - [`labels`](#labels)
     - [`nodeSelector`](#nodeselector)
     - [`affinity`](#affinity)
+    - [`runAsUser`](#runasuser)
   - [WebLogic domain management](#weblogic-domain-management)
     - [`domainNamespaceSelectionStrategy`](#domainnamespaceselectionstrategy)
     - [`domainNamespaces`](#domainnamespaces)

--- a/documentation/3.4/content/userguide/managing-operators/using-helm.md
+++ b/documentation/3.4/content/userguide/managing-operators/using-helm.md
@@ -288,6 +288,14 @@ affinity:
           - another-node-label-value
 ```
 
+##### `runAsUser`
+Specifies the UID to run the operator container process. If not specified, it defaults to the user specified in the operator's container image.
+
+Example:
+```yaml
+runAsUser: 1000
+```
+
 #### WebLogic domain management
 
 The settings in this section determine the namespaces that an operator

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -33,6 +33,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .serviceAccount | quote }}
+      {{- if .runAsUser }}
+      securityContext:
+        runAsUser: {{ .runAsUser }}
+      {{- end }}
       {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -228,3 +228,8 @@ clusterSizePaddingValidationEnabled: true
 # Defaults to 5 retries and 10 seconds between each retry.
 # domainPresenceFailureRetryMaxCount: 5
 # domainPresenceFailureRetrySeconds: 10
+
+# runAsUser specifies the UID to run the operator container process. If not specified, 
+# it defaults to the user specified in the operator's container image.
+#runAsUser: 1000
+


### PR DESCRIPTION
merging to release/3.4 branch

resolves #3122 

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11010/