### PR TITLE
OWLS-99505 refactoring validating webhook code

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/model/AdmissionRequest.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/model/AdmissionRequest.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
 import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.readDomain;
 import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.writeMap;
@@ -124,11 +123,11 @@ public class AdmissionRequest {
     return this;
   }
 
-  public DomainResource getExistingDomain() {
+  public Object getExistingResource() {
     return readDomain(writeMap(getOldObject()));
   }
 
-  public DomainResource getProposedDomain() {
+  public Object getProposedResource() {
     return readDomain(writeMap(getObject()));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/model/AdmissionRequest.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/model/AdmissionRequest.java
@@ -9,6 +9,9 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
+import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.readDomain;
+import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.writeMap;
+
 /**
  * AdmissionRequest represents a Kubernetes admission request sent by the Kubernetes ApiServer upon invoking an
  * admission webhook. It describes the details of the request, including the information about the resource object
@@ -54,14 +57,14 @@ public class AdmissionRequest {
    */
   @SerializedName("object")
   @Expose
-  private DomainResource object;
+  private Map<String,Object> object;
 
   /**
    * The existing object.
    */
   @SerializedName("oldObject")
   @Expose
-  private DomainResource oldObject;
+  private Map<String,Object> oldObject;
 
   public String getUid() {
     return uid;
@@ -95,30 +98,38 @@ public class AdmissionRequest {
     this.subResource = subResource;
   }
 
-  public DomainResource getObject() {
+  public Map<String,Object> getObject() {
     return object;
   }
 
-  public void setObject(DomainResource object) {
+  public void setObject(Map<String,Object> object) {
     this.object = object;
   }
 
-  public AdmissionRequest object(DomainResource object) {
+  public AdmissionRequest object(Map<String,Object> object) {
     setObject(object);
     return this;
   }
 
-  public DomainResource getOldObject() {
+  public Map<String,Object> getOldObject() {
     return oldObject;
   }
 
-  public void setOldObject(DomainResource oldObject) {
+  public void setOldObject(Map<String,Object> oldObject) {
     this.oldObject = oldObject;
   }
 
-  public AdmissionRequest oldObject(DomainResource oldObject) {
+  public AdmissionRequest oldObject(Map<String,Object> oldObject) {
     setOldObject(oldObject);
     return this;
+  }
+
+  public DomainResource getExistingDomain() {
+    return readDomain(writeMap(getOldObject()));
+  }
+
+  public DomainResource getProposedDomain() {
+    return readDomain(writeMap(getObject()));
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionChecker.java
@@ -6,13 +6,11 @@ package oracle.kubernetes.operator.webhooks.resource;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
-import oracle.kubernetes.operator.webhooks.model.AdmissionResponseStatus;
 import oracle.kubernetes.weblogic.domain.model.ClusterSpec;
 import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
@@ -23,15 +21,10 @@ import org.jetbrains.annotations.NotNull;
 import static java.lang.System.lineSeparator;
 import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_REPLICAS_CANNOT_BE_HONORED;
 import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_REPLICAS_TOO_HIGH;
-import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_INTROSPECTION_TRIGGER_CHANGED;
-import static oracle.kubernetes.operator.KubernetesConstants.AUXILIARY_IMAGES;
-import static oracle.kubernetes.operator.KubernetesConstants.DOMAIN_IMAGE;
-import static oracle.kubernetes.operator.KubernetesConstants.DOMAIN_INTROSPECT_VERSION;
-import static org.apache.commons.collections4.CollectionUtils.isEqualCollection;
 
 /**
- * AdmissionChecker provides the validation functionality for the validating webhook. It takes an existing resource and
- * a proposed resource and returns a result to indicate if the proposed changes are allowed, and if not,
+ * AdmissionChecker provides the common validation functionality for the validating webhook. It takes an existing
+ * resource and a proposed resource and returns a result to indicate if the proposed changes are allowed, and if not,
  * what the problem is.
  *
  * <p>Currently it checks the following:
@@ -42,131 +35,25 @@ import static org.apache.commons.collections4.CollectionUtils.isEqualCollection;
  * </p>
  */
 
-public class AdmissionChecker {
+public abstract class AdmissionChecker {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Webhook", "Operator");
 
-  private final DomainResource existingDomain;
-  private final DomainResource proposedDomain;
-  private final List<String> messages = new ArrayList<>();
-  private final List<String> warnings = new ArrayList<>();
-  private final String domainUid;
+  final List<String> messages = new ArrayList<>();
+  final List<String> warnings = new ArrayList<>();
+  final String domainUid;
 
   /** Construct a AdmissionChecker. */
-  public AdmissionChecker(@NotNull DomainResource existingDomain, @NotNull DomainResource proposedDomain) {
-    this.existingDomain = existingDomain;
-    this.proposedDomain = proposedDomain;
-    this.domainUid = existingDomain.getDomainUid();
+  protected AdmissionChecker(@NotNull String domainUid) {
+    this.domainUid = domainUid;
   }
 
-  /**
-   * Validating a proposed DomainResource resource against an existing DomainResource resource.
-   *
-   * @return a AdmissionResponse object
-   */
-  public AdmissionResponse validate() {
-    LOGGER.fine("Validating DomainResource " + proposedDomain + " against " + existingDomain);
+  abstract AdmissionResponse validate();
 
-    AdmissionResponse response = new AdmissionResponse().allowed(isProposedChangeAllowed());
-    if (!response.isAllowed()) {
-      return response.status(new AdmissionResponseStatus().message(createMessage()));
-    } else if (!warnings.isEmpty()) {
-      return response.warnings(warnings);
-    }
-    return response;
-  }
-
-  private String createMessage() {
+  String createMessage() {
     return perLine(messages);
   }
 
-  /**
-   * Validating a proposed Domain resource against an existing DomainResource resource. It returns true if the
-   * proposed changes in the proposed DomainResource resource can be honored, otherwise, returns false.
-   *
-   * @return true if valid, otherwise false
-   */
-  public boolean isProposedChangeAllowed() {
-    return isUnchanged()
-        || areAllClusterReplicaCountsValid(proposedDomain)
-        || shouldIntrospect();
-  }
-
-  private boolean isUnchanged() {
-    return isSpecUnchanged();
-  }
-
-  private boolean isSpecUnchanged() {
-    return Optional.of(existingDomain)
-        .map(DomainResource::getSpec)
-        .map(this::isProposedSpecUnchanged)
-        .orElse(false);
-  }
-
-  private boolean isProposedSpecUnchanged(@NotNull DomainSpec existingSpec) {
-    return Objects.equals(existingSpec, proposedDomain.getSpec());
-  }
-
-  private boolean shouldIntrospect() {
-    return isIntrospectVersionChanged() || imagesChanged();
-  }
-
-  private boolean isIntrospectVersionChanged() {
-    boolean changed = !Objects.equals(existingDomain.getIntrospectVersion(), proposedDomain.getIntrospectVersion());
-    if (changed) {
-      warnings.add(LOGGER.formatMessage(DOMAIN_INTROSPECTION_TRIGGER_CHANGED, DOMAIN_INTROSPECT_VERSION));
-    }
-    return changed;
-  }
-
-  private boolean imagesChanged() {
-    if (!Objects.equals(existingDomain.getDomainHomeSourceType(), proposedDomain.getDomainHomeSourceType())) {
-      return true;
-    }
-    switch (proposedDomain.getDomainHomeSourceType()) {
-      case IMAGE:
-        return isDomainImageChanged();
-      case FROM_MODEL:
-        return areAuxiliaryImagesOrDomainImageChanged();
-      default:
-        return false;
-    }
-  }
-
-  private boolean areAuxiliaryImagesOrDomainImageChanged() {
-    if (noAuxiliaryImagesConfigured(existingDomain) && noAuxiliaryImagesConfigured(proposedDomain)) {
-      return isDomainImageChanged();
-    } else {
-      boolean changed =  noAuxiliaryImagesConfigured(existingDomain)
-          || noAuxiliaryImagesConfigured(proposedDomain)
-          || areAuxiliaryImagesChanged();
-      if (changed) {
-        warnings.add(LOGGER.formatMessage(DOMAIN_INTROSPECTION_TRIGGER_CHANGED, AUXILIARY_IMAGES));
-      }
-      return changed;
-    }
-  }
-
-  private boolean isDomainImageChanged() {
-    boolean imageChanged = !Objects.equals(getImage(existingDomain), getImage(proposedDomain));
-    if (imageChanged) {
-      warnings.add(LOGGER.formatMessage(DOMAIN_INTROSPECTION_TRIGGER_CHANGED, DOMAIN_IMAGE));
-    }
-    return imageChanged;
-  }
-
-  private boolean areAuxiliaryImagesChanged() {
-    return !isEqualCollection(existingDomain.getAuxiliaryImages(), proposedDomain.getAuxiliaryImages());
-  }
-
-  private String getImage(@NotNull DomainResource existingDomain) {
-    return Optional.of(existingDomain).map(DomainResource::getSpec).map(DomainSpec::getImage).orElse(null);
-  }
-
-  private boolean noAuxiliaryImagesConfigured(@NotNull DomainResource domain) {
-    return domain.getAuxiliaryImages() == null;
-  }
-
-  private boolean areAllClusterReplicaCountsValid(@NotNull DomainResource domain) {
+  boolean areAllClusterReplicaCountsValid(@NotNull DomainResource domain) {
     return getClusterStatusList(domain).stream().allMatch(c -> isClusterReplicaCountValid(domain, c));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionWebhookResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionWebhookResource.java
@@ -120,7 +120,12 @@ public class AdmissionWebhookResource extends BaseResource {
     LOGGER.fine("validating " +  request.getObject() + " against " + request.getOldObject()
         + " Kind = " + request.getKind() + " uid = " + request.getUid() + " resource = " + request.getResource()
         + " subResource = " + request.getSubResource());
-    return new AdmissionChecker(request.getOldObject(), request.getObject()).validate().uid(getUid(request));
+    return createAdmissionChecker(request).validate().uid(getUid(request));
+  }
+
+  @NotNull
+  private AdmissionChecker createAdmissionChecker(@NotNull AdmissionRequest request) {
+    return new DomainAdmissionChecker(request.getExistingDomain(), request.getProposedDomain());
   }
 
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionWebhookResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionWebhookResource.java
@@ -16,6 +16,7 @@ import oracle.kubernetes.operator.webhooks.model.AdmissionRequest;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponseStatus;
 import oracle.kubernetes.operator.webhooks.model.AdmissionReview;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -125,7 +126,8 @@ public class AdmissionWebhookResource extends BaseResource {
 
   @NotNull
   private AdmissionChecker createAdmissionChecker(@NotNull AdmissionRequest request) {
-    return new DomainAdmissionChecker(request.getExistingDomain(), request.getProposedDomain());
+    return new DomainAdmissionChecker((DomainResource)request.getExistingResource(),
+        (DomainResource)request.getProposedResource());
   }
 
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainAdmissionChecker.java
@@ -1,0 +1,153 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.webhooks.resource;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
+import oracle.kubernetes.operator.webhooks.model.AdmissionResponseStatus;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
+import oracle.kubernetes.weblogic.domain.model.DomainSpec;
+import org.jetbrains.annotations.NotNull;
+
+import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_INTROSPECTION_TRIGGER_CHANGED;
+import static oracle.kubernetes.operator.KubernetesConstants.AUXILIARY_IMAGES;
+import static oracle.kubernetes.operator.KubernetesConstants.DOMAIN_IMAGE;
+import static oracle.kubernetes.operator.KubernetesConstants.DOMAIN_INTROSPECT_VERSION;
+import static org.apache.commons.collections4.CollectionUtils.isEqualCollection;
+
+/**
+ * AdmissionChecker provides the validation functionality for the validating webhook. It takes an existing resource and
+ * a proposed resource and returns a result to indicate if the proposed changes are allowed, and if not,
+ * what the problem is.
+ *
+ * <p>Currently it checks the following:
+ * <ul>
+ * <li>The proposed replicas settings at the domain level and/or cluster level can be honored by WebLogic domain config.
+ * </li>
+ * </ul>
+ * </p>
+ */
+
+public class DomainAdmissionChecker extends AdmissionChecker {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Webhook", "Operator");
+
+  private final DomainResource existingDomain;
+  private final DomainResource proposedDomain;
+
+  /** Construct a AdmissionChecker. */
+  public DomainAdmissionChecker(@NotNull DomainResource existingDomain, @NotNull DomainResource proposedDomain) {
+    super(existingDomain.getDomainUid());
+    this.existingDomain = existingDomain;
+    this.proposedDomain = proposedDomain;
+  }
+
+  /**
+   * Validating a proposed DomainResource resource against an existing DomainResource resource.
+   *
+   * @return a AdmissionResponse object
+   */
+  @Override
+  public AdmissionResponse validate() {
+    LOGGER.fine("Validating DomainResource " + proposedDomain + " against " + existingDomain);
+
+    AdmissionResponse response = new AdmissionResponse().allowed(isProposedChangeAllowed());
+    if (!response.isAllowed()) {
+      return response.status(new AdmissionResponseStatus().message(createMessage()));
+    } else if (!warnings.isEmpty()) {
+      return response.warnings(warnings);
+    }
+    return response;
+  }
+
+  /**
+   * Validating a proposed Domain resource against an existing DomainResource resource. It returns true if the
+   * proposed changes in the proposed DomainResource resource can be honored, otherwise, returns false.
+   *
+   * @return true if valid, otherwise false
+   */
+  public boolean isProposedChangeAllowed() {
+    return isUnchanged()
+        || areAllClusterReplicaCountsValid(proposedDomain)
+        || shouldIntrospect();
+  }
+
+  private boolean isUnchanged() {
+    return isSpecUnchanged();
+  }
+
+  private boolean isSpecUnchanged() {
+    return Optional.of(existingDomain)
+        .map(DomainResource::getSpec)
+        .map(this::isProposedSpecUnchanged)
+        .orElse(false);
+  }
+
+  private boolean isProposedSpecUnchanged(@NotNull DomainSpec existingSpec) {
+    return Objects.equals(existingSpec, proposedDomain.getSpec());
+  }
+
+  private boolean shouldIntrospect() {
+    return isIntrospectVersionChanged() || imagesChanged();
+  }
+
+  private boolean isIntrospectVersionChanged() {
+    boolean changed = !Objects.equals(existingDomain.getIntrospectVersion(), proposedDomain.getIntrospectVersion());
+    if (changed) {
+      warnings.add(LOGGER.formatMessage(DOMAIN_INTROSPECTION_TRIGGER_CHANGED, DOMAIN_INTROSPECT_VERSION));
+    }
+    return changed;
+  }
+
+  private boolean imagesChanged() {
+    if (!Objects.equals(existingDomain.getDomainHomeSourceType(), proposedDomain.getDomainHomeSourceType())) {
+      return true;
+    }
+    switch (proposedDomain.getDomainHomeSourceType()) {
+      case IMAGE:
+        return isDomainImageChanged();
+      case FROM_MODEL:
+        return areAuxiliaryImagesOrDomainImageChanged();
+      default:
+        return false;
+    }
+  }
+
+  private boolean areAuxiliaryImagesOrDomainImageChanged() {
+    if (noAuxiliaryImagesConfigured(existingDomain) && noAuxiliaryImagesConfigured(proposedDomain)) {
+      return isDomainImageChanged();
+    } else {
+      boolean changed =  noAuxiliaryImagesConfigured(existingDomain)
+          || noAuxiliaryImagesConfigured(proposedDomain)
+          || areAuxiliaryImagesChanged();
+      if (changed) {
+        warnings.add(LOGGER.formatMessage(DOMAIN_INTROSPECTION_TRIGGER_CHANGED, AUXILIARY_IMAGES));
+      }
+      return changed;
+    }
+  }
+
+  private boolean isDomainImageChanged() {
+    boolean imageChanged = !Objects.equals(getImage(existingDomain), getImage(proposedDomain));
+    if (imageChanged) {
+      warnings.add(LOGGER.formatMessage(DOMAIN_INTROSPECTION_TRIGGER_CHANGED, DOMAIN_IMAGE));
+    }
+    return imageChanged;
+  }
+
+  private boolean areAuxiliaryImagesChanged() {
+    return !isEqualCollection(existingDomain.getAuxiliaryImages(), proposedDomain.getAuxiliaryImages());
+  }
+
+  private String getImage(@NotNull DomainResource existingDomain) {
+    return Optional.of(existingDomain).map(DomainResource::getSpec).map(DomainSpec::getImage).orElse(null);
+  }
+
+  private boolean noAuxiliaryImagesConfigured(@NotNull DomainResource domain) {
+    return domain.getAuxiliaryImages() == null;
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
@@ -47,7 +47,7 @@ public class GsonBuilderUtils {
     return readMap(getGsonBuilder().toJson(domain, DomainResource.class));
   }
 
-  public static String writeMap(Map map) {
+  public static String writeMap(Map<String, Object> map) {
     return getGsonBuilder().toJson(map, Map.class);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
@@ -4,12 +4,14 @@
 package oracle.kubernetes.operator.webhooks.utils;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import oracle.kubernetes.operator.helpers.GsonOffsetDateTime;
 import oracle.kubernetes.operator.webhooks.model.AdmissionReview;
 import oracle.kubernetes.operator.webhooks.model.ConversionReviewModel;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
 public class GsonBuilderUtils {
 
@@ -31,6 +33,26 @@ public class GsonBuilderUtils {
 
   public static String writeAdmissionReview(AdmissionReview admissionReview) {
     return getGsonBuilder().toJson(admissionReview, AdmissionReview.class);
+  }
+
+  public static DomainResource readDomain(String resourceName) {
+    return getGsonBuilder().fromJson(resourceName, DomainResource.class);
+  }
+
+  public static String writeDomain(DomainResource domain) {
+    return getGsonBuilder().toJson(domain,DomainResource.class);
+  }
+
+  public static Map<String, Object> writeDomainToMap(DomainResource domain) {
+    return readMap(getGsonBuilder().toJson(domain, DomainResource.class));
+  }
+
+  public static String writeMap(Map map) {
+    return getGsonBuilder().toJson(map, Map.class);
+  }
+
+  public static Map<String, Object> readMap(String map) {
+    return getGsonBuilder().fromJson(map, Map.class);
   }
 
   private static Gson getGsonBuilder() {

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
@@ -39,10 +39,6 @@ public class GsonBuilderUtils {
     return getGsonBuilder().fromJson(resourceName, DomainResource.class);
   }
 
-  public static String writeDomain(DomainResource domain) {
-    return getGsonBuilder().toJson(domain,DomainResource.class);
-  }
-
   public static Map<String, Object> writeDomainToMap(DomainResource domain) {
     return readMap(getGsonBuilder().toJson(domain, DomainResource.class));
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/AdmissionCheckerTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/AdmissionCheckerTest.java
@@ -6,7 +6,7 @@ package oracle.kubernetes.operator.webhooks;
 import java.util.Collections;
 
 import oracle.kubernetes.operator.DomainSourceType;
-import oracle.kubernetes.operator.webhooks.resource.AdmissionChecker;
+import oracle.kubernetes.operator.webhooks.resource.DomainAdmissionChecker;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +27,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 class AdmissionCheckerTest {
   private final DomainResource existingDomain = createDomain();
   private final DomainResource proposedDomain = createDomain();
-  private final AdmissionChecker admissionChecker = new AdmissionChecker(existingDomain, proposedDomain);
+  private final DomainAdmissionChecker admissionChecker = new DomainAdmissionChecker(existingDomain, proposedDomain);
 
   @Test
   void whenSameObject_returnTrue() {

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
@@ -64,6 +64,7 @@ import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.readAdm
 import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.readConversionReview;
 import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.writeAdmissionReview;
 import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.writeConversionReview;
+import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.writeDomainToMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -474,7 +475,7 @@ class WebhookRestTest extends RestTestBase {
   }
 
   private void setExistingAndProposedDomain() {
-    admissionReview.getRequest().oldObject(existingDomain).object(proposedDomain);
+    admissionReview.getRequest().oldObject(writeDomainToMap(existingDomain)).object(writeDomainToMap(proposedDomain));
   }
 
   private void setProposedDomain() {
@@ -482,7 +483,7 @@ class WebhookRestTest extends RestTestBase {
   }
 
   private void setProposedDomain(DomainResource domain) {
-    admissionReview.getRequest().setObject(domain);
+    admissionReview.getRequest().setObject(writeDomainToMap(domain));
   }
 
   private void setExistingDomain() {
@@ -490,7 +491,7 @@ class WebhookRestTest extends RestTestBase {
   }
 
   private void setExistingDomain(DomainResource domain) {
-    admissionReview.getRequest().setOldObject(domain);
+    admissionReview.getRequest().setOldObject(writeDomainToMap(domain));
   }
 
   private AdmissionReview sendValidatingRequestAsAdmissionReview(AdmissionReview admissionReview) {


### PR DESCRIPTION
Refactor the validating webhook in order to support ClusterResource.

- Change each resource object in the request to a raw JSON map so that it can be a DomainResource or a ClusterResource. The webhook converts the JSON map to the corresponding strong-typed resource object when it performs the validation.
- Split AdmissionChecker into AdmissionChecker and DomainAdmissionChecker; prepared to add a ClusterAdmissionChecker.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11029/