### PR TITLE
Fix script create-secret.sh to use bash instead of sh 

### DIFF
--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -41,9 +41,6 @@ def _kind_image = null
 
 pipeline {
     agent { label 'VM.Standard2.8' }
-    triggers {
-        cron('H 5 * * *')
-    }
     options {
         timeout(time: 800, unit: 'MINUTES')
     }

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/utils/create-secret.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/utils/create-secret.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #


### PR DESCRIPTION
Resolution to  MiiSample tests failure

Info: Creating weblogic domain secret
/tmp/workspace/wko-kind-nightly-parallel/logdir/jenkins-wko-kind-nightly-parallel-921/wl_k8s_test_results/workdir/ns-vlgvbx/model-in-image-sample-work-dir/utils/create-secret.sh: line 146: syntax error near unexpected token `('
@@ [2022-06-16T08:10:19] [run-test.sh:302]: Error: Error running command '$MIIWRAPPERDIR/create-secrets.sh', output='/tmp/workspace/wko-kind-nightly-parallel/logdir/jenkins-wko-kind-nightly-parallel-921/wl_k8s_test_results/workdir/ns-vlgvbx/model-in-image-sample-work-dir/test-out/20714.003.2022-06-16T08:10:19.create-secrets.sh.out'. Output dumped above.

Also modified Jenkinfile to remove explicit timer configuration 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11033/  ( in progress )