### PR TITLE
remove duplicate procedures

### DIFF
--- a/documentation/staging/content/quickstart/create-domain.md
+++ b/documentation/staging/content/quickstart/create-domain.md
@@ -80,41 +80,7 @@ weight: 3
 
 1.	Create an ingress route for the domain, in the domain namespace, by using the following YAML file.
 
-    a. Copy the following IngressRoute YAML to a file called `/tmp/quickstart/ingress-route.yaml` or similar:
-
-
-    {{%expand "Click here to view the ingress route YAML file." %}}
-    # Copyright (c) 2022, Oracle and/or its affiliates.
-    # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-    apiVersion: traefik.containo.us/v1alpha1
-    kind: IngressRoute
-    metadata:
-      name: console
-      namespace: sample-domain1-ns
-    spec:
-      routes:
-        - kind: Rule
-          match: PathPrefix(`/console`)
-          services:
-            - kind: Service
-              name: sample-domain1-admin-server
-              port: 7001
-    ---
-    apiVersion: traefik.containo.us/v1alpha1
-    kind: IngressRoute
-    metadata:
-      name: quickstart
-      namespace: sample-domain1-ns
-    spec:
-      routes:
-      - kind: Rule
-        match: PathPrefix(`/quickstart`)
-        services:
-        - kind: Service
-          name: sample-domain1-cluster-cluster-1
-          port: 8001
-    {{% /expand %}}
+    a. Download the [ingress route YAML](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/ingress-route.yaml) to a file called `/tmp/quickstart/ingress-route.yaml` or similar:
 
     b. Then apply the file using:
     ```shell

--- a/documentation/staging/content/quickstart/create-domain.md
+++ b/documentation/staging/content/quickstart/create-domain.md
@@ -31,15 +31,13 @@ weight: 3
 
    - Use the following command to apply the sample domain resource:
 
-       ```shell
-       $ kubectl apply -f https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml
-       ```
+     ```shell
+     $ kubectl apply -f https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml
+     ```
 
-    - **NOTE**: If you want to view or need to modify the sample domain YAML file, you can download it to `/tmp/quickstart/domain-resource.yaml` or similar, using the following command. Then apply the file using `kubectl apply -f /tmp/quickstart/domain-resource.yaml`.
+   - **NOTE**: If you want to view or need to modify it, you can download the [sample domain resource](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml) to a file called `/tmp/quickstart/domain-resource.yaml` or similar. Then apply the file using `kubectl apply -f /tmp/quickstart/domain-resource.yaml`.
 
-      ```shell
-      $ curl -m 120 -fL https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml -o /tmp/quickstart/domain-resource.yaml
-      ```
+
    This domain resource references a WebLogic Server installation image, the secrets you defined, and a sample "auxiliary image," which contains traditional WebLogic configuration and a WebLogic application.
 
      - To examine the domain resource, click [here](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml).

--- a/documentation/staging/content/quickstart/create-domain.md
+++ b/documentation/staging/content/quickstart/create-domain.md
@@ -35,7 +35,7 @@ weight: 3
        $ kubectl apply -f https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml
        ```
 
-    - **NOTE**: If you need to modify the sample domain YAML file, you can download the file to `/tmp/quickstart/domain-resource.yaml` or similar, using the following command, and make any changes needed. Then apply the file using `kubectl apply -f /tmp/quickstart/domain-resource.yaml`:
+    - **NOTE**: If you want to view or need to modify the sample domain YAML file, you can download it to `/tmp/quickstart/domain-resource.yaml` or similar, using the following command. Then apply the file using `kubectl apply -f /tmp/quickstart/domain-resource.yaml`.
 
       ```shell
       $ curl -m 120 -fL https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml -o /tmp/quickstart/domain-resource.yaml
@@ -117,21 +117,12 @@ weight: 3
           name: sample-domain1-cluster-cluster-1
           port: 8001
     {{% /expand %}}
+
+    b. Then apply the file using:
     ```shell
     $ kubectl apply -f /tmp/quickstart/ingress-route.yaml \
       --namespace sample-domain1-ns
     ```
-
-      b. **NOTE**: Instead of running the previous  `kubectl apply` command, you can download the ingress route YAML file to `/tmp/quickstart/ingress-route.yaml` or similar, using the following command:
-
-      ```shell
-      $ curl -m 120 -fL https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/ingress-route.yaml -o /tmp/quickstart/ingress-route.yaml
-      ```
-      c. Then apply the file using:
-      ```shell
-      $ kubectl apply -f /tmp/quickstart/ingress-route.yaml \
-        --namespace sample-domain1-ns
-      ```
 
 1.  To confirm that the ingress controller noticed the new ingress route and is successfully routing to the domain's server pods, send a request to the URL for the "quick start app", as shown in the following example, which will return an HTTP 200 status code.
 

--- a/documentation/staging/content/quickstart/prepare.md
+++ b/documentation/staging/content/quickstart/prepare.md
@@ -38,7 +38,7 @@ weight: 2
 
     c. From the drop-down menu, select your language and click Continue.
 
-    d. Then, read and accept the license agreement.
+    d. Then read and accept the license agreement.
 
 1. Create a `docker-registry` secret to enable pulling the example WebLogic Server image from the registry:
 

--- a/documentation/staging/content/quickstart/summary.md
+++ b/documentation/staging/content/quickstart/summary.md
@@ -76,7 +76,7 @@ These steps help you understand and customize auxiliary image creation. Then you
    You will use WIT and its cached reference to the WDT installer later in the sample for creating model images.
 
 1. Download the sample WDT model, web application, and properties files to be included in the auxiliary image and put them in your `/tmp/quickstart/models` directory.
-Then, use the JAR command to put the web application files into a model archive ZIP file.
+Then use the JAR command to put the web application files into a model archive ZIP file.
 
    For example:
    ```shell
@@ -168,11 +168,7 @@ If you followed the previous steps to create an auxiliary image, then use these 
 
 1. Prepare the domain resource.
 
-    a. Copy the [WLS Domain YAML](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml) to a file called `/tmp/quickstart/domain-resource.yaml` or similar. Alternatively, you can download the WLS Domain YAML file to `/tmp/quickstart/domain-resource.yaml` or similar, using the following command:
-
-      ```shell
-      $ curl -m 120 -fL https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml -o /tmp/quickstart/domain-resource.yaml
-      ```
+    a. Copy the [WLS Domain YAML](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml) to a file called `/tmp/quickstart/domain-resource.yaml` or similar. 
 
     b. If you chose a different name and tag for the auxiliary image you created, then update the image field under the `spec.configuration.model.auxiliaryImages`
     section to use that name and tag. For example, if you named the auxiliary image `my-aux-image:v1`, then update the `spec.configuration.model.auxiliaryImages` section as shown:

--- a/documentation/staging/content/quickstart/summary.md
+++ b/documentation/staging/content/quickstart/summary.md
@@ -168,7 +168,7 @@ If you followed the previous steps to create an auxiliary image, then use these 
 
 1. Prepare the domain resource.
 
-    a. Copy the [WLS Domain YAML](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml) to a file called `/tmp/quickstart/domain-resource.yaml` or similar. 
+    a. Download the [sample domain resource](https://raw.githubusercontent.com/oracle/weblogic-kubernetes-operator/main/kubernetes/samples/quick-start/domain-resource.yaml) to a file called `/tmp/quickstart/domain-resource.yaml` or similar. 
 
     b. If you chose a different name and tag for the auxiliary image you created, then update the image field under the `spec.configuration.model.auxiliaryImages`
     section to use that name and tag. For example, if you named the auxiliary image `my-aux-image:v1`, then update the `spec.configuration.model.auxiliaryImages` section as shown:


### PR DESCRIPTION
In a Quick Start guide, it goes against technical writing best practices to implement duplicate procedures without a **known** benefit. (Please correct me if there is one.) These add to its maintenance and the likelihood of becoming out-of-sync. @ankedia advised me that copy & paste is easier for users, so I removed the procedural duplicate curl commands to download the files in two instances. From discussions with @tbarnes-us, I know he doesn't agree. **NOTE**: I kept the curl command to download the sample domain YAML file because there was no other way for users to view or modify it, if needed.