### PR TITLE
Enable aux image upgrade test from 3.4.1 to current and remove usage of OCIR operator image.

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -216,26 +216,10 @@ class ItOperatorWlsUpgrade {
     installAndUpgradeOperator(domainType, "3.4.1", OLD_DOMAIN_VERSION, DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
   }
 
-  /**
-   * Auxiliary Image Domain upgrade from Operator v3.4.0 to current.
-   */
-  @Test
-  @DisplayName("Upgrade 3.4.0 Auxiliary Domain(v8 schema) Image to current")
-  void testOperatorWlsAuxDomainUpgradeFrom340ToCurrent() {
-    logger.info("Starting test to upgrade Domain with Auxiliary Image with v8 schema to current");
-    upgradeWlsAuxDomain("3.4.0");
-  }
 
   /**
    * Auxiliary Image Domain upgrade from Operator v3.4.1 to current.
-   * The current release of the 3.4.1 does not conatin the resolution
-   * described in the following PR 
-   * https://github.com/oracle/weblogic-kubernetes-operator/pull/3165/files
-   *
-   * Note testOperatorWlsAuxDomainUpgradeFrom340ToCurrent() uses a 
-   * patched Operator 3.4.0 image to make it pass. See utils/OperatorUtils.java
    */
-  @Disabled
   @Test
   @DisplayName("Upgrade 3.4.1 Auxiliary Domain(v8 schema) Image to current")
   void testOperatorWlsAuxDomainUpgradeFrom341ToCurrent() {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
@@ -47,10 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OperatorUtils {
 
-  public static final String OPERATOR_VERSION_340 = "3.4.0";
-  public static final String OPERATOR_340_IMAGE_OWLS_99380 =
-      "phx.ocir.io/weblogick8s/weblogic-kubernetes-operator:owls_99380";
-
   /**
    * Install WebLogic operator and wait up to five minutes until the operator pod is ready.
    *
@@ -446,12 +442,7 @@ public class OperatorUtils {
     logger.info("Created service account: {0}", opServiceAccount);
 
     // get operator image name.
-    // For operator version 3.4.0, temporarily use the image with OWLS_99380 fix from OCIR.
-    if (OPERATOR_VERSION_340.equals(opHelmParams.getChartVersion())) {
-      operatorImage = OPERATOR_340_IMAGE_OWLS_99380;
-    } else {
-      operatorImage = getOperatorImageName();
-    }
+    operatorImage = getOperatorImageName();
 
     assertFalse(operatorImage.isEmpty(), "operator image name can not be empty");
     logger.info("operator image name {0}", operatorImage);
@@ -484,7 +475,7 @@ public class OperatorUtils {
     }
 
     // use default image in chart when repoUrl is set, otherwise use latest/current branch operator image
-    if ((opHelmParams.getRepoUrl() == null) || (OPERATOR_VERSION_340.equals(opHelmParams.getChartVersion()))) {
+    if ((opHelmParams.getRepoUrl() == null)) {
       opParams.image(operatorImage);
     }
 


### PR DESCRIPTION
This PR enables the upgrade test `testOperatorWlsAuxDomainUpgradeFrom341ToCurrent` which was previously disabled. This test passes after the latest upgrade related changes. It also removes the `testOperatorWlsAuxDomainUpgradeFrom340ToCurrent` which uses the patched operator image from OCIR.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11098/