### PR TITLE
Added AuxImageUpgrade test from Release 3.4.1

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItLiftAndShiftFromOnPremDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItLiftAndShiftFromOnPremDomain.java
@@ -161,7 +161,13 @@ class ItLiftAndShiftFromOnPremDomain {
     final String adminServerPodName = domainUid + "-admin-server";
     final String managedServerPrefix = domainUid + "-managed-server";
     final String clusterService = domainUid + "-cluster-cluster-1";
-    final int replicaCount = 5;
+    // As of WDT v2.3.1, the discovery tool will not put the replica count 
+    // in genererated domain resource yaml file. So the Operator will start 
+    // only one managed servers (default replica count)  
+    // To add custom replica count, need to create a wdt model file with 
+    // kubernates section with custom repilca count
+    // final int replicaCount = 5;
+    final int replicaCount = 1;
 
     assertDoesNotThrow(() -> {
       logger.info("Deleting and recreating {0}", LIFT_AND_SHIFT_WORK_DIR);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -217,16 +217,6 @@ class ItOperatorWlsUpgrade {
   }
 
   /**
-   * Auxiliary Image Domain upgrade from Operator v3.4.0 to current.
-   */
-  @Test
-  @DisplayName("Upgrade 3.4.0 Auxiliary Domain(v8 schema) Image to current")
-  void testOperatorWlsAuxDomainUpgradeFrom340ToCurrent() {
-    logger.info("Starting test to upgrade Domain with Auxiliary Image with v8 schema to current");
-    upgradeWlsAuxDomain("3.4.0");
-  }
-
-  /**
    * Auxiliary Image Domain upgrade from Operator v3.4.1 to current.
    * The current release of the 3.4.1 does not conatin the resolution
    * described in the following PR 
@@ -235,7 +225,6 @@ class ItOperatorWlsUpgrade {
    * Note testOperatorWlsAuxDomainUpgradeFrom340ToCurrent() uses a 
    * patched Operator 3.4.0 image to make it pass. See utils/OperatorUtils.java
    */
-  @Disabled
   @Test
   @DisplayName("Upgrade 3.4.1 Auxiliary Domain(v8 schema) Image to current")
   void testOperatorWlsAuxDomainUpgradeFrom341ToCurrent() {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -218,12 +218,6 @@ class ItOperatorWlsUpgrade {
 
   /**
    * Auxiliary Image Domain upgrade from Operator v3.4.1 to current.
-   * The current release of the 3.4.1 does not conatin the resolution
-   * described in the following PR 
-   * https://github.com/oracle/weblogic-kubernetes-operator/pull/3165/files
-   *
-   * Note testOperatorWlsAuxDomainUpgradeFrom340ToCurrent() uses a 
-   * patched Operator 3.4.0 image to make it pass. See utils/OperatorUtils.java
    */
   @Test
   @DisplayName("Upgrade 3.4.1 Auxiliary Domain(v8 schema) Image to current")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;
@@ -46,10 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OperatorUtils {
-
-  public static final String OPERATOR_VERSION_340 = "3.4.0";
-  public static final String OPERATOR_340_IMAGE_OWLS_99380 =
-      "phx.ocir.io/weblogick8s/weblogic-kubernetes-operator:owls_99380";
 
   /**
    * Install WebLogic operator and wait up to five minutes until the operator pod is ready.
@@ -445,13 +441,7 @@ public class OperatorUtils {
             .name(opServiceAccount))));
     logger.info("Created service account: {0}", opServiceAccount);
 
-    // get operator image name.
-    // For operator version 3.4.0, temporarily use the image with OWLS_99380 fix from OCIR.
-    if (OPERATOR_VERSION_340.equals(opHelmParams.getChartVersion())) {
-      operatorImage = OPERATOR_340_IMAGE_OWLS_99380;
-    } else {
-      operatorImage = getOperatorImageName();
-    }
+    operatorImage = getOperatorImageName();
 
     assertFalse(operatorImage.isEmpty(), "operator image name can not be empty");
     logger.info("operator image name {0}", operatorImage);
@@ -484,7 +474,7 @@ public class OperatorUtils {
     }
 
     // use default image in chart when repoUrl is set, otherwise use latest/current branch operator image
-    if ((opHelmParams.getRepoUrl() == null) || (OPERATOR_VERSION_340.equals(opHelmParams.getChartVersion()))) {
+    if (opHelmParams.getRepoUrl() == null)  {
       opParams.image(operatorImage);
     }
 

--- a/integration-tests/src/test/resources/bash-scripts/syncTestImagesRepo.sh
+++ b/integration-tests/src/test/resources/bash-scripts/syncTestImagesRepo.sh
@@ -40,7 +40,7 @@ dockerPullPushImage() {
  docker rmi -f ${tgt_image} 
 }
 
-dockerPullPushImages {
+dockerPullPushImages() {
  file="images.properties"
  egrep -v '^#' $file | grep -v "^$" |
    while IFS=";" read -r f1 f2 
@@ -75,4 +75,3 @@ if [ ${SOURCE_REPO} == ${TARGET_REPO} ]; then
 fi
 
 dockerLogin 
-dockerPullPushImages


### PR DESCRIPTION
The PR covers the following changes 
 
(a) Added AuxImageUpgrade test from Release 3.4.1
(b) update the script to sync images from OCIR 
(c) Resolution to ItLiftAndShiftFromOnPremDomain failure to check for only single replica 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11147/ (ItLiftAndShiftFromOnPremDomain)
https://build.weblogick8s.org:8443/job/wko-kind-nightly-seqential/709/  (Upgrade Test All PASSED)
