### PR TITLE
Owls 100113 - Fix for intermittent nightly failure in ItMiiSampleFmwAux.testAIFmwInitialUseCase 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ItMiiSampleHelper.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ItMiiSampleHelper.java
@@ -6,11 +6,13 @@ package oracle.weblogic.kubernetes.utils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -226,11 +228,9 @@ public class ItMiiSampleHelper {
                 .redirect(true)
         ).executeAndReturnResult();
 
-        // check if kill command failed during cleanup, it will cause the exit value to be non-zero.
-        boolean cleaupFailed = result.stderr() != null && result.stderr().contains("kill: usage");
         boolean success =
             result != null
-                && (result.exitValue() == 0 || cleaupFailed)
+                && (result.exitValue() == 0 || cleaupFailed(result))
                 && result.stdout() != null
                 && result.stdout().contains(successSearchString);
 
@@ -246,6 +246,12 @@ public class ItMiiSampleHelper {
 
       previousTestSuccessful = true;
     }
+  }
+
+  @NotNull
+  private Boolean cleaupFailed(ExecResult result) {
+    // check if kill command failed during cleanup, it will cause the exit value to be non-zero.
+    return Optional.ofNullable(result.stderr()).map(c -> c.contains("kill: usage")).orElse(false);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ItMiiSampleHelper.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ItMiiSampleHelper.java
@@ -6,13 +6,11 @@ package oracle.weblogic.kubernetes.utils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -230,7 +228,7 @@ public class ItMiiSampleHelper {
 
         boolean success =
             result != null
-                && (result.exitValue() == 0 || cleaupFailed(result))
+                && result.exitValue() == 0
                 && result.stdout() != null
                 && result.stdout().contains(successSearchString);
 
@@ -246,12 +244,6 @@ public class ItMiiSampleHelper {
 
       previousTestSuccessful = true;
     }
-  }
-
-  @NotNull
-  private Boolean cleaupFailed(ExecResult result) {
-    // check if kill command failed during cleanup, it will cause the exit value to be non-zero.
-    return Optional.ofNullable(result.stderr()).map(c -> c.contains("kill: usage")).orElse(false);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ItMiiSampleHelper.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ItMiiSampleHelper.java
@@ -226,9 +226,11 @@ public class ItMiiSampleHelper {
                 .redirect(true)
         ).executeAndReturnResult();
 
+        // check if kill command failed during cleanup, it will cause the exit value to be non-zero.
+        boolean cleaupFailed = result.stderr() != null && result.stderr().contains("kill: usage");
         boolean success =
             result != null
-                && result.exitValue() == 0
+                && (result.exitValue() == 0 || cleaupFailed)
                 && result.stdout() != null
                 && result.stdout().contains(successSearchString);
 

--- a/operator/integration-tests/model-in-image/run-test.sh
+++ b/operator/integration-tests/model-in-image/run-test.sh
@@ -12,7 +12,7 @@
 
 set -eu
 set -o pipefail
-trap '[ -z "$(jobs -pr)" ] || kill $(jobs -pr)' SIGINT SIGTERM EXIT
+trap 'status=$? ; set +eu ; set +o pipefail ; kill $(jobs -pr) > /dev/null 2>&1 ; exit $status' SIGINT SIGTERM EXIT
 
 TESTDIR="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 


### PR DESCRIPTION
Owls 100113 - Fix for intermittent nightly failure in ItMiiSampleFmwAux.testAIFmwInitialUseCase. The issue is caused by a race between the check for "no processes" and the "kill existing processes" during cleanup causing exit value to be non-zero. This PR uses an updated trap command.