### PR TITLE
owls-100118 - backport PR 3212 to release/3.4 

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -240,6 +240,31 @@ class OfflineWlstEnv(object):
       ret = None
     return ret
 
+ # Work-around bug in off-line WLST where cluster.getDynamicServers() may throw
+  # when there are no 'real' DynamicServers.  Exception looks like:
+  #     at com.sun.proxy.$Proxy46.getDynamicServers(Unknown Source)
+  #     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+  #     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+  #     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+  #     at java.lang.reflect.Method.invoke(Method.java:498)
+  def getDynamicServersOrNone(self,cluster):
+    ret = None
+    try:
+      cd('/Cluster/' + cluster.getName() + '/DynamicServers')
+      # DynamicServers MBean can be found under
+      # /Cluster/<clusterName>/DynamicServers/<clusterName>/
+      # or
+      # /Cluster/<clusterName>/DynamicServers/NO_NAME_0/
+      childObjs = ls(returnMap='true', returnType='c')
+      if not childObjs.isEmpty():
+        cd(childObjs[0])
+        if get('ServerTemplate') is not None:
+          # Cluster is a dynamic cluster if a ServerTemplate MBean is found
+          ret = cmo
+    except:
+      trace("Ignoring cd() exception for cluster '" + cluster.getName() + "' in getDynamicServerOrNone() and returning None.")
+    return ret;
+
   def addGeneratedFile(self, filePath):
     self.generatedFiles.append(filePath)
 
@@ -366,25 +391,6 @@ class TopologyGenerator(Generator):
     finally:
       self.close()
 
-  # Work-around bug in off-line WLST where cluster.getDynamicServers() may throw
-  # when there are no 'real' DynamicServers.  Exception looks like:
-  #     at com.sun.proxy.$Proxy46.getDynamicServers(Unknown Source)
-  #     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  #     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  #     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  #     at java.lang.reflect.Method.invoke(Method.java:498)
-  def getDynamicServersOrNone(self,cluster):
-    try:
-      ret = cluster.getDynamicServers()
-      # Dynamic Servers must be configured with a ServerTemplate
-      if ret is not None:
-        if ret.getServerTemplate() is None:
-          ret = None
-    except:
-      trace("Ignoring getDynamicServers() exception, this is expected.")
-      ret = None
-    return ret
-
   def validateAdminServer(self):
     adminServerName = self.env.getDomain().getAdminServerName()
     if adminServerName is None:
@@ -405,18 +411,22 @@ class TopologyGenerator(Generator):
   def validateDynamicClustersDuplicateServerNamePrefix(self):
     serverNamePrefixes = []
     for cluster in self.env.getDomain().getClusters():
-      if self.getDynamicServersOrNone(cluster) is not None:
-        if cluster.getDynamicServers().getServerNamePrefix() in serverNamePrefixes:
-          self.addError("The ServerNamePrefix '" + cluster.getDynamicServers().getServerNamePrefix() + "' specified for WebLogic dynamic cluster " + self.name(cluster) + "'s dynamic servers is already in use. The ServerNamePrefix must be unique for each WebLogic dynamic cluster.")
+      dynamicServers = self.env.getDynamicServersOrNone(cluster)
+      if dynamicServers is not None:
+        if dynamicServers.getServerNamePrefix() is None:
+          self.addError("The ServerNamePrefix is not set for WebLogic dynamic cluster " + self.name(cluster) + "'s dynamic servers. The ServerNamePrefix must be set for each WebLogic dynamic cluster.")
         else:
-          serverNamePrefixes.append(cluster.getDynamicServers().getServerNamePrefix())
+          if dynamicServers.getServerNamePrefix() in serverNamePrefixes:
+            self.addError("The ServerNamePrefix '" + dynamicServers.getServerNamePrefix() + "' specified for WebLogic dynamic cluster " + self.name(cluster) + "'s dynamic servers is already in use. The ServerNamePrefix must be unique for each WebLogic dynamic cluster.")
+          else:
+            serverNamePrefixes.append(dynamicServers.getServerNamePrefix())
 
   def validateClusters(self):
     for cluster in self.env.getDomain().getClusters():
       self.validateCluster(cluster)
 
   def validateCluster(self, cluster):
-    if self.getDynamicServersOrNone(cluster) is None:
+    if self.env.getDynamicServersOrNone(cluster) is None:
       self.validateNonDynamicCluster(cluster)
     else:
       self.validateDynamicCluster(cluster)
@@ -560,8 +570,10 @@ class TopologyGenerator(Generator):
         self.addError("The WebLogic dynamic cluster " + self.name(cluster) + " is referenced by configured server " + self.name(server) + ", the operator does not support 'mixed clusters' that host both dynamic (templated) servers and configured servers.")
 
   def validateDynamicClusterDynamicServersDoNotUseCalculatedListenPorts(self, cluster):
-    if cluster.getDynamicServers().isCalculatedListenPorts() == True:
-      self.addError("The WebLogic dynamic cluster " + self.name(cluster) + "'s dynamic servers use calculated listen ports.")
+    dynamicServers = self.env.getDynamicServersOrNone(cluster)
+    if dynamicServers is not None:
+      if dynamicServers.isCalculatedListenPorts() == True:
+        self.addError("The WebLogic dynamic cluster " + self.name(cluster) + "'s dynamic servers use calculated listen ports.")
 
   def validateServerCustomChannelName(self):
     reservedNames = ['default','default-secure','default-admin']
@@ -610,13 +622,13 @@ class TopologyGenerator(Generator):
   def getConfiguredClusters(self):
     rtn = []
     for cluster in self.env.getDomain().getClusters():
-      if self.getDynamicServersOrNone(cluster) is None:
+      if self.env.getDynamicServersOrNone(cluster) is None:
         rtn.append(cluster)
     return rtn
 
   def addConfiguredCluster(self, cluster):
     self.writeln("- name: " + self.name(cluster))
-    dynamicServers = self.getDynamicServersOrNone(cluster)
+    dynamicServers = self.env.getDynamicServersOrNone(cluster)
     if dynamicServers is not None:
       self.indent();
       self.writeln("dynamicServersConfig:")
@@ -703,7 +715,7 @@ class TopologyGenerator(Generator):
   def getDynamicClusters(self):
     rtn = []
     for cluster in self.env.getDomain().getClusters():
-      if self.getDynamicServersOrNone(cluster) is not None:
+      if self.env.getDynamicServersOrNone(cluster) is not None:
         rtn.append(cluster)
     return rtn
 
@@ -1195,7 +1207,7 @@ class SitConfigGenerator(Generator):
 
   def customizeServerTemplate(self, template):
     name=template.getName()
-    server_name_prefix=template.getCluster().getDynamicServers().getServerNamePrefix()
+    server_name_prefix=self.env.getDynamicServersOrNone(template.getCluster()).getServerNamePrefix()
     listen_address=self.env.toDNS1123Legal(self.env.getDomainUID() + "-" + server_name_prefix + "${id}")
     self.writeln("<d:server-template>")
     self.indent()


### PR DESCRIPTION
backport owls-100118 - Dynamic cluster configured as configured cluster by introspectDomain.py to release/3.4

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11239/testReport/
- all 3 failed tests are known failures