### PR TITLE
Ensure REPLICAS_TOO_HIGH and DOMAIN_VALIDATION failures do not flicker

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainFailureMessages.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainFailureMessages.java
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
+
+import static oracle.kubernetes.common.logging.MessageKeys.TOO_MANY_REPLICAS_FAILURE;
+
+public class DomainFailureMessages {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
+  private DomainFailureMessages() {
+  }
+
+  public static String createReplicaFailureMessage(String clusterName, int specifiedReplicaCount, int maxReplicaCount) {
+    return LOGGER.formatMessage(TOO_MANY_REPLICAS_FAILURE, specifiedReplicaCount, clusterName, maxReplicaCount);
+  }
+}

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -579,13 +579,13 @@ public class ConfigMapHelper {
     }
 
     private Step createIntrospectionVersionUpdateStep() {
-      return DomainValidationSteps.createValidateDomainTopologyStep(
+      return DomainValidationSteps.createValidateDomainTopologySteps(
             createIntrospectorConfigMapContext().patchOnly().verifyConfigMap(conflictStep.getNext()));
     }
 
     private Step createValidationStep() {
       return Step.chain(
-            DomainValidationSteps.createValidateDomainTopologyStep(null),
+            DomainValidationSteps.createValidateDomainTopologySteps(null),
             new IntrospectionConfigMapStep(data, conflictStep.getNext()));
     }
 
@@ -895,7 +895,7 @@ public class ConfigMapHelper {
       if (domainTopology != null) {
         recordTopology(packet, packet.getSpi(DomainPresenceInfo.class), domainTopology);
         recordIntrospectVersionAndGeneration(result, packet);
-        return doNext(DomainValidationSteps.createValidateDomainTopologyStep(getNext()), packet);
+        return doNext(DomainValidationSteps.createValidateDomainTopologySteps(getNext()), packet);
       } else {
         return doNext(packet);
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -7,6 +7,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -839,9 +840,23 @@ public class DomainPresenceInfo implements PacketComponent {
         .ifPresent(name -> clusters.put(name, clusterResource));
   }
 
+  /**
+   * Remove a named cluster resource.
+   * @param clusterName the name of the resource to remove.
+   */
   public ClusterResource removeClusterResource(String clusterName) {
     return Optional.ofNullable(clusterName)
         .map(clusters::remove).orElse(null);
+  }
+
+  /**
+   * Returns all clusters associated with this domain presence.
+   */
+  public List<ClusterSpec> getClusters() {
+    final Map<String, ClusterSpec> result = new HashMap<>();
+    getDomain().getSpec().getClusters().forEach(c -> result.put(c.getClusterName(), c));
+    clusters.values().stream().map(ClusterResource::getSpec).forEach(c -> result.put(c.getClusterName(), c));
+    return new ArrayList<>(result.values());
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/WlsConfigValidator.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/WlsConfigValidator.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import oracle.kubernetes.operator.DomainFailureMessages;
 import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
@@ -33,6 +34,7 @@ import static oracle.kubernetes.common.logging.MessageKeys.MONITORING_EXPORTER_C
 import static oracle.kubernetes.common.logging.MessageKeys.NO_AVAILABLE_PORT_TO_USE_FOR_REST;
 import static oracle.kubernetes.common.logging.MessageKeys.NO_CLUSTER_IN_DOMAIN;
 import static oracle.kubernetes.common.logging.MessageKeys.NO_MANAGED_SERVER_IN_DOMAIN;
+import static oracle.kubernetes.common.logging.MessageKeys.TOO_MANY_REPLICAS_FAILURE;
 import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_DNS_LABEL_NAME_MAX_LENGTH;
 
 public class WlsConfigValidator {
@@ -47,7 +49,7 @@ public class WlsConfigValidator {
   }
 
   private final String domainUid;
-  private final List<String> failures = new ArrayList<>();
+  private final List<String> topologyFailures = new ArrayList<>();
   private final DomainPresenceInfo info;
   private final WlsDomainConfig domainConfig;
   private LoggingFacade loggingFacade;
@@ -111,14 +113,14 @@ public class WlsConfigValidator {
    *
    * @return a list of strings that describe the failures.
    */
-  List<String> getFailures() {
+  List<String> getTopologyFailures() {
     if (domainConfig != null) {
       verifyDomainResourceReferences();
       verifyGeneratedResourceNames();
       verifyServerPorts();
       reportIfExporterPortConflicts();
     }
-    return failures;
+    return topologyFailures;
   }
 
   // Ensure that all clusters and servers configured by the domain resource actually exist in the topology.
@@ -142,14 +144,14 @@ public class WlsConfigValidator {
   }
 
   private void reportFailure(String messageKey, Object... params) {
-    failures.add(LOGGER.formatMessage(messageKey, params));
+    topologyFailures.add(LOGGER.formatMessage(messageKey, params));
     if (loggingFacade != null) {
       loggingFacade.warning(messageKey, params);
     }
   }
 
   private List<ClusterSpec> getClusters() {
-    return info.getDomain().getSpec().getClusters();
+    return info.getClusters();
   }
 
   private boolean isUnknownCluster(String clusterName) {
@@ -286,5 +288,43 @@ public class WlsConfigValidator {
           .map(NetworkAccessPoint::getListenPort)
           .filter(Objects::nonNull)
           .collect(Collectors.toList());
+  }
+
+  List<String> getReplicaTooHighFailures() {
+    final List<String> failures = new ArrayList<>();
+
+    for (String clusterName : getTopologyClusterNames()) {
+      new ClusterReplicaCheck(failures, clusterName).validateCluster();
+    }
+    return failures;
+  }
+
+  class ClusterReplicaCheck {
+    private final List<String> failures;
+    private final String clusterName;
+    private final int replicaCount;
+    private final int maxClusterSize;
+
+    ClusterReplicaCheck(List<String> failures, String clusterName) {
+      this.failures = failures;
+      this.clusterName = clusterName;
+      this.replicaCount = info.getReplicaCount(clusterName);
+      this.maxClusterSize = domainConfig.getClusterConfig(clusterName).getMaxClusterSize();
+    }
+
+    private void validateCluster() {
+      if (replicaCount > maxClusterSize) {
+        failures.add(DomainFailureMessages.createReplicaFailureMessage(clusterName, replicaCount, maxClusterSize));
+        if (loggingFacade != null) {
+          loggingFacade.warning(TOO_MANY_REPLICAS_FAILURE, replicaCount, clusterName, maxClusterSize);
+        }
+      }
+    }
+
+  }
+
+  @NotNull
+  private String[] getTopologyClusterNames() {
+    return Optional.ofNullable(domainConfig).map(WlsDomainConfig::getClusterNames).orElse(new String[0]);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -289,7 +289,6 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
         Step.chain(
             ConfigMapHelper.createOrReplaceFluentdConfigMapStep(),
             domainIntrospectionSteps(),
-            DomainValidationSteps.createAfterIntrospectValidationSteps(),
             new DomainStatusStep(),
             DomainProcessorImpl.bringAdminServerUp(info, delegate.getPodAwaiterStepFactory(info.getNamespace())),
             managedServerStrategy);

--- a/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfig.java
@@ -111,7 +111,7 @@ public class WlsClusterConfig {
    * @return the name of the cluster that this WlsClusterConfig is created for
    */
   public String getName() {
-    return name;
+    return getClusterName();
   }
 
   public WlsDynamicServersConfig getDynamicServersConfig() {
@@ -191,21 +191,21 @@ public class WlsClusterConfig {
   /**
    * Returns the maximum size of the dynamic cluster.
    *
-   * @return the maximum size of the dynamic cluster, or -1 if there is no dynamic servers in this
+   * @return the maximum size of the dynamic cluster, or 0 if there are no dynamic servers in this
    *     cluster
    */
   public int getMaxDynamicClusterSize() {
-    return dynamicServersConfig != null ? dynamicServersConfig.getMaxDynamicClusterSize() : -1;
+    return Optional.ofNullable(dynamicServersConfig).map(WlsDynamicServersConfig::getMaxDynamicClusterSize).orElse(0);
   }
 
   /**
    * Returns the minimum size of the dynamic cluster.
    *
-   * @return the minimum size of the dynamic cluster, or -1 if there is no dynamic servers in this
+   * @return the minimum size of the dynamic cluster, or 0 if there are no dynamic servers in this
    *     cluster
    */
   public int getMinDynamicClusterSize() {
-    return dynamicServersConfig != null ? dynamicServersConfig.getMinDynamicClusterSize() : -1;
+    return dynamicServersConfig != null ? dynamicServersConfig.getMinDynamicClusterSize() : 0;
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/work/NextAction.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/NextAction.java
@@ -25,8 +25,8 @@ public final class NextAction implements BreadCrumbFactory {
   private static String commentPrefix;
 
   Kind kind;
-  Step next;
-  Packet packet;
+  private Step next;
+  private Packet packet;
   Consumer<AsyncFiber> onExit;
   Throwable throwable;
   private String comment;
@@ -99,6 +99,14 @@ public final class NextAction implements BreadCrumbFactory {
     return next;
   }
 
+  void setPacket(Packet packet) {
+    this.packet = packet;
+  }
+
+  public Packet getPacket() {
+    return packet;
+  }
+
   @Override
   public BreadCrumb createBreadCrumb() {
     return new NextActionBreadCrumb(this);
@@ -168,7 +176,7 @@ public final class NextAction implements BreadCrumbFactory {
               sb.append(", ");
             }
             sb.append(na.next.getResourceName());
-            dumper.dump(sb, na.packet);
+            dumper.dump(sb, na.getPacket());
           }
           break;
         case SUSPEND:

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainValidationMessages.java
@@ -18,7 +18,7 @@ import oracle.kubernetes.utils.OperatorUtils;
 import static oracle.kubernetes.operator.helpers.LegalNames.LEGAL_CONTAINER_PORT_NAME_MAX_LENGTH;
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_AUXILIARY_IMAGE_MOUNT_PATH;
 
-class DomainValidationMessages {
+public class DomainValidationMessages {
 
   private DomainValidationMessages() {
     // no-op
@@ -94,7 +94,7 @@ class DomainValidationMessages {
                             new String[] {getBundleString("singularToBe"), getBundleString("pluralToBe")});
   }
 
-  static String noSuchSecret(String secretName, String namespace, SecretType type) {
+  public static String noSuchSecret(String secretName, String namespace, SecretType type) {
     return getMessage(MessageKeys.SECRET_NOT_FOUND, secretName, namespace, type);
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/FluentdUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/FluentdUtils.java
@@ -1,0 +1,60 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateRunning;
+import io.kubernetes.client.openapi.models.V1ContainerStateTerminated;
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+
+import static oracle.kubernetes.operator.LabelConstants.JOBNAME_LABEL;
+import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONTAINER_NAME;
+
+public class FluentdUtils {
+
+  /**
+   * define the introspector job pod container status.
+   * @param jobPod jobPad object
+   * @param jobName job name
+   * @param terminateJobContainer set introspector container with terminate status if true, otherwise running.
+   * @param terminateFluentd set inrospector fluentd container with terminate status if true, otherwise running.
+   */
+  public static void defineFluentdJobContainersCompleteStatus(
+      V1Pod jobPod, String jobName, boolean terminateJobContainer, boolean terminateFluentd) {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(JOBNAME_LABEL, jobName);
+    jobPod.getMetadata().setLabels(labels);
+    jobPod.spec(new V1PodSpec());
+    jobPod.getSpec().addContainersItem(new V1Container().name(FLUENTD_CONTAINER_NAME));
+    jobPod.getSpec().addContainersItem(new V1Container().name(jobName));
+    V1PodStatus podStatus = new V1PodStatus();
+    V1ContainerState jobContainerState = new V1ContainerState();
+    if (terminateJobContainer) {
+      jobContainerState.setTerminated(new V1ContainerStateTerminated().exitCode(0));
+    } else {
+      jobContainerState.setRunning(new V1ContainerStateRunning());
+    }
+    podStatus.addContainerStatusesItem(new V1ContainerStatus()
+            .name(jobName).state(jobContainerState));
+
+    V1ContainerState fluentdContainerState = new V1ContainerState();
+    if (terminateFluentd) {
+      fluentdContainerState.setTerminated(new V1ContainerStateTerminated().exitCode(1));
+    } else {
+      fluentdContainerState.setRunning(new V1ContainerStateRunning());
+    }
+    podStatus.addContainerStatusesItem(new V1ContainerStatus()
+            .name(FLUENTD_CONTAINER_NAME).state(fluentdContainerState));
+
+    jobPod.setStatus(podStatus);
+
+  }
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/JobWatcherTest.java
@@ -356,7 +356,7 @@ class JobWatcherTest extends WatcherTestBase implements WatchListener<V1Job> {
     V1Job persistedJob = jobFunction.apply(createJob());
     testSupport.defineResources(persistedJob);
     V1Pod jobPod = new V1Pod().metadata(new V1ObjectMeta().name(persistedJob.getMetadata().getName()));
-    testSupport.defineFluentdJobContainersCompleteStatus(jobPod, persistedJob.getMetadata().getName(),
+    FluentdUtils.defineFluentdJobContainersCompleteStatus(jobPod, persistedJob.getMetadata().getName(),
             true, true);
     testSupport.defineResources(jobPod);
 

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/SimulatedStep.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/SimulatedStep.java
@@ -1,0 +1,11 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.calls;
+
+/**
+ * A marker interface for a step used in unit tests to simulate production behavior.
+ */
+public interface SimulatedStep {
+
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -41,6 +41,7 @@ import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.kubernetes.common.utils.SchemaConversionUtils;
 import oracle.kubernetes.operator.DomainSourceType;
+import oracle.kubernetes.operator.FluentdUtils;
 import oracle.kubernetes.operator.JobAwaiterStepFactory;
 import oracle.kubernetes.operator.JobWatcher;
 import oracle.kubernetes.operator.LabelConstants;
@@ -203,6 +204,8 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
     mementos.add(testSupport.install());
     mementos.add(ScanCacheStub.install());
     mementos.add(SystemClockTestSupport.installClock());
+    mementos.add(UnitTestHash.install());
+
     testSupport.addToPacket(JOB_POD_NAME, jobPodName);
     testSupport.addDomainPresenceInfo(domainPresenceInfo);
     testSupport.defineResources(domain);
@@ -622,7 +625,7 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
     String jobName = UID + "-introspector";
     DomainConfiguratorFactory.forDomain(domain).withFluentdConfiguration(true, "elastic-cred", null);
     V1Pod jobPod = new V1Pod().metadata(new V1ObjectMeta().name(jobName).namespace(NS));
-    testSupport.defineFluentdJobContainersCompleteStatus(jobPod, jobName, true, true);
+    FluentdUtils.defineFluentdJobContainersCompleteStatus(jobPod, jobName, true, true);
     testSupport.defineResources(jobPod);
     defineFailedFluentdContainerInIntrospection();
 
@@ -645,8 +648,7 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
     DomainConfiguratorFactory.forDomain(domain)
         .withFluentdConfiguration(true, "elastic-cred", null);
     V1Pod jobPod = new V1Pod().metadata(new V1ObjectMeta().name(jobName).namespace(NS));
-    testSupport.defineFluentdJobContainersCompleteStatus(jobPod, jobName,
-        true, false);
+    FluentdUtils.defineFluentdJobContainersCompleteStatus(jobPod, jobName, true, false);
     testSupport.defineResources(jobPod);
     defineNormalFluentdContainerInIntrospection();
     testSupport.addToPacket(DOMAIN_TOPOLOGY, createDomainConfig("cluster-1"));

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionTestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/IntrospectionTestUtils.java
@@ -54,7 +54,7 @@ public class IntrospectionTestUtils {
    * @param testSupport a kubernetes test support instance
    * @param introspectResult the log to be returned from the job pod
    */
-  static void defineIntrospectionPodLog(KubernetesTestSupport testSupport, String introspectResult) {
+  public static void defineIntrospectionPodLog(KubernetesTestSupport testSupport, String introspectResult) {
     defineIntrospectionResult(testSupport, introspectResult, IntrospectionTestUtils::createCompletedStatus);
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -32,11 +32,6 @@ import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.CoreV1EventList;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
-import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1ContainerState;
-import io.kubernetes.client.openapi.models.V1ContainerStateRunning;
-import io.kubernetes.client.openapi.models.V1ContainerStateTerminated;
-import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobList;
@@ -52,8 +47,6 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodDisruptionBudget;
 import io.kubernetes.client.openapi.models.V1PodDisruptionBudgetList;
 import io.kubernetes.client.openapi.models.V1PodList;
-import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1SelfSubjectAccessReview;
@@ -78,6 +71,7 @@ import oracle.kubernetes.operator.calls.CallFactory;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.calls.RequestParams;
 import oracle.kubernetes.operator.calls.RetryStrategy;
+import oracle.kubernetes.operator.calls.SimulatedStep;
 import oracle.kubernetes.operator.calls.SynchronousCallDispatcher;
 import oracle.kubernetes.operator.calls.SynchronousCallFactory;
 import oracle.kubernetes.operator.work.Component;
@@ -98,10 +92,8 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
-import static oracle.kubernetes.operator.LabelConstants.JOBNAME_LABEL;
 import static oracle.kubernetes.operator.calls.AsyncRequestStep.CONTINUE;
 import static oracle.kubernetes.operator.calls.AsyncRequestStep.RESPONSE_COMPONENT_NAME;
-import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONTAINER_NAME;
 
 @SuppressWarnings("WeakerAccess")
 public class KubernetesTestSupport extends FiberTestSupport {
@@ -334,44 +326,6 @@ public class KubernetesTestSupport extends FiberTestSupport {
 
   public void definePodLog(String name, String namespace, Object contents) {
     repositories.get(PODLOG).createResourceInNamespace(name, namespace, contents);
-  }
-
-  /**
-   * define the introspector job pod container status.
-   * @param jobPod jobPad object
-   * @param jobName job name
-   * @param terminateJobContainer set introspector container with terminate status if true, otherwise running.
-   * @param terminateFluentd set inrospector fluentd container with terminate status if true, otherwise running.
-   */
-  public void defineFluentdJobContainersCompleteStatus(V1Pod jobPod, String jobName, boolean terminateJobContainer,
-                                                       boolean terminateFluentd) {
-    Map<String, String> labels = new HashMap<>();
-    labels.put(JOBNAME_LABEL, jobName);
-    jobPod.getMetadata().setLabels(labels);
-    jobPod.spec(new V1PodSpec());
-    jobPod.getSpec().addContainersItem(new V1Container().name(FLUENTD_CONTAINER_NAME));
-    jobPod.getSpec().addContainersItem(new V1Container().name(jobName));
-    V1PodStatus podStatus = new V1PodStatus();
-    V1ContainerState jobContainerState = new V1ContainerState();
-    if (terminateJobContainer) {
-      jobContainerState.setTerminated(new V1ContainerStateTerminated().exitCode(0));
-    } else {
-      jobContainerState.setRunning(new V1ContainerStateRunning());
-    }
-    podStatus.addContainerStatusesItem(new V1ContainerStatus()
-            .name(jobName).state(jobContainerState));
-
-    V1ContainerState fluentdContainerState = new V1ContainerState();
-    if (terminateFluentd) {
-      fluentdContainerState.setTerminated(new V1ContainerStateTerminated().exitCode(1));
-    } else {
-      fluentdContainerState.setRunning(new V1ContainerStateRunning());
-    }
-    podStatus.addContainerStatusesItem(new V1ContainerStatus()
-            .name(FLUENTD_CONTAINER_NAME).state(fluentdContainerState));
-
-    jobPod.setStatus(podStatus);
-
   }
 
   /**
@@ -1289,7 +1243,7 @@ public class KubernetesTestSupport extends FiberTestSupport {
     }
   }
 
-  private class SimulatedResponseStep extends Step {
+  private class SimulatedResponseStep extends Step implements SimulatedStep {
     private final CallContext callContext;
 
     SimulatedResponseStep(

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/FailureReportingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/FailureReportingTest.java
@@ -1,0 +1,320 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.makeright;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import com.meterware.simplestub.Stub;
+import oracle.kubernetes.operator.DomainProcessorDelegateStub;
+import oracle.kubernetes.operator.DomainProcessorTestSetup;
+import oracle.kubernetes.operator.MakeRightDomainOperation;
+import oracle.kubernetes.operator.MakeRightExecutor;
+import oracle.kubernetes.operator.Processors;
+import oracle.kubernetes.operator.calls.SimulatedStep;
+import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.IntrospectionTestUtils;
+import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.SecretType;
+import oracle.kubernetes.operator.helpers.UnitTestHash;
+import oracle.kubernetes.operator.tuning.TuningParametersStub;
+import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
+import oracle.kubernetes.operator.work.Fiber;
+import oracle.kubernetes.operator.work.NextAction;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.operator.work.TerminalStep;
+import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.weblogic.domain.model.DomainCommonConfigurator;
+import oracle.kubernetes.weblogic.domain.model.DomainCondition;
+import oracle.kubernetes.weblogic.domain.model.DomainFailureReason;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
+import oracle.kubernetes.weblogic.domain.model.DomainStatus;
+import oracle.kubernetes.weblogic.domain.model.DomainValidationMessages;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static oracle.kubernetes.operator.DomainFailureMessages.createReplicaFailureMessage;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
+import static oracle.kubernetes.weblogic.domain.model.DomainConditionType.FAILED;
+import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.DOMAIN_INVALID;
+import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.INTROSPECTION;
+import static oracle.kubernetes.weblogic.domain.model.DomainFailureReason.REPLICAS_TOO_HIGH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class FailureReportingTest {
+
+  private static final String INFO_MESSAGE = "@[INFO] just letting you know";
+  private static final String SEVERE_MESSAGE = "@[SEVERE] really bad";
+  public static final String CLUSTER_1 = "cluster1";
+  public static final int MAXIMUM_CLUSTER_SIZE = 5;
+  public static final int TOO_HIGH_REPLICA_COUNT = MAXIMUM_CLUSTER_SIZE + 1;
+  private final DomainResource domain = DomainProcessorTestSetup.createTestDomain();
+  private final DomainPresenceInfo info = new DomainPresenceInfo(domain);
+  private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
+  private final List<Memento> mementos = new ArrayList<>();
+  private final MakeRightExecutorStub executor = Stub.createNiceStub(MakeRightExecutorStub.class);
+  private final DomainProcessorDelegateStub delegate
+      = Stub.createStrictStub(DomainProcessorDelegateStub.class, testSupport);
+  private final MakeRightDomainOperation makeRight = new MakeRightDomainOperationImpl(executor, delegate, info);
+  private final TerminalStep terminalStep = new TerminalStep();
+  private String introspectionString = INFO_MESSAGE;
+  private Step steps;
+
+  @BeforeEach
+  void setUp() throws NoSuchFieldException {
+    mementos.add(TestUtils.silenceOperatorLogger());
+    mementos.add(testSupport.install());
+    mementos.add(TuningParametersStub.install());
+    mementos.add(UnitTestHash.install());
+
+    testSupport.defineResources(domain);
+    defineDomainTopology();
+
+    DomainProcessorTestSetup.defineRequiredResources(testSupport);
+    steps = makeRight.createSteps();
+  }
+
+  private void defineDomainTopology() {
+    WlsDomainConfigSupport configSupport = new WlsDomainConfigSupport("domain");
+    configSupport.addWlsServer("admin", 8045);
+    configSupport.setAdminServerName("admin");
+    configSupport.addWlsCluster(
+          new WlsDomainConfigSupport.DynamicClusterConfigBuilder(CLUSTER_1)
+                .withClusterLimits(0, MAXIMUM_CLUSTER_SIZE)
+                .withServerNames("ms1", "ms2", "ms3", "ms4", "ms5"));
+    testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
+  }
+
+  @AfterEach
+  void tearDown() {
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  void withNoProblems_reachEndOfFiber() {
+    executeMakeRight(null, test -> {});
+
+    assertThat(terminalStep.wasRun(), is(true));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = TestCase.class, names = "DOMAIN_VALIDATION_FAILURE"
+  )
+  void abortMakeRightAfterFailureDetected(TestCase testCase) {
+    executeMakeRight(testCase.getStepToAvoid(), testCase.getMutator());
+
+    assertThat(terminalStep.wasRun(), is(false));
+  }
+
+  private void executeMakeRight(String stepClassName, Consumer<FailureReportingTest> mutator) {
+    steps.insertBefore(terminalStep, stepClassName);
+    mutator.accept(this);
+    executeMakeRight();
+  }
+
+  private void executeMakeRight() {
+    copyFrom(testSupport.getPacket(), makeRight.createPacket());
+    IntrospectionTestUtils.defineIntrospectionPodLog(testSupport, introspectionString);
+
+    testSupport.runSteps(steps);
+  }
+
+  private void removeCredentialsSecret() {
+    DomainCommonConfigurator commonConfigurator = new DomainCommonConfigurator(domain);
+    commonConfigurator.withWebLogicCredentialsSecret("no-such-secret");
+  }
+
+  private void copyFrom(Packet target, Packet source) {
+    target.getComponents().putAll(source.getComponents());
+    target.putAll(source);
+  }
+
+  private void defineSevereIntrospectionFailure() {
+    introspectionString = SEVERE_MESSAGE;
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = TestCase.class, names = {"DOMAIN_VALIDATION_FAILURE", "REPLICAS_TOO_HIGH_FAILURE"}
+  )
+  void whenMakeWithExistingFailureFails_failuresDoNotFlicker(TestCase testCase) throws NoSuchFieldException {
+    final DomainCondition domainCondition = createDomainConditionFor(testCase);
+    final FlickerDetector detector = new FlickerDetector(testCase.getReason(), domainCondition);
+    domain.getStatus().addCondition(domainCondition);
+    mementos.add(detector.install());
+    testCase.getMutator().accept(this);
+
+    executeMakeRight();
+
+    detector.assertNotFlickered(testSupport.getPacket());
+  }
+
+  private DomainCondition createDomainConditionFor(TestCase testCase) {
+    return new DomainCondition(FAILED).withReason(testCase.getReason()).withMessage(testCase.getExpectedMessage());
+  }
+
+  private void setReplicasTooHigh() {
+    domain.getSpec().setReplicas(TOO_HIGH_REPLICA_COUNT);
+  }
+
+  enum TestCase {
+    DOMAIN_VALIDATION_FAILURE {
+      @Override
+      Consumer<FailureReportingTest> getMutator() {
+        return FailureReportingTest::removeCredentialsSecret;
+      }
+
+      @Override
+      DomainFailureReason getReason() {
+        return DOMAIN_INVALID;
+      }
+
+      @Override
+      String getStepToAvoid() {
+        return "StartPlanStep";
+      }
+
+      @Override
+      String getExpectedMessage() {
+        return DomainValidationMessages.noSuchSecret("no-such-secret", NS, SecretType.WEBLOGIC_CREDENTIALS);
+      }
+    },
+    SEVERE_INTROSPECTION_FAILURE {
+      @Override
+      Consumer<FailureReportingTest> getMutator() {
+        return FailureReportingTest::defineSevereIntrospectionFailure;
+      }
+
+      @Override
+      DomainFailureReason getReason() {
+        return INTROSPECTION;
+      }
+
+      @Override
+      String getStepToAvoid() {
+        return "BeforeAdminServiceStep";
+      }
+
+      @Override
+      String getExpectedMessage() {
+        return null;
+      }
+    },
+    REPLICAS_TOO_HIGH_FAILURE {
+      @Override
+      Consumer<FailureReportingTest> getMutator() {
+        return FailureReportingTest::setReplicasTooHigh;
+      }
+
+      @Override
+      DomainFailureReason getReason() {
+        return REPLICAS_TOO_HIGH;
+      }
+
+      @Override
+      String getStepToAvoid() {
+        return null;
+      }
+
+      @Override
+      String getExpectedMessage() {
+        return createReplicaFailureMessage(CLUSTER_1, TOO_HIGH_REPLICA_COUNT, MAXIMUM_CLUSTER_SIZE);
+      }
+    };
+
+    abstract DomainFailureReason getReason();
+    
+    abstract Consumer<FailureReportingTest> getMutator();
+
+    abstract String getStepToAvoid();
+
+    abstract String getExpectedMessage();
+  }
+
+
+  static class FlickerDetector {
+    private final DomainFailureReason reason;
+    private final Set<DomainCondition> expectedConditions;
+    private Step currentStep;
+    private Step flickeredStep;
+
+    FlickerDetector(DomainFailureReason reason, DomainCondition... expectedConditionList) {
+      this.reason = reason;
+      this.expectedConditions = Set.of(expectedConditionList);
+    }
+
+    Memento install() throws NoSuchFieldException {
+      final BiConsumer<NextAction,String> detector = this::detectFlicker;
+      return StaticStubSupport.install(Fiber.class, "preApplyReport", detector);
+    }
+
+    void detectFlicker(NextAction nextAction, String fiberName) {
+      final Set<DomainCondition> conditions = getMatchingConditions(nextAction);
+      if (flickeredStep != null) { // already found a problem; no need to keep looking
+        return;
+      }
+
+      if (!expectedConditions.equals(conditions)) {
+        flickeredStep = currentStep;
+      } else if (!(nextAction.getNext() instanceof SimulatedStep)) {
+        currentStep = nextAction.getNext();
+      }
+    }
+
+    private Set<DomainCondition> getMatchingConditions(NextAction nextAction) {
+      return getMatchingConditions(nextAction.getPacket());
+    }
+
+    @NotNull
+    private Set<DomainCondition> getMatchingConditions(Packet packet) {
+      return DomainPresenceInfo.fromPacket(packet)
+          .map(DomainPresenceInfo::getDomain)
+          .map(DomainResource::getStatus)
+          .map(DomainStatus::getConditions)
+          .orElse(Collections.emptyList()).stream()
+          .filter(this::hasReason)
+          .collect(Collectors.toSet());
+    }
+
+    void assertNotFlickered(Packet packet) {
+      assertThat("Flicker step", flickeredStep, nullValue());
+      assertThat("Final conditions", getMatchingConditions(packet), equalTo(expectedConditions));
+    }
+
+    private boolean hasReason(DomainCondition condition) {
+      return reason.equals(condition.getReason());
+    }
+  }
+
+  abstract static class MakeRightExecutorStub implements MakeRightExecutor {
+
+    @Override
+    public void registerDomainPresenceInfo(DomainPresenceInfo info) {
+      
+    }
+
+    @Override
+    public Step createNamespacedResourceSteps(Processors processors, DomainPresenceInfo info) {
+      return null;
+    }
+  }
+
+}

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -28,6 +28,7 @@ import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.KubernetesUtils;
 import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.PodHelper;
+import oracle.kubernetes.operator.helpers.UnitTestHash;
 import oracle.kubernetes.operator.http.client.HttpAsyncRequestStep;
 import oracle.kubernetes.operator.http.client.HttpAsyncTestSupport;
 import oracle.kubernetes.operator.http.client.HttpResponseStub;
@@ -91,11 +92,9 @@ class ShutdownManagedServerStepTest {
   private final V1Pod configuredManagedServer1 = defineManagedPod(CONFIGURED_MANAGED_SERVER1);
   private final V1Pod standaloneManagedServer1 = defineManagedPod(MANAGED_SERVER1);
   private final V1Pod dynamicManagedServer1 = defineManagedPod(DYNAMIC_MANAGED_SERVER1);
-  private final V1Service configuredServerService = createServerService(CONFIGURED_MANAGED_SERVER1,
-      CONFIGURED_CLUSTER_NAME);
-  private final V1Service standaloneServerService = createServerService(MANAGED_SERVER1, null);
-  private final V1Service dynamicServerService = createServerService(DYNAMIC_MANAGED_SERVER1,
-      DYNAMIC_CLUSTER_NAME);
+  private V1Service configuredServerService;
+  private V1Service standaloneServerService;
+  private V1Service dynamicServerService;
   private final List<LogRecord> logRecords = new ArrayList<>();
   private final List<Memento> mementos = new ArrayList<>();
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
@@ -128,11 +127,15 @@ class ShutdownManagedServerStepTest {
     mementos.add(httpSupport.install());
     mementos.add(SystemClockTestSupport.installClock());
     mementos.add(TuningParametersStub.install());
+    mementos.add(UnitTestHash.install());
 
     testSupport.addDomainPresenceInfo(info);
     testSupport.addToPacket(DOMAIN_TOPOLOGY, configSupport.createDomainConfig());
     testSupport.defineResources(domain);
 
+    configuredServerService = createServerService(CONFIGURED_MANAGED_SERVER1, CONFIGURED_CLUSTER_NAME);
+    standaloneServerService = createServerService(MANAGED_SERVER1, null);
+    dynamicServerService = createServerService(DYNAMIC_MANAGED_SERVER1, DYNAMIC_CLUSTER_NAME);
     DomainProcessorTestSetup.defineSecretData(testSupport);
     defineServerPodsInDomainPresenceInfo();
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsClusterConfigTest.java
@@ -3,18 +3,12 @@
 
 package oracle.kubernetes.operator.wlsconfig;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import com.meterware.simplestub.Memento;
-import oracle.kubernetes.operator.work.NextAction;
-import oracle.kubernetes.operator.work.Packet;
-import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,10 +17,10 @@ import org.junit.jupiter.api.Test;
 import static oracle.kubernetes.common.logging.MessageKeys.NO_WLS_SERVER_IN_CLUSTER;
 import static oracle.kubernetes.common.logging.MessageKeys.REPLICA_MORE_THAN_WLS_SERVERS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 class WlsClusterConfigTest {
 
@@ -35,7 +29,6 @@ class WlsClusterConfigTest {
     NO_WLS_SERVER_IN_CLUSTER, REPLICA_MORE_THAN_WLS_SERVERS
   };
 
-  Field nextField;
   private final List<LogRecord> logRecords = new ArrayList<>();
   private Memento consoleControl;
 
@@ -73,81 +66,81 @@ class WlsClusterConfigTest {
   @Test
   void verifyClusterSizeIsSameAsNumberOfServers() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", null, null));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-1", 8011, null));
-    assertEquals(2, wlsClusterConfig.getClusterSize());
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-1", 8011));
+    assertThat(wlsClusterConfig.getClusterSize(), equalTo(2));
   }
 
   @Test
   void verifyMaxClusterSizeIsSameAsNumberOfServers() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", null, null));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-1", 8011, null));
-    assertEquals(2, wlsClusterConfig.getMaxClusterSize());
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-1", 8011));
+    assertThat(wlsClusterConfig.getMaxClusterSize(), equalTo(2));
   }
 
   @Test
   void verifyClusterSizeIs0IfNoServers() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    assertEquals(0, wlsClusterConfig.getClusterSize());
+    assertThat(wlsClusterConfig.getClusterSize(), equalTo(0));
   }
 
   @Test
   void verifyHasStaticServersIsFalseIfNoServers() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    assertFalse(wlsClusterConfig.hasStaticServers());
+    assertThat(wlsClusterConfig.hasStaticServers(), is(false));
   }
 
   @Test
   void verifyHasStaticServersIsTrueIfStaticServers() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", null, null));
-    assertTrue(wlsClusterConfig.hasStaticServers());
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", null));
+    assertThat(wlsClusterConfig.hasStaticServers(), is(true));
   }
 
   @Test
   void verifyHasDynamicServersIsFalseIfNoDynamicServers() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    assertFalse(wlsClusterConfig.hasDynamicServers());
+    assertThat(wlsClusterConfig.hasDynamicServers(), is(false));
   }
 
   @Test
   void verifyHasDynamicServersIsTrueForDynamicCluster() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
-    assertTrue(wlsClusterConfig.hasDynamicServers());
+    assertThat(wlsClusterConfig.hasDynamicServers(), is(true));
   }
 
   @Test
   void verifyHasStaticServersIsFalseForDynamicCluster() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
-    assertFalse(wlsClusterConfig.hasStaticServers());
+    assertThat(wlsClusterConfig.hasStaticServers(), is(false));
   }
 
   @Test
   void verifyHasDynamicServersIsTrueForMixedCluster() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("mss-0", 8011, null));
-    assertTrue(wlsClusterConfig.hasDynamicServers());
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("mss-0", 8011));
+    assertThat(wlsClusterConfig.hasDynamicServers(), is(true));
   }
 
   @Test
   void verifyHasStaticServersIsTrueForMixedCluster() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("mss-0", 8011, null));
-    assertTrue(wlsClusterConfig.hasStaticServers());
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("mss-0", 8011));
+    assertThat(wlsClusterConfig.hasStaticServers(), is(true));
   }
 
   @Test
   void verifyMaxClusterSizeIsSameAsNumberOfServersPlusDynamicSizeForMixedCluster() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("mss-0", 8011, null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("mss-0", 8011));
 
-    assertEquals(6, wlsClusterConfig.getMaxClusterSize());
+    assertThat(wlsClusterConfig.getMaxClusterSize(), equalTo(6));
   }
 
   @Test
@@ -155,41 +148,29 @@ class WlsClusterConfigTest {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
 
-    assertEquals(5, wlsClusterConfig.getMaxClusterSize());
+    assertThat(wlsClusterConfig.getMaxClusterSize(), equalTo(5));
   }
 
   @Test
   void verifyDynamicClusterSizeIsSameAsNumberOfDynamicServers() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(2, 5, 1, "ms-", "cluster1"));
-    assertEquals(0, wlsClusterConfig.getClusterSize());
-    assertEquals(2, wlsClusterConfig.getDynamicClusterSize());
-    assertEquals(5, wlsClusterConfig.getMaxDynamicClusterSize());
-    assertEquals(1, wlsClusterConfig.getMinDynamicClusterSize());
-  }
-
-  @Test
-  void verifyDynamicClusterSizeIsNeg1IfNoDynamicServers() {
-    WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    assertEquals(-1, wlsClusterConfig.getDynamicClusterSize());
-  }
-
-  @Test
-  void verifyMinDynamicClusterSizeIsNeg1IfNoDynamicServers() {
-    WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    assertEquals(-1, wlsClusterConfig.getMinDynamicClusterSize());
+    assertThat(wlsClusterConfig.getClusterSize(), equalTo(0));
+    assertThat(wlsClusterConfig.getDynamicClusterSize(), equalTo(2));
+    assertThat(wlsClusterConfig.getMaxDynamicClusterSize(), equalTo(5));
+    assertThat(wlsClusterConfig.getMinDynamicClusterSize(), equalTo(1));
   }
 
   @Test
   void verifyGetServerConfigsReturnListOfAllServerConfigs() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", 8011, null));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-1", 8012, null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", 8011));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-1", 8012));
 
     List<WlsServerConfig> wlsServerConfigList = wlsClusterConfig.getServerConfigs();
-    assertEquals(2, wlsServerConfigList.size());
-    assertTrue(containsServer(wlsClusterConfig, "ms-0"));
-    assertTrue(containsServer(wlsClusterConfig, "ms-1"));
+    assertThat(wlsServerConfigList.size(), equalTo(2));
+    assertThat(containsServer(wlsClusterConfig, "ms-0"), is(true));
+    assertThat(containsServer(wlsClusterConfig, "ms-1"), is(true));
   }
 
   @Test
@@ -197,25 +178,25 @@ class WlsClusterConfigTest {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(0, 0, 0, "ms-", "cluster1"));
 
-    assertTrue(wlsClusterConfig.getServerConfigs().isEmpty());
+    assertThat(wlsClusterConfig.getServerConfigs(), empty());
   }
 
   @Test
   void verifyGetServerConfigsReturnListOfAllServerConfigsWithDynamicServers() {
     WlsClusterConfig wlsClusterConfig =
         new WlsClusterConfig("cluster1", createDynamicServersConfig(3, 5, 1, "ms-", "cluster1"));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("static-0", 8011, null));
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("static-1", 8012, null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("static-0", 8011));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("static-1", 8012));
 
     List<WlsServerConfig> wlsServerConfigList = wlsClusterConfig.getServerConfigs();
-    assertEquals(5, wlsServerConfigList.size());
+    assertThat(wlsServerConfigList, hasSize(5));
     // verify dynamic servers
-    assertTrue(containsServer(wlsClusterConfig, "ms-1"));
-    assertTrue(containsServer(wlsClusterConfig, "ms-2"));
-    assertTrue(containsServer(wlsClusterConfig, "ms-3"));
+    assertThat(containsServer(wlsClusterConfig, "ms-1"), is(true));
+    assertThat(containsServer(wlsClusterConfig, "ms-2"), is(true));
+    assertThat(containsServer(wlsClusterConfig, "ms-3"), is(true));
     // verify static servers
-    assertTrue(containsServer(wlsClusterConfig, "static-0"));
-    assertTrue(containsServer(wlsClusterConfig, "static-1"));
+    assertThat(containsServer(wlsClusterConfig, "static-0"), is(true));
+    assertThat(containsServer(wlsClusterConfig, "static-1"), is(true));
   }
 
   private boolean containsServer(WlsClusterConfig wlsClusterConfig, String serverName) {
@@ -231,7 +212,7 @@ class WlsClusterConfigTest {
   @Test
   void verifyMaxClusterSizeForStaticCluster() {
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1");
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", 8011, null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", 8011));
 
     assertThat(wlsClusterConfig.getMaxClusterSize(), equalTo(1));
   }
@@ -250,36 +231,13 @@ class WlsClusterConfigTest {
     WlsDynamicServersConfig wlsDynamicServersConfig =
         createDynamicServersConfig(1, 1, 1, "ms-", "cluster1");
     WlsClusterConfig wlsClusterConfig = new WlsClusterConfig("cluster1", wlsDynamicServersConfig);
-    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", 8011, null));
+    wlsClusterConfig.addServerConfig(createWlsServerConfig("ms-0", 8011));
 
     assertThat(wlsClusterConfig.getMaxClusterSize(), equalTo(2));
   }
 
-  private WlsServerConfig createWlsServerConfig(
-      String serverName, Integer listenPort, String listenAddress) {
-    Map<String, Object> serverConfigMap = new HashMap<>();
-    serverConfigMap.put("name", serverName);
-    serverConfigMap.put("listenPort", listenPort);
-    serverConfigMap.put("listenAddress", listenAddress);
-    return new WlsServerConfig(serverName, listenAddress, null, listenPort, null, null, null);
+  private WlsServerConfig createWlsServerConfig(String serverName, Integer listenPort) {
+    return new WlsServerConfig(serverName, null, null, listenPort, null, null, null);
   }
 
-  Step getNext(Step step) throws IllegalAccessException, NoSuchFieldException {
-    if (nextField == null) {
-      nextField = Step.class.getDeclaredField("next");
-      nextField.setAccessible(true);
-    }
-    return (Step) nextField.get(step);
-  }
-
-  static class MockStep extends Step {
-    public MockStep(Step next) {
-      super(next);
-    }
-
-    @Override
-    public NextAction apply(Packet packet) {
-      return null;
-    }
-  }
 }


### PR DESCRIPTION
This takes advantage of some recent refactoring to create tests that:
- confirm that the make-right is aborted when we get a severe error
- confirm that failures do not "flicker." That is, a subsequent make-right will not remove them and then put them back.