### PR TITLE
Owls 100376 - Fix repeated Cluster CRD updates and a race condition in CRD presence check

### DIFF
--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -129,7 +129,7 @@ WLSKO-0175=Job {0} in namespace {1} failed with status {2}. Check log messages \
   copied from the introspector pod {3} log for additional information.
 WLSKO-0176=Job {1} in namespace {0} failed, job details are {2}
 WLSKO-0177=Pod {0} in namespace {1} failed, the pod status is {2}
-WLSKO-0178=Operator cannot proceed, as the Custom Resource Definition for ''domains.weblogic.oracle'' is not installed.
+WLSKO-0178=Operator cannot proceed, as the Custom Resource Definition for ''domains.weblogic.oracle'' or ''clusters.weblogic.oracle'' is not installed.
 WLSKO-0179=Pod {0} in namespace {1} detected as stuck, and force-deleted
 WLSKO-0180=Creating event: {0}
 WLSKO-0181=Replacing event: {0}

--- a/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
@@ -6,17 +6,18 @@ package oracle.kubernetes.operator;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.kubernetes.client.common.KubernetesListObject;
 import oracle.kubernetes.common.logging.MessageKeys;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.EventHelper;
-import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.helpers.WebhookHelper;
 import oracle.kubernetes.operator.http.rest.BaseRestServer;
 import oracle.kubernetes.operator.http.rest.RestConfig;
 import oracle.kubernetes.operator.http.rest.RestConfigImpl;
+import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.steps.InitializeWebhookIdentityStep;
 import oracle.kubernetes.operator.tuning.TuningParameters;
 import oracle.kubernetes.operator.utils.Certificates;
@@ -40,7 +41,7 @@ public class WebhookMain extends BaseMain {
 
   private final WebhookMainDelegate conversionWebhookMainDelegate;
   private boolean warnedOfCrdAbsence;
-  private int crdRecheckCount;
+  private AtomicInteger crdPresenceCheckCount = new AtomicInteger(0);
   private final RestConfig restConfig = new RestConfigImpl(new Certificates(delegate));
   @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"})
   private static NextStepFactory nextStepFactory = WebhookMain::createInitializeWebhookIdentityStep;
@@ -165,26 +166,28 @@ public class WebhookMain extends BaseMain {
   }
 
   // on failure, aborts the processing.
-  private class  CrdPresenceResponseStep<L extends KubernetesListObject> extends ResponseStep<L> {
+  private class  CrdPresenceResponseStep<L extends KubernetesListObject> extends DefaultResponseStep<L> {
 
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<L> callResponse) {
       warnedOfCrdAbsence = false;
-      return doNext(packet);
+      return super.onSuccess(packet, callResponse);
     }
 
     @Override
     public NextAction onFailure(Packet packet, CallResponse<L> callResponse) {
-      if (crdRecheckCount < TuningParameters.getInstance().getCallBuilderTuning().getCallMaxRetryCount()) {
-        crdRecheckCount++;
+      if (crdPresenceCheckCount.getAndIncrement() < getCrdPresenceFailureRetryMaxCount()) {
         return doNext(this, packet);
-      } else {
-        if (!warnedOfCrdAbsence) {
-          LOGGER.severe(MessageKeys.CRD_NOT_INSTALLED);
-          warnedOfCrdAbsence = true;
-        }
-        return doNext(null, packet);
       }
+      if (!warnedOfCrdAbsence) {
+        LOGGER.severe(MessageKeys.CRD_NOT_INSTALLED);
+        warnedOfCrdAbsence = true;
+      }
+      return doNext(null, packet);
+    }
+
+    private int getCrdPresenceFailureRetryMaxCount() {
+      return TuningParameters.getInstance().getCrdPresenceFailureRetryMaxCount();
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
@@ -171,6 +171,7 @@ public class WebhookMain extends BaseMain {
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<L> callResponse) {
       warnedOfCrdAbsence = false;
+      crdPresenceCheckCount.set(0);
       return super.onSuccess(packet, callResponse);
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -63,6 +63,7 @@ import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
+import static oracle.kubernetes.operator.KubernetesConstants.CLUSTER_CRD_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.WEBHOOK;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getWebhookNamespace;
 import static oracle.kubernetes.operator.http.rest.RestConfigImpl.CONVERSION_WEBHOOK_HTTPS_PORT;
@@ -482,8 +483,12 @@ public class CrdHelper {
       }
 
       private boolean existingCrdContainsCompatibleConversionWebhook(V1CustomResourceDefinition existingCrd) {
-        return hasConversionWebhookStrategy(existingCrd)
-            && webhookIsCompatible(existingCrd);
+        return isClusterCrd(existingCrd)
+            || (hasConversionWebhookStrategy(existingCrd) && webhookIsCompatible(existingCrd));
+      }
+
+      private boolean isClusterCrd(V1CustomResourceDefinition existingCrd) {
+        return existingCrd.getMetadata().getName().equals(CLUSTER_CRD_NAME);
       }
 
       private Boolean hasConversionWebhookStrategy(V1CustomResourceDefinition existingCrd) {
@@ -714,7 +719,7 @@ public class CrdHelper {
 
     @Override
     protected String getCrdName() {
-      return KubernetesConstants.CLUSTER_CRD_NAME;
+      return CLUSTER_CRD_NAME;
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
@@ -75,6 +75,7 @@ public class TuningParameters {
   public static final String KUBERNETES_PLATFORM_NAME = "kubernetesPlatform";
   public static final String FEATURE_GATES = "featureGates";
   public static final String SERVICE_ACCOUNT_NAME = "serviceaccount";
+  public static final String CRD_PRESENCE_FAILURE_RETRY_MAX_COUNT = "crdPresenceFailureRetryMaxCount";
 
   public static final long DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS = 60L;
 
@@ -217,6 +218,10 @@ public class TuningParameters {
 
   public long getActiveDeadlineMaxNumIncrements() {
     return getParameter(INTROSPECTOR_JOB_MAX_NUM_INCREMENTS, 5);
+  }
+
+  public int getCrdPresenceFailureRetryMaxCount() {
+    return getParameter(CRD_PRESENCE_FAILURE_RETRY_MAX_COUNT, 3);
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
@@ -97,6 +97,7 @@ import static oracle.kubernetes.operator.helpers.WebhookHelper.UPDATE;
 import static oracle.kubernetes.operator.helpers.WebhookHelper.VALIDATING_WEBHOOK_NAME;
 import static oracle.kubernetes.operator.helpers.WebhookHelper.VALIDATING_WEBHOOK_PATH;
 import static oracle.kubernetes.operator.http.rest.RestConfigImpl.CONVERSION_WEBHOOK_HTTPS_PORT;
+import static oracle.kubernetes.operator.tuning.TuningParameters.CALL_MAX_RETRY_COUNT;
 import static oracle.kubernetes.operator.utils.SelfSignedCertUtils.WEBLOGIC_OPERATOR_WEBHOOK_SVC;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -252,6 +253,7 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   @ParameterizedTest
   @ValueSource(strings = {DOMAIN, CLUSTER})
   void whenNoCRD_logReasonForFailure(String resourceType) {
+    TuningParametersStub.setParameter(CALL_MAX_RETRY_COUNT, "0");
     loggerControl.withLogLevel(Level.SEVERE).collectLogMessages(logRecords, CRD_NOT_INSTALLED);
     simulateMissingCRD(resourceType);
 
@@ -276,6 +278,7 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
   @ParameterizedTest
   @ValueSource(strings = {DOMAIN, CLUSTER})
   void afterMissingCRDcorrected_subsequentFailureLogsReasonForFailure(String resourceType) {
+    TuningParametersStub.setParameter(CALL_MAX_RETRY_COUNT, "0");
     simulateMissingCRD(resourceType);
     recheckCRD();
     testSupport.cancelFailures();


### PR DESCRIPTION
Owls 100376 - This PR fixes the issue with repeated update of the cluster CRD and a race condition during the CRD presence check.  The webhook deployment updates the CRD if the newly created or existing CRD has "None" conversion strategy or if it doesn't have a compatible conversion webhook definition. For the cluster CRD, there is no need for a conversion webhook and conversion strategy should always be None. This PR avoids updating/replacing cluster CRD when it has "None" conversion strategy.

In addition, the webhook does a list of domains to validate that the CRD is available. The list domains call fails with 404 error if it's called immediately after creating the CRD and this results in a SEVERE error in webhook logs. This PR retries the list domain operation 3 times to prevent the SEVERE message from being logged.

Integration test results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11259/