### PR TITLE
owls-100237 - backport PR 3228 to release/3.4

### DIFF
--- a/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
+++ b/kubernetes/samples/scripts/create-fmw-infrastructure-domain/domain-home-on-pv/wdt_k8s_model_template.yaml
@@ -52,6 +52,8 @@ kubernetes:
     # data storage directories are determined from the WebLogic domain home configuration.
     dataHome: "%DATA_HOME%"
 
+    replicas: %INITIAL_MANAGED_SERVER_REPLICAS%
+
     # serverStartPolicy legal values are "NEVER", "IF_NEEDED", or "ADMIN_ONLY"
     # This determines which WebLogic Servers the Operator will start up when it discovers this Domain
     # - "NEVER" will not start any server in the domain


### PR DESCRIPTION
Backport PR #3228 - owls-100237 - [wko-nightly] oracle.weblogic.kubernetes.ItFmwSample.testFmwDomainInPv(String)[1] failure to release/3.4

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11272/