### PR TITLE
OWLS-95596: Scale cluster through Operator REST API  by patching Cluster Resource

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -169,8 +169,6 @@ public class MessageKeys {
   public static final String POD_EVICTED_NO_RESTART = "WLSKO-0227";
   public static final String WATCH_CLUSTER = "WLSKO-0228";
   public static final String WATCH_CLUSTER_DELETED = "WLSKO-0229";
-  public static final String NULL_CLUSTER_NAME = "WLSKO-0230";
-  public static final String MATCHING_CLUSTER_NOT_FOUND = "WLSKO-0231";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -169,6 +169,8 @@ public class MessageKeys {
   public static final String POD_EVICTED_NO_RESTART = "WLSKO-0227";
   public static final String WATCH_CLUSTER = "WLSKO-0228";
   public static final String WATCH_CLUSTER_DELETED = "WLSKO-0229";
+  public static final String NULL_CLUSTER_NAME = "WLSKO-0230";
+  public static final String MATCHING_CLUSTER_NOT_FOUND = "WLSKO-0231";
 
   // domain status messages
   public static final String DUPLICATE_SERVER_NAME_FOUND = "WLSDO-0001";

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -178,6 +178,8 @@ WLSKO-0226=Pod {0} was evicted due to {1}; validating domain
 WLSKO-0227=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
 WLSKO-0228=Watch event triggered for WebLogic Cluster {0} in WebLogic Domain with UID: {1}.
 WLSKO-0229=Watch event triggered for deletion of WebLogic Cluster {0} in WebLogic Domain with UID: {1}.
+WLSKO-0230=Null Cluster name.
+WLSKO-0231=Cluster matching {0} not found.
 
 # Domain status messages
 

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -178,9 +178,6 @@ WLSKO-0226=Pod {0} was evicted due to {1}; validating domain
 WLSKO-0227=Pod {0} was evicted due to {1} but the operator is configured not to restart it.
 WLSKO-0228=Watch event triggered for WebLogic Cluster {0} in WebLogic Domain with UID: {1}.
 WLSKO-0229=Watch event triggered for deletion of WebLogic Cluster {0} in WebLogic Domain with UID: {1}.
-WLSKO-0230=Null Cluster name.
-WLSKO-0231=Cluster matching {0} not found.
-
 # Domain status messages
 
 WLSDO-0001=More than one item under ''spec.managedServers'' in the domain resource has DNS-1123 name ''{0}''

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -72,6 +72,7 @@ import oracle.kubernetes.operator.tuning.TuningParameters;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.api.WeblogicApi;
 import oracle.kubernetes.weblogic.domain.model.ClusterList;
+import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
@@ -427,6 +428,19 @@ public class CallBuilder {
                   null,
                   null,
                   null);
+  private final SynchronousCallFactory<ClusterList> listClusterCall =
+      (client, requestParams) ->
+          new WeblogicApi(client)
+              .listNamespacedCluster(
+                  requestParams.namespace,
+                  pretty,
+                  null,
+                  fieldSelector,
+                  labelSelector,
+                  limit,
+                  resourceVersion,
+                  timeoutSeconds,
+                  watch);
   private final SynchronousCallFactory<DomainList> listDomainCall =
       (client, requestParams) ->
           new WeblogicApi(client)
@@ -461,6 +475,11 @@ public class CallBuilder {
                   requestParams.name,
                   requestParams.namespace,
                   (DomainResource) requestParams.body);
+  private final SynchronousCallFactory<ClusterResource> patchClusterCall =
+      (client, requestParams) ->
+          new WeblogicApi(client)
+              .patchNamespacedCluster(
+                  requestParams.name, requestParams.namespace, (V1Patch) requestParams.body);
   private final SynchronousCallFactory<DomainResource> patchDomainCall =
       (client, requestParams) ->
           new WeblogicApi(client)
@@ -652,6 +671,18 @@ public class CallBuilder {
   }
 
   /**
+   * List clusters.
+   *
+   * @param namespace Namespace
+   * @return Cluster list
+   * @throws ApiException API exception
+   */
+  public @Nonnull ClusterList listCluster(String namespace) throws ApiException {
+    RequestParams requestParams = new RequestParams("listCluster", namespace, null, null, callParams);
+    return executeSynchronousCall(requestParams, listClusterCall);
+  }
+
+  /**
    * Asynchronous step for listing clusters.
    *
    * @param namespace Namespace
@@ -676,6 +707,22 @@ public class CallBuilder {
             timeoutSeconds,
             callback);
   }
+
+  /**
+   * Patch cluster.
+   *
+   * @param name the domain uid (unique within the k8s cluster)
+   * @param namespace the namespace containing the domain
+   * @param patchBody the patch to apply
+   * @return Updated cluster
+   * @throws ApiException APIException
+   */
+  public ClusterResource patchCluster(String name, String namespace, V1Patch patchBody) throws ApiException {
+    RequestParams requestParams =
+            new RequestParams("patchCluster", namespace, name, patchBody, name);
+    return executeSynchronousCall(requestParams, patchClusterCall);
+  }
+
 
   /**
    * List domains.

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
@@ -269,18 +269,6 @@ public class RestBackendImpl implements RestBackend {
     getDomain(domainUid).ifPresentOrElse(consumer, () -> reportNotFound(domainUid));
   }
 
-  private void forClusterDo(String domainUid, String clusterName, Consumer<ClusterResource> consumer) {
-    if (clusterName == null) {
-      throw new AssertionError(LOGGER.formatMessage(MessageKeys.NULL_CLUSTER_NAME));
-    }
-
-    getClusterResource(domainUid, clusterName).ifPresentOrElse(consumer, () -> reportClusterNotFound(clusterName));
-  }
-
-  private void reportClusterNotFound(String clusterName) {
-    throw createWebApplicationException(Status.NOT_FOUND, MessageKeys.MATCHING_CLUSTER_NOT_FOUND, clusterName);
-  }
-
   private void reportNotFound(String domainUid) {
     throw createWebApplicationException(Status.NOT_FOUND, MessageKeys.MATCHING_DOMAIN_NOT_FOUND, domainUid);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
@@ -57,7 +57,7 @@ public class RestBackendImpl implements RestBackend {
 
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   private static final String NEW_CLUSTER_REPLICAS =
-      "{'clusterName':'%s','replicas':%d}".replaceAll("'", "\"");
+      "{'clusterName':'%s','replicas':%d}".replace("'", "\"");
   private static final String INITIAL_VERSION = "1";
 
   @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"}) // used by unit test

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
@@ -282,8 +282,11 @@ public class RestBackendImpl implements RestBackend {
   private Optional<ClusterResource> getClusterResource(String domainUid, String clusterName) {
     authorize(null, Operation.LIST);
 
-    return getClusterStream().filter(c -> (clusterName.equals(c.getClusterName())
-            && domainUid.equals(c.getDomainUid()))).findFirst();
+    return getClusterStream().filter(c -> isMatchingClusterResource(domainUid, clusterName, c)).findFirst();
+  }
+
+  private boolean isMatchingClusterResource(String domainUid, String clusterName, ClusterResource c) {
+    return clusterName.equals(c.getClusterName()) && domainUid.equals(c.getDomainUid());
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/api/WeblogicApi.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/api/WeblogicApi.java
@@ -16,6 +16,7 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import okhttp3.Call;
 import oracle.kubernetes.weblogic.domain.model.ClusterList;
+import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainList;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
@@ -113,6 +114,37 @@ public class WeblogicApi extends CustomObjectsApi {
   }
 
   /**
+   * List clusters.
+   *
+   * @param namespace       namespace
+   * @param pretty          pretty flag
+   * @param cont            continuation
+   * @param fieldSelector   field selector
+   * @param labelSelector   label selector
+   * @param limit           limit
+   * @param resourceVersion resource version
+   * @param timeoutSeconds  timeout
+   * @param watch           if watch
+   * @return cluster list
+   * @throws ApiException on failure
+   */
+  public ClusterList listNamespacedCluster(
+          String namespace,
+          String pretty,
+          String cont,
+          String fieldSelector,
+          String labelSelector,
+          Integer limit,
+          String resourceVersion,
+          Integer timeoutSeconds,
+          Boolean watch)
+          throws ApiException {
+    return toClusterList(listNamespacedCustomObject(DOMAIN_GROUP, CLUSTER_VERSION, namespace, CLUSTER_PLURAL, pretty,
+            null, cont, fieldSelector, labelSelector, limit, resourceVersion, null,
+            timeoutSeconds, watch));
+  }
+
+  /**
    * List domains.
    *
    * @param namespace       namespace
@@ -201,6 +233,21 @@ public class WeblogicApi extends CustomObjectsApi {
     return listNamespacedCustomObjectAsync(DOMAIN_GROUP, DOMAIN_VERSION, namespace, DOMAIN_PLURAL,
         pretty, null, cont, fieldSelector, labelSelector, limit, resourceVersion, null,
         timeoutSeconds, watch, wrapForDomainList(callback));
+  }
+
+  /**
+   * Patch Cluster Resource.
+   *
+   * @param name      name
+   * @param namespace namespace
+   * @param body      patch
+   * @return Cluster Resource
+   * @throws ApiException on failure
+   */
+  public ClusterResource patchNamespacedCluster(String name, String namespace, V1Patch body)
+          throws ApiException {
+    return toCluster(patchNamespacedCustomObject(DOMAIN_GROUP, CLUSTER_VERSION, namespace, CLUSTER_PLURAL,
+            name, body, null, null, null));
   }
 
   /**
@@ -421,11 +468,25 @@ public class WeblogicApi extends CustomObjectsApi {
     return gson.toJsonTree(o);
   }
 
+  private ClusterResource toCluster(Object o) {
+    if (o == null) {
+      return null;
+    }
+    return getApiClient().getJSON().getGson().fromJson(convertToJson(o), ClusterResource.class);
+  }
+
   private DomainResource toDomain(Object o) {
     if (o == null) {
       return null;
     }
     return getApiClient().getJSON().getGson().fromJson(convertToJson(o), DomainResource.class);
+  }
+
+  private ClusterList toClusterList(Object o) {
+    if (o == null) {
+      return null;
+    }
+    return getApiClient().getJSON().getGson().fromJson(convertToJson(o), ClusterList.class);
   }
 
   private DomainList toDomainList(Object o) {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/api/WeblogicApi.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/api/WeblogicApi.java
@@ -426,13 +426,6 @@ public class WeblogicApi extends CustomObjectsApi {
     public void onDownloadProgress(long l, long l1, boolean b) {
       clusterListApiCallback.onDownloadProgress(l, l1, b);
     }
-
-    private ClusterList toClusterList(Object o) {
-      if (o == null) {
-        return null;
-      }
-      return getApiClient().getJSON().getGson().fromJson(convertToJson(o), ClusterList.class);
-    }
   }
 
   private class DomainListApiCallbackWrapper implements ApiCallback<Object> {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterResource.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterResource.java
@@ -258,4 +258,9 @@ public class ClusterResource implements KubernetesObject {
   public String getNamespace() {
     return getMetadata().getNamespace();
   }
+
+  public ClusterResource withReplicas(int i) {
+    setReplicas(i);
+    return this;
+  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CallBuilderTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CallBuilderTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -304,7 +305,7 @@ class CallBuilderTest {
     DomainResource domain
         = new DomainResource().withMetadata(createMetadata()).withSpec(new DomainSpec().withReplicas(5));
     defineHttpPatchResponse(
-        DOMAIN_RESOURCE, UID, domain, (json) -> requestBody.set(json));
+        DOMAIN_RESOURCE, UID, domain, requestBody::set);
 
     KubernetesTestSupportTest.TestResponseStep<DomainResource> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
@@ -317,6 +318,15 @@ class CallBuilderTest {
     DomainResource received = responseStep.waitForAndGetCallResponse().getResult();
 
     assertThat(received, equalTo(domain));
+  }
+
+  @Test
+  @ResourceLock(value = "server")
+  void listClusters_returnsList() throws ApiException {
+    ClusterList list = new ClusterList().withItems(Arrays.asList(new ClusterResource(), new ClusterResource()));
+    defineHttpGetResponse(CLUSTER_RESOURCE, list).expectingParameter("fieldSelector", "xxx");
+
+    assertThat(callBuilder.withFieldSelector("xxx").listCluster(NAMESPACE), equalTo(list));
   }
 
   @Test
@@ -362,7 +372,7 @@ class CallBuilderTest {
     cluster1.setKind(myKind);
     cluster1.setApiVersion(apiVersion);
 
-    ClusterList list = new ClusterList().withItems(Arrays.asList(cluster1));
+    ClusterList list = new ClusterList().withItems(List.of(cluster1));
 
     defineHttpGetResponse(CLUSTER_RESOURCE, list);
 
@@ -378,6 +388,24 @@ class CallBuilderTest {
     assertThat(received.toString(), containsString("apiVersion=apiVersion"));
     assertThat(received.hashCode(), equalTo(cluster1.hashCode()));
     assertThat(received.getStatus(), equalTo(status));
+  }
+
+  @Test
+  @ResourceLock(value = "server")
+  void patchClusterResource_returnsResource() throws ApiException {
+    AtomicReference<Object> requestBody = new AtomicReference<>();
+    ClusterResource resource = new ClusterResource()
+            .withMetadata(createMetadata().name(UID + "-cluster1"))
+            .withReplicas(5);
+    defineHttpPatchResponse(
+            CLUSTER_RESOURCE, UID, resource, requestBody::set);
+
+    JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
+    patchBuilder.add("/spec/replicas", 5);
+
+    ClusterResource received = callBuilder.patchCluster(UID, NAMESPACE, new V1Patch(patchBuilder.build().toString()));
+
+    assertThat(received, equalTo(resource));
   }
 
   @Test
@@ -466,7 +494,8 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1Service> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .deleteServiceAsync(service.getMetadata().getName(), NAMESPACE, UID, new DeleteOptions(), responseStep));
+        .deleteServiceAsync(Objects.requireNonNull(service.getMetadata()).getName(),
+                NAMESPACE, UID, new DeleteOptions(), responseStep));
 
     V1Service received = responseStep.waitForAndGetCallResponse().getResult();
 
@@ -529,7 +558,7 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1Secret> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .replaceSecretAsync(secret.getMetadata().getName(), NAMESPACE, secret, responseStep));
+        .replaceSecretAsync(Objects.requireNonNull(secret.getMetadata()).getName(), NAMESPACE, secret, responseStep));
 
     V1Secret received = responseStep.waitForAndGetCallResponse().getResult();
 
@@ -606,7 +635,7 @@ class CallBuilderTest {
     AtomicReference<Object> requestBody = new AtomicReference<>();
     V1Pod resource = new V1Pod().metadata(createMetadata());
     defineHttpPatchResponse(
-        POD_RESOURCE, UID, resource, (json) -> requestBody.set(json));
+        POD_RESOURCE, UID, resource, requestBody::set);
 
     KubernetesTestSupportTest.TestResponseStep<V1Pod> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
@@ -627,7 +656,7 @@ class CallBuilderTest {
     AtomicReference<Object> requestBody = new AtomicReference<>();
     V1Pod resource = new V1Pod().metadata(createMetadata());
     defineHttpPatchResponse(
-        POD_RESOURCE, UID, resource, (json) -> requestBody.set(json));
+        POD_RESOURCE, UID, resource, requestBody::set);
 
     JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
     patchBuilder.add("/spec/replicas", 5);
@@ -647,7 +676,7 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<Object> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .deletePodAsync(resource.getMetadata().getName(),
+        .deletePodAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
             NAMESPACE, UID, new DeleteOptions(), responseStep));
 
     Object received = responseStep.waitForAndGetCallResponse().getResult();
@@ -729,7 +758,7 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1Status> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .deleteJobAsync(resource.getMetadata().getName(),
+        .deleteJobAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
             NAMESPACE, UID, new DeleteOptions(), responseStep));
 
     V1Status received = responseStep.waitForAndGetCallResponse().getResult();
@@ -791,7 +820,7 @@ class CallBuilderTest {
     AtomicReference<Object> requestBody = new AtomicReference<>();
     V1PodDisruptionBudget resource = new V1PodDisruptionBudget().metadata(createMetadata());
     defineHttpPatchResponse(
-        PDB_RESOURCE, UID, resource, (json) -> requestBody.set(json));
+        PDB_RESOURCE, UID, resource, requestBody::set);
 
     KubernetesTestSupportTest.TestResponseStep<V1PodDisruptionBudget> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
@@ -816,7 +845,7 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1Status> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .deletePodDisruptionBudgetAsync(resource.getMetadata().getName(),
+        .deletePodDisruptionBudgetAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
             NAMESPACE, UID, new DeleteOptions(), responseStep));
 
     V1Status received = responseStep.waitForAndGetCallResponse().getResult();
@@ -913,7 +942,8 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1CustomResourceDefinition> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .replaceCustomResourceDefinitionAsync(resource.getMetadata().getName(), resource, responseStep));
+        .replaceCustomResourceDefinitionAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
+                resource, responseStep));
 
     V1CustomResourceDefinition received = responseStep.waitForAndGetCallResponse().getResult();
 
@@ -976,7 +1006,8 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1ConfigMap> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
-        .replaceConfigMapAsync(resource.getMetadata().getName(), NAMESPACE, resource, responseStep));
+        .replaceConfigMapAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
+                NAMESPACE, resource, responseStep));
 
     V1ConfigMap received = responseStep.waitForAndGetCallResponse().getResult();
 
@@ -989,7 +1020,7 @@ class CallBuilderTest {
     AtomicReference<Object> requestBody = new AtomicReference<>();
     V1ConfigMap resource = new V1ConfigMap().metadata(createMetadata());
     defineHttpPatchResponse(
-        CM_RESOURCE, UID, resource, (json) -> requestBody.set(json));
+        CM_RESOURCE, UID, resource, requestBody::set);
 
     KubernetesTestSupportTest.TestResponseStep<V1ConfigMap> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
@@ -1015,7 +1046,7 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1Status> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder().withGracePeriodSeconds(5)
-        .deleteConfigMapAsync(resource.getMetadata().getName(),
+        .deleteConfigMapAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
             NAMESPACE, UID, new DeleteOptions(), responseStep));
 
     V1Status received = responseStep.waitForAndGetCallResponse().getResult();
@@ -1184,7 +1215,8 @@ class CallBuilderTest {
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder()
         .replaceValidatingWebhookConfigurationAsync(
-            validatingWebhookConfig.getMetadata().getName(), validatingWebhookConfig, responseStep));
+            Objects.requireNonNull(validatingWebhookConfig.getMetadata()).getName(),
+                validatingWebhookConfig, responseStep));
 
     V1ValidatingWebhookConfiguration received = responseStep.waitForAndGetCallResponse().getResult();
 
@@ -1201,7 +1233,7 @@ class CallBuilderTest {
             .service(new AdmissionregistrationV1ServiceReference().namespace("ns1"))));
     defineHttpPatchResponse(
         VALIDATING_WEBHOOK_CONFIGURATION_RESOURCE, TEST_VALIDATING_WEBHOOK_NAME,
-        resource, (json) -> requestBody.set(json));
+        resource, requestBody::set);
 
     KubernetesTestSupportTest.TestResponseStep<V1ValidatingWebhookConfiguration> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
@@ -1229,7 +1261,7 @@ class CallBuilderTest {
     KubernetesTestSupportTest.TestResponseStep<V1Status> responseStep
         = new KubernetesTestSupportTest.TestResponseStep<>();
     testSupport.runSteps(new CallBuilder().withGracePeriodSeconds(5)
-        .deleteValidatingWebhookConfigurationAsync(resource.getMetadata().getName(),
+        .deleteValidatingWebhookConfigurationAsync(Objects.requireNonNull(resource.getMetadata()).getName(),
             new DeleteOptions(), responseStep));
 
     V1Status received = responseStep.waitForAndGetCallResponse().getResult();
@@ -1285,11 +1317,6 @@ class CallBuilderTest {
   private void defineHttpPostResponse(
       String resourceName, Object response, Consumer<String> bodyValidation) {
     defineResource(resourceName, new JsonPostServlet(response, bodyValidation));
-  }
-
-  private void defineHttpPostResponse(
-      String resourceName, String name, Object response, Consumer<String> bodyValidation) {
-    defineResource(resourceName + "/" + name, new JsonPostServlet(response, bodyValidation));
   }
 
   @SuppressWarnings("unused")

--- a/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
@@ -351,6 +351,9 @@ class RestBackendImplTest {
   void whenPerClusterResourceNotFound_updateClusterSpecOfDomain() {
     final String cluster1 = "cluster1";
     configureCluster(cluster1).withReplicas(2);
+    for (String name : new String[]{"cluster2", "cluster3", "cluster4"}) {
+      testSupport.defineResources(createClusterResource(DOMAIN2, NS, name));
+    }
 
     restBackend.scaleCluster(DOMAIN1, cluster1, 4);
 
@@ -372,6 +375,12 @@ class RestBackendImplTest {
 
     assertThrows(WebApplicationException.class,
             () -> restBackend.scaleCluster(DOMAIN1, cluster1, 10));
+  }
+
+  @Test
+  void whenScalingAndDomainNotFound_throwException() {
+    assertThrows(WebApplicationException.class,
+            () -> restBackend.scaleCluster(DOMAIN3, "cluster1", 4));
   }
 
   private ClusterResource createClusterResource(String uid, String namespace, String clusterName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("SameParameterValue")
 class RestBackendImplTest {
 
+  public static final String CLUSTER_1 = "cluster1";
   private static final int REPLICA_LIMIT = 4;
   private static final String NS = "namespace1";
   private static final String DOMAIN1 = "domain";
@@ -325,56 +326,52 @@ class RestBackendImplTest {
 
   @Test
   void whenPerClusterResourceReplicaSetting_scaleClusterUpdatesClusterResource() {
-    final String cluster1 = "cluster1";
-    final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, cluster1)
+    final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, CLUSTER_1)
             .withReplicas(1);
     testSupport.defineResources(clusterResource);
 
-    restBackend.scaleCluster(DOMAIN1, cluster1, 5);
+    restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 5);
 
     assertThat(getUpdatedClusterResource().getSpec().getReplicas(), equalTo(5));
   }
 
   @Test
   void whenPerClusterResourceReplicaSettingMatchesScaleRequest_doNothing() {
-    final String cluster1 = "cluster1";
-    final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, cluster1)
+    final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, CLUSTER_1)
             .withReplicas(1);
     testSupport.defineResources(clusterResource);
 
-    restBackend.scaleCluster(DOMAIN1, cluster1, 1);
+    restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 1);
 
     assertThat(getUpdatedClusterResource(), nullValue());
   }
 
   @Test
   void whenPerClusterResourceNotFound_updateClusterSpecOfDomain() {
-    final String cluster1 = "cluster1";
-    configureCluster(cluster1).withReplicas(2);
+    configureCluster(CLUSTER_1).withReplicas(2);
     for (String name : new String[]{"cluster2", "cluster3", "cluster4"}) {
       testSupport.defineResources(createClusterResource(DOMAIN2, NS, name));
     }
 
-    restBackend.scaleCluster(DOMAIN1, cluster1, 4);
+    restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 4);
 
     DomainResource updatedDomain = getUpdatedDomain();
     assertThat(updatedDomain, notNullValue());
-    ClusterSpec cluster = updatedDomain.getSpec().getCluster(cluster1);
+    ClusterSpec cluster = updatedDomain.getSpec().getCluster(CLUSTER_1);
     assertThat(cluster, notNullValue());
     assertThat(cluster.getReplicas(), equalTo(4));
   }
 
   @Test
   void whenPerClusterResourceReplicaSettingGreaterThanMax_throwsException() {
-    final String cluster1 = "cluster1";
-    final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, cluster1)
+    final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, CLUSTER_1)
             .withReplicas(1);
     testSupport.defineResources(clusterResource);
-    domain1ConfigSupport.addWlsCluster(new WlsDomainConfigSupport.DynamicClusterConfigBuilder(cluster1)
+    domain1ConfigSupport.addWlsCluster(new WlsDomainConfigSupport.DynamicClusterConfigBuilder(CLUSTER_1)
             .withClusterLimits(0, 5));
 
     assertThrows(WebApplicationException.class,
-            () -> restBackend.scaleCluster(DOMAIN1, cluster1, 10));
+            () -> restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 10));
   }
 
   @Test


### PR DESCRIPTION
This change allows scaling of clusters through the Operator REST Api by issuing patch commands, ,on the 'scale ' subresource, directly on the corresponding  Cluster Resource.  If Cluster Resource does not exist then it will look for corresponding Cluster spec in the Domain spec (until we're ready to delete the Cluster spec from the Domain spec).  