### PR TITLE
Update jenkin files for Kind/K8s and WDT/WIT downlaod URL

### DIFF
--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -97,8 +97,8 @@ pipeline {
         choice(name: 'KIND_VERSION',
                description: 'Kind version.',
                choices: [
-                   '0.11.1',
                    '0.13.0',
+                   '0.11.1',
                    '0.12.0',
                ]
         )
@@ -106,6 +106,7 @@ pipeline {
                description: 'Kubernetes version. Supported values depend on the Kind version. Kind 0.13.0: 1.24, 1.24.0, 1.23, 1.23.6, 1.22, 1.22.9, 1.21, 1.21.12, 1.20, 1.20.15, Kind 0.12.0: 1.23, 1.23.4, 1.22, 1.22.7, 1.21, 1.21.10, 1.20, 1.20.15. Kind 0.11.1: 1.23, 1.23.3, 1.22, 1.22.5, 1.21, 1.21.1, 1.20, 1.20.7, 1.19, 1.19.11.',
                choices: [
                     // The first item in the list is the default value...
+                    '1.21.12',
                     '1.21.1',
                     '1.24',
                     '1.24.0',
@@ -155,11 +156,11 @@ pipeline {
         )
         string(name: 'WDT_DOWNLOAD_URL',
                description: 'URL to download WDT.',
-               defaultValue: 'https://github.com/oracle/weblogic-deploy-tooling/releases/latest'
+               defaultValue: 'https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/weblogic-deploy-main.zip'
         )
         string(name: 'WIT_DOWNLOAD_URL',
                description: 'URL to download WIT.',
-               defaultValue: 'https://github.com/oracle/weblogic-image-tool/releases/latest'
+               defaultValue: 'https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/imagetool-main.zip'
         )
         string(name: 'TEST_IMAGES_REPO',
                description: '',

--- a/Jenkinsfile.oke
+++ b/Jenkinsfile.oke
@@ -87,11 +87,11 @@ pipeline {
         )
         string(name: 'WDT_DOWNLOAD_URL',
                description: 'URL to download WDT.',
-               defaultValue: 'https://github.com/oracle/weblogic-deploy-tooling/releases/latest'
+               defaultValue: 'https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/weblogic-deploy-main.zip'
         )
         string(name: 'WIT_DOWNLOAD_URL',
                description: 'URL to download WIT.',
-               defaultValue: 'https://github.com/oracle/weblogic-image-tool/releases/latest'
+               defaultValue: 'https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/imagetool-main.zip'
         )
         string(name: 'REPO_REGISTRY',
                description: '',


### PR DESCRIPTION
This  PR updates the nightly Jenkin file

(a) Kind Version to 1.13.0
(b) Kubectl version to 1.21.12
(c) WDT URL to  https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/weblogic-deploy-main.zip
(d) WIT URL to https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/imagetool-main.zip