### PR TITLE
Owls 100719 - Fix server shutdown with HTTP failures and changes to poll the server status after shutdown

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -150,7 +150,6 @@ public class MessageKeys {
   public static final String BEGIN_SERVER_SHUTDOWN_REST = "WLSKO-0199";
   public static final String SERVER_SHUTDOWN_REST_SUCCESS = "WLSKO-0200";
   public static final String SERVER_SHUTDOWN_REST_FAILURE = "WLSKO-0201";
-  public static final String SERVER_SHUTDOWN_REST_TIMEOUT = "WLSKO-0202";
   public static final String SERVER_SHUTDOWN_REST_THROWABLE = "WLSKO-0203";
   public static final String SERVER_SHUTDOWN_REST_RETRY = "WLSKO-0204";
   public static final String INPUT_FILE_NON_EXISTENT = "WLSKO-0213";

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -154,7 +154,6 @@ WLSKO-0198={0} Fiber {1}
 WLSKO-0199=WL pod shutdown: Initiating shutdown of WebLogic server {0} via REST interface.
 WLSKO-0200=WL pod shutdown: Successfully shutdown WebLogic server {0} via REST interface.
 WLSKO-0201=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface with response: {1}.
-WLSKO-0202=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface due to HTTP request timeout after {1} seconds.
 WLSKO-0203=WL pod shutdown: Failed to shutdown WebLogic server {0} via REST interface due to exception: {1}.
 WLSKO-0204=WL pod shutdown: Retry shutdown of WebLogic server {0} via REST interface.
 WLSKO-0213=InputFile: {0} does not exist or could not be read.

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -59,4 +59,6 @@ public interface ProcessingConstants {
   String OPERATOR_EVENT_LABEL_FILTER = LabelConstants.getCreatedByOperatorSelector();
 
   String WEBHOOK = "Webhook";
+
+  String SHUTDOWN_WITH_HTTP_SUCCEEDED = "SHUTDOWN_WITH_HTTP_SUCCEEDED";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -195,7 +195,7 @@ public class ServerStatusReader {
                   LOGGER.fine("readState exit: " + exitValue + ", readState for " + pod.getMetadata().getName());
                   if (exitValue == 1 || exitValue == 2) {
                     state =
-                        PodHelper.isDeleting(pod)
+                        isPodBeingDeleted()
                             ? WebLogicConstants.SHUTDOWN_STATE
                             : WebLogicConstants.STARTING_STATE;
                   } else if (exitValue != 0) {
@@ -225,6 +225,10 @@ public class ServerStatusReader {
             }
             fiber.resume(packet);
           });
+    }
+
+    private boolean isPodBeingDeleted() {
+      return PodHelper.isDeleting(pod) || info.isServerPodBeingDeleted(PodHelper.getPodServerName(pod));
     }
 
     private String getNamespace(@Nonnull V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -266,17 +266,29 @@ public class PodHelper {
   }
 
   /**
+   * Returns the pod's cluster-name.
+   * The cluster-name is the value of the weblogic.clusterName label in the given pod.
+   *
+   * @param pod the pod
+   * @return cluster name.
+   */
+  public static String getPodClusterName(V1Pod pod) {
+    return Optional.ofNullable(pod)
+        .map(V1Pod::getMetadata)
+        .map(V1ObjectMeta::getLabels)
+        .map(labels -> labels.get(CLUSTERNAME_LABEL)).orElse(null);
+  }
+
+  /**
    * get pod's server name.
    * @param pod pod
    * @return server name
    */
   public static String getPodServerName(V1Pod pod) {
-    V1ObjectMeta meta = pod.getMetadata();
-    Map<String, String> labels = meta.getLabels();
-    if (labels != null) {
-      return labels.get(LabelConstants.SERVERNAME_LABEL);
-    }
-    return null;
+    return Optional.ofNullable(pod)
+        .map(V1Pod::getMetadata)
+        .map(V1ObjectMeta::getLabels)
+        .map(labels -> labels.get(SERVERNAME_LABEL)).orElse(null);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
@@ -129,10 +129,15 @@ public class HttpAsyncRequestStep extends Step {
       try (ThreadLoggingContext ignored =
                setThreadContext().namespace(getNamespaceFromInfo(info)).domainUid(getDomainUIDFromInfo(info))) {
         if (throwable instanceof HttpTimeoutException) {
+          LOGGER.info("DEBUG: Got HttpTimeoutException " + throwable);
           LOGGER.fine(MessageKeys.HTTP_REQUEST_TIMED_OUT, throwable.getMessage());
         } else if (response != null) {
+          LOGGER.info("DEBUG: For server " + getServerName() + " got response " + response + ", status code is "
+              + response.statusCode() + ", response.body is " + response.body() + ", request is " 
+              + response.request() + ", headers is " + response.headers());
           recordResponse(response);
         } else if (throwable != null) {
+          LOGGER.info("DEBUG: Got throwable " + throwable);
           recordThrowableResponse(throwable);
         }
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
@@ -130,6 +130,7 @@ public class HttpAsyncRequestStep extends Step {
                setThreadContext().namespace(getNamespaceFromInfo(info)).domainUid(getDomainUIDFromInfo(info))) {
         if (throwable instanceof HttpTimeoutException) {
           LOGGER.info("DEBUG: Got HttpTimeoutException " + throwable);
+          HttpResponseStep.addToPacket(packet, throwable);
           LOGGER.fine(MessageKeys.HTTP_REQUEST_TIMED_OUT, throwable.getMessage());
         } else if (response != null) {
           LOGGER.info("DEBUG: For server " + getServerName() + " got response " + response + ", status code is "

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
@@ -25,6 +25,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_OK;
+import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.http.client.TrustAllX509ExtendedTrustManager.getTrustingSSLContext;
 import static oracle.kubernetes.operator.logging.ThreadLoggingContext.setThreadContext;
 
@@ -92,6 +93,7 @@ public class HttpAsyncRequestStep extends Step {
   @Override
   public NextAction apply(Packet packet) {
     AsyncProcessing processing = new AsyncProcessing(packet);
+    LOGGER.info("DEBUG: suspending processing for server " + packet.getValue(SERVER_NAME));
     return doSuspend(processing::process);
   }
 
@@ -147,7 +149,7 @@ public class HttpAsyncRequestStep extends Step {
     }
 
     private String getServerName() {
-      return packet.getValue(ProcessingConstants.SERVER_NAME);
+      return packet.getValue(SERVER_NAME);
     }
 
     private boolean isServerShuttingDown() {

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
@@ -92,7 +92,6 @@ public class HttpAsyncRequestStep extends Step {
   @Override
   public NextAction apply(Packet packet) {
     AsyncProcessing processing = new AsyncProcessing(packet);
-    LOGGER.info("DEBUG: suspending processing for server " + packet.getValue(SERVER_NAME));
     return doSuspend(processing::process);
   }
 
@@ -130,16 +129,11 @@ public class HttpAsyncRequestStep extends Step {
       try (ThreadLoggingContext ignored =
                setThreadContext().namespace(getNamespaceFromInfo(info)).domainUid(getDomainUIDFromInfo(info))) {
         if (throwable instanceof HttpTimeoutException) {
-          LOGGER.info("DEBUG: Got HttpTimeoutException " + throwable);
           HttpResponseStep.addToPacket(packet, throwable);
           LOGGER.fine(MessageKeys.HTTP_REQUEST_TIMED_OUT, throwable.getMessage());
         } else if (response != null) {
-          LOGGER.info("DEBUG: For server " + getServerName() + " got response " + response + ", status code is "
-              + response.statusCode() + ", response.body is " + response.body() + ", request is " 
-              + response.request() + ", headers is " + response.headers());
           recordResponse(response);
         } else if (throwable != null) {
-          LOGGER.info("DEBUG: Got throwable " + throwable);
           recordThrowableResponse(throwable);
         }
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.common.logging.MessageKeys;
+import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
@@ -24,7 +25,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_OK;
-import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.http.client.TrustAllX509ExtendedTrustManager.getTrustingSSLContext;
 import static oracle.kubernetes.operator.logging.ThreadLoggingContext.setThreadContext;
 
@@ -142,7 +142,7 @@ public class HttpAsyncRequestStep extends Step {
     }
 
     private String getServerName() {
-      return packet.getValue(SERVER_NAME);
+      return packet.getValue(ProcessingConstants.SERVER_NAME);
     }
 
     private boolean isServerShuttingDown() {

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStep.java
@@ -13,7 +13,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.common.logging.MessageKeys;
-import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
@@ -16,6 +16,7 @@ import oracle.kubernetes.operator.work.Step;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_FORBIDDEN;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_OK;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_UNAUTHORIZED;
+import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 
 public abstract class HttpResponseStep extends Step {
   private static final String RESPONSE = "httpResponse";
@@ -26,6 +27,8 @@ public abstract class HttpResponseStep extends Step {
 
   @Override
   public NextAction apply(Packet packet) {
+    System.out.println("DEBUG: In HttpResponseStep. response is " + getResponse(packet) + ", and server is "
+        + packet.get(SERVER_NAME));
     return Optional.ofNullable(getResponse(packet))
         .map(r -> doApply(packet, r))
         .orElse(handlePossibleThrowableOrContinue(packet));
@@ -42,10 +45,12 @@ public abstract class HttpResponseStep extends Step {
   }
 
   private NextAction doApply(Packet packet, HttpResponse<String> response) {
+    System.out.println("DEBUG: doApply. response is " + response + ", isSuccess(response) is " + isSuccess(response));
     return isSuccess(response) ? onSuccess(packet, response) : wrapOnFailure(packet, response);
   }
 
   private NextAction wrapOnFailure(Packet packet, HttpResponse<String> response) {
+    System.out.println("DEBUG: wrapOnFailure response is " + response + ", status is " + response.statusCode());
     if (response != null && (response.statusCode() == HTTP_FORBIDDEN || response.statusCode() == HTTP_UNAUTHORIZED)) {
       Optional.ofNullable(SecretHelper.getAuthorizationSource(packet)).ifPresent(AuthorizationSource::onFailure);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
@@ -50,7 +50,10 @@ public abstract class HttpResponseStep extends Step {
   }
 
   private NextAction wrapOnFailure(Packet packet, HttpResponse<String> response) {
-    System.out.println("DEBUG: wrapOnFailure response is " + response + ", status is " + response.statusCode());
+    System.out.println("DEBUG: wrapOnFailure response is " + response);
+    if (response != null) {
+      System.out.println("DEBUG: wrapOnFailure response is not null, code is " + response.statusCode());
+    }
     if (response != null && (response.statusCode() == HTTP_FORBIDDEN || response.statusCode() == HTTP_UNAUTHORIZED)) {
       Optional.ofNullable(SecretHelper.getAuthorizationSource(packet)).ifPresent(AuthorizationSource::onFailure);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
@@ -16,7 +16,6 @@ import oracle.kubernetes.operator.work.Step;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_FORBIDDEN;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_OK;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_UNAUTHORIZED;
-import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 
 public abstract class HttpResponseStep extends Step {
   private static final String RESPONSE = "httpResponse";
@@ -27,16 +26,12 @@ public abstract class HttpResponseStep extends Step {
 
   @Override
   public NextAction apply(Packet packet) {
-    System.out.println("DEBUG: In HttpResponseStep. response is " + getResponse(packet) + ", and server is "
-        + packet.get(SERVER_NAME));
     return Optional.ofNullable(getResponse(packet))
         .map(r -> doApply(packet, r))
         .orElse(handlePossibleThrowableOrContinue(packet));
   }
 
   private NextAction handlePossibleThrowableOrContinue(Packet packet) {
-    System.out.println("DEBUG: In HttpResponseStep. getThrowableResponse is " + getThrowableResponse(packet)
-        + ", and server is " + packet.get(SERVER_NAME));
     return Optional.ofNullable(getThrowableResponse(packet))
         .map(t -> wrapOnFailure(packet, null))
         .orElse(doNext(packet));
@@ -47,15 +42,10 @@ public abstract class HttpResponseStep extends Step {
   }
 
   private NextAction doApply(Packet packet, HttpResponse<String> response) {
-    System.out.println("DEBUG: doApply. response is " + response + ", isSuccess(response) is " + isSuccess(response));
     return isSuccess(response) ? onSuccess(packet, response) : wrapOnFailure(packet, response);
   }
 
   private NextAction wrapOnFailure(Packet packet, HttpResponse<String> response) {
-    System.out.println("DEBUG: wrapOnFailure response is " + response);
-    if (response != null) {
-      System.out.println("DEBUG: wrapOnFailure response is not null, code is " + response.statusCode());
-    }
     if (response != null && (response.statusCode() == HTTP_FORBIDDEN || response.statusCode() == HTTP_UNAUTHORIZED)) {
       Optional.ofNullable(SecretHelper.getAuthorizationSource(packet)).ifPresent(AuthorizationSource::onFailure);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
@@ -35,6 +35,8 @@ public abstract class HttpResponseStep extends Step {
   }
 
   private NextAction handlePossibleThrowableOrContinue(Packet packet) {
+    System.out.println("DEBUG: In HttpResponseStep. getThrowableResponse is " + getThrowableResponse(packet)
+        + ", and server is " + packet.get(SERVER_NAME));
     return Optional.ofNullable(getThrowableResponse(packet))
         .map(t -> wrapOnFailure(packet, null))
         .orElse(doNext(packet));

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -146,7 +146,7 @@ public class ManagedServersUpStep extends Step {
   }
 
   private boolean podNotAlreadyMarkedForShutdown(V1Pod pod, ServersUpStepFactory factory) {
-    return !factory.getShutdownInfos().stream().anyMatch(ssi -> ssi.getServerName().equals(getPodServerName(pod)));
+    return factory.getShutdownInfos().stream().noneMatch(ssi -> ssi.getServerName().equals(getPodServerName(pod)));
   }
 
   private void shutdownServersNotPresentInDomainConfig(ServersUpStepFactory factory, V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -211,9 +211,6 @@ public class ManagedServersUpStep extends Step {
         return;
       }
       String clusterName = getClusterName(clusterConfig);
-      LOGGER.info("DEBUG: In addServerIfNeeded.. serverName is " + serverName
-          + ", and cluster name is " + clusterName);
-
       EffectiveServerSpec server = info.getServer(serverName, clusterName);
 
       if (server.shouldStart(getReplicaCount(clusterName))) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ManagedServersUpStep.java
@@ -210,6 +210,7 @@ public class ManagedServersUpStep extends Step {
       if (adminServerOrDone(serverName)) {
         return;
       }
+
       String clusterName = getClusterName(clusterConfig);
       EffectiveServerSpec server = info.getServer(serverName, clusterName);
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
@@ -25,8 +25,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
-import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
-
 public class ServerDownIteratorStep extends Step {
   private final List<ServerShutdownInfo> serverShutdownInfos;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
@@ -85,12 +85,8 @@ public class ServerDownIteratorStep extends Step {
 
     private StepAndPacket createManagedServerDownDetails(Packet packet, ServerShutdownInfo ssi) {
       if (ssi.isServiceOnly()) {
-        System.out.println("DEBUG: In createManagedServerDownDetails for server " + packet.getValue(SERVER_NAME));
         return new StepAndPacket(createServiceStep(ssi), createPacketForServer(packet, ssi));
       } else {
-        System.out.println("DEBUG: In createManagedServerDownDetails for server " + packet.getValue(SERVER_NAME));
-        System.out.println("DEBUG: In createManagedServerDownDetails for server " + ssi.getName());
-        //return new StepAndPacket(new ServerDownStep(ssi.getName(), null), packet.copy());
         return new StepAndPacket(new ServerDownStep(ssi.getName(), null), createPacketForServer(packet, ssi));
       }
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownIteratorStep.java
@@ -25,6 +25,8 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
+import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
+
 public class ServerDownIteratorStep extends Step {
   private final List<ServerShutdownInfo> serverShutdownInfos;
 
@@ -83,9 +85,13 @@ public class ServerDownIteratorStep extends Step {
 
     private StepAndPacket createManagedServerDownDetails(Packet packet, ServerShutdownInfo ssi) {
       if (ssi.isServiceOnly()) {
+        System.out.println("DEBUG: In createManagedServerDownDetails for server " + packet.getValue(SERVER_NAME));
         return new StepAndPacket(createServiceStep(ssi), createPacketForServer(packet, ssi));
       } else {
-        return new StepAndPacket(new ServerDownStep(ssi.getName(), null), packet.copy());
+        System.out.println("DEBUG: In createManagedServerDownDetails for server " + packet.getValue(SERVER_NAME));
+        System.out.println("DEBUG: In createManagedServerDownDetails for server " + ssi.getName());
+        //return new StepAndPacket(new ServerDownStep(ssi.getName(), null), packet.copy());
+        return new StepAndPacket(new ServerDownStep(ssi.getName(), null), createPacketForServer(packet, ssi));
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -13,7 +13,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import org.jetbrains.annotations.NotNull;
 
-import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownWithHttpStep;
 
 public class ServerDownStep extends Step {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -46,7 +46,6 @@ public class ServerDownStep extends Step {
       PodAwaiterStepFactory pw = packet.getSpi(PodAwaiterStepFactory.class);
       next = pw.waitForDelete(oldPod, new DomainPresenceInfoUpdateStep(serverName, next));
     }
-    System.out.println("DEBUG: In ServerDownStep for server " + packet.getValue(SERVER_NAME));
 
     return doNext(oldPod != null ? createShutdownManagedServerStep(oldPod, next) : next, packet);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -13,6 +13,8 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import org.jetbrains.annotations.NotNull;
 
+import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownStep;
+
 public class ServerDownStep extends Step {
   private final String serverName;
   private final boolean isPreserveServices;
@@ -50,6 +52,7 @@ public class ServerDownStep extends Step {
   @NotNull
   private Step createShutdownManagedServerStep(V1Pod oldPod, Step next) {
     return ShutdownManagedServerStep
-        .createShutdownManagedServerStep(PodHelper.deletePodStep(serverName, next), serverName, oldPod);
+        .createShutdownManagedServerStep(createWaitForServerShutdownStep(
+            (PodHelper.deletePodStep(serverName, next)), serverName), serverName, oldPod);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -13,6 +13,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import org.jetbrains.annotations.NotNull;
 
+import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownWithHttpStep;
 
 public class ServerDownStep extends Step {
@@ -45,6 +46,7 @@ public class ServerDownStep extends Step {
       PodAwaiterStepFactory pw = packet.getSpi(PodAwaiterStepFactory.class);
       next = pw.waitForDelete(oldPod, new DomainPresenceInfoUpdateStep(serverName, next));
     }
+    System.out.println("DEBUG: In ServerDownStep for server " + packet.getValue(SERVER_NAME));
 
     return doNext(oldPod != null ? createShutdownManagedServerStep(oldPod, next) : next, packet);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -13,7 +13,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import org.jetbrains.annotations.NotNull;
 
-import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownStep;
+import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownWithHttpStep;
 
 public class ServerDownStep extends Step {
   private final String serverName;
@@ -52,7 +52,7 @@ public class ServerDownStep extends Step {
   @NotNull
   private Step createShutdownManagedServerStep(V1Pod oldPod, Step next) {
     return ShutdownManagedServerStep
-        .createShutdownManagedServerStep(createWaitForServerShutdownStep(
+        .createShutdownManagedServerStep(createWaitForServerShutdownWithHttpStep(
             (PodHelper.deletePodStep(serverName, next)), serverName), serverName, oldPod);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -378,6 +378,8 @@ public class ShutdownManagedServerStep extends Step {
 
     @Override
     public NextAction onSuccess(Packet packet, HttpResponse<String> response) {
+      LOGGER.info("DEBUG: In onSuccess.. response is " + response + ", and getResponse is " + getResponse(packet));
+      LOGGER.info("DEBUG: In onSuccess.. requestTimeout is " + requestTimeout);
       LOGGER.fine(MessageKeys.SERVER_SHUTDOWN_REST_SUCCESS, serverName);
       removeShutdownRequestRetryCount(packet);
       return doNext(packet);
@@ -385,22 +387,28 @@ public class ShutdownManagedServerStep extends Step {
 
     @Override
     public NextAction onFailure(Packet packet, HttpResponse<String> response) {
+      LOGGER.info("DEBUG: In onFailure.. response is " + response + ", and getResponse is " + getResponse(packet));
+      LOGGER.info("DEBUG: In onFailure.. requestTimeout is " + requestTimeout);
       if (getThrowableResponse(packet) != null) {
+        LOGGER.info("DEBUG: In onFailure.. getThrowableResponse is " + getThrowableResponse(packet));
         Throwable throwable = getThrowableResponse(packet);
         if (retryRequest(packet)) {
           return doNext(requestStep, packet);
         }
         LOGGER.info(MessageKeys.SERVER_SHUTDOWN_REST_THROWABLE, serverName, throwable.getMessage());
       } else if (getResponse(packet) == null) {
+        LOGGER.info("DEBUG: In onFailure.. getThrowableResponse is " + getResponse(packet));
         // Request timed out
         if (retryRequest(packet)) {
           return doNext(requestStep, packet);
         }
         LOGGER.info(MessageKeys.SERVER_SHUTDOWN_REST_TIMEOUT, serverName, Long.toString(requestTimeout));
       } else {
+        LOGGER.info("DEBUG: In onFailure, third else");
         LOGGER.info(MessageKeys.SERVER_SHUTDOWN_REST_FAILURE, serverName, response);
       }
 
+      LOGGER.info("DEBUG: In onFailure, calling removeShutdownRequestRetryCount and next step.");
       removeShutdownRequestRetryCount(packet);
       return doNext(packet);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -49,7 +49,6 @@ import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.KubernetesConstants.WLS_CONTAINER_NAME;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
-import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.SHUTDOWN_WITH_HTTP_SUCCEEDED;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -397,7 +397,7 @@ public class ShutdownManagedServerStep extends Step {
         }
         LOGGER.info(MessageKeys.SERVER_SHUTDOWN_REST_THROWABLE, serverName, throwable.getMessage());
       } else if (getResponse(packet) == null) {
-        LOGGER.info("DEBUG: In onFailure.. getThrowableResponse is " + getResponse(packet));
+        LOGGER.info("DEBUG: In onFailure.. getResponse is " + getResponse(packet));
         // Request timed out
         if (retryRequest(packet)) {
           return doNext(requestStep, packet);
@@ -416,6 +416,7 @@ public class ShutdownManagedServerStep extends Step {
     private boolean retryRequest(Packet packet) {
       if (getShutdownRequestRetryCount(packet) == null) {
         addShutdownRequestRetryCountToPacket(packet, 1);
+        LOGGER.info("DEBUG: in retryRequest .. ");
         if (requestStep != null) {
           // Retry request
           LOGGER.info(MessageKeys.SERVER_SHUTDOWN_REST_RETRY, serverName);

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -344,7 +344,7 @@ public class ShutdownManagedServerStep extends Step {
       LOGGER.info("DEBUG: shutdownCallSucceeded for server " + serverName + " is "
           + shutdownCallSucceeded);
       String serverState = getServerState(getDomainPresenceInfo(packet).getDomain());
-      if (serverNotShutdown(serverState) || shutdownAttemptSucceeded(shutdownCallSucceeded)) {
+      if (shutdownAttemptSucceeded(shutdownCallSucceeded) && serverNotShutdown(serverState)) {
         LOGGER.info("DEBUG: serverNotShutdown and shutdownAttemptSucceeded.. for " + serverName + ", waiting");
         return doDelay(this, packet, 3, TimeUnit.SECONDS);
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
@@ -77,7 +77,9 @@ public class TuningParameters {
   public static final String SERVICE_ACCOUNT_NAME = "serviceaccount";
   public static final String CRD_PRESENCE_FAILURE_RETRY_MAX_COUNT = "crdPresenceFailureRetryMaxCount";
   public static final String HTTP_REQUEST_FAILURE_COUNT_THRESHOLD = "httpRequestFailureCountThreshold";
+  public static final String HTTP_SHUTDOWN_POLLING_INTERVAL = "httpShutdownPollingInterval";
   public static final int DEFAULT_HTTP_REQUEST_FAILURE_COUNT_THRESHOLD = 10;
+  public static final int DEFAULT_HTTP_SHUTDOWN_POLLING_INTERVAL = 3;
 
   public static final long DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS = 60L;
 
@@ -228,6 +230,10 @@ public class TuningParameters {
 
   public int getHttpRequestFailureCountThreshold() {
     return getParameter(HTTP_REQUEST_FAILURE_COUNT_THRESHOLD, DEFAULT_HTTP_REQUEST_FAILURE_COUNT_THRESHOLD);
+  }
+
+  public int getHttpShutdownPollingInterval() {
+    return getParameter(HTTP_SHUTDOWN_POLLING_INTERVAL, DEFAULT_HTTP_SHUTDOWN_POLLING_INTERVAL);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
@@ -77,9 +77,9 @@ public class TuningParameters {
   public static final String SERVICE_ACCOUNT_NAME = "serviceaccount";
   public static final String CRD_PRESENCE_FAILURE_RETRY_MAX_COUNT = "crdPresenceFailureRetryMaxCount";
   public static final String HTTP_REQUEST_FAILURE_COUNT_THRESHOLD = "httpRequestFailureCountThreshold";
-  public static final String HTTP_SHUTDOWN_POLLING_INTERVAL = "httpShutdownPollingInterval";
+  public static final String SHUTDOWN_WITH_HTTP_POLLING_INTERVAL = "shutdownWithHttpPollingInterval";
   public static final int DEFAULT_HTTP_REQUEST_FAILURE_COUNT_THRESHOLD = 10;
-  public static final int DEFAULT_HTTP_SHUTDOWN_POLLING_INTERVAL = 3;
+  public static final int DEFAULT_SHUTDOWN_WITH_HTTP_POLLING_INTERVAL = 3;
 
   public static final long DEFAULT_ACTIVE_DEADLINE_INCREMENT_SECONDS = 60L;
 
@@ -232,8 +232,8 @@ public class TuningParameters {
     return getParameter(HTTP_REQUEST_FAILURE_COUNT_THRESHOLD, DEFAULT_HTTP_REQUEST_FAILURE_COUNT_THRESHOLD);
   }
 
-  public int getHttpShutdownPollingInterval() {
-    return getParameter(HTTP_SHUTDOWN_POLLING_INTERVAL, DEFAULT_HTTP_SHUTDOWN_POLLING_INTERVAL);
+  public int getShutdownWithHttpPollingInterval() {
+    return getParameter(SHUTDOWN_WITH_HTTP_POLLING_INTERVAL, DEFAULT_SHUTDOWN_WITH_HTTP_POLLING_INTERVAL);
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -444,13 +444,13 @@ class DomainProcessorTest {
   }
 
   @Test
-  void afterMakeRightAndChangeServerToNever_serverPodNotDeletedWhenServerIsSuspending() {
+  void afterMakeRightAndChangeServerToNever_serverPodsWaitForShutdownWithHttpToCompleteBeforeTerminating() {
     domainConfigurator.configureCluster(CLUSTER).withReplicas(MIN_REPLICAS);
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
 
     domainConfigurator.withDefaultServerStartPolicy(ServerStartPolicy.NEVER);
     DomainStatus status = new DomainPresenceInfo(newDomain).getDomain().getStatus();
-    invokeServerShutdownWithHttp();
+    defineServerShutdownWithHttpOkResponse();
     setAdminServerStatus(status, SUSPENDING_STATE);
     setManagedServerState(status, SUSPENDING_STATE);
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).withExplicitRecheck().execute();
@@ -464,7 +464,7 @@ class DomainProcessorTest {
     assertThat(getResourceVersion(updatedDomain), not(getResourceVersion(domain)));
   }
 
-  private void invokeServerShutdownWithHttp() {
+  private void defineServerShutdownWithHttpOkResponse() {
     httpSupport.defineResponse(createShutdownRequest(ADMIN_NAME, 7001),
         createStub(HttpResponseStub.class, HTTP_OK, OK_RESPONSE));
     IntStream.range(1, 3).forEach(idx -> httpSupport.defineResponse(

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -56,6 +56,7 @@ import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_THROWABLE;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_TIMEOUT;
 import static oracle.kubernetes.common.utils.LogMatcher.containsFine;
+import static oracle.kubernetes.common.utils.LogMatcher.containsInfo;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
@@ -247,7 +248,7 @@ class ShutdownManagedServerStepTest {
 
     testSupport.runSteps(shutdownConfiguredManagedServer);
 
-    assertThat(logRecords, containsFine(SERVER_SHUTDOWN_REST_FAILURE));
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_FAILURE));
   }
 
   @Test
@@ -269,7 +270,7 @@ class ShutdownManagedServerStepTest {
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
 
-    assertThat(logRecords, containsFine(SERVER_SHUTDOWN_REST_FAILURE));
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_FAILURE));
   }
 
   @Test
@@ -291,7 +292,7 @@ class ShutdownManagedServerStepTest {
 
     testSupport.runSteps(shutdownDynamicManagedServer);
 
-    assertThat(logRecords, containsFine(SERVER_SHUTDOWN_REST_FAILURE));
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_FAILURE));
   }
 
   @Test
@@ -323,7 +324,7 @@ class ShutdownManagedServerStepTest {
 
     // Null HTTP response and no response recorded in packet implies HTTP request timed out
     responseStep.onFailure(testSupport.getPacket(), null);
-    assertThat(logRecords, containsFine(SERVER_SHUTDOWN_REST_TIMEOUT));
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_TIMEOUT));
   }
 
   @Test
@@ -343,12 +344,12 @@ class ShutdownManagedServerStepTest {
     // Assert that we will retry due to exception
     responseStep.onFailure(p, null);
     assertThat(p.get(SHUTDOWN_REQUEST_RETRY_COUNT), equalTo(1));
-    assertThat(logRecords, containsFine(SERVER_SHUTDOWN_REST_RETRY));
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_RETRY));
 
     // Assert we only retry once
     responseStep.onFailure(p, null);
     assertThat(p.get(SHUTDOWN_REQUEST_RETRY_COUNT), is(nullValue()));
-    assertThat(logRecords, containsFine(SERVER_SHUTDOWN_REST_THROWABLE));
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_THROWABLE));
   }
 
   private void setForcedShutdownType(String serverName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -54,7 +54,6 @@ import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_RETRY;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_SUCCESS;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_THROWABLE;
-import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_TIMEOUT;
 import static oracle.kubernetes.common.utils.LogMatcher.containsFine;
 import static oracle.kubernetes.common.utils.LogMatcher.containsInfo;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
@@ -72,7 +71,7 @@ class ShutdownManagedServerStepTest {
   // The log messages to be checked during this test
   private static final String[] LOG_KEYS = {
       SERVER_SHUTDOWN_REST_SUCCESS, SERVER_SHUTDOWN_REST_FAILURE,
-      SERVER_SHUTDOWN_REST_TIMEOUT, SERVER_SHUTDOWN_REST_RETRY,
+      SERVER_SHUTDOWN_REST_RETRY,
       SERVER_SHUTDOWN_REST_THROWABLE
   };
   private static final String UID = "test-domain";
@@ -318,19 +317,9 @@ class ShutdownManagedServerStepTest {
   }
 
   @Test
-  void whenShutdownResponseTimesOut_logTimeout() {
-    ShutdownManagedServerResponseStep responseStep = new ShutdownManagedServerResponseStep(MANAGED_SERVER1,
-        30L, terminalStep);
-
-    // Null HTTP response and no response recorded in packet implies HTTP request timed out
-    responseStep.onFailure(testSupport.getPacket(), null);
-    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_TIMEOUT));
-  }
-
-  @Test
   void whenShutdownResponseThrowsException_logRetry() {
-    ShutdownManagedServerResponseStep responseStep = new ShutdownManagedServerResponseStep(MANAGED_SERVER1,
-        30L, terminalStep);
+    ShutdownManagedServerResponseStep responseStep =
+        new ShutdownManagedServerResponseStep(MANAGED_SERVER1, terminalStep);
     Packet p = testSupport.getPacket();
 
     // Setup Throwable exception


### PR DESCRIPTION
Owls 100719 - Fix for HTTP request failures with status code 400 for shutdown. When shutting down the servers that are not part of the domain config, the shutdown step was getting executed twice for some servers. This resulted in duplicate HTTP calls that resulted in  "ServerLifecycleException: java.lang.IllegalStateException" error.

This PR also has changes to poll the server status after issuing the shutdown request using HTTP. It allows the pod termination to wait until the server has reached the shutdown state and the server process has exited. If the shutdown request fails after two attempts, we proceed to terminate the pod. Finally, it has changes to handle the HTTP timeout failures and perform a retry when the HTTP request times out.

Integration test run (in progress) - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11461