### PR TITLE
Clean up mismatch validation

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -443,5 +443,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-engine</artifactId>
+        <version>1.8.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -443,11 +443,5 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-suite-engine</artifactId>
-        <version>1.8.1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -39,8 +39,6 @@ import oracle.kubernetes.operator.helpers.EventHelper;
 import oracle.kubernetes.operator.helpers.EventHelper.EventData;
 import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.helpers.ResponseStep;
-import oracle.kubernetes.operator.http.rest.Scan;
-import oracle.kubernetes.operator.http.rest.ScanCache;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.processing.EffectiveServerSpec;
@@ -1028,13 +1026,7 @@ public class DomainStatusUpdater {
       }
 
       private Optional<WlsDomainConfig> getDomainConfig() {
-        return Optional.ofNullable(config).or(this::getScanCacheDomainConfig);
-      }
-
-      private Optional<WlsDomainConfig> getScanCacheDomainConfig() {
-        DomainPresenceInfo info = getInfo();
-        Scan scan = ScanCache.INSTANCE.lookupScan(info.getNamespace(), info.getDomainUid());
-        return Optional.ofNullable(scan).map(Scan::getWlsDomainConfig);
+        return Optional.ofNullable(config);
       }
 
       private boolean isServerReady(@Nonnull String serverName) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ConfigMapHelper.java
@@ -579,14 +579,14 @@ public class ConfigMapHelper {
     }
 
     private Step createIntrospectionVersionUpdateStep() {
-      return DomainValidationSteps.createValidateDomainTopologySteps(
-            createIntrospectorConfigMapContext().patchOnly().verifyConfigMap(conflictStep.getNext()));
+      return createIntrospectorConfigMapContext().patchOnly().verifyConfigMap(conflictStep.getNext());
     }
 
     private Step createValidationStep() {
       return Step.chain(
-            DomainValidationSteps.createValidateDomainTopologySteps(null),
-            new IntrospectionConfigMapStep(data, conflictStep.getNext()));
+            new IntrospectionConfigMapStep(data, conflictStep.getNext()),
+            DomainValidationSteps.createValidateDomainTopologySteps(null)
+            );
     }
 
     private class IntrospectionConfigMapStep extends Step {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -209,7 +209,7 @@ public class JobHelper {
       return Step.chain(
             DomainValidationSteps.createAdditionalDomainValidationSteps(getJobModelPodSpec()),
             verifyIntrospectorJob(),
-            next);
+            DomainValidationSteps.createValidateDomainTopologySteps(next));
     }
 
     private Step verifyIntrospectorJob() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -133,7 +133,6 @@ import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_AUXILIARY_IM
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -195,16 +194,16 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
 
   @BeforeEach
   public void setUp() throws Exception {
-    mementos.add(
-        consoleHandlerMemento = TestUtils.silenceOperatorLogger()
-            .collectLogMessages(logRecords, getMessageKeys())
-            .withLogLevel(Level.FINE)
-            .ignoringLoggedExceptions(ApiException.class));
     mementos.add(TuningParametersStub.install());
     mementos.add(testSupport.install());
     mementos.add(ScanCacheStub.install());
     mementos.add(SystemClockTestSupport.installClock());
     mementos.add(UnitTestHash.install());
+    mementos.add(
+        consoleHandlerMemento = TestUtils.silenceOperatorLogger()
+            .collectLogMessages(logRecords, getMessageKeys())
+            .withLogLevel(Level.FINE)
+            .ignoringLoggedExceptions(ApiException.class));
 
     testSupport.addToPacket(JOB_POD_NAME, jobPodName);
     testSupport.addDomainPresenceInfo(domainPresenceInfo);
@@ -1207,7 +1206,7 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
   }
 
   @Test
-  void whenIntrospectorJobNotNeeded_doesNotValidateDomainTopology() throws JsonProcessingException {
+  void whenIntrospectorJobNotNeeded_validateDomainAgainstPreviousTopology() throws JsonProcessingException {
     // create WlsDomainConfig with "cluster-2" whereas domain spec contains "cluster-1"
     WlsDomainConfig wlsDomainConfig = createDomainConfig("cluster-2");
     IntrospectionTestUtils.defineIntrospectionTopology(testSupport, wlsDomainConfig);
@@ -1219,7 +1218,7 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
 
     testSupport.runSteps(JobHelper.createIntrospectionStartStep());
 
-    assertThat(logRecords, empty());
+    assertThat(logRecords, containsWarning(NO_CLUSTER_IN_DOMAIN));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/IntrospectionValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/IntrospectionValidationTest.java
@@ -24,12 +24,13 @@ import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.TestUtils;
+import oracle.kubernetes.weblogic.domain.DomainConfigurator;
+import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainFailureReason;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -39,6 +40,7 @@ import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR
 import static oracle.kubernetes.operator.ProcessingConstants.JOBWATCHER_COMPONENT_NAME;
 import static oracle.kubernetes.operator.ProcessingConstants.JOB_POD_NAME;
 import static oracle.kubernetes.operator.makeright.IntrospectionValidationTest.DomainType.ONE_CLUSTER_REF;
+import static oracle.kubernetes.operator.makeright.IntrospectionValidationTest.DomainType.TWO_CLUSTER_REFS;
 import static oracle.kubernetes.operator.makeright.IntrospectionValidationTest.TopologyType.ONE_CLUSTER;
 import static oracle.kubernetes.operator.makeright.IntrospectionValidationTest.TopologyType.TWO_CLUSTERS;
 import static oracle.kubernetes.weblogic.domain.model.DomainConditionMatcher.hasCondition;
@@ -71,7 +73,6 @@ class IntrospectionValidationTest {
     mementos.forEach(Memento::revert);
   }
 
-  @Disabled("Still working getting this to work")
   @ParameterizedTest
   @EnumSource(Scenario.class)
   void introspectionRespondsToNewConditions(Scenario scenario) throws JsonProcessingException {
@@ -125,20 +126,32 @@ class IntrospectionValidationTest {
       boolean isCompatibleWith(TopologyType topologyType) {
         return topologyType == TWO_CLUSTERS;
       }
+
+      @Override
+      DomainConfigurator configureDomain(DomainResource domainResource) {
+        final DomainConfigurator domainConfigurator = super.configureDomain(domainResource);
+        domainConfigurator.configureCluster("cluster-2");
+        return domainConfigurator;
+      }
     };
 
     abstract boolean isCompatibleWith(TopologyType topologyType);
+
+    DomainConfigurator configureDomain(DomainResource domainResource) {
+      final DomainConfigurator domainConfigurator = DomainConfiguratorFactory.forDomain(domainResource);
+      domainConfigurator.configureCluster("cluster-1");
+      return domainConfigurator;
+    }
   }
 
   enum Scenario {
     INITIAL_TOPOLOGY_PASS(ONE_CLUSTER_REF, ONE_CLUSTER_REF, null, ONE_CLUSTER),
-//    INITIAL_TOPOLOGY_FAIL(ONE_CLUSTER_REF, ONE_CLUSTER_REF, null, TWO_CLUSTERS),
-//    NO_CHANGE_FAIL_AGAIN(TWO_CLUSTER_REFS, TWO_CLUSTER_REFS, ONE_CLUSTER, ONE_CLUSTER),
-//    NEW_DOMAIN_RECOVER(TWO_CLUSTER_REFS, ONE_CLUSTER_REF, ONE_CLUSTER, ONE_CLUSTER),
-//    NEW_DOMAIN_FAIL(ONE_CLUSTER_REF, TWO_CLUSTER_REFS, ONE_CLUSTER, ONE_CLUSTER),
-//    NEW_INTROSPECTION_RECOVER(TWO_CLUSTER_REFS, TWO_CLUSTER_REFS, ONE_CLUSTER, TWO_CLUSTERS),
-//    NEW_INTROSPECTION_FAIL(TWO_CLUSTER_REFS, TWO_CLUSTER_REFS, TWO_CLUSTERS, ONE_CLUSTER)
-;
+    INITIAL_TOPOLOGY_FAIL(ONE_CLUSTER_REF, ONE_CLUSTER_REF, null, TWO_CLUSTERS),
+    NO_CHANGE_FAIL_AGAIN(TWO_CLUSTER_REFS, TWO_CLUSTER_REFS, ONE_CLUSTER, ONE_CLUSTER),
+    NEW_DOMAIN_RECOVER(TWO_CLUSTER_REFS, ONE_CLUSTER_REF, ONE_CLUSTER, ONE_CLUSTER),
+    NEW_DOMAIN_FAIL(ONE_CLUSTER_REF, TWO_CLUSTER_REFS, ONE_CLUSTER, ONE_CLUSTER),
+    NEW_INTROSPECTION_RECOVER(TWO_CLUSTER_REFS, TWO_CLUSTER_REFS, ONE_CLUSTER, TWO_CLUSTERS),
+    NEW_INTROSPECTION_FAIL(TWO_CLUSTER_REFS, TWO_CLUSTER_REFS, TWO_CLUSTERS, ONE_CLUSTER);
 
     private final DomainType initialDomain;
     private final DomainType finalDomain;
@@ -168,6 +181,7 @@ class IntrospectionValidationTest {
                 .withReason(DomainFailureReason.TOPOLOGY_MISMATCH)
                 .withMessage("preset for test"));
       }
+      finalDomain.configureDomain(getDomain(testSupport));
     }
 
     private DomainResource getDomain(KubernetesTestSupport testSupport) {


### PR DESCRIPTION
Enabled the introspection validation test to verify the introspection logic. This involved simplifying some of it, including ensuring that the actual mismatch validation happens whenever the logic completes. 
