### PR TITLE
fix NullPointerException in integration-test/oracle.weblogic.kubernetes.assertions.impl.Kubernetes in release/3.4

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomain.java
@@ -1022,8 +1022,8 @@ class ItMiiDomain {
         .atMost(15, MINUTES)
         .await()
         .conditionEvaluationListener(
-            condition -> logger.info("Waiting for patched application running on all managed servers in namespace {1} "
-                + "(elapsed time {2}ms, remaining time {3}ms)",
+            condition -> logger.info("Waiting for patched application running on all managed servers in namespace {0} "
+                + "(elapsed time {1}ms, remaining time {2}ms)",
             namespace,
             condition.getElapsedTimeInMS(),
             condition.getRemainingTimeInMS()))

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Kubernetes.java
@@ -371,7 +371,7 @@ public class Kubernetes {
     boolean status = false;
     String labelSelector = String.format("weblogic.operatorName in (%s)", namespace);
     V1Pod pod = getPod(namespace, labelSelector, "weblogic-operator-");
-    if (pod != null) {
+    if (pod != null && pod.getStatus() != null && pod.getStatus().getConditions() != null) {
       // get the podCondition with the 'Ready' type field
       V1PodCondition v1PodReadyCondition = pod.getStatus().getConditions().stream()
           .filter(v1PodCondition -> "Ready".equals(v1PodCondition.getType()))


### PR DESCRIPTION
Fix NullPointerException in integration-test/oracle.weblogic.kubernetes.assertions.impl.Kubernetes.isOperatorPodReady

Jenkins result:
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/11515/
https://build.weblogick8s.org:8443/view/all/job/weblogic-kubernetes-operator-kind-new/11514/