### PR TITLE
Fixes for the incorrect introspector messages from `traceDirs` caused by changes forward ported from 3.4.

### DIFF
--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -1390,5 +1390,6 @@ expandWdtArchiveCustomDir() {
         ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/custom
     done
 
-  traceDirs before ${DOMAIN_HOME}/wlsdeploy/custom
+  CUSTOM_DIR=${DOMAIN_HOME}/wlsdeploy/custom
+  traceDirs before CUSTOM_DIR
 }

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -702,7 +702,7 @@ checkAuxiliaryImage() {
   fi
 
   trace FINE "Auxiliary Image: AUXILIARY_IMAGE_MOUNT_PATH is '$AUXILIARY_IMAGE_MOUNT_PATH'."
-  traceDirs before $AUXILIARY_IMAGE_MOUNT_PATH
+  traceDirs before AUXILIARY_IMAGE_MOUNT_PATH
   touch ${AUXILIARY_IMAGE_MOUNT_PATH}/testaccess.tmp
   if [ $? -ne 0 ]; then
     trace SEVERE "Auxiliary Image: Cannot write to the AUXILIARY_IMAGE_MOUNT_PATH '${AUXILIARY_IMAGE_MOUNT_PATH}'. " \

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -756,7 +756,7 @@ checkCompatibilityModeInitContainersWithLegacyAuxImages() {
   trace FINE "Compatibility Auxiliary Image: AUXILIARY_IMAGE_PATHS is '$AUXILIARY_IMAGE_PATHS'."
   for AUXILIARY_IMAGE_PATH in ${AUXILIARY_IMAGE_PATHS/,/ }; do
     trace FINE "Compatibility Auxiliary Image: AUXILIARY_IMAGE_PATH is '$AUXILIARY_IMAGE_PATH'."
-    traceDirs $AUXILIARY_IMAGE_PATH
+    traceDirs AUXILIARY_IMAGE_PATH
     touch ${AUXILIARY_IMAGE_PATH}/testaccess.tmp
     if [ $? -ne 0 ]; then
       trace SEVERE "Compatibility Auxiliary Image: Cannot write to the AUXILIARY_IMAGE_PATH '${AUXILIARY_IMAGE_PATH}'. " \

--- a/operator/src/main/resources/scripts/utils_base.sh
+++ b/operator/src/main/resources/scripts/utils_base.sh
@@ -377,7 +377,7 @@ initCompatibilityModeInitContainersWithLegacyAuxImages() {
 
   trace FINE "Compatibility Auxiliary Image: About to execute command '$AUXILIARY_IMAGE_COMMAND' in container image='$AUXILIARY_IMAGE_CONTAINER_IMAGE'. " \
              "AUXILIARY_IMAGE_PATH is '$AUXILIARY_IMAGE_PATH' and AUXILIARY_IMAGE_TARGET_PATH is '${AUXILIARY_IMAGE_TARGET_PATH}'."
-  traceDirs before $AUXILIARY_IMAGE_PATH
+  traceDirs before AUXILIARY_IMAGE_PATH
 
   trace FINE "Compatibility Auxiliary Image: About to execute AUXILIARY_IMAGE_COMMAND='$AUXILIARY_IMAGE_COMMAND' ."
   results=$(eval $AUXILIARY_IMAGE_COMMAND 2>&1)


### PR DESCRIPTION
I noticed some incorrect messages from `traceDirs` function in the introspector logs when printing the contents of certain directories. We forward ported changes from `release/3.4` branch and `traceDirs` function is bit different in 3.4 branch. This PR has changes to fix these log messages.  