### PR TITLE
Owls 95882 part 1 - Fixes for the stop server script, changes to capture script output and make grace period dynamic

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -180,6 +180,12 @@ public class PodHelper {
         .filter(PodHelper::isReadyNotTrueCondition).findFirst().orElse(null);
   }
 
+  /**
+   * Get the server state From the domain resource.
+   * @param domain domain resource.
+   * @param serverName Name of the server.
+   * @return server state, if exists, otherwise null.
+   */
   public static String getServerState(DomainResource domain, String serverName) {
     return Optional.ofNullable(domain)
         .map(DomainResource::getStatus)

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -737,7 +737,7 @@ public class PodHelper {
 
     @NotNull
     private Boolean isServerShutdown(String serverState) {
-      return Optional.ofNullable(serverState).map(s -> SHUTDOWN_STATE.equals(s)).orElse(false);
+      return Optional.ofNullable(serverState).map(SHUTDOWN_STATE::equals).orElse(false);
     }
 
     @Nullable

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -41,12 +41,17 @@ import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
+import oracle.kubernetes.weblogic.domain.model.DomainStatus;
+import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
+import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.KubernetesConstants.EVICTED_REASON;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVERS_TO_ROLL;
+import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 
 @SuppressWarnings("ConstantConditions")
 public class PodHelper {
@@ -173,6 +178,22 @@ public class PodHelper {
         .orElse(Collections.emptyList())
         .stream()
         .filter(PodHelper::isReadyNotTrueCondition).findFirst().orElse(null);
+  }
+
+  public static String getServerState(DomainResource domain, String serverName) {
+    return Optional.ofNullable(domain)
+        .map(DomainResource::getStatus)
+        .map(s -> getServerStatus(s, serverName))
+        .map(ServerStatus::getState).orElse(null);
+  }
+
+  private static ServerStatus getServerStatus(DomainStatus domainStatus, String serverName) {
+    return domainStatus.getServers().stream().filter(s -> matchingServerName(s, serverName))
+        .findAny().orElse(null);
+  }
+
+  private static boolean matchingServerName(ServerStatus serverStatus, String serverName) {
+    return serverStatus.getServerName().equals(serverName);
   }
 
   private static boolean isRunning(@Nonnull V1PodStatus status) {
@@ -698,11 +719,20 @@ public class PodHelper {
         info.setServerPodBeingDeleted(serverName, Boolean.TRUE);
         final String clusterName = getClusterName(oldPod);
         final String name = oldPod.getMetadata().getName();
-        final long gracePeriodSeconds = getGracePeriodSeconds(info, clusterName);
+        long gracePeriodSeconds = getGracePeriodSeconds(info, clusterName);
+        String serverState = getServerState(info.getDomain(), serverName);
+        if (serverIsShutdown(serverState)) {
+          gracePeriodSeconds = 0;
+        }
         return doNext(
             deletePod(name, info.getNamespace(), getPodDomainUid(oldPod), gracePeriodSeconds, getNext()),
             packet);
       }
+    }
+
+    @NotNull
+    private Boolean serverIsShutdown(String serverState) {
+      return Optional.ofNullable(serverState).map(s -> s.equals(SHUTDOWN_STATE)).orElse(false);
     }
 
     @Nullable

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -726,8 +726,7 @@ public class PodHelper {
         final String clusterName = getClusterName(oldPod);
         final String name = oldPod.getMetadata().getName();
         long gracePeriodSeconds = getGracePeriodSeconds(info, clusterName);
-        String serverState = getServerState(info.getDomain(), serverName);
-        if (serverIsShutdown(serverState)) {
+        if (isServerShutdown(getServerState(info.getDomain(), serverName))) {
           gracePeriodSeconds = 0;
         }
         return doNext(
@@ -737,8 +736,8 @@ public class PodHelper {
     }
 
     @NotNull
-    private Boolean serverIsShutdown(String serverState) {
-      return Optional.ofNullable(serverState).map(s -> s.equals(SHUTDOWN_STATE)).orElse(false);
+    private Boolean isServerShutdown(String serverState) {
+      return Optional.ofNullable(serverState).map(s -> SHUTDOWN_STATE.equals(s)).orElse(false);
     }
 
     @Nullable

--- a/operator/src/main/resources/scripts/stop-server.py
+++ b/operator/src/main/resources/scripts/stop-server.py
@@ -251,8 +251,9 @@ while (stayInConnectLoop):
       waitUntilCoherenceSafe()
       cohSafe = True
 
-    print('Shutdown: Calling server shutdown with force = ' + force)
-    shutdown(server_name, 'Server', ignoreSessions=ignore_sessions, timeOut=int(timeout), force=force, block='true', properties=None, waitForAllSessions=wait_for_all_sessions)
+    print('Shutdown: Calling server shutdown with force = ' + force + ', timeout = ' + timeout)
+    print('Shutdown: Calling server shutdown with wait_for_all_sessions = ' + wait_for_all_sessions)
+    shutdown(server_name, 'Server', ignoreSessions=ignore_sessions, timeOut=int(timeout), force=force, block='true', waitForAllSessions=wait_for_all_sessions)
     print('Shutdown: Successfully shutdown the server')
 
   except Exception, e:

--- a/operator/src/main/resources/scripts/stop-server.py
+++ b/operator/src/main/resources/scripts/stop-server.py
@@ -251,8 +251,7 @@ while (stayInConnectLoop):
       waitUntilCoherenceSafe()
       cohSafe = True
 
-    print('Shutdown: Calling server shutdown with force = ' + force + ', timeout = ' + timeout)
-    print('Shutdown: Calling server shutdown with wait_for_all_sessions = ' + wait_for_all_sessions)
+    print('Shutdown: Calling server shutdown with force = ' + force + ', timeout = ' + timeout + ' and wait_for_all_sessions = ' + wait_for_all_sessions)
     shutdown(server_name, 'Server', ignoreSessions=ignore_sessions, timeOut=int(timeout), force=force, block='true', waitForAllSessions=wait_for_all_sessions)
     print('Shutdown: Successfully shutdown the server')
 

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -114,6 +114,6 @@ fi
 
 trace "Exit script"  &>> ${STOP_OUT_FILE}
 
-trace "stopServer.sh: Contents of ${STOP_OUT_FILE}:" > /proc/1/fd/1
+trace "Stop Server: === Contents of the script output file ${STOP_OUT_FILE} ===" > /proc/1/fd/1
 cat ${STOP_OUT_FILE} >> /proc/1/fd/1
-trace "stopServer.sh: End of ${STOP_OUT_FILE} contents." >> /proc/1/fd/1
+trace "Stop Server: === End of ${STOP_OUT_FILE} contents. ===" >> /proc/1/fd/1

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -8,8 +8,6 @@
 # before its pod is deleted.  It requires the SERVER_NAME env var.
 #
 
-echo "Stopping container now...">/proc/1/fd/1 && touch /shared/logs/debug2_stop && touch /tmp/debug2_stop
-
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
 [ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1
@@ -115,3 +113,7 @@ if [ -f ${SERVER_PID_FILE} ]; then
 fi
 
 trace "Exit script"  &>> ${STOP_OUT_FILE}
+
+trace "stopServer.sh: Contents of ${STOP_OUT_FILE}:"
+cat ${STOP_OUT_FILE} >> /proc/1/fd/1
+trace "stopServer.sh: End of ${STOP_OUT_FILE} contents."

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -114,6 +114,6 @@ fi
 
 trace "Exit script"  &>> ${STOP_OUT_FILE}
 
-trace "stopServer.sh: Contents of ${STOP_OUT_FILE}:"
+trace "stopServer.sh: Contents of ${STOP_OUT_FILE}:" > /proc/1/fd/1
 cat ${STOP_OUT_FILE} >> /proc/1/fd/1
-trace "stopServer.sh: End of ${STOP_OUT_FILE} contents."
+trace "stopServer.sh: End of ${STOP_OUT_FILE} contents." >> /proc/1/fd/1

--- a/operator/src/main/resources/scripts/stopServer.sh
+++ b/operator/src/main/resources/scripts/stopServer.sh
@@ -8,6 +8,8 @@
 # before its pod is deleted.  It requires the SERVER_NAME env var.
 #
 
+echo "Stopping container now...">/proc/1/fd/1 && touch /shared/logs/debug2_stop && touch /tmp/debug2_stop
+
 SCRIPTPATH="$( cd "$(dirname "$0")" > /dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/utils.sh
 [ $? -ne 0 ] && echo "[SEVERE] Missing file ${SCRIPTPATH}/utils.sh" && exit 1
@@ -15,7 +17,7 @@ source ${SCRIPTPATH}/utils.sh
 # setup ".out" location for a WL server
 serverLogHome="${LOG_HOME:-${DOMAIN_HOME}}"
 if [ -z ${LOG_HOME_LAYOUT} ] || [ "BY_SERVERS" = ${LOG_HOME_LAYOUT} ] ; then
-  serverLogHome="${serverLogHome/servers/${SERVER_NAME}/logs"
+  serverLogHome="${serverLogHome}/servers/${SERVER_NAME}/logs"
 fi
 STOP_OUT_FILE="${serverLogHome}/${SERVER_NAME}.stop.out"
 SHUTDOWN_MARKER_FILE="${serverLogHome}/${SERVER_NAME}.shutdown"


### PR DESCRIPTION
Owls 95882 part 1 - This PR has couple of fixes for the stop server script, (1) there was a right brace missing and (2) shutdown call was being made with unexpected argument properties. In addition, I have made changes to capture the script output in the exited container logs. Finally, it sets the pod deletion grace period seconds to 0 when the server has already shutdown.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11634/