### PR TITLE
increase retry time for pods to roll

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Pod.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/impl/Pod.java
@@ -37,7 +37,7 @@ public class Pod {
 
     // reusable condition factory
     ConditionFactory retry
-        = with().pollInterval(5, SECONDS).atMost(5, MINUTES).await();
+        = with().pollInterval(5, SECONDS).atMost(10, MINUTES).await();
 
     for (Map.Entry<String, OffsetDateTime> entry : pods.entrySet()) {
       // check pods are replaced


### PR DESCRIPTION
ItMiiUpdateDomainConfig.testMiiUpdateDynamicClusterSize test failed intermittently waiting for the pods to roll as the pods took little longer.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11640/