### PR TITLE
Detect failure to reach RUNNING state within timeout

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -208,6 +208,7 @@ public class MessageKeys {
   public static final String PODS_NOT_READY = "WLSDO-0041";
   public static final String CYCLING_POD_EVICTED = "WLSDO-0042";
   public static final String CYCLING_POD_SPEC_CHANGED = "WLSDO-0043";
+  public static final String PODS_NOT_RUNNING = "WLSDO-0044";
 
   // domain event messages
   public static final String DOMAIN_AVAILABLE_EVENT_PATTERN = "WLSEO-0001";

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -230,6 +230,11 @@ WLSDO-0041=One or more server pods that are supposed to be available are not rea
   Adjust the value of 'serverPod.maxReadyWaitTimeSeconds' setting if needed."
 WLSDO-0042=Pod was evicted
 WLSDO-0043=Pod spec has changed
+WLSDO-0044=One or more server pods that are supposed to be available did not start within the period of time \
+  defined in 'serverPod.maxPendingWaitTimeSeconds' under "domain.spec', 'domain.adminServer', 'managedServer', or 'domain.cluster'. \
+  Check the server status in the domain status, the server pod status and logs, and WebLogic Server logs for possible reasons. \
+  One common cause of this issue is a problem pulling the WebLogicServer image. \
+  Adjust the value of 'serverPod.maxPendingWaitTimeSeconds' setting if needed."
 
 oneEnvVar=variable
 multipleEnvVars=variables

--- a/documentation/domains/Cluster.json
+++ b/documentation/domains/Cluster.json
@@ -891,7 +891,6 @@
           "type": "string"
         },
         "maxReadyWaitTimeSeconds": {
-          "default": 1800,
           "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready state before it considers the pod failed. Defaults to 1800 seconds.",
           "type": "integer"
         },
@@ -925,6 +924,10 @@
             "Never",
             "OnFailure"
           ]
+        },
+        "maxPendingWaitTimeSeconds": {
+          "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running state before it considers the pod failed. Defaults to 5 minutes.",
+          "type": "integer"
         },
         "labels": {
           "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
@@ -991,7 +994,7 @@
           "description": "Status of the WebLogic Server pod\u0027s Ready condition if the pod is in Running phase, otherwise Unknown. Possible values are: True, False or Unknown.",
           "type": "string"
         },
-        "desiredState": {
+        "stateGoal": {
           "description": "Desired state of this WebLogic Server instance. Values are RUNNING, ADMIN, or SHUTDOWN.",
           "type": "string"
         },

--- a/documentation/domains/Cluster.md
+++ b/documentation/domains/Cluster.md
@@ -57,6 +57,7 @@
 | `initContainers` | Array of [Container](k8s1.13.5.md#container) | Initialization containers to be included in the server Pod. See `kubectl explain pods.spec.initContainers`. |
 | `labels` | Map | The labels to be added to generated resources. The label names must not start with "weblogic.". |
 | `livenessProbe` | [Probe Tuning](#probe-tuning) | Settings for the liveness probe associated with a WebLogic Server instance. |
+| `maxPendingWaitTimeSeconds` | integer | The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running state before it considers the pod failed. Defaults to 5 minutes. |
 | `maxReadyWaitTimeSeconds` | integer | The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready state before it considers the pod failed. Defaults to 1800 seconds. |
 | `nodeName` | string | NodeName is a request to schedule this Pod onto a specific Node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits the resource requirements. See `kubectl explain pods.spec.nodeName`. |
 | `nodeSelector` | Map | Selector which must match a Node's labels for the Pod to be scheduled on that Node. See `kubectl explain pods.spec.nodeSelector`. |

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -891,7 +891,6 @@
           "type": "string"
         },
         "maxReadyWaitTimeSeconds": {
-          "default": 1800,
           "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready state before it considers the pod failed. Defaults to 1800 seconds.",
           "type": "integer"
         },
@@ -925,6 +924,10 @@
             "Never",
             "OnFailure"
           ]
+        },
+        "maxPendingWaitTimeSeconds": {
+          "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running state before it considers the pod failed. Defaults to 5 minutes.",
+          "type": "integer"
         },
         "labels": {
           "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
@@ -991,7 +994,7 @@
           "description": "Status of the WebLogic Server pod\u0027s Ready condition if the pod is in Running phase, otherwise Unknown. Possible values are: True, False or Unknown.",
           "type": "string"
         },
-        "desiredState": {
+        "stateGoal": {
           "description": "Desired state of this WebLogic Server instance. Values are RUNNING, ADMIN, or SHUTDOWN.",
           "type": "string"
         },

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -149,6 +149,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `initContainers` | Array of [Container](k8s1.13.5.md#container) | Initialization containers to be included in the server Pod. See `kubectl explain pods.spec.initContainers`. |
 | `labels` | Map | The labels to be added to generated resources. The label names must not start with "weblogic.". |
 | `livenessProbe` | [Probe Tuning](#probe-tuning) | Settings for the liveness probe associated with a WebLogic Server instance. |
+| `maxPendingWaitTimeSeconds` | integer | The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running state before it considers the pod failed. Defaults to 5 minutes. |
 | `maxReadyWaitTimeSeconds` | integer | The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready state before it considers the pod failed. Defaults to 1800 seconds. |
 | `nodeName` | string | NodeName is a request to schedule this Pod onto a specific Node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits the resource requirements. See `kubectl explain pods.spec.nodeName`. |
 | `nodeSelector` | Map | Selector which must match a Node's labels for the Pod to be scheduled on that Node. See `kubectl explain pods.spec.nodeSelector`. |
@@ -201,13 +202,13 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | Name | Type | Description |
 | --- | --- | --- |
 | `clusterName` | string | WebLogic cluster name, if the server is a member of a cluster. |
-| `desiredState` | string | Desired state of this WebLogic Server instance. Values are RUNNING, ADMIN, or SHUTDOWN. |
 | `health` | [Server Health](#server-health) | Current status and health of a specific WebLogic Server instance. |
 | `nodeName` | string | Name of Node that is hosting the Pod containing this WebLogic Server instance. |
 | `podPhase` | string | Phase of the WebLogic Server pod. Possible values are: Pending, Succeeded, Failed, Running, or Unknown. |
 | `podReady` | string | Status of the WebLogic Server pod's Ready condition if the pod is in Running phase, otherwise Unknown. Possible values are: True, False or Unknown. |
 | `serverName` | string | WebLogic Server instance name. |
 | `state` | string | Current state of this WebLogic Server instance. |
+| `stateGoal` | string | Desired state of this WebLogic Server instance. Values are RUNNING, ADMIN, or SHUTDOWN. |
 
 ### Admin Service
 

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1843,6 +1843,11 @@ window.onload = function() {
             "OnFailure"
           ]
         },
+        "maxPendingWaitTimeSeconds": {
+          "default": 300.0,
+          "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running state before it considers the pod failed. Defaults to 5 minutes.",
+          "type": "integer"
+        },
         "labels": {
           "description": "The labels to be added to generated resources. The label names must not start with \"weblogic.\".",
           "additionalProperties": {
@@ -1908,7 +1913,7 @@ window.onload = function() {
           "description": "Status of the WebLogic Server pod\u0027s Ready condition if the pod is in Running phase, otherwise Unknown. Possible values are: True, False or Unknown.",
           "type": "string"
         },
-        "desiredState": {
+        "stateGoal": {
           "description": "Desired state of this WebLogic Server instance. Values are RUNNING, ADMIN, or SHUTDOWN.",
           "type": "string"
         },

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1808,7 +1808,6 @@ window.onload = function() {
           "type": "string"
         },
         "maxReadyWaitTimeSeconds": {
-          "default": 1800.0,
           "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready state before it considers the pod failed. Defaults to 1800 seconds.",
           "type": "integer"
         },
@@ -1844,7 +1843,6 @@ window.onload = function() {
           ]
         },
         "maxPendingWaitTimeSeconds": {
-          "default": 300.0,
           "description": "The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running state before it considers the pod failed. Defaults to 5 minutes.",
           "type": "integer"
         },

--- a/kubernetes/crd/cluster-crd.yaml
+++ b/kubernetes/crd/cluster-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 8e8726bd6806d0b9e08363cc2c3b80a32dbc452baf8a6bf069fe8c66960dfba7
+    weblogic.sha256: 72c437b7f72c1b9372ee95e866aa0bc6ef694b843ce70524484c91f7dd1503be
   name: clusters.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -377,7 +377,6 @@ spec:
                       default scheduler. See `kubectl explain pods.spec.schedulerName`.
                     type: string
                   maxReadyWaitTimeSeconds:
-                    default: 1800
                     description: The maximum time in seconds that the operator waits
                       for a WebLogic Server pod to reach the ready state before it
                       considers the pod failed. Defaults to 1800 seconds.
@@ -1257,6 +1256,11 @@ spec:
                     - Never
                     - OnFailure
                     type: string
+                  maxPendingWaitTimeSeconds:
+                    description: The maximum time in seconds that the operator waits
+                      for a WebLogic Server pod to reach the running state before
+                      it considers the pod failed. Defaults to 5 minutes.
+                    type: integer
                   labels:
                     additionalProperties:
                       type: string

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 95ba0952cbd5f2e0bca8dc55307e57cc1e0155a74774d2b1963f33f5b6d19b20
+    weblogic.sha256: bcd59427bd7c22321507c4f3a0e07c27b089497e0d56959d58efe14f36dbc210
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -861,7 +861,6 @@ spec:
                           by the default scheduler. See `kubectl explain pods.spec.schedulerName`.
                         type: string
                       maxReadyWaitTimeSeconds:
-                        default: 1800
                         description: The maximum time in seconds that the operator
                           waits for a WebLogic Server pod to reach the ready state
                           before it considers the pod failed. Defaults to 1800 seconds.
@@ -1743,6 +1742,11 @@ spec:
                         - Never
                         - OnFailure
                         type: string
+                      maxPendingWaitTimeSeconds:
+                        description: The maximum time in seconds that the operator
+                          waits for a WebLogic Server pod to reach the running state
+                          before it considers the pod failed. Defaults to 5 minutes.
+                        type: integer
                       labels:
                         additionalProperties:
                           type: string
@@ -3930,7 +3934,6 @@ spec:
                             pods.spec.schedulerName`.
                           type: string
                         maxReadyWaitTimeSeconds:
-                          default: 1800
                           description: The maximum time in seconds that the operator
                             waits for a WebLogic Server pod to reach the ready state
                             before it considers the pod failed. Defaults to 1800 seconds.
@@ -4814,6 +4817,11 @@ spec:
                           - Always
                           - Never
                           - OnFailure
+                        maxPendingWaitTimeSeconds:
+                          description: The maximum time in seconds that the operator
+                            waits for a WebLogic Server pod to reach the running state
+                            before it considers the pod failed. Defaults to 5 minutes.
+                          type: integer
                         labels:
                           description: The labels to be added to generated resources.
                             The label names must not start with "weblogic.".
@@ -6991,7 +6999,6 @@ spec:
                       default scheduler. See `kubectl explain pods.spec.schedulerName`.
                     type: string
                   maxReadyWaitTimeSeconds:
-                    default: 1800
                     description: The maximum time in seconds that the operator waits
                       for a WebLogic Server pod to reach the ready state before it
                       considers the pod failed. Defaults to 1800 seconds.
@@ -7871,6 +7878,11 @@ spec:
                     - Never
                     - OnFailure
                     type: string
+                  maxPendingWaitTimeSeconds:
+                    description: The maximum time in seconds that the operator waits
+                      for a WebLogic Server pod to reach the running state before
+                      it considers the pod failed. Defaults to 5 minutes.
+                    type: integer
                   labels:
                     additionalProperties:
                       type: string
@@ -9924,7 +9936,6 @@ spec:
                             pods.spec.schedulerName`.
                           type: string
                         maxReadyWaitTimeSeconds:
-                          default: 1800
                           description: The maximum time in seconds that the operator
                             waits for a WebLogic Server pod to reach the ready state
                             before it considers the pod failed. Defaults to 1800 seconds.
@@ -10808,6 +10819,11 @@ spec:
                           - Always
                           - Never
                           - OnFailure
+                        maxPendingWaitTimeSeconds:
+                          description: The maximum time in seconds that the operator
+                            waits for a WebLogic Server pod to reach the running state
+                            before it considers the pod failed. Defaults to 5 minutes.
+                          type: integer
                         labels:
                           description: The labels to be added to generated resources.
                             The label names must not start with "weblogic.".
@@ -12559,7 +12575,7 @@ spec:
                         if the pod is in Running phase, otherwise Unknown. Possible
                         values are: True, False or Unknown.'
                       type: string
-                    desiredState:
+                    stateGoal:
                       description: Desired state of this WebLogic Server instance.
                         Values are RUNNING, ADMIN, or SHUTDOWN.
                       type: string

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -1102,7 +1102,7 @@ public class DomainStatusUpdater {
         return Optional.ofNullable(getInfo().getDomain())
             .map(d -> getInfo().getServer(getServerName(pod), getClusterNameFromPod(pod)))
             .map(EffectiveServerSpec::getMaximumPendingWaitTimeSeconds)
-            .orElse(TuningParameters.getInstance().getMaxReadyWaitTimeSeconds());
+            .orElse(TuningParameters.getInstance().getMaxPendingWaitTimeSeconds());
       }
 
       private String getServerName(V1Pod pod) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -67,6 +67,7 @@ import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_FATAL_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_ROLL_START;
 import static oracle.kubernetes.common.logging.MessageKeys.PODS_FAILED;
 import static oracle.kubernetes.common.logging.MessageKeys.PODS_NOT_READY;
+import static oracle.kubernetes.common.logging.MessageKeys.PODS_NOT_RUNNING;
 import static oracle.kubernetes.operator.ClusterResourceStatusUpdater.createClusterResourceStatusUpdaterStep;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
@@ -626,6 +627,8 @@ public class DomainStatusUpdater {
 
         if (isHasFailedPod()) {
           addFailure(status, new DomainCondition(FAILED).withReason(SERVER_POD).withMessage(getPodFailedMessage()));
+        } else if (hasPodNotRunningInTime()) {
+          addFailure(status, new DomainCondition(FAILED).withReason(SERVER_POD).withMessage(getPodNotRunningMessage()));
         } else if (hasPodNotReadyInTime()) {
           addFailure(status, new DomainCondition(FAILED).withReason(SERVER_POD).withMessage(getPodNotReadyMessage()));
         } else {
@@ -638,6 +641,10 @@ public class DomainStatusUpdater {
         if (miiNondynamicRestartRequired() && isCommitUpdateOnly()) {
           setOnlineUpdateNeedRestartCondition(status);
         }
+      }
+
+      private String getPodNotRunningMessage() {
+        return LOGGER.formatMessage(PODS_NOT_RUNNING);
       }
 
       private String getPodNotReadyMessage() {
@@ -1044,8 +1051,16 @@ public class DomainStatusUpdater {
         return getInfo().getServerPods().anyMatch(this::isNotReadyInTime);
       }
 
-      public boolean isNotReadyInTime(V1Pod pod) {
+      private boolean isNotReadyInTime(V1Pod pod) {
         return !PodHelper.isReady(pod) && hasBeenUnreadyExceededWaitTime(pod);
+      }
+
+      private boolean hasPodNotRunningInTime() {
+        return getInfo().getServerPods().anyMatch(this::isNotRunningInTime);
+      }
+
+      private boolean isNotRunningInTime(V1Pod pod) {
+        return PodHelper.isPending(pod) && hasBeenPendingExceededWaitTime(pod);
       }
 
       private boolean hasBeenUnreadyExceededWaitTime(V1Pod pod) {
@@ -1053,6 +1068,13 @@ public class DomainStatusUpdater {
         return SystemClock.now()
             .isAfter(getLater(creationTime, getReadyConditionLastTransitTimestamp(pod, creationTime))
                 .plusSeconds(getMaxReadyWaitTime(pod)));
+      }
+
+      private boolean hasBeenPendingExceededWaitTime(V1Pod pod) {
+        OffsetDateTime creationTime = getCreationTimestamp(pod);
+        return SystemClock.now()
+            .isAfter(getLater(creationTime, getReadyConditionLastTransitTimestamp(pod, creationTime))
+                .plusSeconds(getMaxPendingWaitTime(pod)));
       }
 
       private OffsetDateTime getLater(OffsetDateTime time1, OffsetDateTime time2) {
@@ -1073,6 +1095,13 @@ public class DomainStatusUpdater {
         return Optional.ofNullable(getInfo().getDomain())
             .map(d -> getInfo().getServer(getServerName(pod), getClusterNameFromPod(pod)))
             .map(EffectiveServerSpec::getMaximumReadyWaitTimeSeconds)
+            .orElse(TuningParameters.getInstance().getMaxReadyWaitTimeSeconds());
+      }
+
+      private long getMaxPendingWaitTime(V1Pod pod) {
+        return Optional.ofNullable(getInfo().getDomain())
+            .map(d -> getInfo().getServer(getServerName(pod), getClusterNameFromPod(pod)))
+            .map(EffectiveServerSpec::getMaximumPendingWaitTimeSeconds)
             .orElse(TuningParameters.getInstance().getMaxReadyWaitTimeSeconds());
       }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -1222,16 +1222,16 @@ public class DomainStatusUpdater {
         return new ServerStatus()
             .withServerName(serverName)
             .withClusterName(clusterName)
-            .withDesiredState(getDesiredState())
+            .withStateGoal(getStateGoal())
             .withIsAdminServer(isAdminServer);
       }
 
-      private String getDesiredState() {
-        return wasServerStarted() ? getDesiredState(serverName, clusterName) : SHUTDOWN_STATE;
+      private String getStateGoal() {
+        return wasServerStarted() ? getStateGoal(serverName, clusterName) : SHUTDOWN_STATE;
       }
 
-      private String getDesiredState(String serverName, String clusterName) {
-        return info.getServer(serverName, clusterName).getDesiredState();
+      private String getStateGoal(String serverName, String clusterName) {
+        return info.getServer(serverName, clusterName).getStateGoal();
       }
 
       private boolean wasServerStarted() {

--- a/operator/src/main/java/oracle/kubernetes/operator/IntrospectionStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/IntrospectionStatus.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.models.V1ContainerState;
 import io.kubernetes.client.openapi.models.V1ContainerStateTerminated;
@@ -23,7 +24,6 @@ import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.work.Step;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.Nullable;
 
 import static java.util.Collections.emptyList;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_POD_FAILURE;
@@ -85,8 +85,7 @@ public class IntrospectionStatus {
   }
 
   private static String getWaitingMessageFromStatus(@Nonnull V1Pod pod) {
-    return Optional.ofNullable(getWaitingMessageFromStatus(getIntrospectorStatus(pod)))
-          .orElse(null);
+    return getWaitingMessageFromStatus(getIntrospectorStatus(pod));
   }
 
   private static String getWaitingMessageFromStatus(V1ContainerStatus status) {
@@ -121,19 +120,6 @@ public class IntrospectionStatus {
             .map(V1ContainerState::getWaiting)
             .map(V1ContainerStateWaiting::getReason)
             .orElse(null);
-  }
-
-  private static boolean isReady(@Nonnull V1Pod pod) {
-    return Optional.of(pod).map(IntrospectionStatus::getContainerStatus).map(V1ContainerStatus::getReady).orElse(false);
-
-  }
-
-  private static V1ContainerStatus getContainerStatus(@Nonnull V1Pod pod) {
-    return getContainerStatuses(pod).stream().findFirst().orElse(new V1ContainerStatus());
-  }
-
-  private static List<V1ContainerStatus> getContainerStatuses(@Nonnull V1Pod pod) {
-    return Optional.ofNullable(pod.getStatus()).map(V1PodStatus::getContainerStatuses).orElse(emptyList());
   }
 
   abstract static class PodStatus {

--- a/operator/src/main/java/oracle/kubernetes/operator/processing/EffectiveServerSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/processing/EffectiveServerSpec.java
@@ -170,4 +170,6 @@ public interface EffectiveServerSpec {
   boolean alwaysStart();
 
   Long getMaximumReadyWaitTimeSeconds();
+
+  Long getMaximumPendingWaitTimeSeconds();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/processing/EffectiveServerSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/processing/EffectiveServerSpec.java
@@ -47,7 +47,7 @@ public interface EffectiveServerSpec {
    *
    * @return desired state
    */
-  String getDesiredState();
+  String getStateGoal();
 
   /**
    * Returns true if the specified server should be started, based on the current domain spec.

--- a/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/tuning/TuningParameters.java
@@ -68,6 +68,7 @@ public class TuningParameters {
   public static final String STATUS_UPDATE_EVENTUAL_LONG_DELAY = "statusUpdateEventualLongDelay";
   public static final String SECRET_REREAD_INTERVAL_SECONDS = "weblogicCredentialsSecretRereadIntervalSeconds";
   public static final String MAX_READY_WAIT_TIME_SECONDS = "maxReadyWaitTimeSeconds";
+  public static final String MAX_PENDING_WAIT_TIME_SECONDS = "maxPendingWaitTimeSeconds";
   public static final String RESTART_EVICTED_PODS = "restartEvictedPods";
   public static final String INTROSPECTOR_JOB_ACTIVE_DEADLINE_SECONDS = "introspectorJobActiveDeadlineSeconds";
   public static final String INTROSPECTOR_JOB_DEADLINE_INCREMENT_SECONDS = "introspectorJobDeadlineIncrementSeconds";
@@ -206,6 +207,10 @@ public class TuningParameters {
 
   public long getMaxReadyWaitTimeSeconds() {
     return getParameter(MAX_READY_WAIT_TIME_SECONDS, 1800);
+  }
+
+  public long getMaxPendingWaitTimeSeconds() {
+    return getParameter(MAX_PENDING_WAIT_TIME_SECONDS, 300);
   }
 
   public boolean isRestartEvictedPods() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/ClusterConfigurator.java
@@ -134,4 +134,6 @@ public interface ClusterConfigurator extends ServiceConfigurator {
 
   ClusterConfigurator withMaximumReadyWaitTimeSeconds(long maximumReadyWaitTimeSeconds);
 
+  ClusterConfigurator withMaximumPendingWaitTimeSeconds(long maximumReadyWaitTimeSeconds);
+
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/ServerConfigurator.java
@@ -119,6 +119,8 @@ public interface ServerConfigurator extends ServiceConfigurator {
 
   ServerConfigurator withMaximumReadyWaitTimeSeconds(long waitTime);
 
+  ServerConfigurator withMaximumPendingWaitTimeSeconds(long waitTime);
+
   ServerConfigurator withSchedulerName(String schedulerName);
 
   ServerConfigurator withRuntimeClassName(String runtimeClassName);

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
@@ -358,13 +358,20 @@ public abstract class BaseConfiguration {
     this.restartVersion = restartVersion;
   }
 
-
   Long getMaximumReadyWaitTimeSeconds() {
     return serverPod.getMaxReadyWaitTimeSeconds();
   }
 
+  Long getMaximumPendingWaitTimeSeconds() {
+    return serverPod.getMaxPendingWaitTimeSeconds();
+  }
+
   public void setMaxReadyWaitTimeSeconds(long waitTime) {
     serverPod.setMaxReadyWaitTimeSeconds(waitTime);
+  }
+
+  public void setMaxPendingWaitTimeSeconds(long waitTime) {
+    serverPod.setMaxPendingWaitTimeSeconds(waitTime);
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/EffectiveServerSpecCommonImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/EffectiveServerSpecCommonImpl.java
@@ -113,7 +113,7 @@ public abstract class EffectiveServerSpecCommonImpl extends EffectiveServerSpecB
   }
 
   @Override
-  public String getDesiredState() {
+  public String getStateGoal() {
     return getEffectiveServerStartPolicy().equals(ServerStartPolicy.NEVER) ? SHUTDOWN_STATE : RUNNING_STATE;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/EffectiveServerSpecCommonImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/EffectiveServerSpecCommonImpl.java
@@ -257,6 +257,11 @@ public abstract class EffectiveServerSpecCommonImpl extends EffectiveServerSpecB
   }
 
   @Override
+  public Long getMaximumPendingWaitTimeSeconds() {
+    return server.getMaximumPendingWaitTimeSeconds();
+  }
+
+  @Override
   public String toString() {
     return new ToStringBuilder(this)
         .appendSuper(super.toString())

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerPod.java
@@ -33,7 +33,6 @@ import io.kubernetes.client.openapi.models.V1VolumeBuilder;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.kubernetes.client.openapi.models.V1VolumeMountBuilder;
 import jakarta.validation.Valid;
-import oracle.kubernetes.json.Default;
 import oracle.kubernetes.json.Description;
 import oracle.kubernetes.operator.ShutdownType;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -241,10 +240,18 @@ class ServerPod extends KubernetesResource {
    *
    * @since 4.0
    */
-  @Description("The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready state "
-      + "before it considers the pod failed. Defaults to 1800 seconds.")
-  @Default(intDefault = 1800)
-  private Long maxReadyWaitTimeSeconds = 1800L;
+  @Description("The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the ready "
+      + "state before it considers the pod failed. Defaults to 1800 seconds.")
+  private Long maxReadyWaitTimeSeconds = null;
+
+  /**
+   * The maximum pending wait time.
+   *
+   * @since 4.0
+   */
+  @Description("The maximum time in seconds that the operator waits for a WebLogic Server pod to reach the running "
+      + "state before it considers the pod failed. Defaults to 5 minutes.")
+  private Long maxPendingWaitTimeSeconds = null;
 
   private static void copyValues(V1ResourceRequirements to, V1ResourceRequirements from) {
     if (from != null) {
@@ -380,6 +387,14 @@ class ServerPod extends KubernetesResource {
     this.maxReadyWaitTimeSeconds = maxReadyWaitTimeSeconds;
   }
 
+  public Long getMaxPendingWaitTimeSeconds() {
+    return this.maxPendingWaitTimeSeconds;
+  }
+
+  public void setMaxPendingWaitTimeSeconds(@Nullable Long maxPendingWaitTimeSeconds) {
+    this.maxPendingWaitTimeSeconds = maxPendingWaitTimeSeconds;
+  }
+
   void fillInFrom(ServerPod serverPod1) {
     for (V1EnvVar envVar : serverPod1.getV1EnvVars()) {
       addIfMissing(envVar);
@@ -404,7 +419,12 @@ class ServerPod extends KubernetesResource {
     copyValues(resources, serverPod1.resources);
     copyValues(podSecurityContext, serverPod1.podSecurityContext);
     copyValues(containerSecurityContext, serverPod1.containerSecurityContext);
-    maxReadyWaitTimeSeconds = serverPod1.maxReadyWaitTimeSeconds;
+    if (maxReadyWaitTimeSeconds == null) {
+      maxReadyWaitTimeSeconds = serverPod1.maxReadyWaitTimeSeconds;
+    }
+    if (maxPendingWaitTimeSeconds == null) {
+      maxPendingWaitTimeSeconds = serverPod1.maxPendingWaitTimeSeconds;
+    }
     if (serverPod1.affinity != null && isNullOrDefaultAffinity()) {
       affinity = serverPod1.affinity;
     }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -34,7 +34,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
 
   @Description("Desired state of this WebLogic Server instance. Values are RUNNING, ADMIN, or SHUTDOWN.")
   @Expose
-  private String desiredState;
+  private String stateGoal;
 
   @Description("WebLogic cluster name, if the server is a member of a cluster.")
   @Expose
@@ -73,7 +73,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
   ServerStatus(ServerStatus other) {
     this.serverName = other.serverName;
     this.state = other.state;
-    this.desiredState = other.desiredState;
+    this.stateGoal = other.stateGoal;
     this.clusterName = other.clusterName;
     this.nodeName = other.nodeName;
     this.isAdminServer = other.isAdminServer;
@@ -149,17 +149,17 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
    *
    * @return requested state
    */
-  public String getDesiredState() {
-    return desiredState;
+  public String getStateGoal() {
+    return stateGoal;
   }
 
   /**
    * Desired state of this WebLogic Server. Required.
    *
-   * @param desiredState Requested state
+   * @param stateGoal Requested state
    */
-  public void setDesiredState(String desiredState) {
-    this.desiredState = desiredState;
+  public void setStateGoal(String stateGoal) {
+    this.stateGoal = stateGoal;
   }
 
   /**
@@ -169,7 +169,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
    * @return this
    */
   public ServerStatus withDesiredState(String stateGoal) {
-    this.desiredState = stateGoal;
+    this.stateGoal = stateGoal;
     return this;
   }
 
@@ -310,7 +310,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .append("serverName", serverName)
         .append("isAdminServer", isAdminServer)
         .append("state", state)
-        .append("desiredState", desiredState)
+        .append("desiredState", stateGoal)
         .append("clusterName", clusterName)
         .append("nodeName", nodeName)
         .append("podPhase", podPhase)
@@ -326,7 +326,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .append(serverName)
         .append(health)
         .append(state)
-        .append(desiredState)
+        .append(stateGoal)
         .append(clusterName)
         .append(podPhase)
         .append(podReady)
@@ -347,7 +347,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .append(serverName, rhs.serverName)
         .append(health, rhs.health)
         .append(state, rhs.state)
-        .append(desiredState, rhs.desiredState)
+        .append(stateGoal, rhs.stateGoal)
         .append(clusterName, rhs.clusterName)
         .append(podPhase, rhs.podPhase)
         .append(podReady, rhs.podReady)
@@ -378,7 +378,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .withStringField("serverName", ServerStatus::getServerName)
         .withStringField("clusterName", ServerStatus::getClusterName)
         .withStringField("state", ServerStatus::getState)
-        .withStringField("desiredState", ServerStatus::getDesiredState)
+        .withStringField("desiredState", ServerStatus::getStateGoal)
         .withStringField("nodeName", ServerStatus::getNodeName)
         .withStringField("podPhase", ServerStatus::getPodPhaseAsString)
         .withStringField("podReady", ServerStatus::getPodReady)

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -78,6 +78,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
     this.nodeName = other.nodeName;
     this.isAdminServer = other.isAdminServer;
     this.podReady = other.podReady;
+    this.podPhase = other.podPhase;
     this.health = Optional.ofNullable(other.health).map(ServerHealth::new).orElse(null);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -157,19 +157,10 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
   /**
    * Desired state of this WebLogic Server. Required.
    *
-   * @param stateGoal Requested state
-   */
-  public void setStateGoal(String stateGoal) {
-    this.stateGoal = stateGoal;
-  }
-
-  /**
-   * Desired state of this WebLogic Server. Required.
-   *
    * @param stateGoal stateGoal
    * @return this
    */
-  public ServerStatus withDesiredState(String stateGoal) {
+  public ServerStatus withStateGoal(String stateGoal) {
     this.stateGoal = stateGoal;
     return this;
   }
@@ -181,15 +172,6 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
    */
   public String getClusterName() {
     return clusterName;
-  }
-
-  /**
-   * WebLogic cluster name, if the server is part of a cluster.
-   *
-   * @param clusterName cluster name
-   */
-  public void setClusterName(String clusterName) {
-    this.clusterName = clusterName;
   }
 
   /**
@@ -311,7 +293,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .append("serverName", serverName)
         .append("isAdminServer", isAdminServer)
         .append("state", state)
-        .append("desiredState", stateGoal)
+        .append("stateGoal", stateGoal)
         .append("clusterName", clusterName)
         .append("nodeName", nodeName)
         .append("podPhase", podPhase)
@@ -379,7 +361,7 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
         .withStringField("serverName", ServerStatus::getServerName)
         .withStringField("clusterName", ServerStatus::getClusterName)
         .withStringField("state", ServerStatus::getState)
-        .withStringField("desiredState", ServerStatus::getStateGoal)
+        .withStringField("stateGoal", ServerStatus::getStateGoal)
         .withStringField("nodeName", ServerStatus::getNodeName)
         .withStringField("podPhase", ServerStatus::getPodPhaseAsString)
         .withStringField("podReady", ServerStatus::getPodReady)

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -2097,7 +2097,7 @@ class DomainProcessorTest {
   }
 
   private String getDesiredState(DomainResource domain, String serverName) {
-    return Optional.ofNullable(getServerStatus(domain, serverName)).map(ServerStatus::getDesiredState).orElse("");
+    return Optional.ofNullable(getServerStatus(domain, serverName)).map(ServerStatus::getStateGoal).orElse("");
   }
 
   private ServerStatus getServerStatus(DomainResource domain, String serverName) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -431,11 +431,11 @@ class DomainProcessorTest {
 
     DomainResource updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
 
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[0]), equalTo(RUNNING_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[1]), equalTo(RUNNING_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[2]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[3]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[0]), equalTo(RUNNING_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[1]), equalTo(RUNNING_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[2]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[3]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
     assertThat(getResourceVersion(updatedDomain), not(getResourceVersion(domain)));
     assertThat(updatedDomain.getStatus().getObservedGeneration(), equalTo(2L));
   }
@@ -470,7 +470,7 @@ class DomainProcessorTest {
   }
 
   @Test
-  void afterMakeRightAndChangeServerToNever_desiredStateIsShutdown() {
+  void afterMakeRightAndChangeServerToNever_stateGoalIsShutdown() {
     domainConfigurator.configureCluster(CLUSTER).withReplicas(MIN_REPLICAS);
     processor.createMakeRightOperation(new DomainPresenceInfo(newDomain)).execute();
 
@@ -479,11 +479,11 @@ class DomainProcessorTest {
 
     DomainResource updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
 
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[0]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[1]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[2]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[3]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[0]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[1]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[2]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[3]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
     assertThat(getResourceVersion(updatedDomain), not(getResourceVersion(domain)));
   }
 
@@ -556,7 +556,7 @@ class DomainProcessorTest {
   }
 
   @Test
-  void afterChangeToNever_statusUpdateRetainsDesiredState() {
+  void afterChangeToNever_statusUpdateRetainsStateGoal() {
     domainConfigurator.configureCluster(CLUSTER).withReplicas(MIN_REPLICAS);
     final DomainPresenceInfo info1 = new DomainPresenceInfo(newDomain);
     processor.createMakeRightOperation(info1).execute();
@@ -569,12 +569,12 @@ class DomainProcessorTest {
     triggerStatusUpdate();
 
     DomainResource updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
-    assertThat(getDesiredState(updatedDomain, ADMIN_NAME), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[0]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[1]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[2]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[3]), equalTo(SHUTDOWN_STATE));
-    assertThat(getDesiredState(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, ADMIN_NAME), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[0]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[1]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[2]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[3]), equalTo(SHUTDOWN_STATE));
+    assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
   }
 
   private void triggerStatusUpdate() {
@@ -2096,7 +2096,7 @@ class DomainProcessorTest {
     return Optional.ofNullable(updatedDomain).map(DomainResource::getStatus).map(DomainStatus::getMessage).orElse(null);
   }
 
-  private String getDesiredState(DomainResource domain, String serverName) {
+  private String getStateGoal(DomainResource domain, String serverName) {
     return Optional.ofNullable(getServerStatus(domain, serverName)).map(ServerStatus::getStateGoal).orElse("");
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -171,7 +171,7 @@ abstract class DomainStatusUpdateTestBase {
         equalTo(
             new ServerStatus()
                 .withState(RUNNING_STATE)
-                .withDesiredState(RUNNING_STATE)
+                .withStateGoal(RUNNING_STATE)
                 .withNodeName("node1")
                 .withServerName("server1")
                 .withPodPhase(V1PodStatus.PhaseEnum.RUNNING)
@@ -182,7 +182,7 @@ abstract class DomainStatusUpdateTestBase {
         equalTo(
             new ServerStatus()
                 .withState(SHUTDOWN_STATE)
-                .withDesiredState(RUNNING_STATE)
+                .withStateGoal(RUNNING_STATE)
                 .withClusterName("clusterB")
                 .withNodeName("node2")
                 .withServerName("server2")
@@ -223,12 +223,12 @@ abstract class DomainStatusUpdateTestBase {
     assertThat(getRecordedDomain(),
           hasStatusForServer("server3")
                 .withState(RUNNING_STATE)
-                .withDesiredState(RUNNING_STATE)
+                .withStateGoal(RUNNING_STATE)
                 .withClusterName("clusterC"));
     assertThat(getRecordedDomain(),
           hasStatusForServer("server4")
                 .withState(SHUTDOWN_STATE)
-                .withDesiredState(SHUTDOWN_STATE)
+                .withStateGoal(SHUTDOWN_STATE)
                 .withClusterName("clusterC"));
   }
 
@@ -296,7 +296,7 @@ abstract class DomainStatusUpdateTestBase {
     updateDomainStatus();
 
     assertThat(getRecordedDomain(),
-          hasStatusForServer("server1").withState(SHUTDOWN_STATE).withDesiredState(SHUTDOWN_STATE));
+          hasStatusForServer("server1").withState(SHUTDOWN_STATE).withStateGoal(SHUTDOWN_STATE));
   }
 
   @Test
@@ -308,7 +308,7 @@ abstract class DomainStatusUpdateTestBase {
                 Collections.singletonList(
                     new ServerStatus()
                         .withState(SHUTDOWN_STATE)
-                        .withDesiredState(SHUTDOWN_STATE)
+                        .withStateGoal(SHUTDOWN_STATE)
                         .withServerName("server1")
                         .withHealth(overallHealth("health1"))))
               .addCondition(new DomainCondition(AVAILABLE).withStatus(false))
@@ -1647,7 +1647,7 @@ abstract class DomainStatusUpdateTestBase {
       return this;
     }
 
-    ServerStatusMatcher withDesiredState(String expectedValue) {
+    ServerStatusMatcher withStateGoal(String expectedValue) {
       matcher.addField("desired state", ServerStatus::getStateGoal, expectedValue);
       return this;
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -31,6 +31,7 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.tuning.TuningParameters;
 import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.wlsconfig.WlsDomainConfig;
@@ -942,7 +943,7 @@ abstract class DomainStatusUpdateTestBase {
 
   @Test
   void whenPodPendingForTooLong_reportServerPodFailure() {
-    domain.getSpec().setMaxPendingWaitTimeSeconds(20);
+    TuningParametersStub.setParameter(TuningParameters.MAX_PENDING_WAIT_TIME_SECONDS, Long.toString(20));
     defineScenario().withServers("ms1", "ms2")
         .withServerState("ms1", new V1ContainerStateWaiting().reason("ImageBackOff"))
         .build();
@@ -955,7 +956,7 @@ abstract class DomainStatusUpdateTestBase {
 
   @Test
   void whenPodPendingWithinTimeLimit_doNotReportServerPodFailure() {
-    domain.getSpec().setMaxPendingWaitTimeSeconds(20);
+    TuningParametersStub.setParameter(TuningParameters.MAX_PENDING_WAIT_TIME_SECONDS, Long.toString(20));
     defineScenario().withServers("ms1", "ms2")
         .withServerState("ms1", new V1ContainerStateWaiting().reason("ImageBackOff"))
         .build();

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -21,6 +21,9 @@ import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodCondition;
@@ -102,8 +105,6 @@ abstract class DomainStatusUpdateTestBase {
   private final List<Memento> mementos = new ArrayList<>();
   private final DomainResource domain = DomainProcessorTestSetup.createTestDomain();
   private final DomainPresenceInfo info = new DomainPresenceInfo(domain);
-  private final DomainProcessorImpl processor =
-      new DomainProcessorImpl(DomainProcessorDelegateStub.createDelegate(testSupport));
   private List<String> liveServers;
 
   @BeforeEach
@@ -124,7 +125,7 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   private V1ObjectMeta createPodMetadata(String serverName) {
-    return new V1ObjectMeta().namespace(NS).name(serverName);
+    return new V1ObjectMeta().namespace(NS).name(serverName).creationTimestamp(SystemClock.now());
   }
 
   @AfterEach
@@ -832,6 +833,7 @@ abstract class DomainStatusUpdateTestBase {
     domain.getSpec().setMaxReadyWaitTimeSeconds(0L);
     unreadyPod("server2");
 
+    SystemClockTestSupport.increment();
     updateDomainStatus();
 
     assertThat(getRecordedDomain(), hasCondition(FAILED).withStatus(TRUE));
@@ -854,6 +856,7 @@ abstract class DomainStatusUpdateTestBase {
     domain.getSpec().setMaxReadyWaitTimeSeconds(0L);
     markPodRunningPhaseFalse("server2");
 
+    SystemClockTestSupport.increment();
     updateDomainStatus();
 
     assertThat(getRecordedDomain(), hasCondition(FAILED).withStatus(TRUE));
@@ -936,6 +939,48 @@ abstract class DomainStatusUpdateTestBase {
     assertThat(getRecordedDomain(),
         hasStatusForServer("server2").withPodReady("False").withPodPhase(V1PodStatus.PhaseEnum.RUNNING));
   }
+
+  @Test
+  void whenPodPendingForTooLong_reportServerPodFailure() {
+    domain.getSpec().setMaxPendingWaitTimeSeconds(20);
+    defineScenario().withServers("ms1", "ms2")
+        .withServerState("ms1", new V1ContainerStateWaiting().reason("ImageBackOff"))
+        .build();
+
+    SystemClockTestSupport.increment(21);
+    updateDomainStatus();
+
+    assertThat(getRecordedDomain(), hasCondition(FAILED).withReason(SERVER_POD).withMessageContaining("did not start"));
+  }
+
+  @Test
+  void whenPodPendingWithinTimeLimit_doNotReportServerPodFailure() {
+    domain.getSpec().setMaxPendingWaitTimeSeconds(20);
+    defineScenario().withServers("ms1", "ms2")
+        .withServerState("ms1", new V1ContainerStateWaiting().reason("ImageBackOff"))
+        .build();
+
+    SystemClockTestSupport.increment(19);
+    updateDomainStatus();
+
+    assertThat(getRecordedDomain(), not(hasCondition(FAILED)));
+  }
+
+  @Test
+  void whenPodPendingWithinTimeLimit_removePreviousServerPodFailures() {
+    domain.getStatus().addCondition(new DomainCondition(FAILED).withReason(SERVER_POD).withMessage("unit test"));
+    domain.getSpec().setMaxPendingWaitTimeSeconds(20);
+    defineScenario().withServers("ms1", "ms2")
+        .withServerState("ms1", new V1ContainerStateWaiting().reason("ImageBackOff"))
+        .build();
+
+    SystemClockTestSupport.increment(19);
+    updateDomainStatus();
+
+    assertThat(getRecordedDomain(), not(hasCondition(FAILED)));
+  }
+
+  // todo remove server pod failures when OK
 
   @Test
   void whenNoDynamicClusters_doNotAddReplicasTooHighFailure() {
@@ -1426,6 +1471,7 @@ abstract class DomainStatusUpdateTestBase {
     private final List<String> terminatingServers = new ArrayList<>();
     private final List<String> nonStartedServers = new ArrayList<>();
     private final Map<String,String[]> serverStates = new HashMap<>();
+    private final Map<String, V1ContainerStateWaiting> waitingStates = new HashMap<>();
 
     private ScenarioBuilder() {
       configSupport = new WlsDomainConfigSupport("testDomain");
@@ -1477,6 +1523,12 @@ abstract class DomainStatusUpdateTestBase {
 
     ScenarioBuilder withServersReachingState(String state, String... servers) {
       serverStates.put(state, servers);
+      return this;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    ScenarioBuilder withServerState(String serverName, V1ContainerStateWaiting waitingState) {
+      waitingStates.put(serverName, waitingState);
       return this;
     }
 
@@ -1547,9 +1599,23 @@ abstract class DomainStatusUpdateTestBase {
       final V1Pod pod = getPod(serverName);
 
       Objects.requireNonNull(pod.getSpec()).setNodeName(toNodeName(serverName));
-      pod.setStatus(new V1PodStatus()
-            .phase(V1PodStatus.PhaseEnum.RUNNING)
-            .addConditionsItem(new V1PodCondition().type(V1PodCondition.TypeEnum.READY).status("True")));
+      if (waitingStates.containsKey(serverName)) {
+        pod.setStatus(new V1PodStatus()
+            .startTime(SystemClock.now())
+            .phase(V1PodStatus.PhaseEnum.PENDING)
+            .addConditionsItem(new V1PodCondition().type(V1PodCondition.TypeEnum.READY).status("False"))
+            .addContainerStatusesItem(createContainerStatusItem(serverName))
+        );  
+      } else {
+        pod.setStatus(new V1PodStatus()
+              .startTime(SystemClock.now())
+              .phase(V1PodStatus.PhaseEnum.RUNNING)
+              .addConditionsItem(new V1PodCondition().type(V1PodCondition.TypeEnum.READY).status("True")));
+      }
+    }
+
+    private V1ContainerStatus createContainerStatusItem(String serverName) {
+      return new V1ContainerStatus().state(new V1ContainerState().waiting(waitingStates.get(serverName)));
     }
 
     private void markServerTerminating(String serverName) {
@@ -1581,7 +1647,7 @@ abstract class DomainStatusUpdateTestBase {
     }
 
     ServerStatusMatcher withDesiredState(String expectedValue) {
-      matcher.addField("desired state", ServerStatus::getDesiredState, expectedValue);
+      matcher.addField("desired state", ServerStatus::getStateGoal, expectedValue);
       return this;
     }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -281,7 +281,7 @@ class DomainStatusPatchTest {
     DomainStatus status2 = new DomainStatus()
           .addServer(new ServerStatus()
                 .withServerName("ms1").withClusterName("cluster1")
-                .withState(RUNNING_STATE).withNodeName("node1").withDesiredState(RUNNING_STATE))
+                .withState(RUNNING_STATE).withNodeName("node1").withStateGoal(RUNNING_STATE))
           .addServer(new ServerStatus()
                 .withServerName("ms2").withClusterName("cluster1").withState(STARTING_STATE));
 
@@ -289,8 +289,8 @@ class DomainStatusPatchTest {
 
     assertThat(builder.getPatches(),
           hasItemsInOrder(
-             "ADD /status/servers/- {'clusterName':'cluster1','desiredState':'RUNNING',"
-                 + "'nodeName':'node1','serverName':'ms1','state':'RUNNING'}",
+             "ADD /status/servers/- {'clusterName':'cluster1','nodeName':'node1',"
+                 + "'serverName':'ms1','state':'RUNNING','stateGoal':'RUNNING'}",
              "ADD /status/servers/- {'clusterName':'cluster1','serverName':'ms2','state':'STARTING'}"
              ));
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -31,6 +31,7 @@ import oracle.kubernetes.operator.utils.InMemoryCertificates;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.utils.SystemClock;
+import oracle.kubernetes.utils.SystemClockTestSupport;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.hamcrest.junit.MatcherAssert;
@@ -74,7 +75,6 @@ class PodPresenceTest {
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final DomainProcessorDelegateStub processorDelegate = DomainProcessorDelegateStub.createDelegate(testSupport);
   private final DomainProcessorImpl processor = new DomainProcessorImpl(processorDelegate);
-  private OffsetDateTime clock = SystemClock.now();
   private final Packet packet = new Packet();
   private final V1Pod pod =
       new V1Pod()
@@ -92,6 +92,7 @@ class PodPresenceTest {
     mementos.add(InMemoryCertificates.install());
     mementos.add(ConstantTestHash.install());
     mementos.add(ScanCacheStub.install());
+    mementos.add(SystemClockTestSupport.installClock());
 
     domains.put(NS, new HashMap<>(ImmutableMap.of(UID, info)));
     disableDomainProcessing();
@@ -184,10 +185,24 @@ class PodPresenceTest {
   }
 
   @Test
-  void whenPodPhaseNotFailed_reportNotFailed() {
+  void whenPodPhaseRunning_reportNotFailed() {
     pod.status(new V1PodStatus().phase(V1PodStatus.PhaseEnum.RUNNING));
 
     MatcherAssert.assertThat(PodHelper.isFailed(pod), is(false));
+  }
+
+  @Test
+  void whenPodPhasePending_reportNotFailed() {
+    pod.status(new V1PodStatus().phase(V1PodStatus.PhaseEnum.PENDING));
+
+    MatcherAssert.assertThat(PodHelper.isFailed(pod), is(false));
+  }
+
+  @Test
+  void whenPodPhasePending_reportPending() {
+    pod.status(new V1PodStatus().phase(V1PodStatus.PhaseEnum.PENDING));
+
+    MatcherAssert.assertThat(PodHelper.isPending(pod), is(true));
   }
 
   @Test
@@ -520,7 +535,7 @@ class PodPresenceTest {
 
   @SuppressWarnings("ConstantConditions")
   private V1Pod withTimeAndVersion(V1Pod pod) {
-    pod.getMetadata().creationTimestamp(getDateTime()).resourceVersion(RESOURCE_VERSION);
+    pod.getMetadata().creationTimestamp(advanceAndGetTime()).resourceVersion(RESOURCE_VERSION);
     return pod;
   }
 
@@ -528,9 +543,9 @@ class PodPresenceTest {
     return pod.status(new V1PodStatus().phase(FAILED).reason(EVICTED_REASON));
   }
 
-  private OffsetDateTime getDateTime() {
-    clock = clock.plusSeconds(1);
-    return clock;
+  private OffsetDateTime advanceAndGetTime() {
+    SystemClockTestSupport.increment(1);
+    return SystemClock.now();
   }
 
   // Returns a constant hash value to make canUseCurrentPod() in VerifyPodStep.apply to return true

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -232,6 +232,16 @@ public abstract class DomainConfigurator {
     return this;
   }
 
+  public DomainConfigurator withMaximumReadyWaitTimeSeconds(Long readyWaitTimeSeconds) {
+    getDomainSpec().setMaxReadyWaitTimeSeconds(readyWaitTimeSeconds);
+    return this;
+  }
+
+  public DomainConfigurator withMaximumPendingWaitTimeSeconds(Long pendingWaitTimeSeconds) {
+    getDomainSpec().setMaxPendingWaitTimeSeconds(pendingWaitTimeSeconds);
+    return this;
+  }
+
   public DomainConfigurator withMaxConcurrentShutdown(Integer maxConcurrentShutdown) {
     getDomainSpec().setMaxClusterConcurrentShutdown(maxConcurrentShutdown);
     return this;

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
@@ -631,6 +631,12 @@ public class DomainCommonConfigurator extends DomainConfigurator {
     }
 
     @Override
+    public ServerConfigurator withMaximumPendingWaitTimeSeconds(long waitTime) {
+      server.setMaxPendingWaitTimeSeconds(waitTime);
+      return this;
+    }
+
+    @Override
     public ServerConfigurator withSchedulerName(String schedulerName) {
       getDomainSpec().setSchedulerName(schedulerName);
       return this;
@@ -828,6 +834,12 @@ public class DomainCommonConfigurator extends DomainConfigurator {
     @Override
     public ClusterConfigurator withMaximumReadyWaitTimeSeconds(long maximumReadyWaitTimeSeconds) {
       clusterSpec.setMaxReadyWaitTimeSeconds(maximumReadyWaitTimeSeconds);
+      return this;
+    }
+
+    @Override
+    public ClusterConfigurator withMaximumPendingWaitTimeSeconds(long maximumReadyWaitTimeSeconds) {
+      clusterSpec.setMaxPendingWaitTimeSeconds(maximumReadyWaitTimeSeconds);
       return this;
     }
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainResourceBasicTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainResourceBasicTest.java
@@ -367,6 +367,34 @@ class DomainResourceBasicTest extends DomainTestBase {
   }
 
   @Test
+  void whenWaitTimeSpecifiedOnMultipleLevels_ServerOverridesClusterValue() {
+    configureCluster(CLUSTER_NAME)
+        .withMaximumReadyWaitTimeSeconds(250)
+        .withMaximumPendingWaitTimeSeconds(27);
+
+    configureServer(SERVER1)
+        .withMaximumReadyWaitTimeSeconds(100)
+        .withMaximumPendingWaitTimeSeconds(32);
+
+    EffectiveServerSpec spec = info.getServer(SERVER1, CLUSTER_NAME);
+    
+    assertThat(spec.getMaximumReadyWaitTimeSeconds(), equalTo(100L));
+    assertThat(spec.getMaximumPendingWaitTimeSeconds(), equalTo(32L));
+  }
+
+  @Test
+  void whenWaitTimeSpecifiedOnMultipleLevels_DomainOverridesTuningValue() {
+    configureDomain(domain)
+        .withMaximumReadyWaitTimeSeconds(250L)
+        .withMaximumPendingWaitTimeSeconds(80L);
+
+    EffectiveServerSpec spec = info.getServer(SERVER1, CLUSTER_NAME);
+
+    assertThat(spec.getMaximumReadyWaitTimeSeconds(), equalTo(250L));
+    assertThat(spec.getMaximumPendingWaitTimeSeconds(), equalTo(80L));
+  }
+
+  @Test
   void whenDomainReadFromYaml_Server1OverridesDefaults() throws IOException {
     DomainPresenceInfo info = readDomainPresence(DOMAIN_V2_SAMPLE_YAML);
     EffectiveServerSpec effectiveServerSpec = info.getServer("server1", null);

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ServerStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/ServerStatusTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 class ServerStatusTest {
@@ -145,5 +146,19 @@ class ServerStatusTest {
     assertThat(
           new ServerStatus().withClusterName("1").withServerName("1"),
           equalTo(new ServerStatus().withClusterName("1").withServerName("1").withIsAdminServer(true)));
+  }
+
+  @Test
+  void whenToStringInvoked_includesCurrentValues() {
+    assertThat(new ServerStatus().withStateGoal("RUNNING").toString(),
+        stringContainsInOrder("stateGoal", "RUNNING"));
+  }
+
+  @Test
+  void valuesCreatedInDifferentOrders_haveSameHashCode() {
+    ServerStatus status1 = new ServerStatus().withServerName("ms1").withStateGoal("RUNNING").withState("UNKNOWN");
+    ServerStatus status2 = new ServerStatus().withServerName("ms1").withState("UNKNOWN").withStateGoal("RUNNING");
+
+    assertThat(status1.hashCode(), equalTo(status2.hashCode()));
   }
 }

--- a/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample-4.yaml
+++ b/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample-4.yaml
@@ -126,7 +126,7 @@ spec:
   # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
   clusters:
     - clusterName: cluster2
-      desiredState: "RUNNING"
+      stateGoal: "RUNNING"
       replicas: 5
       serverPod:
         containers:

--- a/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample-5.yaml
+++ b/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample-5.yaml
@@ -89,7 +89,7 @@ spec:
   # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
   clusters:
     - clusterName: cluster2
-      desiredState: "RUNNING"
+      stateGoal: "RUNNING"
       replicas: 5
       serverPod:
         priorityClassName: high-priority

--- a/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample.yaml
+++ b/operator/src/test/resources/oracle/kubernetes/weblogic/domain/model/domain-sample.yaml
@@ -99,7 +99,7 @@ spec:
   # If you use this entry, then the rules will be applied to ALL servers that are members of the named clusters.
   clusters:
   - clusterName: cluster2
-    desiredState: "RUNNING"
+    stateGoal: "RUNNING"
     replicas: 5
     serverPod:
       env:


### PR DESCRIPTION
- Added a new timeout the the ServerPod domain element, and used it to detect a problem starting a server pod
- Renamed the server status field `desiredState` to `stateGoal`