### PR TITLE
remove wdt.version from pom.xml

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -51,7 +51,6 @@
         <wko.it.okd.cluster>${env.OKD}</wko.it.okd.cluster>
         <wko.it.oracle.db.operator.release>${env.ORACLE_DB_OPERATOR_RELEASE}</wko.it.oracle.db.operator.release>
         <wko.it.oraclelinux.test.version>${env.ORACLELINUX_TEST_VERSION}</wko.it.oraclelinux.test.version>
-        <wko.it.wdt.version>${wdt.version}</wko.it.wdt.version>
         <wko.it.wdt.download.url>${wdt.download.url}</wko.it.wdt.download.url>
         <wko.it.wit.download.url>${wit.download.url}</wko.it.wit.download.url>
         <wko.it.remoteconsole.download.url>${remoteconsole.download.url}</wko.it.remoteconsole.download.url>
@@ -229,7 +228,6 @@
                                 <wko.it.okd.cluster>${wko.it.okd.cluster}</wko.it.okd.cluster>
                                 <wko.it.oracle.db.operator.release>${wko.it.oracle.db.operator.release}</wko.it.oracle.db.operator.release>
                                 <wko.it.oraclelinux.test.version>${wko.it.oraclelinux.test.version}</wko.it.oraclelinux.test.version>
-                                <wko.it.wdt.version>${wko.it.wdt.version}</wko.it.wdt.version>
                                 <wko.it.wdt.download.url>${wko.it.wdt.download.url}</wko.it.wdt.download.url>
                                 <wko.it.wit.download.url>${wko.it.wit.download.url}</wko.it.wit.download.url>
                                 <wko.it.remoteconsole.download.url>${wko.it.remoteconsole.download.url}</wko.it.remoteconsole.download.url>

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/ActionConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/ActionConstants.java
@@ -50,8 +50,8 @@ public interface ActionConstants {
       "https://github.com/oracle/weblogic-deploy-tooling/releases/latest";
   public static final String WDT_DOWNLOAD_URL =
       getNonEmptySystemProperty("wko.it.wdt.download.url", WDT_DOWNLOAD_URL_DEFAULT);
-  public static final String WDT_VERSION =
-      getNonEmptySystemProperty("wko.it.wdt.version", "latest");
+  public static final String WDT_VERSION = "latest";
+
   public static final String WDT_DOWNLOAD_FILENAME_DEFAULT = "weblogic-deploy.zip";
 
   public static final String IMAGE_TOOL = WORK_DIR + "/imagetool/bin/imagetool.sh";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/ActionConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/ActionConstants.java
@@ -50,6 +50,10 @@ public interface ActionConstants {
       "https://github.com/oracle/weblogic-deploy-tooling/releases/latest";
   public static final String WDT_DOWNLOAD_URL =
       getNonEmptySystemProperty("wko.it.wdt.download.url", WDT_DOWNLOAD_URL_DEFAULT);
+  //WDT_VERSION is used as the sub-directory identifier when we need to find out
+  //from where we can locate weblogic-deploy.zip file. Right now when we install WDT
+  //we always put zip file under "latest" sub-directory no matter using "latest" branch or
+  //explicit version download URL or custom download URL.
   public static final String WDT_VERSION = "latest";
 
   public static final String WDT_DOWNLOAD_FILENAME_DEFAULT = "weblogic-deploy.zip";


### PR DESCRIPTION
With latest WDT/WITbranch
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11722/
ItDiagnosticsFailedCondition passed at
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11734


With https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/weblogic-deploy-main.zip and
https://objectstorage.us-phoenix-1.oraclecloud.com/n/weblogick8s/b/wko-system-test-files/o/imagetool-main.zip

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11724
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11743/