### PR TITLE
Add validation check to kindtest.sh and JenkinFile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -547,7 +547,7 @@ EOF
                                 error("Aborting the build. (ERROR) All tests cannot be run with [integration-tests] profile")
                             elif [ "${IT_TEST}" != '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
                                 currentBuild.result = 'ABORTED'
-                                error("Aborting the build. (ERROR) (ERROR) Individual Test MUST be run with [integration-tests] profile")
+                                error("Aborting the build. (ERROR) Individual Test MUST be run with [integration-tests] profile")
                             elif [ "${MAVEN_PROFILE_NAME}" != "kind-sequential" ]; then
                                 PARALLEL_RUN=false
                                 NUMBER_OF_THREADS="1"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -544,7 +544,8 @@ EOF
                             export NO_PROXY="${K8S_NODEPORT_HOST}"
 
                             if [ "${IT_TEST}" = '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" = "integration-tests" ]; then
-                                echo "-Dit.test=\"!ItOperatorWlsUpgrade,!ItAuxV8DomainImplicitUpgrade,!ItFmwDomainInPVUsingWDT,!ItFmwDynamicDomainInPV,!ItDedicatedMode,!ItT3Channel,!ItOperatorFmwUpgrade,!ItOCILoadBalancer,!ItMiiSampleFmwMain,!ItIstioCrossClusters*,!ItMultiDomainModels\"" >> ${WORKSPACE}/.mvn/maven.config
+                                currentBuild.result = 'ABORTED'
+                                error("Aborting the build. [integration-tests] profile MUST be used for individual Test(s)")
                             elif [ ! -z "${IT_TEST}" ]; then
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -542,10 +542,15 @@ EOF
                             export KUBECONFIG=${kubeconfig_file}
                             K8S_NODEPORT_HOST=$(kubectl get node kind-worker -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}')
                             export NO_PROXY="${K8S_NODEPORT_HOST}"
-
                             if [ "${IT_TEST}" = '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" = "integration-tests" ]; then
                                 currentBuild.result = 'ABORTED'
-                                error("Aborting the build. [integration-tests] profile MUST be used for individual Test(s)")
+                                error("Aborting the build. (ERROR) All tests cannot be run with [integration-tests] profile")
+                            elif [ "${IT_TEST}" != '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
+                                currentBuild.result = 'ABORTED'
+                                error("Aborting the build. (ERROR) (ERROR) Individual Test MUST be run with [integration-tests] profile")
+                            elif [ "${MAVEN_PROFILE_NAME}" != "kind-sequential" ]; then
+                                PARALLEL_RUN=false
+                                NUMBER_OF_THREADS="1"
                             elif [ ! -z "${IT_TEST}" ]; then
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -543,13 +543,13 @@ EOF
                             K8S_NODEPORT_HOST=$(kubectl get node kind-worker -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}')
                             export NO_PROXY="${K8S_NODEPORT_HOST}"
                             if [ "${IT_TEST}" = '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" = "integration-tests" ]; then
-                                currentBuild.result = 'ABORTED'
-                                error("ERROR Aborting the build. All tests cannot be run with integration-tests profile")
+                                currentBuild.result='ABORTED'
+                                error('ERROR Aborting the build. All tests cannot be run with integration-tests profile')
                             elif [ "${IT_TEST}" != '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
-                                currentBuild.result = 'ABORTED'
-                                error("ERROR Aborting the build. Individual Test MUST be run with integration-tests profile")
+                                currentBuild.result='ABORTED'
+                                error('ERROR Aborting the build. Individual Test MUST be run with integration-tests profile')
                             elif [ "${MAVEN_PROFILE_NAME}" != "kind-sequential" ]; then
-                                PARALLEL_RUN=false
+                                PARALLEL_RUN='false'
                             elif [ ! -z "${IT_TEST}" ]; then
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -544,13 +544,12 @@ EOF
                             export NO_PROXY="${K8S_NODEPORT_HOST}"
                             if [ "${IT_TEST}" = '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" = "integration-tests" ]; then
                                 currentBuild.result = 'ABORTED'
-                                error("Aborting the build. (ERROR) All tests cannot be run with [integration-tests] profile")
+                                error("ERROR Aborting the build. All tests cannot be run with integration-tests profile")
                             elif [ "${IT_TEST}" != '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
                                 currentBuild.result = 'ABORTED'
-                                error("Aborting the build. (ERROR) Individual Test MUST be run with [integration-tests] profile")
+                                error("ERROR Aborting the build. Individual Test MUST be run with integration-tests profile")
                             elif [ "${MAVEN_PROFILE_NAME}" != "kind-sequential" ]; then
                                 PARALLEL_RUN=false
-                                NUMBER_OF_THREADS="1"
                             elif [ ! -z "${IT_TEST}" ]; then
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi

--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -460,11 +460,11 @@ EOF
                             export NO_PROXY="${K8S_NODEPORT_HOST}"
 
                             if [ "${IT_TEST}" = '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" = "integration-tests" ]; then
-                                currentBuild.result = 'ABORTED'
-                                error("ERROR Aborting the build. All tests cannot be run with integration-tests profile")
+                                currentBuild.result='ABORTED'
+                                error('ERROR Aborting the build. All tests cannot be run with integration-tests profile')
                             elif [ "${IT_TEST}" != '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
-                                currentBuild.result = 'ABORTED'
-                                error("ERROR Aborting the build. Individual Test MUST be run with integration-tests profile")
+                                currentBuild.result='ABORTED'
+                                error('ERROR Aborting the build. Individual Test MUST be run with integration-tests profile')
                             elif [ "${MAVEN_PROFILE_NAME}" != "kind-sequential" ]; then
                                 PARALLEL_RUN=false
                             elif [ ! -z "${IT_TEST}" ]; then

--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -460,7 +460,13 @@ EOF
                             export NO_PROXY="${K8S_NODEPORT_HOST}"
 
                             if [ "${IT_TEST}" = '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" = "integration-tests" ]; then
-                                echo "-Dit.test=\"!ItOperatorWlsUpgrade,!ItAuxV8DomainImplicitUpgrade,!ItFmwDomainInPVUsingWDT,!ItFmwDynamicDomainInPV,!ItDedicatedMode,!ItT3Channel,!ItOperatorFmwUpgrade,!ItOCILoadBalancer,!ItMiiSampleFmwMain,!ItIstioCrossClusters*,!ItMultiDomainModels\"" >> ${WORKSPACE}/.mvn/maven.config
+                                currentBuild.result = 'ABORTED'
+                                error("ERROR Aborting the build. All tests cannot be run with integration-tests profile")
+                            elif [ "${IT_TEST}" != '**/It*' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
+                                currentBuild.result = 'ABORTED'
+                                error("ERROR Aborting the build. Individual Test MUST be run with integration-tests profile")
+                            elif [ "${MAVEN_PROFILE_NAME}" != "kind-sequential" ]; then
+                                PARALLEL_RUN=false
                             elif [ ! -z "${IT_TEST}" ]; then
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -298,7 +298,6 @@ fi
 # Test Filter (all) and Maven Profile is integration-tests
 if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
-     echo 'Test Filter[ ${test_filter} ] and MVN Profile[ ${maven_profile_name} ]'
      echo '(ERROR) All tests cannot be run with [integration-tests] profile'
      exit 0
 fi
@@ -307,7 +306,6 @@ fi
 # not integration-tests
 if [ "x${maven_profile_name}" != "xintegration-tests" ] && 
    [ "${test_filter}" != "**/It*" ] ; then
-    echo 'Test Filter[ ${test_filter} ] and MVN Profile[ ${maven_profile_name} ]'
     echo '(ERROR) Individual Test MUST be run with [integration-tests] profile'
     exit 0
 fi

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -287,19 +287,23 @@ docker ps
 echo 'Clean up result root...'
 rm -rf "${RESULT_ROOT:?}/*"
 
+if [ "x${maven_profile_name}" = "xkind-sequential" ] ; then
+  parallel_run="false"
+  threads=1
+  echo 'Setting the variable parallel_run to [${parallel_run}] for kind-sequential profile"
+fi
+
 echo "Run tests..."
 
 if [ "${test_filter}" != "**/It*" ]; then
+  maven_profile_name = "integration-tests"
+  echo "Running individual class [${test_filter}] with profile [${maven_profile_name}]"
   echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
   time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
 else
-  if [ "${maven_profile_name}" = "toolkits-srg" ] || [ "${maven_profile_name}" = "wls-srg" ] || [ "${maven_profile_name}" = "kind-sequential" ]; then
+    echo "Running Integration tests with profile  [${maven_profile_name}]"
     echo "Running mvn -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads} -pl integration-tests -P ${maven_profile_name} verify"
     time mvn -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
-  else
-    echo "Running mvn -Dit.test=!ItAuxV8DomainImplicitUpgrade, !ItOperatorWlsUpgrade, !ItDedicatedMode, !ItT3Channel, !ItOperatorFmwUpgrade, !ItOCILoadBalancer, !ItMiiSampleFmwMain, !ItOperatorUpgradeWithIstio, !ItIstioCrossClusters* -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
-    time mvn -Dit.test="!ItAuxV8DomainImplicitUpgrade, !ItOperatorWlsUpgrade, !ItFmwDomainInPVUsingWDT, !ItFmwDynamicDomainInPV, !ItDedicatedMode, !ItT3Channel, !ItOperatorFmwUpgrade, !ItOperatorUpgradeWithIstio, !ItOCILoadBalancer, !ItMiiSampleFmwMain, !ItIstioCrossClusters*" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
-  fi
 fi
 
 echo "Collect journalctl logs"

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -296,7 +296,8 @@ fi
 echo "Run tests..."
 
 if [ "${test_filter}" != "**/It*" ]; then
-  maven_profile_name = "integration-tests"
+  maven_profile_name="integration-tests"
+  echo "Overwriting the maven profile to [integration-tests]" 
   echo "Running individual class [${test_filter}] with profile [${maven_profile_name}]"
   echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
   time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -290,7 +290,7 @@ rm -rf "${RESULT_ROOT:?}/*"
 if [ "x${maven_profile_name}" = "xkind-sequential" ] ; then
   parallel_run="false"
   threads=1
-  echo 'Setting the variable parallel_run to [${parallel_run}] for kind-sequential profile"
+  echo "Setting the variable parallel_run to [${parallel_run}] for kind-sequential profile"
 fi
 
 echo "Run tests..."

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -295,7 +295,7 @@ fi
 
 if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
-  echo '[integration-tests] profile MUST be used for individual Test(s) '
+  echo '[integration-tests] profile MUST be used for individual Test(s)'
   exit 0
 fi
 

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -293,17 +293,27 @@ if [ "x${maven_profile_name}" = "xkind-sequential" ] ; then
   echo "Setting the variable parallel_run to [${parallel_run}] for kind-sequential profile"
 fi
 
+# Check for invalid Test Filter/Maven Profile Combination
+
+# Test Filter (all) and Maven Profile is integration-tests
 if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
-  echo '[integration-tests] profile MUST be used for individual Test(s)'
-  exit 0
+     echo 'Test Filter[${test_filter}] and MVN Profile[${maven_profile_name}]'
+     echo '(ERROR) All tests cannot be run with [integration-tests] profile'
+     exit 0
+fi
+
+# Test Filter is Individual Test Clas(es) and Maven Profile is 
+# not integration-tests
+if [ "x${maven_profile_name}" != "xintegration-tests" ] && 
+   [ "${test_filter}" != "**/It*" ] ; then
+    echo 'Test Filter[${test_filter}] and MVN Profile[${maven_profile_name}]'
+    echo '(ERROR) Individual Test MUST be run with [integration-tests] profile'
+    exit 0
 fi
 
 echo "Run tests..."
 if [ "${test_filter}" != "**/It*" ]; then
-  maven_profile_name="integration-tests"
-  echo "Overwriting the maven profile to [integration-tests]" 
-  echo "Running individual class [${test_filter}] with profile [${maven_profile_name}]"
   echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
   time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
 else

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -298,7 +298,7 @@ fi
 # Test Filter (all) and Maven Profile is integration-tests
 if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
-     echo 'Test Filter[${test_filter}] and MVN Profile[${maven_profile_name}]'
+     echo 'Test Filter[ ${test_filter} ] and MVN Profile[ ${maven_profile_name} ]'
      echo '(ERROR) All tests cannot be run with [integration-tests] profile'
      exit 0
 fi
@@ -307,7 +307,7 @@ fi
 # not integration-tests
 if [ "x${maven_profile_name}" != "xintegration-tests" ] && 
    [ "${test_filter}" != "**/It*" ] ; then
-    echo 'Test Filter[${test_filter}] and MVN Profile[${maven_profile_name}]'
+    echo 'Test Filter[ ${test_filter} ] and MVN Profile[ ${maven_profile_name} ]'
     echo '(ERROR) Individual Test MUST be run with [integration-tests] profile'
     exit 0
 fi

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -293,8 +293,13 @@ if [ "x${maven_profile_name}" = "xkind-sequential" ] ; then
   echo "Setting the variable parallel_run to [${parallel_run}] for kind-sequential profile"
 fi
 
-echo "Run tests..."
+if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
+   [ "${test_filter}" = "**/It*" ] ; then
+  echo '[integration-tests] profile MUST be used for individual Test(s) '
+  exit 0
+fi
 
+echo "Run tests..."
 if [ "${test_filter}" != "**/It*" ]; then
   maven_profile_name="integration-tests"
   echo "Overwriting the maven profile to [integration-tests]" 


### PR DESCRIPTION
This PR address the following infra change

(a) Remove the test exclusion from mvn command in kindtest.sh, since we have tagged all the Test class with appropriate tag   ie. kind-parallel or kind-sequential
(b) Added validation check for 
        (1) to run individual test(s) the intergration-test profile MUST be used which includes all the classes
        (2) All the test can not be run with integration-test profile 
        (3) When running kind-sequential profile the parallel variable overwritten to false and number-of-thread set to 1       


https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11786/testReport/ ( kind-parallel) 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11709/testReport/  (kind-sequential) 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/11733  ( individual test )

