### PR TITLE
Update startNodeManager.sh to use port test instead of grepping log message to determine if nodemanager is running

### DIFF
--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -333,7 +333,10 @@ start_secs=$SECONDS
 max_wait_secs=${NODE_MANAGER_MAX_WAIT:-60}
 while [ 1 -eq 1 ]; do
   sleep 1
-  if [ -e ${nodemgr_log_file} ] && [ `grep -c "Plain socket listener started" ${nodemgr_log_file}` -gt 0 ]; then
+  # Test if node manager listen port is reachable
+  $(timeout 1 bash -c 'cat < /dev/null > /dev/tcp/127.0.0.1/5556')
+  res="$?"
+  if [ $res -eq 0 ]; then
     break
   fi
   if [ $((SECONDS - $start_secs)) -ge $max_wait_secs ]; then

--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -334,7 +334,7 @@ max_wait_secs=${NODE_MANAGER_MAX_WAIT:-60}
 while [ 1 -eq 1 ]; do
   sleep 1
   # Test if node manager listen port is reachable
-  $(timeout 1 bash -c 'cat < /dev/null > /dev/tcp/127.0.0.1/5556')
+  $(timeout 1 bash -c 'cat < /dev/null > /dev/tcp/127.0.0.1/5556' > /dev/null 2>&1)
   res="$?"
   if [ $res -eq 0 ]; then
     break


### PR DESCRIPTION
This PR is for release/3.4 branch

jenkins (in progress) https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12035/