### PR TITLE
Forward port startNodeManager.sh fix to main

### DIFF
--- a/operator/src/main/resources/scripts/startNodeManager.sh
+++ b/operator/src/main/resources/scripts/startNodeManager.sh
@@ -330,7 +330,10 @@ start_secs=$SECONDS
 max_wait_secs=${NODE_MANAGER_MAX_WAIT:-60}
 while [ 1 -eq 1 ]; do
   sleep 1
-  if [ -e ${nodemgr_log_file} ] && [ `grep -c "Plain socket listener started" ${nodemgr_log_file}` -gt 0 ]; then
+  # Test if node manager listen port is reachable
+  $(timeout 1 bash -c 'cat < /dev/null > /dev/tcp/127.0.0.1/5556' > /dev/null 2>&1)
+  res="$?"
+  if [ $res -eq 0 ]; then
     break
   fi
   if [ $((SECONDS - $start_secs)) -ge $max_wait_secs ]; then


### PR DESCRIPTION
Use port test instead of grep log message to determine if nodemanager is running

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12054/