### PR TITLE
Modify kindtest.sh to choose right profile to run individual tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -537,14 +537,11 @@ EOF
                      script {
                       def res = 0
                       res = sh ( script: '''
-                         echo "Maven Profile [${MAVEN_PROFILE_NAME}]"
-                         echo "Selected IT Tests [${IT_TEST}]"
+                        echo "Maven Profile [${MAVEN_PROFILE_NAME}]"
+                        echo "Selected IT Tests [${IT_TEST}]"
                         if [ "x${IT_TEST}" == 'x' ] && [ "${MAVEN_PROFILE_NAME}" == "integration-tests" ]; then
                            echo 'ERROR: All tests cannot be run with integration-tests profile'
                            exit 1 
-                        elif [ "x${IT_TEST}" != 'x' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
-                           echo 'ERROR: Individual test MUST be run with integration-tests profile'
-                         exit 1 
                         else 
                            echo 'Profile/ItTests Validation Passed'
                            exit 0
@@ -565,6 +562,8 @@ EOF
                             if [ "${MAVEN_PROFILE_NAME}" == "kind-sequential" ]; then
                                PARALLEL_RUN='false'
                             elif [ ! -z "${IT_TEST}" ]; then
+                               echo 'Overriding MAVEN_PROFILE_NAME to integration-test when running individual test(s)'
+                                MAVEN_PROFILE_NAME="integration-tests"
                                echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi
                             echo "-Dwko.it.wle.download.url=\"${wle_download_url}\""                                     >> ${WORKSPACE}/.mvn/maven.config

--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -480,7 +480,7 @@ EOF
                                 PARALLEL_RUN=false
                             fi
                             if [ ! -z "${IT_TEST}" ]; then
-                                echo 'Overriding the MAVEN_PROFILE_NAME to integration-test'
+                                echo 'Overriding MAVEN_PROFILE_NAME to integration-test when running individual test(s)'
                                 MAVEN_PROFILE_NAME="integration-tests"
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi

--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -458,9 +458,6 @@ EOF
                         if [ "x${IT_TEST}" == 'x' ] && [ "${MAVEN_PROFILE_NAME}" == "integration-tests" ]; then
                            echo 'ERROR: All tests cannot be run with integration-tests profile'
                            exit 1 
-                        elif [ "x${IT_TEST}" != 'x' ] && [ "${MAVEN_PROFILE_NAME}" != "integration-tests" ]; then
-                           echo 'ERROR: Individual test MUST be run with integration-tests profile'
-                         exit 1 
                         else 
                            echo 'Profile/ItTests Validation Passed'
                            exit 0
@@ -481,7 +478,10 @@ EOF
                             if [ "${MAVEN_PROFILE_NAME}" == "kind-sequential" ]; then
                                 echo 'Overriding the PARALLEL_RUN to false for kind-sequential profile'
                                 PARALLEL_RUN=false
-                            elif [ ! -z "${IT_TEST}" ]; then
+                            fi
+                            if [ ! -z "${IT_TEST}" ]; then
+                                echo 'Overriding the MAVEN_PROFILE_NAME to integration-test'
+                                MAVEN_PROFILE_NAME="integration-tests"
                                 echo "-Dit.test=\"${IT_TEST}\"" >> ${WORKSPACE}/.mvn/maven.config
                             fi
                             echo "-Dwko.it.wle.download.url=\"${wle_download_url}\""                                     >> ${WORKSPACE}/.mvn/maven.config

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -294,8 +294,6 @@ if [ "x${maven_profile_name}" = "xkind-sequential" ] ; then
 fi
 
 # Check for invalid Test Filter/Maven Profile Combination
-
-# Test Filter (all) and Maven Profile is integration-tests
 if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
      echo '(ERROR) All tests cannot be run with [integration-tests] profile'
@@ -313,11 +311,11 @@ if [ "${maven_profile_name}" == "kind-sequential" ]; then
    parallel_run=false
 fi
 
-# If the IT_TEST is not set to "**/It*" (i.e. individual tests are choosen), 
+# If the IT_TEST is not set to "**/It*" (i.e. individual tests are chosen), 
 # the maven_profile parameter is ignored and run individual test(s) with 
 # integration-tests profile 
 
-# If a specific maven profile is choosen, all tests are run with the choosen 
+# If a specific maven profile is chosen, all tests are run with the chosen 
 # profile and IT_TEST parameter is ignored
 
 echo "Run tests..."

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -287,28 +287,17 @@ docker ps
 echo 'Clean up result root...'
 rm -rf "${RESULT_ROOT:?}/*"
 
-if [ "x${maven_profile_name}" = "xkind-sequential" ] ; then
-  parallel_run="false"
-  threads=1
-  echo "Setting the variable parallel_run to [${parallel_run}] for kind-sequential profile"
-fi
-
 # Check for invalid Test Filter/Maven Profile Combination
-if [ "x${maven_profile_name}" = "xintegration-tests" ] && 
+if [ "${maven_profile_name}" == "integration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
      echo '(ERROR) All tests cannot be run with [integration-tests] profile'
      exit 0
 fi
 
-if [ "${maven_profile_name}" == "integration-tests" ] && 
-   [ "${test_filter}" == "**/It*" ] ; then
-    echo 'ERROR: All tests cannot be run with integration-tests profile'
-    exit 0
-fi
-
 if [ "${maven_profile_name}" == "kind-sequential" ]; then
    echo "Overriding the parallel_run to false for kind-sequential profile'
    parallel_run=false
+   threads=1
 fi
 
 # If the IT_TEST is not set to "**/It*" (i.e. individual tests are chosen), 

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -289,8 +289,8 @@ rm -rf "${RESULT_ROOT:?}/*"
 
 # Check for invalid Test Filter/Maven Profile Combination
 if [ "${maven_profile_name}" == "integration-tests" ] && 
-   [ "${test_filter}" = "**/It*" ] ; then
-     echo "(ERROR) All tests cannot be run with [integration-tests] profile"
+   [ "${test_filter}" == "**/It*" ] ; then
+     echo "(ERROR) All tests cannot be run with [integration-tests] profile, choose different profile"
      exit 0
 fi
 
@@ -299,10 +299,8 @@ if [ "${maven_profile_name}" == "kind-sequential" ]; then
    parallel_run=false
    threads=1
 fi
-
-# If the IT_TEST is not set to "**/It*" (i.e. individual tests are chosen), 
-# the maven_profile parameter is ignored and run individual test(s) with 
-# integration-tests profile 
+# If IT_TEST is set, integration-test profile is used to run the tests and 
+# MAVEN_PROFILE_NAME parameter is ignored
 
 # If a specific maven profile is chosen, all tests are run with the chosen 
 # profile and IT_TEST parameter is ignored

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -290,12 +290,12 @@ rm -rf "${RESULT_ROOT:?}/*"
 # Check for invalid Test Filter/Maven Profile Combination
 if [ "${maven_profile_name}" == "integration-tests" ] && 
    [ "${test_filter}" = "**/It*" ] ; then
-     echo '(ERROR) All tests cannot be run with [integration-tests] profile'
+     echo "(ERROR) All tests cannot be run with [integration-tests] profile"
      exit 0
 fi
 
 if [ "${maven_profile_name}" == "kind-sequential" ]; then
-   echo "Overriding the parallel_run to false for kind-sequential profile'
+   echo "Overriding the parallel_run to false for kind-sequential profiler"
    parallel_run=false
    threads=1
 fi

--- a/kindtest.sh
+++ b/kindtest.sh
@@ -302,18 +302,29 @@ if [ "x${maven_profile_name}" = "xintegration-tests" ] &&
      exit 0
 fi
 
-# Test Filter is Individual Test Clas(es) and Maven Profile is 
-# not integration-tests
-if [ "x${maven_profile_name}" != "xintegration-tests" ] && 
-   [ "${test_filter}" != "**/It*" ] ; then
-    echo '(ERROR) Individual Test MUST be run with [integration-tests] profile'
+if [ "${maven_profile_name}" == "integration-tests" ] && 
+   [ "${test_filter}" == "**/It*" ] ; then
+    echo 'ERROR: All tests cannot be run with integration-tests profile'
     exit 0
 fi
 
+if [ "${maven_profile_name}" == "kind-sequential" ]; then
+   echo "Overriding the parallel_run to false for kind-sequential profile'
+   parallel_run=false
+fi
+
+# If the IT_TEST is not set to "**/It*" (i.e. individual tests are choosen), 
+# the maven_profile parameter is ignored and run individual test(s) with 
+# integration-tests profile 
+
+# If a specific maven profile is choosen, all tests are run with the choosen 
+# profile and IT_TEST parameter is ignored
+
 echo "Run tests..."
 if [ "${test_filter}" != "**/It*" ]; then
-  echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P ${maven_profile_name} verify"
-  time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P ${maven_profile_name} verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
+  echo "Overriding the profile to integration-test"
+  echo "Running mvn -Dit.test=${test_filter} -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads}  -pl integration-tests -P integration-tests verify"
+  time mvn -Dit.test="${test_filter}" -Dwdt.download.url="${wdt_download_url}" -Dwit.download.url="${wit_download_url}" -Dwle.download.url="${wle_download_url}" -DPARALLEL_CLASSES="${parallel_run}" -DNUMBER_OF_THREADS="${threads}" -pl integration-tests -P integration-tests verify 2>&1 | tee "${RESULT_ROOT}/kindtest.log" || captureLogs
 else
     echo "Running Integration tests with profile  [${maven_profile_name}]"
     echo "Running mvn -Dwdt.download.url=${wdt_download_url} -Dwit.download.url=${wit_download_url} -Dwle.download.url=${wle_download_url} -DPARALLEL_CLASSES=${parallel_run} -DNUMBER_OF_THREADS=${threads} -pl integration-tests -P ${maven_profile_name} verify"


### PR DESCRIPTION
With this change, no need to change the maven profile to integration-tests while running individual tests.
The kind script and Jenkinfile  will automatically override the profile to integration-tests

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12115/ (single test with default)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12118/ (all test and integration-tests) (-)
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12119/ (all test and default )

https://build.weblogick8s.org:8443/job/WebLogic%20Kubernetes%20Operator%20Kind/view/change-requests/job/PR-3333/6
