### PR TITLE
Restendpoint fix

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
@@ -341,17 +341,9 @@ public class RestBackendImpl implements RestBackend {
 
     authorize(domainUid, Operation.UPDATE);
     forDomainDo(domainUid, d -> performScaling(d, cluster, managedServerCount));
-    //    getClusterResource(domainUid, cluster)
-    //        .ifPresentOrElse(cr -> performScaling(domainUid, cr, managedServerCount),
-    //          () ->  forDomainDo(domainUid, d -> performScaling(d, cluster, managedServerCount)));
 
     LOGGER.exiting();
   }
-
-  //private void performScaling(String domainUid, ClusterResource cluster, int managedServerCount) {
-  //  verifyWlsConfiguredClusterCapacity(domainUid, cluster.getClusterName(), managedServerCount);
-  // patchClusterResourceReplicas(cluster, managedServerCount);
-  //}
 
   private void performScaling(DomainResource domain, String cluster, int managedServerCount) {
     verifyWlsConfiguredClusterCapacity(domain.getDomainUid(), cluster, managedServerCount);
@@ -359,8 +351,6 @@ public class RestBackendImpl implements RestBackend {
     getClusterResource(domain, cluster)
         .ifPresentOrElse(cr -> patchClusterResourceReplicas(cr, managedServerCount),
             () -> createClusterIfNecessary(domain, cluster, managedServerCount));
-
-    //createCluster(domain, cluster, managedServerCount);
   }
 
   private List<String> getReferencedClusterResourceNames(DomainResource domain) {

--- a/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
@@ -333,6 +333,22 @@ class RestBackendImplTest {
   }
 
   @Test
+  void whenMultipleClusterResourceWithSameClusterName_scaleClusterUpdatesCorrectClusterResource() {
+    final ClusterResource clusterResource1 = createClusterResource(DOMAIN1, NS, CLUSTER_1)
+        .withReplicas(1);
+    final ClusterResource clusterResource2 = createClusterResource(DOMAIN2, NS, CLUSTER_1)
+        .withReplicas(1);
+    testSupport.defineResources(clusterResource1, clusterResource2);
+
+    configureDomain().withClusterReference(clusterResource1.getMetadata().getName());
+    restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 5);
+
+    assertThat(getUpdatedClusterResource().getMetadata().getName(),
+        equalTo(clusterResource1.getMetadata().getName()));
+    assertThat(getUpdatedClusterResource().getSpec().getReplicas(), equalTo(5));
+  }
+
+  @Test
   void whenPerClusterResourceReplicaSettingMatchesScaleRequest_doNothing() {
     final ClusterResource clusterResource = createClusterResource(DOMAIN1, NS, CLUSTER_1)
             .withReplicas(1);

--- a/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
@@ -326,6 +326,7 @@ class RestBackendImplTest {
             .withReplicas(1);
     testSupport.defineResources(clusterResource);
 
+    configureDomain().withClusterReference(clusterResource.getMetadata().getName());
     restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 5);
 
     assertThat(getUpdatedClusterResource().getSpec().getReplicas(), equalTo(5));

--- a/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/rest/RestBackendImplTest.java
@@ -336,38 +336,33 @@ class RestBackendImplTest {
 
   @Test
   void whenMultipleClusterResourceWithSameClusterName_scaleClusterUpdatesClusterInCorrectDomain() {
-    final ClusterResource clusterResource1 = createClusterResource(DOMAIN1, NS, CLUSTER_1)
-        .withReplicas(1);
-    final ClusterResource clusterResource2 = createClusterResource(DOMAIN2, NS, CLUSTER_1)
-        .withReplicas(1);
-    final ClusterResource clusterResource3 = createClusterResource(DOMAIN3, NS, CLUSTER_1)
-        .withReplicas(1);
-    testSupport.defineResources(clusterResource2, clusterResource1, clusterResource3);
-
-    configureDomain().withClusterReference(clusterResource1.getMetadata().getName());
+    defineClusterResources(new String[] {DOMAIN2, DOMAIN1, DOMAIN3}, new String[] {NS, NS, NS});
     restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 5);
 
-    assertThat(getUpdatedClusterResource().getMetadata().getName(),
-        equalTo(clusterResource1.getMetadata().getName()));
+    assertThat(getUpdatedClusterResource().getMetadata().getName(), equalTo(DOMAIN1 + '-' + CLUSTER_1));
     assertThat(getUpdatedClusterResource().getSpec().getReplicas(), equalTo(5));
   }
 
   @Test
   void whenMultipleClusterResourceWithSameResourceName_scaleClusterUpdatesClusterInCorrectNamespace() {
-    final ClusterResource clusterResource1 = createClusterResource(DOMAIN1, NS, CLUSTER_1)
-        .withReplicas(1);
-    final ClusterResource clusterResource2 = createClusterResource(DOMAIN1, NS2, CLUSTER_1)
-        .withReplicas(1);
-    final ClusterResource clusterResource3 = createClusterResource(DOMAIN1, NS3, CLUSTER_1)
-        .withReplicas(1);
-    testSupport.defineResources(clusterResource2, clusterResource1, clusterResource3);
-
-    configureDomain().withClusterReference(clusterResource1.getMetadata().getName());
+    defineClusterResources(new String[] {DOMAIN1, DOMAIN1, DOMAIN1}, new String[] {NS2, NS, NS3});
     restBackend.scaleCluster(DOMAIN1, CLUSTER_1, 5);
 
-    assertThat(getUpdatedClusterResource().getMetadata().getName(),
-        equalTo(clusterResource1.getMetadata().getName()));
+    assertThat(getUpdatedClusterResource().getMetadata().getNamespace(), equalTo(NS));
     assertThat(getUpdatedClusterResource().getSpec().getReplicas(), equalTo(5));
+  }
+
+  private void defineClusterResources(String[] domainNames, String[] namespaces) {
+
+    ClusterResource[] clusterResources  = new ClusterResource[domainNames.length];
+    for (int i = 0; i < clusterResources.length; i++) {
+      clusterResources[i] =
+          createClusterResource(domainNames[i], namespaces[i], CLUSTER_1).withReplicas(1);
+    }
+    testSupport.defineResources(clusterResources);
+
+    ClusterResource clusterToReturn = clusterResources[1]; // return the middle one
+    configureDomain().withClusterReference(DOMAIN1 + '-' + CLUSTER_1);
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -248,6 +248,11 @@ public abstract class DomainConfigurator {
     return this;
   }
 
+  public DomainConfigurator withClusterReference(String clusterResourceName) {
+    getDomainSpec().getClusters().add(new V1LocalObjectReference().name(clusterResourceName));
+    return this;
+  }
+
   /**
    * Sets the WebLogic configuration overrides configmap name for the domain.
    *


### PR DESCRIPTION
For merging to cluster-reference branch

Changes to RestEndPointImpl to find the correct Cluster Resource for performing the `scale` REST API operation. The Cluster resource has to be referenced in the `spec.clusters` of the Domain resource, and must be in the same namespace as the Domain resource.