### PR TITLE
Changes to ItMiiDynamicUpdatePart1 and ItMiiDynamicUpdatePart2 for v9

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/domain/ClusterList.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/ClusterList.java
@@ -1,0 +1,151 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@ApiModel(description = "ClusterList is a list of Clusters.")
+public class ClusterList implements KubernetesListObject {
+
+  @ApiModelProperty("The API version for the Cluster.")
+  private String apiVersion;
+
+  @ApiModelProperty("The type of resource. Must be 'ClusterList'.")
+  private String kind;
+
+  @ApiModelProperty(
+      "Standard list metadata. "
+          + "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds.")
+  private V1ListMeta metadata;
+
+  @ApiModelProperty(
+      "List of domains. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md. Required.")
+  private List<ClusterResource> items = new ArrayList<>();
+
+  public ClusterList apiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return this;
+  }
+
+  public String apiVersion() {
+    return apiVersion;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public ClusterList kind(String kind) {
+    this.kind = kind;
+    return this;
+  }
+
+  public String kind() {
+    return kind;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public ClusterList metadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public V1ListMeta metadata() {
+    return metadata;
+  }
+
+  public V1ListMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public List<ClusterResource> items() {
+    return items;
+  }
+
+  public List<ClusterResource> getItems() {
+    return items;
+  }
+
+  public void setItems(List<ClusterResource> items) {
+    this.items = items;
+  }
+
+  public ClusterList withItems(List<ClusterResource> items) {
+    this.items = items;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .append(metadata)
+        .append(apiVersion)
+        .append(items)
+        .append(kind)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof ClusterList)) {
+      return false;
+    }
+    ClusterList rhs = ((ClusterList) other);
+    return new EqualsBuilder()
+        .append(metadata, rhs.metadata)
+        .append(apiVersion, rhs.apiVersion)
+        .append(items, rhs.items)
+        .append(kind, rhs.kind)
+        .isEquals();
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("apiVersion", apiVersion)
+        .append("items", items)
+        .append("kind", kind)
+        .append("metadata", metadata)
+        .toString();
+  }
+
+  /**
+   * Standard list metadata. More info:
+   * https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+   *
+   * @param metadata metadata
+   * @return this
+   */
+  public ClusterList withMetadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDBOperator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDBOperator.java
@@ -398,9 +398,7 @@ class ItDBOperator {
     // Scale down the cluster to repilca count of 1, this will shutdown
     // the managed server managed-server2 in the cluster to trigger
     // JMS/JTA Service Migration.
-    boolean psuccess = assertDoesNotThrow(()
-        -> scaleCluster(wlsDomainUid, wlsDomainNamespace, "cluster-1", 1),
-        String.format("replica patching to 1 failed for domain %s in namespace %s", wlsDomainUid, wlsDomainNamespace));
+    boolean psuccess = scaleCluster("cluster-1", wlsDomainNamespace, 1);
     assertTrue(psuccess,
         String.format("Cluster replica patching failed for domain %s in namespace %s",
             wlsDomainUid, wlsDomainNamespace));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDBOperator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDBOperator.java
@@ -197,7 +197,6 @@ class ItDBOperator {
   @Test
   @DisplayName("Create FMW Domain model in image")
   void  testFmwModelInImageWithDbOperator() {
-    int replicaCount = 1;
 
     // Create the repo secret to pull the image
     // this secret is used only for non-kind cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -810,10 +810,8 @@ class ItIntrospectVersion {
       checkPodReadyAndServiceExists(cluster1ManagedServerPodNamePrefix + i, domainUid, introDomainNamespace);
     }
     // scale down the cluster by 1
-    boolean scalingSuccess = assertDoesNotThrow(()
-        -> scaleCluster(domainUid, introDomainNamespace, "cluster-1", cluster1ReplicaCount - 1),
-        String.format("Scaling down the cluster cluster-1 of domain %s in namespace %s failed",
-            domainUid, introDomainNamespace));
+    boolean scalingSuccess =
+        scaleCluster("cluster-1", introDomainNamespace, cluster1ReplicaCount - 1);
     assertTrue(scalingSuccess,
         String.format("Cluster scaling down failed for domain %s in namespace %s", domainUid, introDomainNamespace));
 
@@ -825,10 +823,7 @@ class ItIntrospectVersion {
     cluster1ReplicaCount--;
 
     // scale up the cluster to cluster1ReplicaCount + 1
-    scalingSuccess = assertDoesNotThrow(()
-        -> scaleCluster(domainUid, introDomainNamespace, "cluster-1", cluster1ReplicaCount + 1),
-        String.format("Scaling up the cluster cluster-1 of domain %s in namespace %s failed",
-            domainUid, introDomainNamespace));
+    scalingSuccess = scaleCluster("cluster-1", introDomainNamespace, cluster1ReplicaCount + 1);
     assertTrue(scalingSuccess,
         String.format("Cluster scaling up failed for domain %s in namespace %s", domainUid, introDomainNamespace));
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDBOperator.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDBOperator.java
@@ -496,9 +496,7 @@ class ItIstioDBOperator {
     // Scale down the cluster to repilca count of 1, this will shutdown
     // the managed server managed-server2 in the cluster to trigger
     // JMS/JTA Service Migration.
-    boolean psuccess = assertDoesNotThrow(()
-        -> scaleCluster(wlsDomainUid, wlsDomainNamespace, "cluster-1", 1),
-        String.format("replica patching to 1 failed for domain %s in namespace %s", wlsDomainUid, wlsDomainNamespace));
+    boolean psuccess = scaleCluster("cluster-1", wlsDomainNamespace, 1);
     assertTrue(psuccess,
         String.format("Cluster replica patching failed for domain %s in namespace %s",
             wlsDomainUid, wlsDomainNamespace));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioDomainInPV.java
@@ -362,20 +362,14 @@ class ItIstioDomainInPV  {
     checkPodDeleted(adminServerPodName, domainUid, domainNamespace);
     logger.info("Administration server shutdown success");
 
-    boolean scalingSuccess = assertDoesNotThrow(() ->
-        scaleCluster(domainUid, domainNamespace, "cluster-1", 1),
-        String.format("Scaling down cluster cluster-1 of domain %s in namespace %s failed",
-        domainUid, domainNamespace));
+    boolean scalingSuccess = scaleCluster("cluster-1", domainNamespace, 1);
     assertTrue(scalingSuccess,
         String.format("Cluster scaling failed for domain %s in namespace %s", domainUid, domainNamespace));
     logger.info("Cluster is scaled down in absence of administration server");
     checkPodDeleted(managedServerPodNamePrefix + "2", domainUid, domainNamespace);
     logger.info("Managed Server stopped in absence of administration server");
 
-    scalingSuccess = assertDoesNotThrow(() ->
-        scaleCluster(domainUid, domainNamespace, "cluster-1", 2),
-        String.format("Scaling up cluster cluster-1 of domain %s in namespace %s failed",
-        domainUid, domainNamespace));
+    scalingSuccess = scaleCluster("cluster-1", domainNamespace, 2);
     assertTrue(scalingSuccess,
         String.format("Cluster scaling failed for domain %s in namespace %s", domainUid, domainNamespace));
     logger.info("Cluster is scaled up in absence of administration server");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -365,7 +365,7 @@ class ItMiiAuxiliaryImage {
 
     patchDomainWithAuxiliaryImageAndVerify(miiAuxiliaryImage1,
         miiAuxiliaryImage3,
-        domainUid1, domainNamespace);
+        domainUid1, domainNamespace, replicaCount);
 
     // verify the server pods are rolling restarted and back to ready state
     logger.info("Verifying rolling restart occurred for domain {0} in namespace {1}",
@@ -1228,7 +1228,7 @@ class ItMiiAuxiliaryImage {
 
     //updating wdt to latest version by patching the domain with image3
     patchDomainWithAuxiliaryImageAndVerify(miiAuxiliaryImage10,
-        miiAuxiliaryImage11, domainUid, wdtDomainNamespace);
+        miiAuxiliaryImage11, domainUid, wdtDomainNamespace, replicaCount);
 
     //check that WDT version is updated to latest 
     assertDoesNotThrow(() -> {
@@ -1297,7 +1297,7 @@ class ItMiiAuxiliaryImage {
     // patch the domain with correct image which exists
     patchDomainWithAuxiliaryImageAndVerify(aiThatDoesntExist + ":" + MII_BASIC_IMAGE_TAG,
         miiAuxiliaryImage1, domainUid,
-        domainNamespace, false);
+        domainNamespace, false, replicaCount);
 
     // verify there is no status condition type Failed
     verifyDomainStatusConditionTypeDoesNotExist(domainUid, domainNamespace, DOMAIN_STATUS_CONDITION_FAILED_TYPE);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCreateAuxImageWithImageTool.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCreateAuxImageWithImageTool.java
@@ -87,7 +87,7 @@ class ItMiiCreateAuxImageWithImageTool {
   private String domain2Uid = "domain2";
   private static String miiImageTag = "new" + MII_BASIC_IMAGE_TAG;
   private static String miiImage = MII_AUXILIARY_IMAGE_NAME + ":" + miiImageTag;
-  private final int replicaCount = 2;
+  private final int replicaCount = 1;
   private static String adminSecretName;
   private static String encryptionSecretName;
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCustomSslStore.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCustomSslStore.java
@@ -141,7 +141,7 @@ class ItMiiCustomSslStore {
     // create the domain CR with a pre-defined configmap
     DomainResource domain = createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
-        adminSecretName, TEST_IMAGES_REPO_SECRET_NAME, encryptionSecretName, replicaCount, 
+        adminSecretName, TEST_IMAGES_REPO_SECRET_NAME, encryptionSecretName, replicaCount,
         pvName, pvcName, configMapName,
         null, false, false, false);
 
@@ -181,7 +181,7 @@ class ItMiiCustomSslStore {
     runClientOnAdminPod();
 
     boolean psuccess = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", 3),
+            scaleCluster("cluster-1", domainNamespace, 3),
         String.format("replica patching to 3 failed for domain %s in namespace %s", domainUid, domainNamespace));
     assertTrue(psuccess,
         String.format("Cluster replica patching failed for domain %s in namespace %s", domainUid, domainNamespace));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
@@ -32,7 +32,6 @@ import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
 import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
-import static oracle.weblogic.kubernetes.actions.TestActions.scaleClusterAndChangeIntrospectVersion;
 import static oracle.weblogic.kubernetes.utils.ApplicationUtils.checkAppIsRunning;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkApplicationRuntime;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.checkWorkManagerRuntime;
@@ -355,14 +354,16 @@ class ItMiiDynamicUpdatePart1 {
   @Order(5)
   @DisplayName("Test modification to Dynamic cluster size parameters")
   void testMiiUpdateDynamicClusterSize() {
-
+    String clusterName = "cluster-1";
     // Scale the cluster by updating the replica count to 5
     logger.info("[Before Patching] updating the replica count to 5");
     boolean p1Success = assertDoesNotThrow(() ->
-            scaleClusterAndChangeIntrospectVersion(domainUid, helper.domainNamespace, "cluster-1", 5, 1234),
-        String.format("Patching replica to 5 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
+            scaleCluster(clusterName, helper.domainNamespace,5),
+        String.format("Patching replica to 5 failed for cluster %s in namespace %s",
+            clusterName, helper.domainNamespace));
     assertTrue(p1Success,
-        String.format("Patching replica to 5 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
+        String.format("Patching replica to 5 failed for cluster %s in namespace %s",
+            clusterName, helper.domainNamespace));
 
     // Make sure the cluster can be scaled to replica count 5 as MaxDynamicClusterSize is set to 5
     checkPodReadyAndServiceExists(helper.managedServerPrefix + "2", domainUid, helper.domainNamespace);
@@ -373,7 +374,7 @@ class ItMiiDynamicUpdatePart1 {
     // Make sure the cluster can be scaled to replica count 1 as MinDynamicClusterSize is set to 1
     logger.info("[Before Patching] updating the replica count to 1");
     boolean p11Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, helper.domainNamespace, "cluster-1", 1),
+            scaleCluster(clusterName, helper.domainNamespace, 1),
         String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
     assertTrue(p11Success,
         String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
@@ -386,10 +387,12 @@ class ItMiiDynamicUpdatePart1 {
     // Bring back the cluster to originally configured replica count
     logger.info("[Before Patching] updating the replica count to 1");
     boolean p2Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, helper.domainNamespace, "cluster-1", helper.replicaCount),
-        String.format("replica pacthing to 1 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
+            scaleCluster(clusterName, helper.domainNamespace, helper.replicaCount),
+        String.format("replica pacthing to 1 failed for cluster %s in namespace %s",
+            clusterName, helper.domainNamespace));
     assertTrue(p2Success,
-        String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
+        String.format("replica patching to 1 failed for cluster %s in namespace %s",
+            clusterName, helper.domainNamespace));
     checkPodReadyAndServiceExists(helper.managedServerPrefix + "1", domainUid, helper.domainNamespace);
 
     // get the creation time of the server pods before patching
@@ -428,7 +431,7 @@ class ItMiiDynamicUpdatePart1 {
     // Scale the cluster using replica count 5, managed-server5 should not come up as new MaxClusterSize is 4
     logger.info("[After Patching] updating the replica count to 5");
     boolean p3Success = assertDoesNotThrow(() ->
-            scaleClusterAndChangeIntrospectVersion(domainUid, helper.domainNamespace, "cluster-1", 5, 5678),
+            scaleCluster(clusterName, helper.domainNamespace, 5),
         String.format("Scaling the cluster cluster-1 of domain %s in namespace %s failed",
             domainUid, helper.domainNamespace));
     assertTrue(p3Success,
@@ -453,12 +456,12 @@ class ItMiiDynamicUpdatePart1 {
     // only managed-server3 and managed-server4 pod should be removed.
     logger.info("[After Patching] updating the replica count to 1");
     boolean p4Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, helper.domainNamespace, "cluster-1", 1),
-        String.format("replica patching to 1 failed for domain %s in namespace %s",
-            domainUid, helper.domainNamespace));
+            scaleCluster(clusterName, helper.domainNamespace, 1),
+        String.format("replica patching to 1 failed for cluster %s in namespace %s",
+            clusterName, helper.domainNamespace));
     assertTrue(p4Success,
-        String.format("Cluster replica patching failed for domain %s in namespace %s",
-            domainUid, helper.domainNamespace));
+        String.format("Cluster replica patching failed for cluster %s in namespace %s",
+            clusterName, helper.domainNamespace));
 
     checkPodReadyAndServiceExists(helper.managedServerPrefix + "2",
         domainUid, helper.domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
@@ -357,10 +357,7 @@ class ItMiiDynamicUpdatePart1 {
     String clusterName = "cluster-1";
     // Scale the cluster by updating the replica count to 5
     logger.info("[Before Patching] updating the replica count to 5");
-    boolean p1Success = assertDoesNotThrow(() ->
-            scaleCluster(clusterName, helper.domainNamespace,5),
-        String.format("Patching replica to 5 failed for cluster %s in namespace %s",
-            clusterName, helper.domainNamespace));
+    boolean p1Success = scaleCluster(clusterName, helper.domainNamespace,5);
     assertTrue(p1Success,
         String.format("Patching replica to 5 failed for cluster %s in namespace %s",
             clusterName, helper.domainNamespace));
@@ -373,9 +370,7 @@ class ItMiiDynamicUpdatePart1 {
 
     // Make sure the cluster can be scaled to replica count 1 as MinDynamicClusterSize is set to 1
     logger.info("[Before Patching] updating the replica count to 1");
-    boolean p11Success = assertDoesNotThrow(() ->
-            scaleCluster(clusterName, helper.domainNamespace, 1),
-        String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
+    boolean p11Success = scaleCluster(clusterName, helper.domainNamespace, 1);
     assertTrue(p11Success,
         String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
 
@@ -386,10 +381,7 @@ class ItMiiDynamicUpdatePart1 {
 
     // Bring back the cluster to originally configured replica count
     logger.info("[Before Patching] updating the replica count to 1");
-    boolean p2Success = assertDoesNotThrow(() ->
-            scaleCluster(clusterName, helper.domainNamespace, helper.replicaCount),
-        String.format("replica pacthing to 1 failed for cluster %s in namespace %s",
-            clusterName, helper.domainNamespace));
+    boolean p2Success = scaleCluster(clusterName, helper.domainNamespace, helper.replicaCount);
     assertTrue(p2Success,
         String.format("replica patching to 1 failed for cluster %s in namespace %s",
             clusterName, helper.domainNamespace));
@@ -430,10 +422,7 @@ class ItMiiDynamicUpdatePart1 {
 
     // Scale the cluster using replica count 5, managed-server5 should not come up as new MaxClusterSize is 4
     logger.info("[After Patching] updating the replica count to 5");
-    boolean p3Success = assertDoesNotThrow(() ->
-            scaleCluster(clusterName, helper.domainNamespace, 5),
-        String.format("Scaling the cluster cluster-1 of domain %s in namespace %s failed",
-            domainUid, helper.domainNamespace));
+    boolean p3Success = scaleCluster(clusterName, helper.domainNamespace, 5);
     assertTrue(p3Success,
         String.format("replica patching to 5 failed for domain %s in namespace %s", domainUid, helper.domainNamespace));
     //  Make sure the 3rd Managed server comes up
@@ -455,10 +444,7 @@ class ItMiiDynamicUpdatePart1 {
     // false, the replica count cannot go below 2. So during the following scale down operation
     // only managed-server3 and managed-server4 pod should be removed.
     logger.info("[After Patching] updating the replica count to 1");
-    boolean p4Success = assertDoesNotThrow(() ->
-            scaleCluster(clusterName, helper.domainNamespace, 1),
-        String.format("replica patching to 1 failed for cluster %s in namespace %s",
-            clusterName, helper.domainNamespace));
+    boolean p4Success = scaleCluster(clusterName, helper.domainNamespace, 1);
     assertTrue(p4Success,
         String.format("Cluster replica patching failed for cluster %s in namespace %s",
             clusterName, helper.domainNamespace));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiUpdateDomainConfig.java
@@ -627,9 +627,7 @@ class ItMiiUpdateDomainConfig {
     // Make sure that we can scale down upto replica count 1
     // since the MinDynamicClusterSize is set to 1
     logger.info("[Before Patching] updating the replica count to 1");
-    boolean p11Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", 1),
-        String.format("replica pacthing to 1 failed for domain %s in namespace %s", domainUid, domainNamespace));
+    boolean p11Success = scaleCluster("cluster-1", domainNamespace, 1);
     assertTrue(p11Success,
         String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, domainNamespace));
 
@@ -640,9 +638,7 @@ class ItMiiUpdateDomainConfig {
 
     // Bring back the cluster to originally configured replica count
     logger.info("[Before Patching] updating the replica count to 2");
-    boolean p2Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", replicaCount),
-        String.format("replica pacthing to 2 failed for domain %s in namespace %s", domainUid, domainNamespace));
+    boolean p2Success = scaleCluster("cluster-1", domainNamespace, replicaCount);
     assertTrue(p1Success,
         String.format("replica patching to 2 failed for domain %s in namespace %s", domainUid, domainNamespace));
     checkPodReadyAndServiceExists(managedServerPrefix + "2", domainUid, domainNamespace);
@@ -726,9 +722,7 @@ class ItMiiUpdateDomainConfig {
     // count can not go below 2. So during the following scale down operation
     // only managed-server3 and managed-server4 pod should be removed.
     logger.info("[After Patching] updating the replica count to 1");
-    boolean p4Success = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", 1),
-        String.format("replica patching to 1 failed for domain %s in namespace %s", domainUid, domainNamespace));
+    boolean p4Success = scaleCluster("cluster-1", domainNamespace, 1);
     assertTrue(p4Success,
         String.format("Cluster replica patching failed for domain %s in namespace %s", domainUid, domainNamespace));
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -27,6 +27,7 @@ import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
+import static oracle.weblogic.kubernetes.actions.impl.Domain.scaleAllClusters;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.adminNodePortAccessible;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.isPodRestarted;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomainAndVerify;
@@ -35,7 +36,6 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndS
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createAndVerifyDomainInImageUsingWdt;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainOnPvUsingWdt;
-import static oracle.weblogic.kubernetes.utils.DomainUtils.scaleClusters;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.shutdownDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
@@ -148,7 +148,7 @@ class ItMultiDomainModels {
     int numberOfServers = 3;
     logger.info("Scaling cluster {0} of domain {1} in namespace {2} to {3} servers.",
         clusterName, domainUid, domainNamespace, numberOfServers);
-    assertDoesNotThrow(() -> scaleClusters(domainUid,domainNamespace,
+    assertDoesNotThrow(() -> scaleAllClusters(domainUid,domainNamespace,
         numberOfServers), "Could not scale up the cluster");
     // check managed server pods are ready
     for (int i = 1; i <= numberOfServers; i++) {
@@ -166,7 +166,7 @@ class ItMultiDomainModels {
     // then scale cluster back to 1 server
     logger.info("Scaling bacck cluster {0} of domain {1} in namespace {2} from {3} servers to {4} servers.",
         clusterName, domainUid, domainNamespace,numberOfServers,replicaCount);
-    assertDoesNotThrow(() -> scaleClusters(domainUid,domainNamespace,
+    assertDoesNotThrow(() -> scaleAllClusters(domainUid,domainNamespace,
         replicaCount), "Could not scale down the cluster");
     for (int i = (replicaCount + 1); i <= numberOfServers; i++) {
       logger.info("Wait for managed server pod {0} to be deleted in namespace {1}",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestart.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorRestart.java
@@ -186,9 +186,7 @@ class ItOperatorRestart {
 
     // scale up the domain by increasing replica count
     replicaCount = 3;
-    boolean scalingSuccess = assertDoesNotThrow(() ->
-            scaleCluster(domainUid, domainNamespace, "cluster-1", replicaCount),
-        String.format("Scaling the cluster cluster-1 of domain %s in namespace %s failed", domainUid, domainNamespace));
+    boolean scalingSuccess = scaleCluster("cluster-1", domainNamespace, replicaCount);
     assertTrue(scalingSuccess,
         String.format("Cluster scaling failed for domain %s in namespace %s", domainUid, domainNamespace));
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItPodsShutdownOption.java
@@ -348,7 +348,7 @@ class ItPodsShutdownOption {
     int newReplicaCount = replicaCount - 1;
     logger.info("Scaling down the cluster {0} in namespace {1} to set the replicas to {2}",
         clusterName, domainNamespace, newReplicaCount);
-    assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, newReplicaCount),
+    assertDoesNotThrow(() -> scaleCluster(clusterName, domainNamespace, newReplicaCount),
         String.format("failed to scale down cluster %s in namespace %s", clusterName, domainNamespace));
 
     checkPodDeleted(managedServerPodNamePrefix + replicaCount, domainUid, domainNamespace);
@@ -418,7 +418,7 @@ class ItPodsShutdownOption {
     int newReplicaCount = replicaCount - 1;
     logger.info("Scaling down the cluster {0} in namespace {1} to set the replicas to {2}",
         clusterName, domainNamespace, newReplicaCount);
-    assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, newReplicaCount),
+    assertDoesNotThrow(() -> scaleCluster(clusterName, domainNamespace, newReplicaCount),
         String.format("failed to scale down cluster %s in namespace %s", clusterName, domainNamespace));
 
     checkPodDeleted(managedServerPodNamePrefix + replicaCount, domainUid, domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -338,18 +338,30 @@ public class TestActions {
   }
 
   /**
+   * Patch the Cluster Custom Resource.
+   *
+   * @param clusterName unique cluster identifier
+   * @param namespace name of namespace
+   * @param patch patch data in format matching the specified media type
+   * @param patchFormat one of the following types used to identify patch document: "application/json-patch+json",
+  "application/merge-patch+json",
+   * @return true if successful, false otherwise
+   */
+  public static boolean patchClusterCustomResource(String clusterName, String namespace,
+                                                   V1Patch patch, String patchFormat) {
+    return Cluster.patchClusterCutomResource(clusterName, namespace, patch, patchFormat);
+  }
+
+  /**
    * Scale the cluster of the domain in the specified namespace by patching the domain resource.
    *
-   * @param domainUid domainUid of the domain to be scaled
-   * @param namespace name of Kubernetes namespace that the domain belongs to
    * @param clusterName cluster in the domain to be scaled
+   * @param namespace name of Kubernetes namespace that the domain belongs to
    * @param numOfServers number of servers to be scaled to.
    * @return true on success, false otherwise
-   * @throws ApiException if Kubernetes client API call fails
    */
-  public static boolean scaleCluster(String domainUid, String namespace, String clusterName, int numOfServers)
-      throws ApiException {
-    return Domain.scaleCluster(domainUid, namespace, clusterName, numOfServers);
+  public static boolean scaleCluster(String clusterName, String namespace, int numOfServers) {
+    return Cluster.scaleCluster(clusterName, namespace, numOfServers);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Cluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Cluster.java
@@ -3,9 +3,13 @@
 
 package oracle.weblogic.kubernetes.actions.impl;
 
+import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiException;
 import oracle.weblogic.domain.ClusterResource;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
+
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 
 public class Cluster {
 
@@ -22,4 +26,46 @@ public class Cluster {
     return Kubernetes.createClusterCustomResource(cluster, clusterVersion);
   }
 
+  /**
+   * Patch the Cluster Custom Resource.
+   *
+   * @param clusterName unique cluster identifier
+   * @param namespace name of namespace
+   * @param patch patch data in format matching the specified media type
+   * @param patchFormat one of the following types used to identify patch document: "application/json-patch+json",
+  "application/merge-patch+json",
+   * @return true if successful, false otherwise
+   */
+  public static boolean patchClusterCutomResource(String clusterName, String namespace,
+                                                  V1Patch patch, String patchFormat) {
+    return Kubernetes.patchClusterCustomResource(clusterName, namespace,
+        patch, patchFormat);
+  }
+
+  /**
+   * Scale the cluster in the specified namespace.
+   *
+   * @param clusterName name of the WebLogic cluster to be scaled in the domain
+   * @param namespace namespace in which the domain exists
+   * @param numOfServers number of servers to be scaled to
+   * @return true if patch domain custom resource succeeds, false otherwise
+   */
+  public static boolean scaleCluster(String clusterName, String namespace, int numOfServers) {
+    LoggingFacade logger = getLogger();
+
+    // construct the patch string for scaling the cluster
+    StringBuffer patchStr = new StringBuffer("[{")
+        .append("\"op\": \"replace\", ")
+        .append("\"path\": \"/spec/replicas\", ")
+        .append("\"value\": ")
+        .append(numOfServers)
+        .append("}]");
+
+    logger.info("Scaling cluster {0} using patch string: {1}",
+        clusterName, patchStr.toString());
+
+    V1Patch patch = new V1Patch(new String(patchStr));
+
+    return Kubernetes.patchClusterCustomResource(clusterName, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH);
+  }
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Cluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Cluster.java
@@ -60,12 +60,10 @@ public class Cluster {
         .append("\"value\": ")
         .append(numOfServers)
         .append("}]");
-
     logger.info("Scaling cluster {0} using patch string: {1}",
         clusterName, patchStr.toString());
 
     V1Patch patch = new V1Patch(new String(patchStr));
-
     return Kubernetes.patchClusterCustomResource(clusterName, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH);
   }
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -66,7 +66,6 @@ import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.WLS_DOMAIN_TYPE;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createConfigMap;
-import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.createSecret;
 import static oracle.weblogic.kubernetes.actions.TestActions.deleteConfigMap;
 import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
@@ -546,14 +545,6 @@ public class CommonMiiTestUtils {
             .name(domainResourceName)
             .namespace(domNamespace))
         .spec(domainSpec);
-
-    logger.info("Create domain custom resource for domainUid {0} in namespace {1}",
-        domainResourceName, domNamespace);
-    boolean domCreated = assertDoesNotThrow(() -> createDomainCustomResource(domain),
-        String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
-            domainResourceName, domNamespace));
-    assertTrue(domCreated, String.format("Create domain custom resource failed with ApiException "
-        + "for %s in namespace %s", domainResourceName, domNamespace));
 
     setPodAntiAffinity(domain);
     return domain;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -597,8 +597,8 @@ public class CommonMiiTestUtils {
     DomainResource domain = createDomainResourceWithLogHome(domainResourceName, domNamespace, imageName,
         adminSecretName, repoSecretName, encryptionSecretName, pvName, pvcName, configMapName,
         dbSecretName, allowReplicasBelowMinDynClusterSize, onlineUpdateEnabled, setDataHome);
-    domain.getSpec().replicas(replicaCount);
-    return domain;
+    DomainSpec spec = domain.getSpec().replicas(replicaCount);
+    return domain.spec(spec);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -420,7 +420,7 @@ public class CommonTestUtils {
               clusterName, domainUid, domainNamespace))
           .isTrue();
     } else {
-      assertThat(assertDoesNotThrow(() -> scaleCluster(domainUid, domainNamespace, clusterName, replicasAfterScale)))
+      assertThat(assertDoesNotThrow(() -> scaleCluster(clusterName, domainNamespace, replicasAfterScale)))
           .as(String.format("Verify scaling cluster %s of domain %s in namespace %s succeeds",
               clusterName, domainUid, domainNamespace))
           .withFailMessage(String.format("Scaling cluster %s of domain %s in namespace %s failed",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.Properties;
 
 import io.kubernetes.client.custom.V1Patch;
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -47,7 +46,6 @@ import oracle.weblogic.domain.DomainStatus;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.TestConstants;
-import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import org.jetbrains.annotations.NotNull;
 
@@ -1001,36 +999,6 @@ public class DomainUtils {
     return Optional.ofNullable(domain.getStatus())
           .map(DomainStatus::conditions).orElse(Collections.emptyList()).stream()
           .map(DomainCondition::getType).anyMatch("Rolling"::equals);
-  }
-
-  /**
-   * Scale the all the cluster(s) of the domain in the specified namespace.
-   *
-   * @param domainUid domainUid of the domain to be scaled
-   * @param namespace namespace in which the domain exists
-   * @param replicaCount number of servers to be scaled to
-   * @return true if patch domain custom resource succeeds, false otherwise
-   * @throws ApiException if Kubernetes client API call fails
-   */
-  public static boolean scaleClusters(String domainUid, String namespace, int replicaCount)
-      throws ApiException {
-    LoggingFacade logger = getLogger();
-
-    // construct the patch string for scaling the cluster in the domain
-    StringBuffer patchStr = new StringBuffer("[{")
-        .append("\"op\": \"replace\", ")
-        .append("\"path\": \"/spec")
-        .append("/replicas\", ")
-        .append("\"value\": ")
-        .append(replicaCount)
-        .append("}]");
-
-    logger.info("Scaling all cluster(s) in domain {0} using patch string: {1}",
-        domainUid, patchStr.toString());
-
-    V1Patch patch = new V1Patch(new String(patchStr));
-
-    return Kubernetes.patchDomainCustomResource(domainUid, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH);
   }
 
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -372,25 +372,27 @@ public class DomainUtils {
    * @param newImageName new auxiliary image name
    * @param domainUid uid of the domain
    * @param domainNamespace domain namespace
+   * @param replicaCount replica count to verify
    */
   public static void patchDomainWithAuxiliaryImageAndVerify(String oldImageName, String newImageName,
-                                                            String domainUid, String domainNamespace) {
+                                                            String domainUid, String domainNamespace,
+                                                            int replicaCount) {
     patchDomainWithAuxiliaryImageAndVerify(oldImageName, newImageName, domainUid,
-        domainNamespace, true);
+        domainNamespace, true, replicaCount);
   }
 
   /**
    * Patch a domain with auxiliary image and verify pods are rolling restarted.
-   *
-   * @param oldImageName         old auxiliary image name
+   *  @param oldImageName         old auxiliary image name
    * @param newImageName         new auxiliary image name
    * @param domainUid            uid of the domain
    * @param domainNamespace      domain namespace
    * @param verifyRollingRestart verify if the pods are rolling restarted
+   * @param replicaCount replica count to verify
    */
   public static void patchDomainWithAuxiliaryImageAndVerify(String oldImageName, String newImageName,
                                                             String domainUid, String domainNamespace,
-                                                            boolean verifyRollingRestart) {
+                                                            boolean verifyRollingRestart, int replicaCount) {
 
     String adminServerPodName = domainUid + "-admin-server";
     String managedServerPrefix = domainUid + "-managed-server";
@@ -426,7 +428,7 @@ public class DomainUtils {
     //get current timestamp before domain rolling restart to verify domain roll events
     if (verifyRollingRestart) {
       podsWithTimeStamps = getPodsWithTimeStamps(domainNamespace, adminServerPodName,
-          managedServerPrefix, 2);
+          managedServerPrefix, replicaCount);
     }
     V1Patch patch = new V1Patch((patchStr).toString());
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FmwUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FmwUtils.java
@@ -96,7 +96,8 @@ public class FmwUtils {
                     .domainType("JRF")
                     .runtimeEncryptionSecret(encryptionSecretName))
                 .addSecretsItem(rcuAccessSecretName)
-                .introspectorJobActiveDeadlineSeconds(600L)));
+                .introspectorJobActiveDeadlineSeconds(600L))
+            .replicas(replicaCount));
 
     return domain;
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/MiiDynamicUpdateHelper.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/MiiDynamicUpdateHelper.java
@@ -17,14 +17,12 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_PASSWORD_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.getDomainCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
-import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDatabaseSecret;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResourceWithLogHome;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainSecret;
@@ -39,6 +37,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getUniqueName;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withStandardRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ConfigMapUtils.createConfigMapAndVerify;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createBaseRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createTestRepoSecret;
 import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
@@ -136,20 +135,14 @@ public class MiiDynamicUpdateHelper {
     // setting setDataHome to false, testMiiRemoveTarget fails when data home is set at domain resource level
     // because of bug OWLS-88679
     // testMiiRemoveTarget should work fine after the bug is fixed with setDataHome set to true
-    createDomainResourceWithLogHome(domainUid, domainNamespace,
+    DomainResource domain = createDomainResourceWithLogHome(domainUid, domainNamespace,
         MII_BASIC_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG,
-        adminSecretName, BASE_IMAGES_REPO_SECRET_NAME, encryptionSecretName,
+        adminSecretName, BASE_IMAGES_REPO_SECRET_NAME, encryptionSecretName, replicaCount,
         pvName, pvcName, configMapName,
         dbSecretName, false, true, false);
 
-    // wait for the domain to exist
-    logger.info("Check for domain custom resource in namespace {0}", domainNamespace);
-    testUntil(
-        domainExists(domainUid, DOMAIN_VERSION, domainNamespace),
-        logger,
-        "domain {0} to be created in namespace {1}",
-        domainUid,
-        domainNamespace);
+    createDomainAndVerify(domain, domainNamespace);
+
   }
 
   /**


### PR DESCRIPTION
Changes to ItMiiDynamicUpdatePart1 and ItMiiDynamicUpdatePart2 for v9. Other classes which use scaleCluster methods are also modified for just the method call.

Jenkins results - failures because of defects
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12342/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12351/

Defects
https://jira.oraclecorp.com/jira/browse/OWLS-101872
https://jira.oraclecorp.com/jira/browse/OWLS-101921
