### PR TITLE
owls-101782 - fix test failure in ItMultiDomainModelsWithLoadBalancer.testMiiMultiClustersRollingRestart in cluster-reference branch

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
@@ -37,7 +37,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.DomainUtils;
 import oracle.weblogic.kubernetes.utils.ExecResult;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -681,7 +680,6 @@ class ItMultiDomainModelsWithLoadBalancer {
    * Verify domain changed event is logged.
    * Disabled for now due to bug.
    */
-  @Disabled
   @Test
   @DisplayName("Verify server pods are restarted only once by changing the imagePullPolicy in multi-cluster domain")
   void testMiiMultiClustersRollingRestart() {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -338,7 +338,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
       return true;
     } else if (liveInfo.isFromOutOfDateEvent(operation, cachedInfo) || liveInfo.isDomainProcessingHalted(cachedInfo)) {
       return false;
-    } else if (operation.isExplicitRecheck() || liveInfo.isGenerationChanged(cachedInfo)) {
+    } else if (operation.isExplicitRecheck() || liveInfo.isDomainGenerationChanged(cachedInfo)) {
       return true;
     } else {
       cachedInfo.setDomain(liveInfo.getDomain());

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -128,31 +128,16 @@ public class DomainPresenceInfo implements PacketComponent {
   }
 
   /**
-   * Returns true if the domain or any referenced cluster in this presence info has a later generation
+   * Returns true if the domain in this presence info has a later generation
    * than the passed-in cached info.
    * @param cachedInfo another presence info against which to compare this one.
    */
-  public boolean isGenerationChanged(DomainPresenceInfo cachedInfo) {
-    return isDomainGenerationChanged(cachedInfo) || isAnyClusterGenerationChanged(cachedInfo);
-  }
-
-  private boolean isDomainGenerationChanged(DomainPresenceInfo cachedInfo) {
+  public boolean isDomainGenerationChanged(DomainPresenceInfo cachedInfo) {
     return getGeneration(getDomain()).compareTo(getGeneration(cachedInfo.getDomain())) > 0;
   }
 
   private Long getGeneration(KubernetesObject resource) {
     return Optional.ofNullable(resource).map(KubernetesObject::getMetadata).map(V1ObjectMeta::getGeneration).orElse(0L);
-  }
-
-  private boolean isAnyClusterGenerationChanged(DomainPresenceInfo cachedInfo) {
-    List<ClusterResource> cachedClusters = cachedInfo.getReferencedClusters();
-    List<ClusterResource> currentClusters = getReferencedClusters();
-    if (cachedClusters.size() != currentClusters.size()) {
-      return true;
-    }
-    return currentClusters.stream().anyMatch(x -> cachedClusters.stream()
-        .filter(y -> y.getClusterName().equals(x.getClusterName())).findFirst()
-        .map(y -> getGeneration(x).compareTo(getGeneration(y)) > 0).orElse(true));
   }
 
   /**


### PR DESCRIPTION
`DomainPresenceInfo` created for `MakeRightDomainOperation` for Domain watch responses don't have cluster resources. This causes `isAnyClusterGenerationChanged()` to return true, and `shouldContinue()` in `DomainProcessorImpl` to return true when the domain generation hasn't changed. 

Change is not to perform generation check of `Cluster` resources from `shouldContinue()`. This is ok since `MakeRightDomainOperation` for Cluster watch responses are created with `withExplicitRecheck`.

Test `testMiiMultiClustersRollingRestart` is re-enabled and passed: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12554

jenkins: More tests passed and no regression compared to cluster-reference branch:
cluster-reference branch: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12545
owls101782 branch: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12546


