### PR TITLE
OWLS-101923 fix integration test code in cluster-reference

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIntrospectVersion.java
@@ -288,16 +288,7 @@ class ItIntrospectVersion {
     assertTrue(patchDomainCustomResource(domainUid, introDomainNamespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
         "Failed to patch domain");
 
-    patchStr
-        = "["
-        + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}"
-        + "]";
-    logger.info("Updating replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
-    patch = new V1Patch(patchStr);
-    assertTrue(patchClusterCustomResource(cluster1Name, introDomainNamespace, patch,
-        V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");
-
-    //verify the introspector pod is created and runs
+    // verify the introspector pod is created and runs
     logger.info("Verifying introspector pod is created, runs and deleted");
     String introspectPodNameBase = getIntrospectJobName(domainUid);
     checkPodExists(introspectPodNameBase, domainUid, introDomainNamespace);
@@ -313,6 +304,15 @@ class ItIntrospectVersion {
       }
       return false;
     }, logger, "Domain.status.clusters.{0}.maximumReplicas to be {1}", cluster1Name, 3);
+
+    patchStr
+        = "["
+        + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}"
+        + "]";
+    logger.info("Updating replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
+    patch = new V1Patch(patchStr);
+    assertTrue(patchClusterCustomResource(cluster1Name, introDomainNamespace, patch,
+        V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");
 
     // verify the 3rd server pod comes up
     checkPodReadyAndServiceExists(cluster1ManagedServerPodNamePrefix + 3, domainUid, introDomainNamespace);


### PR DESCRIPTION
The test performs the following:
1. modify the WebLogic domain to increase the cluster size; 
2. patch the domain resource to have a new introspectVersion;
3. patch the cluster resource to increase its replica count.

Step#3 fails because the operator has not completed the re-introspection caused by step #2, and therefore, the new cluster size is not reflected in the cluster's status. 

The fix is to wait for the cluster's status is updated before proceeding to step#3.

The failing test case passed with the changes (https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12590/ ).