### PR TITLE
OWLS-102288 fix test code

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -68,6 +68,7 @@ import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRolling
 import static oracle.weblogic.kubernetes.utils.ClusterUtils.addClusterToDomain;
 import static oracle.weblogic.kubernetes.utils.ClusterUtils.createClusterAndVerify;
 import static oracle.weblogic.kubernetes.utils.ClusterUtils.createClusterResource;
+import static oracle.weblogic.kubernetes.utils.ClusterUtils.removeReplicasSettingAndVerify;
 import static oracle.weblogic.kubernetes.utils.ClusterUtils.scaleCluster;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceExists;
@@ -413,17 +414,20 @@ class ItKubernetesDomainEvents {
   void testDomainK8sEventsScalePastMaxAndChangeIntrospectVersion() {
     OffsetDateTime timestamp = now();
     try {
-      logger.info("Scaling cluster using patching");
+      removeReplicasSettingAndVerify(domainUid, cluster1Name, domainNamespace3, replicaCount,
+          managedServerPodNamePrefix);
+
       String introspectVersion = assertDoesNotThrow(() -> getNextIntrospectVersion(domainUid, domainNamespace3));
-      assertFalse(scaleCluster(cluster1Name, domainNamespace3, 3), "failed to scale cluster via patching");
       String patchStr
           = "["
-          + "{\"op\": \"replace\", \"path\": \"/spec/introspectVersion\", \"value\": \"" + introspectVersion + "\"}"
+          + "{\"op\": \"replace\", \"path\": \"/spec/introspectVersion\", \"value\": \"" + introspectVersion + "\"},"
+          + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}"
           + "]";
 
       logger.info("Updating introspect version  using patch string: {0}",  patchStr);
-      assertFalse(patchDomainCustomResource(domainUid, domainNamespace3, new V1Patch(patchStr),
-              V1Patch.PATCH_FORMAT_JSON_PATCH), "Patch domain did not fail as expected");
+      assertTrue(patchDomainCustomResource(domainUid, domainNamespace3, new V1Patch(patchStr),
+          V1Patch.PATCH_FORMAT_JSON_PATCH), "Patch domain did not fail as expected");
+
 
       logger.info("verify the Failed event is generated");
       checkFailedEvent(opNamespace, domainNamespace3, domainUid, REPLICAS_TOO_HIGH_ERROR, "Warning", timestamp);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ClusterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ClusterUtils.java
@@ -21,6 +21,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.patchClusterCustomR
 import static oracle.weblogic.kubernetes.actions.impl.Cluster.listClusterCustomResources;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.clusterDoesNotExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.clusterExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -153,5 +154,26 @@ public class ClusterUtils {
     // set cluster references
     domain.getSpec().withCluster(new V1LocalObjectReference().name(clusterResName));
     return domain;
+  }
+
+  /**
+   * Remove the replicas setting from a cluster resource.
+   *  @param domainUid uid of the domain
+   * @param clusterName name of the cluster resource
+   * @param namespace namespace
+   * @param replicaCount original replicaCount
+   * @param msPodNamePrefix prefix of managed server pod names
+   * */
+  public static void removeReplicasSettingAndVerify(String domainUid, String clusterName, String namespace,
+                                                    int replicaCount, String msPodNamePrefix) {
+    getLogger().info("Remove replicas setting from cluster resource {0} in namespace {1}", clusterName, namespace);
+    String patchStr = "[{\"op\": \"remove\",\"path\": \"/spec/replicas\"}]";
+    assertTrue(patchClusterCustomResource(clusterName, namespace, new V1Patch(patchStr),
+        V1Patch.PATCH_FORMAT_JSON_PATCH), "Patch cluster resource failed");
+
+    // verify there is no pod created larger than max size of cluster
+    for (int i = 1; i <= replicaCount; i++) {
+      checkPodReadyAndServiceExists(msPodNamePrefix + i, domainUid, namespace);
+    }
   }
 }


### PR DESCRIPTION
Modify integration test case to cover what is intended to test.

The test case does the following:
- patch cluster resource above max of replicas, which failed as expected.
- patch domain with new introspect number
- check domain event to be generated for replicas too high.

Because step #1 failed, the change to the cluster's replicas does not even get to the operator, and therefore, the operator does not know about it, not to mention generating a Failed condition (and events).

In order for an invalid replicas to be accepted and reach to the operator, the cluster resource itself should not have a replicas set, and the domain resource's replicas and introspectVersion need to be changed in a single patch operation.

There are two approaches to make sure that the cluster resource does not have replicas:
1) add a new cluster resource that does not have the replicas set. You need also make sure that the cluster is configured on the WebLogic domain side. 
2) remove the replicas setting from the existing cluster resources. 

This PR contains the integration test code change with approach #2. The failing test case passed with this branch. https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12742/
