### PR TITLE
Fixfor failures in ItMiiDomainModelInPV and ItDiagnosticsCompleteAvailableCondition

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -387,7 +387,7 @@ class ItDiagnosticsCompleteAvailableCondition {
       logger.info("patch the cluster resource with new cluster replica count {0}", newReplicaCount);
       patchStr
           = "["
-          + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": " + newReplicaCount + "},"
+          + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": " + newReplicaCount + "}"
           + "]";
       assertTrue(patchClusterCustomResource(cluster1Name, domainNamespace1,
           new V1Patch(patchStr), V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDomainModelInPV.java
@@ -253,8 +253,8 @@ public class ItMiiDomainModelInPV {
     logger.info("Creating domain custom resource with domainUid {0} and image {1}",
         domainUid, image);
     DomainResource domainCR = CommonMiiTestUtils.createDomainResource(domainUid, domainNamespace,
-        image, adminSecretName, createSecretsForImageRepos(domainNamespace), encryptionSecretName
-    );
+        image, adminSecretName, createSecretsForImageRepos(domainNamespace), encryptionSecretName,
+        2, List.of(clusterName));
     domainCR.spec().configuration().model().withModelHome(modelMountPath + "/model");
     domainCR.spec().serverPod()
         .addVolumesItem(new V1Volume()


### PR DESCRIPTION
remove the extra character in patch string in ItDiagnosticsCompleteAvailableCondition 
add cluster resource in ItMiiDomainModelInPV 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12794/