### PR TITLE
OWLS-101608 - update scalingAction.sh for operator 3.4 to work in k8s clusters with operator 4.0 installed

### DIFF
--- a/operator/scripts/scaling/scalingAction.sh
+++ b/operator/scripts/scaling/scalingAction.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # script parameters
@@ -134,6 +134,13 @@ for i in json.load(sys.stdin)["groups"]:
     print((i["preferredVersion"]["version"]))
 INPUT
 domain_api_version=`echo ${APIS} | python cmds-$$.py 2>> ${log_file_name}`
+  fi
+
+  # This script only supports up to version v8 of Domain resource
+  version=$(echo "${domain_api_version}" | grep -Eo '[0-9]+$')
+  if [ -n "${version}" ] && [ "$version" -gt 8 ]; then
+    trace "Setting domain_api_version from $domain_api_version to v8"
+    domain_api_version="v8"
   fi
   echo "$domain_api_version"
 }
@@ -434,14 +441,8 @@ port=$(get_operator_internal_rest_port)
 trace "port: $port"
 
 # Retrieve the api version of the deployed CRD
-# This script supports up to version v8 of Domain resource 
 domain_api_version=$(get_domain_api_version)
 trace "domain_api_version: $domain_api_version"
-version=$(echo ${domain_api_version} | grep -Eo '[0-9]+$')
-if [ $version -gt 8 ]; then
-  domain_api_version="v8"
-  trace "Setting domain_api_version to v8 which is the highest version supported by this script."
-fi
 
 # Retrieve the Domain configuration
 DOMAIN=$(get_custom_resource_domain)

--- a/operator/scripts/scaling/scalingAction.sh
+++ b/operator/scripts/scaling/scalingAction.sh
@@ -434,8 +434,14 @@ port=$(get_operator_internal_rest_port)
 trace "port: $port"
 
 # Retrieve the api version of the deployed CRD
+# This script supports up to version v8 of Domain resource 
 domain_api_version=$(get_domain_api_version)
 trace "domain_api_version: $domain_api_version"
+version=$(echo ${domain_api_version} | grep -Eo '[0-9]+$')
+if [ $version -gt 8 ]; then
+  domain_api_version="v8"
+  trace "Setting domain_api_version to v8 which is the highest version supported by this script."
+fi
 
 # Retrieve the Domain configuration
 DOMAIN=$(get_custom_resource_domain)

--- a/operator/src/test/sh/scaling/apis3.json
+++ b/operator/src/test/sh/scaling/apis3.json
@@ -1,0 +1,28 @@
+{
+  "kind": "APIGroupList",
+  "apiVersion": "v1",
+  "groups": [
+    {
+      "name": "weblogic.oracle",
+      "versions": [
+        {
+          "groupVersion": "weblogic.oracle/v9",
+          "version": "v9"
+        },
+        {
+          "groupVersion": "weblogic.oracle/v8",
+          "version": "v8"
+        },
+        {
+          "groupVersion": "weblogic.oracle/v1",
+          "version": "v1"
+        }
+      ],
+      "preferredVersion": {
+        "groupVersion": "weblogic.oracle/v9",
+        "version": "v9"
+      }
+    }
+  ]
+}
+

--- a/operator/src/test/sh/scaling/scalingActionTest.sh
+++ b/operator/src/test/sh/scaling/scalingActionTest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021,2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 TEST_OPERATOR_ROOT=/tmp/test/weblogic-operator
@@ -43,6 +43,25 @@ test_get_domain_api_version_jq() {
 
   assertEquals "Did not return expected api version" 'v8' "${result}"  
 }
+
+test_get_domain_api_version_set_to_v8() {
+  CURL_FILE="apis3.json"
+
+  result=$(get_domain_api_version)
+
+  assertEquals "Did not return expected api version" 'v8' "${result}"
+}
+
+test_get_domain_api_version_set_to_v8_jq() {
+  skip_if_jq_not_installed
+
+  CURL_FILE="apis3.json"
+
+  result=$(get_domain_api_version)
+
+  assertEquals "Did not return expected api version" 'v8' "${result}"
+}
+
 
 test_get_domain_api_version_without_weblogic_group() {
   CURL_FILE="apis2.json"

--- a/operator/src/test/sh/scaling/scalingActionTest.sh
+++ b/operator/src/test/sh/scaling/scalingActionTest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2021,2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 TEST_OPERATOR_ROOT=/tmp/test/weblogic-operator


### PR DESCRIPTION
Updates the scalingAction.sh script in release/3.4 branch to request v8 version of Domain resource, so it would work in domains managed by Operator 3.4 in a k8s cluster with Operator 4.0 and v9 Domain CRD installed, and operator Webhook running.

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12772/
