### PR TITLE
WIP: Update wl-pod-wait.sh to use complete & generations

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/utils/wl-pod-wait.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/utils/wl-pod-wait.sh
@@ -16,23 +16,31 @@ usage() {
   Usage:
 
     $(basename $0) [-n mynamespace] [-d mydomainuid] \\
-       [-p expected_pod_count] [-t timeout_secs] [-q]
+       [-p 0|Completed] [-t timeout_secs] [-q]
 
   Description:
 
-    This utility script exits successfully when the designated number of
-    WebLogic Server pods in the given WebLogic Kubernetes Operator domain
-    reach a 'ready' state and have 'restartVersion', 'introspectVersion',
-    'spec.image', and 'spec.serverPod.auxiliaryImages.image' values that match
-    their corresponding values in their domain resource.
+    This utility script exits successfully when a domain UID
+    has reached zero pods (the default), or when the
+    domain resource status 'Completed' condition is True.
 
-    If the designated number of pods is zero, then this script exits
-    successfully when all pods for the given domain have exited.
+    A domain resource is completed when exactly the expected
+    number of WebLogic Server pods reach a 'ready' state
+    and have 'restartVersion', 'introspectVersion',
+    'spec.image', and 'spec.configuration.model.auxiliaryImages.image'
+    values that match their corresponding values in their domain resource.
+    If the Completed condition state expects the number of pods to be zero,
+    such as when 'domain.spec.serverStartPolicy' is set to 'Never',
+    then the '-p Completed' option exits successfully when all pods for
+    the given domain have exited.
 
-    This script exits non-zero if a configurable timeout is reached
-    before the target pod count is reached (default $timeout_secs
-    seconds). It also exists non-zero if the specified domain
-    cannot be found and the target pod count is at least one.
+    This script exits non-zero if:
+    - A configurable timeout is reached before the target pod count
+      is reached (default $timeout_secs seconds).
+    - The '-p Completed' option is specified and the specified domain
+      cannot be found.
+    - When the domain resource '.apiVersion' is less than 9.
+    - When a Failure condition is detected and '-i' is NOT specified.
 
   Parameters:
 
@@ -41,80 +49,95 @@ usage() {
     -n <namespace>  : Kubernetes namespace.
                       Defaults to '$DOMAIN_NAMESPACE'.
 
-    -p 0            : Wait until there are no running WebLogic Server pods
-                      for a domain. The default.
-
-    -p <pod_count>  : Wait until all of the following are true
-                      for exactly 'pod_count' WebLogic Server pods
-                      in the domain:
-                      - ready
-                      - same 'weblogic.domainRestartVersion' label value as
-                        the domain resource's 'spec.restartVersion'
-                      - same 'weblogic.introspectVersion' label value as
-                        the domain resource's 'spec.introspectVersion'
-                      - same image as the domain resource's 'spec.image'
-                      - same image(s) as specified in the domain resource's
-                        optional 'spec.serverPod.auxiliaryImages.image'
-
     -t <timeout>    : Timeout in seconds. Defaults to '$timeout_secs'.
+
+    -p 0            : Expect no pods. This works even when the
+                      domain resource is deleted. The default.
+
+    -p Completed    : Expect domain status condition 'Completed' to be True.
 
     -q              : Quiet mode. Show only a count of wl pods that
                       have reached the desired criteria.
+
+    -i              : Ignore Failure conditions.
 
     -?              : This help.
 
 EOF
 }
 
-expected=0
-syntax_error=false
-verbose=true
-report_interval=120
-
-while [ ! "${1:-}" = "" ]; do
-  if [ ! "$1" = "-?" ] && [ ! "$1" = "-q" ] && [ "${2:-}" = "" ]; then
-    syntax_error=true
-    break
-  fi
-  case "$1" in
-    -n) DOMAIN_NAMESPACE="${2}"
-        ;;
-    -d) DOMAIN_UID="${2}"
-        ;;
-    -t) timeout_secs="$2"
-        case "$2" in
-          ''|*[!0-9]*) syntax_error=true ;;
-        esac
-        ;;
-    -p) expected="$2"
-        case "$2" in
-          ''|*[!0-9]*) syntax_error=true ;;
-        esac
-        ;;
-    -q) verbose=false
-        report_interval=30
-        shift
-        continue
-        ;;
-    -?) usage
-        exit 0
-        ;;
-    *)  syntax_error=true
-        break
-        ;;
-  esac
-  shift
-  shift
-done
-
-if [ "$syntax_error" = "true" ]; then
-  echo "@@ Error: Syntax error when calling $(basename $0). Pass '-?' for usage."
-  exit 1
-fi
-
 timestamp() {
   date --utc '+%Y-%m-%dT%H:%M:%S'
 }
+
+trace() {
+  echo "@@ [$(timestamp)][seconds=$SECONDS]" "$@"
+}
+
+tracen() {
+  echo -n "@@ [$(timestamp)][seconds=$SECONDS]" "$@"
+}
+
+
+syntaxError() {
+  trace "Syntax Error: \"${1:-}\". Pass '-?' for usage."
+  exit 1
+}
+
+expected=0
+verbose=true
+ignore_failures=false
+report_interval=120
+
+while [ ! "${1:-}" = "" ]; do
+
+  key="${1}"
+  val="${2:-}"
+
+  case "$key" in
+    -q|-i|'-?') 
+       shift
+       ;;
+
+    -n|-d|-t|-p)
+       [ "$val" = "" ] && syntaxError "$key is missing an argument"
+       shift
+       shift
+       ;;
+
+    *) syntaxError "unrecognized argument '$key'" ;;
+  esac
+
+  case "$key" in
+    -n) DOMAIN_NAMESPACE="${val}" ;;
+
+    -d) DOMAIN_UID="${val}" ;;
+
+    -t) timeout_secs="${val}"
+        case "${val}" in
+          ''|*[!0-9]*) syntaxError "-t requires a positive integer but got '${val}'" ;;
+        esac
+        ;;
+
+    -p) case "$val" in
+          0|none) expected='0' ;;
+          completed|Completed|COMPLETED) expected='Completed' ;;
+          *) syntaxError '-p requires value "0" or "Completed"' ;;
+        esac
+        ;;
+
+    -q) verbose=false
+        report_interval=30
+        ;;
+
+    -i) ignore_failures=true
+        ;;
+
+    '-?') usage
+        exit 0
+        ;;
+  esac
+done
 
 tempfile() {
   mktemp /tmp/$(basename "$0").$PPID.$(timestamp).XXXXXX
@@ -172,30 +195,57 @@ sortAIImagesUnitTest
 
 
 getDomainValue() {
-  # get domain value specified by $1 and put in env var named by $2
-  #   - if get fails, and global expected is >0, then echo an Error and exit script non-zero
-  #   - example: getDomainValue '.spec.introspectVersion' DOM_VERSION
+  # get domain value specified by $2 and put in env var named by $1
+  #   - if get fails, and global expected is "Completed", then echo an Error and exit script non-zero
+  #   - example: getDomainValue DOM_VERSION '.spec.introspectVersion'
+  local __retvar=$1
+  local ljpath="{$2}"
   local attvalue
-  local ljpath="{$1}"
-  local __retvar=$2
   set +e
   attvalue=$(kubectl -n ${DOMAIN_NAMESPACE} get domain ${DOMAIN_UID} -o=jsonpath="$ljpath" 2>&1)
   if [ $? -ne 0 ]; then
-    if [ $expected -ne 0 ]; then
-      echo "@@ Error: Could not obtain '$1' from '${DOMAIN_UID}' in namespace '${DOMAIN_NAMESPACE}'. Is your domain resource deployed? Err='$attvalue'"
+    if [ "$expected" = "Completed" ]; then
+      trace "Error: Could not obtain '$ljpath' from domain '${DOMAIN_UID}' in namespace '${DOMAIN_NAMESPACE}'. Is your domain resource deployed? Err='$attvalue'"
       exit 1
     else
       # We're waiting for 0 pods - domain might have been deleted, and it doesn't matter what the value is
-      attvalue='':
+      attvalue=''
     fi
   fi
+  # echo "DEBUG kubectl -n ${DOMAIN_NAMESPACE} get domain ${DOMAIN_UID} -o=jsonpath=\"$ljpath\" 2>&1"
+  # echo "DEBUG   = '$attvalue'"
+  eval "$__retvar='$attvalue'"
+  set -e
+}
+
+getClusterValue() {
+  # get cluster value specified by $3 from cluster $1 and put in env var named by $2
+  #   - if get fails, and global expected is "Completed", then echo an Error and exit script non-zero
+  #   - example: getClusterValue my-cluster cgen '.metadata.generation'
+  local cname="$1"
+  local __retvar=$2
+  local ljpath="{$3}"
+  local attvalue
+  set +e
+  attvalue=$(kubectl -n ${DOMAIN_NAMESPACE} get cluster ${cname} -o=jsonpath="$ljpath" 2>&1)
+  if [ $? -ne 0 ]; then
+    if [ "$expected" = "Completed" ]; then
+      trace "Error: Could not obtain '$ljpath' from cluster '${cname}' in namespace '${DOMAIN_NAMESPACE}'. Is your cluster resource deployed? Err='$attvalue'"
+      exit 1
+    else
+      # We're waiting for 0 pods - cluster might have been deleted, and it doesn't matter what the value is
+      attvalue=''
+    fi
+  fi
+  # echo "DEBUG kubectl -n ${DOMAIN_NAMESPACE} get cluster ${cname} -o=jsonpath=\"$ljpath\" 2>&1"
+  # echo "DEBUG   = '$attvalue'"
   eval "$__retvar='$attvalue'"
   set -e
 }
 
 getDomainAIImages() {
   # get list of domain auxiliary images (if any) and place result in the env var named by $1
-  #   - if expected>0 and get fails, then echo an Error and exit script non-zero
+  #   - if expected is "Completed" and get fails, then echo an Error and exit script non-zero
   #   - result is a sorted comma separated list
   local attvalue
   local __retvar=$1
@@ -208,8 +258,8 @@ getDomainAIImages() {
       2>&1
   )
   if [ $? -ne 0 ]; then
-    if [ $expected -ne 0 ]; then
-      echo "@@ Error: Could not obtain '.spec.serverPod' from '${DOMAIN_UID}' in namespace '${DOMAIN_NAMESPACE}'. Is your domain resource deployed? Err='$attvalue'"
+    if [ "$expected" = "Completed" ]; then
+      trace "Error: Could not obtain '.spec.configuration.model.auxiliaryImages' from '${DOMAIN_UID}' in namespace '${DOMAIN_NAMESPACE}'. Is your domain resource deployed? Err='$attvalue'"
       exit 1
     else
       # We're waiting for 0 pods - it doesn't matter what the value is
@@ -221,112 +271,200 @@ getDomainAIImages() {
   eval "$__retvar='$attvalue'"
 }
 
+getDomainInfo() {
+  # Get info about the current domain and populate it into global variables
+  #
+  # If any its gets fail then the following implicitly occurs:
+  #   - we assume that the domain resource was not found
+  #   - silently set global to "" if expected = '0'
+  #   - "exit 1" and report an error if expected = 'Completed'
+
+  getDomainValue    goal_RV_current        ".spec.restartVersion"
+  getDomainValue    goal_IV_current        ".spec.introspectVersion"
+  getDomainValue    goal_image_current     ".spec.image"
+  getDomainValue    clusters               ".spec.clusters"
+  getDomainAIImages goal_aiimages_current
+  getDomainValue    api_version            ".apiVersion"
+  getDomainValue    condition_failed_str   ".status.conditions[?(@.type==\"Failed\")]" # has full failure messages, if any
+  getDomainValue    condition_completed    ".status.conditions[?(@.type==\"Completed\")].status" # "True" when complete
+  getDomainValue    observed_generation    ".status.observedGeneration"
+
+  clusters=$( echo "$clusters" | sed 's/"name"//g' | tr -d '[]{}:' | sortlist | sed 's/,/ /') # convert to sorted space separated list
+
+  cl_observed_generations=""
+  cl_goal_generations=""
+  local lgen
+  local cl
+  for cl in $clusters EOL; do
+    [ "$cl" = "EOL" ] && break
+    getClusterValue $cl lgen ".status.observedGeneration"
+    [ -z "$lgen" ] && lgen="NOTSET"
+    cl_observed_generations="$cl_observed_generations $lgen"
+
+    getClusterValue $cl lgen ".metadata.generation"
+    cl_goal_generations="$cl_goal_generations $lgen"
+  done
+
+  for cl in $clusters EOL; do
+    [ "$cl" = "EOL" ] && break
+  done
+
+  # Get goal generation last in case gen changed while checking the above...
+  getDomainValue    goal_generation        ".metadata.generation"
+
+  all_goals_current="${goal_RV_current}
+${goal_IV_current}
+${goal_image_current}
+${goal_aiimages_current}
+${goal_generation}
+${observed_generation}
+${cl_goal_generations}
+${cl_observed_generations}
+${condition_failed_str}
+${clusters}
+^M"
+}
+
+getPodInfo() {
+  # get interesting info about each pod in DOMAIN_NAMESPACE with DOMAIN_UID
+  # output: stdout in the form "var=;value; var2=;value; ..." (one line per pod)
+  #
+  # NOTE: ljpath must correspond with the regex below and column headers below 
+
+  local ljpath=''
+  ljpath+='{range .items[*]}'
+    ljpath+='{" name="}'
+    ljpath+='{";"}{.metadata.name}{";"}'
+    ljpath+='{" domainRestartVersion="}'
+    ljpath+='{";"}{.metadata.labels.weblogic\.domainRestartVersion}{";"}'
+    ljpath+='{" introspectVersion="}'
+    ljpath+='{";"}{.metadata.labels.weblogic\.introspectVersion}{";"}'
+    ljpath+='{" image="}'
+    ljpath+='{";"}{.spec.containers[?(@.name=="weblogic-server")].image}{";"}'
+    ljpath+='{" aiimages="}'
+    ljpath+='{";"}{.spec.initContainers[?(@.command[0]=="/weblogic-operator/scripts/auxImage.sh")].image}{";"}'
+    ljpath+='{" ready="}'
+    ljpath+='{";"}{.status.containerStatuses[?(@.name=="weblogic-server")].ready}{";"}'
+    ljpath+='{" phase="}'
+    ljpath+='{";"}{.status.phase}{";"}'
+    ljpath+='{"\n"}'
+  ljpath+='{end}'
+
+  # get introspector pod, if any:
+  kubectl -n ${DOMAIN_NAMESPACE} get pods \
+          -l job-name=${DOMAIN_UID}-introspector \
+          -o=jsonpath="$ljpath" \
+          | sortAIImages
+
+  # get wl server pods, if any:
+  kubectl -n ${DOMAIN_NAMESPACE} get pods \
+          -l weblogic.serverName,weblogic.domainUID="${DOMAIN_UID}" \
+          -o=jsonpath="$ljpath" \
+          | sortAIImages
+}
+
+# report timeout setting, criteria, generation, observedGeneration, Failed state, and Completed state
+reportBasics() {
+  local lead_string
+  local criteria
+  local criterion
+  if [ "$expected" = "0" ]; then
+    trace "Info: Waiting up to $timeout_secs seconds for there to be no (0) WebLogic Server pods that match the following criteria:"
+    trace "Info:   namespace='$DOMAIN_NAMESPACE' domainUID='$DOMAIN_UID'"
+  else
+    trace "Info: Waiting up to $timeout_secs seconds for domain status condition 'Completed' to become 'True'" \
+          " and '.metadata.generation' to match '.status.observedGeneration' for the domain and each of its clusters."
+    trace "Info: WebLogic Server pods, if not shutting down, should reach the following criteria:"
+    trace "Info:   namespace='$DOMAIN_NAMESPACE'"
+    trace "Info:   domainUID='$DOMAIN_UID'"
+    trace "Info:   ready='true'"
+    trace "Info:   image='$goal_image_current'"
+    trace "Info:   auxiliaryImages='$goal_aiimages_current'"
+    trace "Info:   domainRestartVersion='$goal_RV_current'"
+    trace "Info:   introspectVersion='$goal_IV_current'"
+    trace "Info: Generations:"
+    trace "Info:   domain metadata.generation='$goal_generation'"
+    trace "Info:   domain.status.observedGeneration='$observed_generation'"
+    trace "Info:   clusters='$clusters'"
+    trace "Info:     cluster.metadata.generation(s)='$cl_goal_generations'"
+    trace "Info:     cluster.status.observedGeneration(s)='$cl_observed_generations'"
+    trace "Info: Completed='$condition_completed'"
+  fi
+  echo
+  trace "Info: Failure conditions (if any): '${condition_failed_str}'."
+}
+
 tmpfileorig=$(tempfile)
 tmpfilecur=$(tempfile)
 
 trap "rm -f $tmpfileorig $tmpfilecur" EXIT
 
-cur_pods=0
-reported=0
-last_pod_count_secs=$SECONDS
-goal_RV_orig="--not-known--"
-goal_IV_orig="--not-known--"
-goal_image_orig="--not-known--"
-goal_aiimages_orig="--not-known--"
+pod_count=0
+reported="false"
+last_report_secs=$SECONDS
+all_goals_orig="--not-known--"
 
-# col_headers must line up with the jpath
-col_headers1="NAME RVER IVER IMAGE AIIMAGES READY PHASE"
-col_headers2="---- ---- ---- ----- -------- ----- -----"
-
-# be careful! if changing jpath, then it must
-# correspond with the regex below and col_headers above
-
-jpath=''
-jpath+='{range .items[*]}'
-  jpath+='{" name="}'
-  jpath+='{";"}{.metadata.name}{";"}'
-  jpath+='{" domainRestartVersion="}'
-  jpath+='{";"}{.metadata.labels.weblogic\.domainRestartVersion}{";"}'
-  jpath+='{" introspectVersion="}'
-  jpath+='{";"}{.metadata.labels.weblogic\.introspectVersion}{";"}'
-  jpath+='{" image="}'
-  jpath+='{";"}{.spec.containers[?(@.name=="weblogic-server")].image}{";"}'
-  jpath+='{" aiimages="}'
-  jpath+='{";"}{.spec.initContainers[?(@.command[0]=="/weblogic-operator/scripts/auxImage.sh")].image}{";"}'
-  jpath+='{" ready="}'
-  jpath+='{";"}{.status.containerStatuses[?(@.name=="weblogic-server")].ready}{";"}'
-  jpath+='{" phase="}'
-  jpath+='{";"}{.status.phase}{";"}'
-  jpath+='{"\n"}'
-jpath+='{end}'
 
 # Loop until we reach the desired pod count for pods at the desired restart version,
 # introspect version, and image -- or until we reach the timeout.
 
 while [ 1 -eq 1 ]; do
 
+  # Populate info about current domain into globals.
+  #   If any gets fail then the following implicitly occurs:
+  #   - we assume that the domain resource was not found
+  #   - silently set the global to "" when expected = '0'
+  #   - "exit 1" and report an error when expected = 'Completed'
+
+  getDomainInfo
+
   #
-  # Get the current domain resource's spec.restartVersion, spec.introspectVersion,
-  # spec.image, and ai images. If any of these fail then these functions
-  # fail we assume that domain resource was not found and "exit 1" if goal pods != 0,
-  # or return "" if goal pods == 0.
+  # This script only works in v9+, so let's check the 'api_version' global
   #
 
-  getDomainValue ".spec.restartVersion"    goal_RV_current
-  getDomainValue ".spec.introspectVersion" goal_IV_current
-  getDomainValue ".spec.image"             goal_image_current
-  getDomainAIImages                        goal_aiimages_current
- 
-  ret="${goal_RV_current}
-${goal_IV_current}
-${goal_image_current}
-${goal_aiimages_current}^M"
-  if [ ! "${ret/Error:/}" = "${ret}" ]; then
-    echo $ret
+  version_str=${api_version:-weblogic.oracle/v9}  # if domain resource is missing, api_version is blank
+  version_num=$(echo "$version_str" | sed 's/[^0-9]//g')
+  if [ $version_num -lt 9 ]; then
+    trace "Error: Unexpected domain resource '.apiVersion' of '$api_version'. Expected version 9 or higher."
     exit 1
   fi
 
   #
-  # Force new reporting for the rare case where domain resource RV, IV, or 
-  # image changed since we last reported.
+  # Force new reporting for the rare case where the domain unexpectedly changes while we're looping
   #
 
-  if [ ! "$goal_RV_orig" = "$goal_RV_current" ] \
-     || [ ! "$goal_IV_orig" = "$goal_IV_current" ] \
-     || [ ! "$goal_image_orig" = "$goal_image_current" ] \
-     || [ ! "$goal_aiimages_orig" = "$goal_aiimages_current" ]
+  if [ ! "$all_goals_orig" = "$all_goals_current" ]
   then
-    [ "$reported" = "1" ] && echo
-    reported=0
-    goal_IV_orig="$goal_IV_current"
-    goal_RV_orig="$goal_RV_current"
-    goal_image_orig="$goal_image_current"
-    goal_aiimages_orig="$goal_aiimages_current"
+    [ "$reported" = "true" ] && echo
+    reported="false"
+    all_goals_orig="$all_goals_current"
   fi
 
+  # Get the current number of pods that match target criteria and also
+  # determine if we have reached our goal.
   #
-  # If 'expected' = 0, get the current number of pods regardless of their
-  # restart version, introspect version, image, or ready state. 
-  # 
-  # If "expected != 0" get the number of ready pods with the current domain
-  # resource restart version and image. 
+  #   If expected = 'Completed'
+  #    - get the number of ready pods that match the target image, restart version, etc.
+  #    - we have reached our goal if the Completed condition is true
+  #      AND .metadata.generation equals .status.conditions.observedGeneration
   #
-  # (Note that grep returns non-zero if it doesn't find anything (sigh), 
-  # so we disable error checking and cross-fingers...)
+  #   If expected = '0'
+  #    - get the current number of pods regardless of their
+  #      restart version, introspect version, image, etc.
+  #    - we have reached our goal if the pod count is 0
   #
+
+  is_done="false"
 
   if [ "$expected" = "0" ]; then
 
-    cur_pods=$( kubectl -n ${DOMAIN_NAMESPACE} get pods \
-        -l weblogic.serverName,weblogic.domainUID="${DOMAIN_UID}" \
-        -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
-        | wc -l ) 
+    pod_count=$( getPodInfo | wc -l )
 
-    lead_string="Waiting up to $timeout_secs seconds for there to be no (0) WebLogic Server pods that match the following criteria:"
-    criteria="namespace='$DOMAIN_NAMESPACE' domainUID='$DOMAIN_UID'"
+    [ $pod_count -eq 0 ] && is_done="true"
 
   else
 
+    # NOTE: this regex must correspond with the jpath in the 'getPodInfo' function
     regex="domainRestartVersion=;$goal_RV_current;"
     regex+=" introspectVersion=;$goal_IV_current;"
     regex+=" image=;$goal_image_current;"
@@ -334,104 +472,113 @@ ${goal_aiimages_current}^M"
     regex+=" ready=;true;"
 
     set +e # disable error checks as grep returns non-zero when it finds nothing (sigh)
-    cur_pods=$( kubectl -n ${DOMAIN_NAMESPACE} get pods \
-        -l weblogic.serverName,weblogic.domainUID="${DOMAIN_UID}" \
-        -o=jsonpath="$jpath" \
-        | sortAIImages \
-        | grep "$regex" | wc -l )
+    pod_count=$( getPodInfo | grep "$regex" | wc -l )
     set -e
 
-    lead_string="Waiting up to $timeout_secs seconds for exactly '$expected' WebLogic Server pods to reach the following criteria:"
-    criteria="ready='true'"
-    criteria+=" image='$goal_image_current'"
-    criteria+=" auxiliaryImages='$goal_aiimages_current'"
-    criteria+=" domainRestartVersion='$goal_RV_current'"
-    criteria+=" introspectVersion='$goal_IV_current'"
-    criteria+=" namespace='$DOMAIN_NAMESPACE'"
-    criteria+=" domainUID='$DOMAIN_UID'"
+    [ "$condition_completed" = "True" ] \
+      && [ "$goal_generation" = "$observed_generation" ] \
+      && [ "$cl_goal_generations" = "$cl_observed_generations" ] \
+      && is_done="true"
 
   fi
 
   #
-  # Report the current state to stdout. Exit 0 if we've reached our
-  # goal, exit non-zero if we've reached our time-out.
+  # Report the current state to stdout.
   #
 
-
   if [ "$verbose" = "false" ]; then
-    if [ $reported -eq 0 ]; then
-      echo "@@ [$(timestamp)][seconds=$SECONDS] Info: $lead_string"
-      for criterion in $criteria; do
-        echo "@@ [$(timestamp)][seconds=$SECONDS] Info:   $criterion"
-      done
-      echo -n "@@ [$(timestamp)][seconds=$SECONDS] Info: Current pods that match the above criteria ="
-      echo -n " $cur_pods"
-      reported=1
-      last_pod_count_secs=$SECONDS
-  
-    elif [ $((SECONDS - last_pod_count_secs)) -gt $report_interval ] \
-         || [ $cur_pods -eq $expected ]; then
-      echo -n " $cur_pods"
-      last_pod_count_secs=$SECONDS
+
+    # "quiet" reporting:
+    # - show the goal criteria once plus any time they happen to change
+    # - append the count of matching pods to a single line "... = 3 3 2" when it changes
+    #   or when a report_interval has passed
+
+    if [ "$reported" = "false" ]; then
+
+      reportBasics # report goal 'lead_string' and criteria, generation, Failed state, and Completed state
+
+      tracen "Info: Current pods that match the above criteria ="
+      echo -n " $pod_count"
+      reported="true"
+      last_report_secs=$SECONDS
+
+    elif [ $((SECONDS - last_report_secs)) -gt $report_interval ] \
+         || [ "$is_done" = "true" ]; then
+
+      echo -n " $pod_count"
+      last_report_secs=$SECONDS
 
     fi
   else
 
-    kubectl -n ${DOMAIN_NAMESPACE} get pods \
-      -l weblogic.domainUID="${DOMAIN_UID}" \
-      -o=jsonpath="$jpath" | sortAIImages > $tmpfilecur
+    # verbose reporting:
+    # - show the goal criteria
+    # - show the state of each pod in table form
+    # - output above again when any pod state changes or 'report_interval' is exceeded
+
+    getPodInfo > $tmpfilecur
 
     set +e
     diff -q $tmpfilecur $tmpfileorig 2>&1 > /dev/null
     diff_res=$?
     set -e
-    if [ ! $diff_res -eq 0 ] \
-       || [ $((SECONDS - last_pod_count_secs)) -gt $report_interval ] \
-       || [ $cur_pods -eq $expected ]; then
+    if [ $diff_res -ne 0 ] \
+       || [ "$reported" = "false" ] \
+       || [ $((SECONDS - last_report_secs)) -gt $report_interval ] \
+       || [ "$is_done" = "true" ]; then
 
-      if [ $reported -eq 0 ]; then
+      if [ "$reported" = "false" ]; then
         echo
-        echo "@@ [$(timestamp)][seconds=$SECONDS] Info: $lead_string"
-        for criterion in $criteria; do
-          echo "@@ [$(timestamp)][seconds=$SECONDS] Info:   $criterion"
-        done
+        reportBasics # report goal 'lead_string' and criteria, generation, Failed state, and Completed state
         echo
-        reported=1
+        reported="true"
       fi
 
-      echo "@@ [$(timestamp)][seconds=$SECONDS] Info: '$cur_pods' WebLogic Server pods currently match all criteria, expecting '$expected'."
-      echo "@@ [$(timestamp)][seconds=$SECONDS] Info: Introspector and WebLogic Server pods with same namespace and domain-uid:"
+      trace "Info: '$pod_count' WebLogic Server pods currently match all criteria."
+      trace "Info: Introspector and WebLogic Server pods with same namespace and domain-uid:"
       echo
 
       # print results as a table
-      #  - first strip out the var= and replace with "val". 
-      #  - note that the quotes are necessary so that 'print_table' 
+      #  - first strip out the var= and replace with "val".
+      #  - note that the quotes are necessary so that 'print_table'
       #    doesn't get confused by col entries that are missing values
       (
-        echo $col_headers1
-        echo $col_headers2
+        # column headers must line up with the jpath in getPodInfo
+        echo "NAME RVER IVER IMAGE AIIMAGES READY PHASE"
+        echo "---- ---- ---- ----- -------- ----- -----"
         cat $tmpfilecur | sed "s|[^ ]*=;\([^;]*\);|'\1'|g"
       ) | column -t
       echo
-   
+
       cp $tmpfilecur $tmpfileorig
-      last_pod_count_secs=$SECONDS
+      last_report_secs=$SECONDS
     fi
   fi
 
-  if [ $cur_pods -eq $expected ]; then
-    if [ ! "$verbose" = "true" ]; then
-      echo ". "
-    else
-      echo
-    fi
-    echo "@@ [$(timestamp)][seconds=$SECONDS] Info: Success!"
+  #
+  # Exit 1 if domain resource is reporting a failure and "ignore_failures" is "false" (the default)
+  #
+  if [ "${ignore_failures}" = "false" ] && [ ! -z "${condition_failed_str}" ]; then
+    echo
+    trace "Error: The domain resource has a failure condition: '${condition_failed_str}'. If you want this script to ignore failure conditions and keep trying regardless, then specify '-i' on the commmand line."
+    exit 1
+  fi
+
+  #
+  # Exit 0 if we've reached our goal
+  #
+  if [ "$is_done" = "true" ]; then
+    echo
+    trace "Info: Success!"
     exit 0
   fi
 
+  #
+  # Exit 1 if too much time has passed.
+  #
   if [ $SECONDS -ge $timeout_secs ]; then
     echo
-    echo "@@ [$(timestamp)][seconds=$SECONDS] Error: Timeout after waiting more than $timeout_secs seconds."
+    trace "Error: Timeout after waiting more than $timeout_secs seconds."
     exit 1
   fi
 


### PR DESCRIPTION
When waiting for a domain stabilize, instead of asking user to specify the number of expected pods on the command line, wait for:

- domain Completed condition to reach True
- domain generation to match observedGeneration
- each cluster generation to match its observedGeneration

This is a "WIP" because:

- waiting for bug fixes to 'Complete' and 'observedGeneration' to be resolved before merging
- still need to modify corresponding doc
- need to modify corresponding tests