### PR TITLE
Fix for testCompleteAvailableConditionWithReplicaExceedMaxSizeAndIntrospectVersionChanged

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -376,13 +376,14 @@ class ItDiagnosticsCompleteAvailableCondition {
   @DisplayName("Test domain status condition with cluster replica set to larger than max size of cluster")
   void testCompleteAvailableConditionWithReplicaExceedMaxSizeAndIntrospectVersionChanged() {
     String patchStr;
+    V1Patch patch;
     try {
       patchStr
           = "["
           + "{\"op\": \"remove\", \"path\": \"/spec/replicas\"}"
           + "]";
       logger.info("Removing replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
-      V1Patch patch = new V1Patch(patchStr);
+      patch = new V1Patch(patchStr);
       assertTrue(patchClusterCustomResource(cluster1Name, domainNamespace1, patch,
           V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");
     
@@ -425,6 +426,14 @@ class ItDiagnosticsCompleteAvailableCondition {
           DOMAIN_STATUS_CONDITION_FAILED_TYPE, "True");
 
     } finally {
+      patchStr
+          = "["
+          + "{\"op\": \"add\", \"path\": \"/spec/replicas\", \"value\": 2}"
+          + "]";
+      logger.info("Removing replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
+      patch = new V1Patch(patchStr);
+      assertTrue(patchClusterCustomResource(cluster1Name, domainNamespace1, patch,
+          V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");
       restoreDomainResource();
     }
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -377,8 +377,17 @@ class ItDiagnosticsCompleteAvailableCondition {
   void testCompleteAvailableConditionWithReplicaExceedMaxSizeAndIntrospectVersionChanged() {
     String patchStr;
     try {
+      patchStr
+          = "["
+          + "{\"op\": \"remove\", \"path\": \"/spec/replicas\"}"
+          + "]";
+      logger.info("Removing replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
+      V1Patch patch = new V1Patch(patchStr);
+      assertTrue(patchClusterCustomResource(cluster1Name, domainNamespace1, patch,
+          V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");
+    
       int newReplicaCount = maxClusterSize + 1;
-      logger.info("patch the domain resource with new introspectVersion");
+      logger.info("patch the domain resource with new introspectVersion and replicas higher than max cluster size");
       patchStr = "["
           + "{\"op\": \"replace\", \"path\": \"/spec/introspectVersion\", \"value\": \"12345\"},"
           + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": " + newReplicaCount + "}"

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -16,6 +16,7 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonTestUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
@@ -373,6 +374,7 @@ class ItDiagnosticsCompleteAvailableCondition {
    * Verify no Failed type condition generated.
    */
   @Test
+  @Disabled
   @DisplayName("Test domain status condition with cluster replica set to larger than max size of cluster")
   void testCompleteAvailableConditionWithReplicaExceedMaxSizeAndIntrospectVersionChanged() {
     String patchStr;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -430,7 +430,7 @@ class ItDiagnosticsCompleteAvailableCondition {
           = "["
           + "{\"op\": \"add\", \"path\": \"/spec/replicas\", \"value\": 2}"
           + "]";
-      logger.info("Removing replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
+      logger.info("Adding replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
       patch = new V1Patch(patchStr);
       assertTrue(patchClusterCustomResource(cluster1Name, domainNamespace1, patch,
           V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -16,7 +16,6 @@ import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.CommonTestUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
@@ -374,25 +373,19 @@ class ItDiagnosticsCompleteAvailableCondition {
    * Verify no Failed type condition generated.
    */
   @Test
-  @Disabled
   @DisplayName("Test domain status condition with cluster replica set to larger than max size of cluster")
   void testCompleteAvailableConditionWithReplicaExceedMaxSizeAndIntrospectVersionChanged() {
     String patchStr;
     try {
+      int newReplicaCount = maxClusterSize + 1;
       logger.info("patch the domain resource with new introspectVersion");
-      patchStr = "[{\"op\": \"replace\", \"path\": \"/spec/introspectVersion\", \"value\": \"12345\"}]";
+      patchStr = "["
+          + "{\"op\": \"replace\", \"path\": \"/spec/introspectVersion\", \"value\": \"12345\"},"
+          + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": " + newReplicaCount + "}"
+          + "]";
       logger.info("Updating domain configuration using patch string: {0}", patchStr);
       assertTrue(patchDomainCustomResource(domainUid, domainNamespace1, new V1Patch(patchStr),
           V1Patch.PATCH_FORMAT_JSON_PATCH), "Patch domain did not fail as expected");
-
-      int newReplicaCount = maxClusterSize + 1;
-      logger.info("patch the cluster resource with new cluster replica count {0}", newReplicaCount);
-      patchStr
-          = "["
-          + "{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": " + newReplicaCount + "}"
-          + "]";
-      assertTrue(patchClusterCustomResource(cluster1Name, domainNamespace1,
-          new V1Patch(patchStr), V1Patch.PATCH_FORMAT_JSON_PATCH), "Failed to patch cluster");
       
       // verify the admin server service exists
       checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace1);


### PR DESCRIPTION
The fix is to patch the domain resource with higher than max cluster size and verify the domain status conditions after removing cluster replicas from cluster resource. 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12813/