### PR TITLE
OWLS-102281: [v9cluster] cluster fails to restart with new restartVersion in domain resource

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -1186,7 +1186,9 @@ public class DomainSpec extends BaseConfiguration {
 
     @Override
     public void setReplicaCount(String clusterName, ClusterSpec clusterSpec, int replicaCount) {
-      clusterSpec.setReplicas(replicaCount);
+      //clusterSpec.setReplicas(replicaCount);
+      Optional.ofNullable(clusterSpec)
+              .ifPresentOrElse(cs -> cs.setReplicas(replicaCount), () -> setReplicas(replicaCount));
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -1186,7 +1186,6 @@ public class DomainSpec extends BaseConfiguration {
 
     @Override
     public void setReplicaCount(String clusterName, ClusterSpec clusterSpec, int replicaCount) {
-      //clusterSpec.setReplicas(replicaCount);
       Optional.ofNullable(clusterSpec)
               .ifPresentOrElse(cs -> cs.setReplicas(replicaCount), () -> setReplicas(replicaCount));
     }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainResourceBasicTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainResourceBasicTest.java
@@ -213,6 +213,14 @@ class DomainResourceBasicTest extends DomainTestBase {
   }
 
   @Test
+  void afterReplicaCountSetForDomain_canReadIt() {
+    // set replica count on DomainSpec since Cluster Resource does not exist.
+    info.setReplicaCount("cluster1", 5);
+
+    assertThat(info.getReplicaCount("cluster1"), equalTo(5));
+  }
+
+  @Test
   void afterReplicaCountMaxUnavailableSetForCluster_zeroMin() {
     configureCluster("cluster1").withReplicas(3).withMaxUnavailable(10);
 


### PR DESCRIPTION
The following NPE caused multiple test failures in integration test suite, ItMiiUpdateDomainConfig:

{"timestamp":"2022-09-07T04:07:52.087895584Z","thread":28,"fiber":"fiber-616 NOT_COMPLETE","namespace":"ns-tbldqx","domainUID":"mii-add-config","level":"SEVERE","class":"oracle.kubernetes.operator.DomainProcessorImpl","method":"logThrowable","timeInMillis":1662523672087,"message":"Exception thrown","exception":"\\\njava.lang.NullPointerException: Cannot invoke \"oracle.kubernetes.weblogic.domain.model.ClusterSpec.setReplicas(java.lang.Integer)\" because \"clusterSpec\" is null\\\n\tat oracle.kubernetes.weblogic.domain.model.DomainSpec$CommonEffectiveConfigurationFactory.setReplicaCount(DomainSpec.java:1189)\\\n\tat oracle.kubernetes.weblogic.domain.model.DomainResource$PrivateDomainApiImpl.setReplicaCount(DomainResource.java:857)\\\n\tat oracle.kubernetes.operator.helpers.DomainPresenceInfo.setReplicaCount(DomainPresenceInfo.java:965)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep$ServersUpStepFactory.logIfReplicasLessThanClusterServersMin(ManagedServersUpStep.java:332)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep$ServersUpStepFactory.logIfInvalidReplicaCount(ManagedServersUpStep.java:354)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep.addClusteredServersToFactory(ManagedServersUpStep.java:180)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep.lambda$addServersToFactory$4(ManagedServersUpStep.java:147)\\\n\tat java.base/java.util.HashMap$Values.forEach(Unknown Source)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep.addServersToFactory(ManagedServersUpStep.java:147)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep.lambda$apply$3(ManagedServersUpStep.java:128)\\\n\tat java.base/java.util.Optional.ifPresent(Unknown Source)\\\n\tat oracle.kubernetes.operator.steps.ManagedServersUpStep.apply(ManagedServersUpStep.java:128)\\\n\tat oracle.kubernetes.operator.work.Fiber.doRunInternal(Fiber.java:481)\\\n\tat oracle.kubernetes.operator.work.Fiber.doRun(Fiber.java:414)\\\n\tat oracle.kubernetes.operator.work.Fiber.run(Fiber.java:328)\\\n\tat oracle.kubernetes.operator.work.ThreadLocalContainerResolver.lambda$wrapExecutor$1(ThreadLocalContainerResolver.java:85)\\\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\\\n\tat java.base/java.util.concurrent.FutureTask.run(Unknown Source)\\\n\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)\\\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\\\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\\\n\tat java.base/java.lang.Thread.run(Unknown Source)\\\n","code":"","headers":{},"body":""}

This change:

1. Prevents the NPE that occurs when updating the DomainSpec.replicas attribute when scaling WebLogic clusters that do not have Cluster Resource defined.
2. Removes integration test code for scaling down clusters beyond the minimum cluster size as this code will eventually be removed when addressing JIRA [OWLS-101032](https://jira.oraclecorp.com/jira/browse/OWLS-101032)