### PR TITLE
fixed test logic to avoid the failure if test order execution changed

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart3.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart3.java
@@ -145,6 +145,7 @@ class ItMiiDynamicUpdatePart3 {
     // Verifying introspector pod is deleted
     logger.info("Verifying introspector pod is deleted");
     checkPodDoesNotExist(getIntrospectJobName(domainUid), domainUid, helper.domainNamespace);
+    checkOperatorLogIntrospectorMsg();
   }
 
   /**
@@ -249,9 +250,7 @@ class ItMiiDynamicUpdatePart3 {
    * the Domain resource specified 'spec.configuration.model.onlineUpdate.enabled=true',
    * but there are unsupported model changes for online update.
    */
-  @Test
-  @DisplayName("verify the operator logs introspector job messages")
-  void testOperatorLogIntrospectorMsg() {
+  void checkOperatorLogIntrospectorMsg() {
     String operatorPodName =
         assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, helper.opNamespace));
     logger.info("operator pod name: {0}", operatorPodName);


### PR DESCRIPTION
Fixed the test logic to avoid the failure if order of execution has changed.
https://build.weblogick8s.org:8443/job/wko34-kind-nightly-parallel/193