### PR TITLE
Owls 101945 - Handle a case where introspector container logs can't be retrieved 

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -78,6 +78,8 @@ public class JobHelper {
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
   public static final String INTROSPECTOR_LOG_PREFIX = "Introspector Job Log: ";
   private static final String EOL_PATTERN = "\\r?\\n";
+  public static final String UNABLE_TO_RETRIEVE_CONTAINER_LOGS_FOR_CONTAINER =
+      "unable to retrieve container logs for container";
 
   private JobHelper() {
   }
@@ -539,6 +541,7 @@ public class JobHelper {
 
       private void processIntrospectionResult(Packet packet, String result) {
         LOGGER.fine("+++++ ReadDomainIntrospectorPodLogResponseStep: \n" + result);
+        LOGGER.info("DEBUG: +++++ ReadDomainIntrospectorPodLogResponseStep: \n" + result);
         convertJobLogsToOperatorLogs(result);
         packet.put(ProcessingConstants.DOMAIN_INTROSPECTOR_LOG_RESULT, result);
         MakeRightDomainOperation.recordInspection(packet);
@@ -586,6 +589,9 @@ public class JobHelper {
           if (line.startsWith("@[")) {
             logToOperator();
             logMessage = new StringBuilder(INTROSPECTOR_LOG_PREFIX).append(line.trim());
+          } else if (line.startsWith(UNABLE_TO_RETRIEVE_CONTAINER_LOGS_FOR_CONTAINER)) {
+            logToOperator();
+            logMessage = new StringBuilder(INTROSPECTOR_LOG_PREFIX).append("[SEVERE] " + line.trim());
           } else if (logMessage.length() > 0) {
             logMessage.append(System.lineSeparator()).append(line.trim());
           }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -541,7 +541,6 @@ public class JobHelper {
 
       private void processIntrospectionResult(Packet packet, String result) {
         LOGGER.fine("+++++ ReadDomainIntrospectorPodLogResponseStep: \n" + result);
-        LOGGER.info("DEBUG: +++++ ReadDomainIntrospectorPodLogResponseStep: \n" + result);
         convertJobLogsToOperatorLogs(result);
         packet.put(ProcessingConstants.DOMAIN_INTROSPECTOR_LOG_RESULT, result);
         MakeRightDomainOperation.recordInspection(packet);


### PR DESCRIPTION
OWLS-101945 - Fix for the intermittent ItMiiAuxiliaryImage.testCreateDomainWithConfigMapAndEmptryModelFileDir integration test failure. The failure is caused because the introspector container logs can't be retrieved after the config-map and secret volumes fail to mount in the given timeout period. This causes the introspector container initialization failure and script fails with exit code 1. The operator then tries to read the introspector pod logs and it gets "unable to retrieve container logs for container" result. This change handles this particular case where the introspector pod logs contain "unable to retrieve container logs for container" result.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12907/