### PR TITLE
Owls 102429 - Fix for unexpected server restart after roll completes

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -375,11 +375,8 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
       public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
         if (callResponse.getResult() == null || callback.didResumeFiber()) {
           callback.proceedFromWait(callResponse.getResult());
-          LOGGER.info("DEBUG: In WaitForDeleteResponseStep.. next step is " + getNext() + ", returning null.");
           return null;
         } else {
-          LOGGER.info("DEBUG: In WaitForDeleteResponseStep.. delaying since pod not deleted. res -> "
-              + callResponse.getResult());
           return doDelay(createReadAndIfReadyCheckStep(callback), packet,
               getWatchBackstopRecheckDelaySeconds(), TimeUnit.SECONDS);
         }

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -375,8 +375,11 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
       public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
         if (callResponse.getResult() == null || callback.didResumeFiber()) {
           callback.proceedFromWait(callResponse.getResult());
-          return doNext(packet);
+          LOGGER.info("DEBUG: In WaitForDeleteResponseStep.. next step is " + getNext() + ", returning null.");
+          return null;
         } else {
+          LOGGER.info("DEBUG: In WaitForDeleteResponseStep.. delaying since pod not deleted. res -> "
+              + callResponse.getResult());
           return doDelay(createReadAndIfReadyCheckStep(callback), packet,
               getWatchBackstopRecheckDelaySeconds(), TimeUnit.SECONDS);
         }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -177,12 +177,9 @@ public abstract class ResponseStep<T> extends Step {
   }
 
   private NextAction logNoRetry(Packet packet, CallResponse<T> callResponse) {
-    if (callResponse != null) {
-      if (callResponse.getStatusCode() != HTTP_NOT_FOUND) {
-        addDomainFailureStatus(packet, callResponse.getRequestParams(), callResponse.getE());
-      }
-
-      if (callResponse.getStatusCode() != HTTP_NOT_FOUND && LOGGER.isWarningEnabled()) {
+    if ((callResponse != null) && (callResponse.getStatusCode() != HTTP_NOT_FOUND)) {
+      addDomainFailureStatus(packet, callResponse.getRequestParams(), callResponse.getE());
+      if (LOGGER.isWarningEnabled()) {
         LOGGER.warning(
             MessageKeys.ASYNC_NO_RETRY,
             Optional.ofNullable(previousStep).map(Step::identityHash).orElse(""),

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -178,7 +178,9 @@ public abstract class ResponseStep<T> extends Step {
 
   private NextAction logNoRetry(Packet packet, CallResponse<T> callResponse) {
     if (callResponse != null) {
-      addDomainFailureStatus(packet, callResponse.getRequestParams(), callResponse.getE());
+      if (callResponse.getStatusCode() != HTTP_NOT_FOUND) {
+        addDomainFailureStatus(packet, callResponse.getRequestParams(), callResponse.getE());
+      }
 
       if (callResponse.getStatusCode() != HTTP_NOT_FOUND && LOGGER.isWarningEnabled()) {
         LOGGER.warning(

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -25,6 +25,7 @@ import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -396,7 +397,7 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
     }
   }
 
-  @Test
+  @Ignore
   void whenPodNotFound_waitForDeleteDoesNotRecordKubernetesFailure() {
     final DomainResource domain = DomainProcessorTestSetup.createTestDomain();
     final AtomicBoolean stopping = new AtomicBoolean(false);

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -359,7 +359,6 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
     try {
       testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
 
-      assertThat(terminalStep.wasRun(), is(true));
       assertThat(terminalStep.getExecutionCount(), is(1));
     } finally {
       stopping.set(true);
@@ -392,7 +391,6 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
       testSupport.failOnResource(KubernetesTestSupport.POD, NAME, NS, HTTP_NOT_FOUND);
       testSupport.setTime(10, TimeUnit.SECONDS);
 
-      assertThat(terminalStep.wasRun(), is(true));
       assertThat(terminalStep.getExecutionCount(), is(1));
     } finally {
       stopping.set(true);

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import static oracle.kubernetes.common.logging.MessageKeys.EXECUTE_MAKE_RIGHT_DOMAIN;
 import static oracle.kubernetes.common.logging.MessageKeys.INTROSPECTOR_POD_FAILED;
 import static oracle.kubernetes.common.utils.LogMatcher.containsFine;
+import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.helpers.LegalNames.DEFAULT_INTROSPECTOR_JOB_NAME_SUFFIX;
@@ -359,6 +360,7 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
       testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
 
       assertThat(terminalStep.wasRun(), is(true));
+      assertThat(terminalStep.getExecutionCount(), is(1));
     } finally {
       stopping.set(true);
     }
@@ -374,6 +376,24 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
       testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
 
       assertThat(terminalStep.wasRun(), is(false));
+    } finally {
+      stopping.set(true);
+    }
+  }
+
+  @Test
+  void whenPodDeletedOnSecondRead_runNextStepOnlyOnce() {
+    AtomicBoolean stopping = new AtomicBoolean(false);
+    PodWatcher watcher = createWatcher(stopping);
+
+    testSupport.defineResources(createPod());
+    try {
+      testSupport.runSteps(watcher.waitForDelete(createPod(), terminalStep));
+      testSupport.failOnResource(KubernetesTestSupport.POD, NAME, NS, HTTP_NOT_FOUND);
+      testSupport.setTime(10, TimeUnit.SECONDS);
+
+      assertThat(terminalStep.wasRun(), is(true));
+      assertThat(terminalStep.getExecutionCount(), is(1));
     } finally {
       stopping.set(true);
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -25,7 +25,6 @@ import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -397,7 +396,7 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
     }
   }
 
-  @Ignore
+  @Test
   void whenPodNotFound_waitForDeleteDoesNotRecordKubernetesFailure() {
     final DomainResource domain = DomainProcessorTestSetup.createTestDomain();
     final AtomicBoolean stopping = new AtomicBoolean(false);

--- a/operator/src/test/java/oracle/kubernetes/operator/work/TerminalStep.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/TerminalStep.java
@@ -3,9 +3,12 @@
 
 package oracle.kubernetes.operator.work;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /** A do-nothing step that can be used as a base for testing. It has no next step. */
 public class TerminalStep extends Step {
   private boolean executed;
+  private AtomicInteger executionCount = new AtomicInteger(0);
 
   public TerminalStep() {
     super(null);
@@ -15,9 +18,14 @@ public class TerminalStep extends Step {
     return executed;
   }
 
+  public int getExecutionCount() {
+    return executionCount.get();
+  }
+
   @Override
   public NextAction apply(Packet packet) {
     executed = true;
+    executionCount.getAndIncrement();
     return doNext(null, packet);
   }
 }


### PR DESCRIPTION
Owls 102429 - Fix for unexpected server restart after roll completes
Before the [change ](https://github.com/oracle/weblogic-kubernetes-operator/commit/68aea63e3da07d9ed1a622fc44e9db933aa5c513) in PR [3356](https://github.com/oracle/weblogic-kubernetes-operator/pull/3356), the `onSuccess` method of `resumeIfReady` step returned null action to terminate the child fiber. According to my understanding, `resumeIfReady` is the response step for the step that we create to check the latest resource value (backstop check for missed watch events) and that step is executed in a new child fiber that is created in `checkUpdatedResource` method. If the resource is ready, then the child fiber should terminate with a `null` action. I have also made a change to the `ResponseStep` to not log the failure status when response status code is 404. 
Integration test runs - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12934/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12933/