### PR TITLE
fix tools download url and image secret for upgrade tests

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -82,7 +82,6 @@ import static oracle.weblogic.kubernetes.actions.TestActions.scaleCluster;
 import static oracle.weblogic.kubernetes.actions.TestActions.scaleClusterWithRestApi;
 import static oracle.weblogic.kubernetes.actions.TestActions.scaleClusterWithWLDF;
 import static oracle.weblogic.kubernetes.actions.impl.UniqueName.random;
-import static oracle.weblogic.kubernetes.actions.impl.primitive.Command.defaultCommandParams;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.credentialsNotValid;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.credentialsValid;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podStateNotChanged;
@@ -1634,67 +1633,7 @@ public class CommonTestUtils {
   ) throws RuntimeException {
     String actualLocation = location;
     if (needToGetActualLocation(location, type)) {
-      String version = "";
-      String command = String.format(
-          "curl -fL %s -o %s/%s-%s",
-          location,
-          downloadDir,
-          type,
-          TMP_FILE_NAME);
-
-      CommandParams params =
-          defaultCommandParams()
-              .command(command)
-              .saveResults(true);
-      if (!Command.withParams(params).execute()) {
-        RuntimeException exception =
-            new RuntimeException(String.format("Failed to get the latest %s release information.", type));
-        getLogger().severe(
-            String.format(
-                "Failed to get the latest %s release information. The stderr is %s",
-                type,
-                params.stderr()),
-            exception);
-        throw exception;
-      }
-
-      command = String.format(
-          "cat %s/%s-%s | grep 'releases/download' | awk '{ split($0,a,/href=\"/);%s | %s",
-          downloadDir,
-          type,
-          TMP_FILE_NAME,
-          " print a[2] }'",
-          " cut -d/ -f 6");
-
-      params =
-          defaultCommandParams()
-          .command(command)
-          .saveResults(true)
-          .redirect(true);
-
-      // the command is considered successful only if we have got back a real version number in params.stdout()
-      if (Command.withParams(params).execute()
-          && params.stdout() != null
-          && params.stdout().length() != 0) {
-        // Because I've updated the name of the logging exporter to remove the version number in the name, but
-        // also preserved the original, there will be two entries located. Take the first.
-        version = params.stdout().lines().findFirst().get().trim();
-      } else {
-        RuntimeException exception =
-            new RuntimeException(String.format("Failed to get the version number of the requested %s release.", type));
-        getLogger().severe(
-            String.format(
-                "Failed to get the version number of the requested %s release. The stderr is %s",
-                type,
-                params.stderr()),
-            exception);
-        throw exception;
-      }
-
-      if (version != null) {
-        actualLocation = location.replace("latest",
-            String.format("download/%s/%s", version, getInstallerFileName(type)));
-      }
+      actualLocation = location + "/download/" + getInstallerFileName(type);
     }
     getLogger().info("The actual download location for {0} is {1}", type, actualLocation);
     return actualLocation;

--- a/integration-tests/src/test/resources/domain/domain-v8.yaml
+++ b/integration-tests/src/test/resources/domain/domain-v8.yaml
@@ -25,8 +25,8 @@ spec:
   imagePullPolicy: "IfNotPresent"
 
   # Identify which Secret contains the credentials for pulling an image
-  #imagePullSecrets:
-  #- name: 
+  imagePullSecrets:
+    - name: test-images-repo-secret
 
   # Identify which Secret contains the WebLogic Admin credentials (note that there is an example of
   # how to create that Secret at the end of this file)

--- a/integration-tests/src/test/resources/domain/mii-domain-v8.yaml
+++ b/integration-tests/src/test/resources/domain/mii-domain-v8.yaml
@@ -26,8 +26,8 @@ spec:
   imagePullPolicy: "IfNotPresent"
 
   # Identify which Secret contains the credentials for pulling an image
-  #imagePullSecrets:
-  #- name: regsecret
+  imagePullSecrets:
+    - name: test-images-repo-secret
   
   # Identify which Secret contains the WebLogic Admin credentials,
   # the secret must contain 'username' and 'password' fields.


### PR DESCRIPTION
Fix tools download URL's not to look for version number. 
Use secret to pull images in the domain.yaml's for upgrade tests as its needed for OCIR in OKE env.

Jenkins results -
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/12999/ - upgrade tests on kind
https://build.weblogick8s.org:8443/job/wko-oke-nightly-seqential/114/ - upgrade tests on oke
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13010/ - full suite on kind

gate tests passed. 