### PR TITLE
minor oper unit test fix: cleanup tmp files once done with them

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/DeploymentLivenessTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DeploymentLivenessTest.java
@@ -6,7 +6,9 @@ package oracle.kubernetes.operator;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -44,6 +46,12 @@ class DeploymentLivenessTest {
   @AfterEach
   public void tearDown() throws Exception {
     mementos.forEach(Memento::revert);
+
+    // delete probesHome dir (java requires a dir be empty before deletion)
+    Files.walk(coreDelegate.probesHome.toPath())
+        .sorted(Comparator.reverseOrder())
+        .map(Path::toFile)
+        .forEach(File::delete);
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DeploymentReadyTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DeploymentReadyTest.java
@@ -6,7 +6,9 @@ package oracle.kubernetes.operator;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -43,6 +45,12 @@ class DeploymentReadyTest {
   @AfterEach
   public void tearDown() throws Exception {
     mementos.forEach(Memento::revert);
+
+    // delete probesHome dir (java requires a dir be empty before deletion)
+    Files.walk(coreDelegate.probesHome.toPath())
+        .sorted(Comparator.reverseOrder()) // so files delete before dirs
+        .map(Path::toFile)
+        .forEach(File::delete);
   }
 
   @Test


### PR DESCRIPTION
Fix two operator unit tests that were leaving temp directories behind in /tmp...