### PR TITLE
OWLS-102534 Display explanation when Available is false

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -210,6 +210,9 @@ public class MessageKeys {
   public static final String CYCLING_POD_EVICTED = "WLSDO-0042";
   public static final String CYCLING_POD_SPEC_CHANGED = "WLSDO-0043";
   public static final String PODS_NOT_RUNNING = "WLSDO-0044";
+  public static final String NO_APPLICATION_SERVERS_READY = "WLSDO-0045";
+  public static final String NON_CLUSTERED_SERVERS_NOT_READY = "WLSDO-0046";
+  public static final String CLUSTER_NOT_READY = "WLSDO-0047";
 
   // domain event messages
   public static final String DOMAIN_AVAILABLE_EVENT_PATTERN = "WLSEO-0001";

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -237,11 +237,16 @@ WLSDO-0044=One or more server pods that are supposed to be available did not sta
   Check the server status in the domain status, the server pod status and logs, and WebLogic Server logs for possible reasons. \
   One common cause of this issue is a problem pulling the WebLogicServer image. \
   Adjust the value of 'serverPod.maxPendingWaitTimeSeconds' setting if needed."
+WLSDO-0045=No application servers are ready.
+WLSDO-0046=Non-clustered server(s) {0} are not ready.
+WLSDO-0047=Cluster ''{0}'' requires at least {1} server(s) to be ready, but only {2} are.
 
 oneEnvVar=variable
 multipleEnvVars=variables
 singularToBe=is
 pluralToBe=are
+conjunction=and
+truncation=more
 
 # Domain event messages
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -50,6 +50,7 @@ import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.OperatorUtils;
 import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.ClusterCondition;
 import oracle.kubernetes.weblogic.domain.model.ClusterConditionType;
@@ -64,9 +65,13 @@ import oracle.kubernetes.weblogic.domain.model.Model;
 import oracle.kubernetes.weblogic.domain.model.OnlineUpdate;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
+import org.jetbrains.annotations.NotNull;
 
+import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_NOT_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_FATAL_ERROR;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_ROLL_START;
+import static oracle.kubernetes.common.logging.MessageKeys.NON_CLUSTERED_SERVERS_NOT_READY;
+import static oracle.kubernetes.common.logging.MessageKeys.NO_APPLICATION_SERVERS_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.PODS_FAILED;
 import static oracle.kubernetes.common.logging.MessageKeys.PODS_NOT_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.PODS_NOT_RUNNING;
@@ -111,6 +116,8 @@ import static oracle.kubernetes.weblogic.domain.model.DomainFailureSeverity.SEVE
 public class DomainStatusUpdater {
 
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+  public static final int SERVER_DISPLAY_LIMIT = 5;
+  public static final int CLUSTER_MESSAGE_LIMIT = 2;
 
   private DomainStatusUpdater() {
   }
@@ -670,7 +677,7 @@ public class DomainStatusUpdater {
           this.status = status != null ? status : new DomainStatus();
           this.clusterChecks = createClusterChecks();
           conditionList.add(new DomainCondition(COMPLETED).withStatus(isProcessingCompleted()));
-          conditionList.add(new DomainCondition(AVAILABLE).withStatus(sufficientServersRunning()));
+          conditionList.add(createAvailableCondition());
           if (allIntendedServersReady()) {
             this.status.removeConditionsWithType(ROLLING);
           }
@@ -750,10 +757,6 @@ public class DomainStatusUpdater {
           return !isStartedServer(serverName);
         }
 
-        private boolean atLeastOneApplicationServerStarted() {
-          return !getInfo().getServerStartupInfo().isEmpty();
-        }
-
         private boolean haveServerData() {
           return StatusUpdateContext.this.serverState != null;
         }
@@ -763,10 +766,6 @@ public class DomainStatusUpdater {
               StatusUpdateContext.this::isNonClusteredServer).collect(Collectors.toList());
         }
 
-        private boolean allNonClusteredServersRunning() {
-          return getNonClusteredServers().stream().allMatch(StatusUpdateContext.this::isServerReady);
-        }
-
         private boolean allIntendedServersReady() {
           return haveServerData()
               && allStartedServersAreComplete()
@@ -774,12 +773,76 @@ public class DomainStatusUpdater {
               && serversMarkedForRoll().isEmpty();
         }
 
-        private boolean sufficientServersRunning() {
-          return atLeastOneApplicationServerStarted() && allNonClusteredServersRunning() && allClustersAvailable();
+        private DomainCondition createAvailableCondition() {
+          final List<String> unreadyNonClusteredServers = getUnreadyNonClusteredServers();
+          final List<ClusterCheck> unavailableClusters = getUnavailableClusters();
+
+          if (noApplicationServersReady()) {
+            return createNotAvailableCondition(LOGGER.formatMessage(NO_APPLICATION_SERVERS_READY));
+          } else if (!unreadyNonClusteredServers.isEmpty()) {
+            return createNotAvailableCondition(
+                LOGGER.formatMessage(NON_CLUSTERED_SERVERS_NOT_READY, formatServers(unreadyNonClusteredServers)));
+          } else if (!unavailableClusters.isEmpty()) {
+            return createNotAvailableCondition(formatClusters(unavailableClusters));
+          } else {
+            return new DomainCondition(AVAILABLE).withStatus(true);
+          }
         }
 
-        private boolean allClustersAvailable() {
-          return Arrays.stream(clusterChecks).allMatch(ClusterCheck::isAvailable);
+        private String formatServers(List<String> servers) {
+          return OperatorUtils.joinListGrammaticallyWithLimit(SERVER_DISPLAY_LIMIT, servers);
+        }
+
+        private String formatClusters(List<ClusterCheck> unavailableClusters) {
+          return OperatorUtils.joinListGrammaticallyWithLimit(
+              CLUSTER_MESSAGE_LIMIT, createUnavailableClustersMessage(unavailableClusters));
+        }
+
+        @NotNull
+        private List<String> createUnavailableClustersMessage(List<ClusterCheck> unavailableClusters) {
+          return unavailableClusters.stream().map(ClusterCheck::createNotReadyMessage).collect(Collectors.toList());
+        }
+
+        private DomainCondition createNotAvailableCondition(String message) {
+          return new DomainCondition(AVAILABLE).withStatus(false).withMessage(message);
+        }
+
+        private List<String> getUnreadyNonClusteredServers() {
+          return getNonClusteredServers().stream().filter(this::isServerNotReady).collect(Collectors.toList());
+        }
+
+        private List<ClusterCheck> getUnavailableClusters() {
+          return Arrays.stream(clusterChecks).filter(this::isUnavailable).collect(Collectors.toList());
+        }
+
+        private boolean isServerNotReady(@Nonnull String serverName) {
+          return !isServerReady(serverName);
+        }
+
+        private boolean isUnavailable(@Nonnull ClusterCheck clusterCheck) {
+          return !clusterCheck.isAvailable();
+        }
+
+        private boolean noApplicationServersReady() {
+          return getInfo().getServerStartupInfo().stream()
+              .map(DomainPresenceInfo.ServerInfo::getName)
+              .filter(this::isApplicationServer)
+              .noneMatch(StatusUpdateContext.this::isServerReady);
+        }
+
+        // when the domain start policy is ADMIN_ONLY, the admin server is considered to be an application server.
+        private boolean isApplicationServer(String serverName) {
+          return isAdminOnlyDomain() || !isAdminServer(serverName);
+        }
+
+        private boolean isAdminOnlyDomain() {
+          return getDomain().getSpec().getServerStartPolicy() == ServerStartPolicy.ADMIN_ONLY;
+        }
+
+        private boolean isAdminServer(String serverName) {
+          return status.getServers().stream()
+              .filter(s -> s.getServerName().equals(serverName))
+              .anyMatch(ServerStatus::isAdminServer);
         }
       }
 
@@ -887,6 +950,10 @@ public class DomainStatusUpdater {
           clusterStatus.addCondition(
               new ClusterCondition(ClusterConditionType.COMPLETED)
                   .withStatus(isProcessingCompleted()));
+        }
+
+        private String createNotReadyMessage() {
+          return LOGGER.formatMessage(CLUSTER_NOT_READY, clusterName, getSufficientServerCount(), numServersReady());
         }
       }
 

--- a/operator/src/main/java/oracle/kubernetes/utils/OperatorUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/utils/OperatorUtils.java
@@ -17,12 +17,7 @@ import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
-import oracle.kubernetes.operator.logging.LoggingFacade;
-import oracle.kubernetes.operator.logging.LoggingFactory;
-
 public class OperatorUtils {
-
-  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   private OperatorUtils() {
     // no-op

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ServerStatus.java
@@ -287,6 +287,13 @@ public class ServerStatus implements Comparable<ServerStatus>, PatchableComponen
     return this;
   }
 
+  /**
+   * Returns true if this server is an admin server.
+   */
+  public boolean isAdminServer() {
+    return isAdminServer;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -31,6 +31,8 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.logging.LoggingFacade;
+import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.tuning.TuningParameters;
 import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.operator.utils.WlsDomainConfigSupport;
@@ -57,6 +59,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_NOT_READY;
+import static oracle.kubernetes.common.logging.MessageKeys.NON_CLUSTERED_SERVERS_NOT_READY;
+import static oracle.kubernetes.common.logging.MessageKeys.NO_APPLICATION_SERVERS_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_POD_EVENT_ERROR;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
@@ -99,9 +104,11 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 abstract class DomainStatusUpdateTestBase {
+  private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
+
   private static final String NAME = UID;
   private static final String ADMIN = "admin";
-  public static final String CLUSTER = "cluster1";
+  private static final String CLUSTER = "cluster1";
   private static final String IMAGE = "initialImage:0";
   private final TerminalStep endStep = new TerminalStep();
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
@@ -306,13 +313,23 @@ abstract class DomainStatusUpdateTestBase {
     domain.setStatus(
         new DomainStatus()
             .withServers(
-                Collections.singletonList(
+                List.of(
+                    new ServerStatus()
+                        .withState(RUNNING_STATE)
+                        .withStateGoal(RUNNING_STATE)
+                        .withServerName("admin")
+                        .withNodeName("node")
+                        .withIsAdminServer(true)
+                        .withPodPhase(V1PodStatus.PhaseEnum.RUNNING)
+                        .withPodReady("True")
+                        .withHealth(overallHealth("health")),
                     new ServerStatus()
                         .withState(SHUTDOWN_STATE)
                         .withStateGoal(SHUTDOWN_STATE)
                         .withServerName("server1")
                         .withHealth(overallHealth("health1"))))
-              .addCondition(new DomainCondition(AVAILABLE).withStatus(false))
+              .addCondition(new DomainCondition(AVAILABLE).withStatus(false)
+                  .withMessage(LOGGER.formatMessage(NO_APPLICATION_SERVERS_READY)))
               .addCondition(new DomainCondition(COMPLETED).withStatus(true)));
 
     testSupport.clearNumCalls();
@@ -455,7 +472,7 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
-  void whenNoServersRunning_establishAvailableConditionFalse() {   
+  void whenNoServersReady_establishAvailableConditionFalse() {
     defineScenario()
           .withServers("server1", "server2")
           .withServersReachingState(SHUTDOWN_STATE, "server1", "server2")
@@ -463,7 +480,8 @@ abstract class DomainStatusUpdateTestBase {
 
     updateDomainStatus();
 
-    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE));
+    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE)
+                                         .withMessageContaining(LOGGER.formatMessage(NO_APPLICATION_SERVERS_READY)));
   }
 
   @Test
@@ -1049,8 +1067,11 @@ abstract class DomainStatusUpdateTestBase {
 
     updateDomainStatus();
 
-    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE));
+    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE)
+        .withMessageContaining(LOGGER.formatMessage(CLUSTER_NOT_READY, "cluster1", 19, 4)));
   }
+
+  // todo add hasCondition matcher for cluster status
 
   @Test
   void whenReplicaCountWithinMaxUnavailableOfReplicas_establishClusterAvailableConditionTrue() {
@@ -1180,12 +1201,13 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
-  void withNonClusteredServerNotStarting_domainIsNotAvailable() {
-    defineScenario().withServers("server1").notStarting("server1").build();
+  void withNonClusteredServerNotReady_domainIsNotAvailable() {
+    defineScenario().withServers("server1", "server2").withServersReachingState(STARTING_STATE, "server1").build();
 
     updateDomainStatus();
 
-    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE));
+    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE)
+        .withMessageContaining(LOGGER.formatMessage(NON_CLUSTERED_SERVERS_NOT_READY, "server1")));
   }
 
   @Test
@@ -1544,9 +1566,19 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
-  void whenAdminOnly_availableIsFalse() {
+  void whenAdminOnlyAndAdminServerIsReady_availableIsTrue() {
     configureDomain().withDefaultServerStartPolicy(ServerStartPolicy.ADMIN_ONLY);
     defineScenario().build();
+
+    updateDomainStatus();
+
+    assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(TRUE));
+  }
+
+  @Test
+  void whenAdminOnlyAndAdminServerIsNotReady_availableIsFalse() {
+    configureDomain().withDefaultServerStartPolicy(ServerStartPolicy.ADMIN_ONLY);
+    defineScenario().withServersReachingState(STARTING_STATE, "admin").build();
 
     updateDomainStatus();
 
@@ -1613,6 +1645,7 @@ abstract class DomainStatusUpdateTestBase {
     private ScenarioBuilder() {
       configSupport = new WlsDomainConfigSupport("testDomain");
       configSupport.setAdminServerName(ADMIN);
+      addServer(ADMIN);
       defineServerPod(ADMIN);
       activateServer(ADMIN);
     }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/OperatorUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/OperatorUtilsTest.java
@@ -1,18 +1,22 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.weblogic.domain.model;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import static oracle.kubernetes.utils.OperatorUtils.compareSortingStrings;
 import static oracle.kubernetes.utils.OperatorUtils.createSortedMap;
+import static oracle.kubernetes.utils.OperatorUtils.joinListGrammatically;
+import static oracle.kubernetes.utils.OperatorUtils.joinListGrammaticallyWithLimit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
 class OperatorUtilsTest {
@@ -43,4 +47,39 @@ class OperatorUtilsTest {
     assertThat(createSortedMap(map).values(), contains("server1-value", "server2-value", "server10-value"));
   }
 
+  @Test
+  void grammaticallySortedListWithOneElement_containsOnlyThatElement() {
+    assertThat(joinListGrammatically(List.of("one")), equalTo("one"));
+  }
+
+  @Test
+  void grammaticallySortedListWithTwoElements_separatesThemWithAnd() {
+    assertThat(joinListGrammatically(List.of("one", "two")), equalTo("one and two"));
+  }
+
+  @Test
+  void grammaticallySortedListWithThreeElements_useOxfordComma() {
+    assertThat(joinListGrammatically(List.of("one", "two", "three")), equalTo("one, two, and three"));
+  }
+
+  @Test
+  void limitedGrammaticallySortedListWithOneElement_containsOnlyThatElement() {
+    assertThat(joinListGrammaticallyWithLimit(5, List.of("one")), equalTo("one"));
+  }
+
+  @Test
+  void limitedGrammaticallySortedListWithTwoElements_separatesThemWithAnd() {
+    assertThat(joinListGrammaticallyWithLimit(5, List.of("one", "two")), equalTo("one and two"));
+  }
+
+  @Test
+  void limitedGrammaticallySortedListWithThreeElements_useOxfordComma() {
+    assertThat(joinListGrammaticallyWithLimit(5, List.of("one", "two", "three")), equalTo("one, two, and three"));
+  }
+
+  @Test
+  void limitedGrammaticallySortedListMoreElementsThanLimit_truncatesTheResult() {
+    assertThat(joinListGrammaticallyWithLimit(5, List.of("one", "two", "three", "four", "five", "six", "seven")),
+        equalTo("one, two, three, four, five, and 2 more"));
+  }
 }


### PR DESCRIPTION
When the domain is not available, include a message which explains why.

There were also some bugs in edge cases for the Available and Completed statuses that were missed because of a unit test error.