### PR TITLE
OWLS-101705 Support resource limits on the monitoring exporter container

### DIFF
--- a/documentation/domains/Cluster.json
+++ b/documentation/domains/Cluster.json
@@ -753,6 +753,10 @@
           "default": 8080,
           "description": "The port exposed by the WebLogic Monitoring Exporter running in the sidecar container. Defaults to 8080. The port value must not conflict with a port used by any WebLogic Server instance, including the ports of built-in channels or network access points (NAPs).",
           "type": "integer"
+        },
+        "resources": {
+          "description": "Memory and CPU minimum requirements and limits for the Monitoring exporter sidecar. See `kubectl explain pods.spec.containers.resources`.",
+          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         }
       }
     },

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -672,6 +672,10 @@
           "default": 8080,
           "description": "The port exposed by the WebLogic Monitoring Exporter running in the sidecar container. Defaults to 8080. The port value must not conflict with a port used by any WebLogic Server instance, including the ports of built-in channels or network access points (NAPs).",
           "type": "integer"
+        },
+        "resources": {
+          "description": "Memory and CPU minimum requirements and limits for the Monitoring exporter sidecar. See `kubectl explain pods.spec.containers.resources`.",
+          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         }
       }
     },

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -117,6 +117,7 @@ The current status of the operation of the WebLogic domain. Updated automaticall
 | `image` | string | The WebLogic Monitoring Exporter sidecar container image name. Defaults to ghcr.io/oracle/weblogic-monitoring-exporter:2.0.7 |
 | `imagePullPolicy` | string | The image pull policy for the WebLogic Monitoring Exporter sidecar container image. Legal values are Always, Never, and IfNotPresent. Defaults to Always if image ends in :latest; IfNotPresent, otherwise. |
 | `port` | integer | The port exposed by the WebLogic Monitoring Exporter running in the sidecar container. Defaults to 8080. The port value must not conflict with a port used by any WebLogic Server instance, including the ports of built-in channels or network access points (NAPs). |
+| `resources` | [Resource Requirements](k8s1.13.5.md#resource-requirements) | Memory and CPU minimum requirements and limits for the Monitoring exporter sidecar. See `kubectl explain pods.spec.containers.resources`. |
 
 ### Server Pod
 

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1589,6 +1589,10 @@ window.onload = function() {
           "default": 8080.0,
           "description": "The port exposed by the WebLogic Monitoring Exporter running in the sidecar container. Defaults to 8080. The port value must not conflict with a port used by any WebLogic Server instance, including the ports of built-in channels or network access points (NAPs).",
           "type": "integer"
+        },
+        "resources": {
+          "description": "Memory and CPU minimum requirements and limits for the Monitoring exporter sidecar. See `kubectl explain pods.spec.containers.resources`.",
+          "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         }
       }
     },

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 2af584e4f5af4a0e5d182199dd64119cb47b53fff82365bcbdf987e6798778fd
+    weblogic.sha256: 4d3978c01ddf8b9f9ba477576355f57ecf2a7df320b4a7ae848210d3d5b21703
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -72,6 +72,19 @@ spec:
                       instance, including the ports of built-in channels or network
                       access points (NAPs).
                     type: integer
+                  resources:
+                    description: Memory and CPU minimum requirements and limits for
+                      the Monitoring exporter sidecar. See `kubectl explain pods.spec.containers.resources`.
+                    properties:
+                      requests:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      limits:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                 type: object
               configuration:
                 description: Models and overrides affecting the WebLogic domain configuration.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -1604,6 +1604,7 @@ public abstract class PodStepContext extends BasePodStepContext {
             .name(EXPORTER_CONTAINER_NAME)
             .image(getDomain().getMonitoringExporterImage())
             .imagePullPolicy(getDomain().getMonitoringExporterImagePullPolicy())
+            .resources(getDomain().getMonitoringExporterResources())
             .addEnvItem(new V1EnvVar().name("JAVA_OPTS").value(createJavaOptions()))
             .addPortsItem(new V1ContainerPort()
                 .name("metrics").protocol(V1ContainerPort.ProtocolEnum.TCP).containerPort(getPort()));

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainResource.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainResource.java
@@ -31,6 +31,7 @@ import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -286,6 +287,10 @@ public class DomainResource implements KubernetesObject, RetryMessageFactory {
 
   public MonitoringExporterSpecification getMonitoringExporterSpecification() {
     return spec.getMonitoringExporterSpecification();
+  }
+
+  public V1ResourceRequirements getMonitoringExporterResources() {
+    return spec.getMonitoringExporterResourceRequirements();
   }
 
   public String getMonitoringExporterImage() {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -343,7 +343,7 @@ public class DomainSpec extends BaseConfiguration {
   }
 
   V1ResourceRequirements getMonitoringExporterResourceRequirements() {
-    return monitoringExporter == null ? null : monitoringExporter.getResources();
+    return Optional.ofNullable(monitoringExporter).map(MonitoringExporterSpecification::getResources).orElse(null);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -15,6 +15,7 @@ import javax.annotation.Nullable;
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
+import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import oracle.kubernetes.common.utils.CommonUtils;
@@ -339,6 +340,20 @@ public class DomainSpec extends BaseConfiguration {
 
   V1Container.ImagePullPolicyEnum getMonitoringExporterImagePullPolicy() {
     return monitoringExporter == null ? null : monitoringExporter.getImagePullPolicy();
+  }
+
+  V1ResourceRequirements getMonitoringExporterResourceRequirements() {
+    return monitoringExporter == null ? null : monitoringExporter.getResources();
+  }
+
+  /**
+   * Specifies the image for the monitoring exporter sidecar.
+   * @param resourceRequirements the name of the docker image
+   */
+  public void setMonitoringExporterResources(V1ResourceRequirements resourceRequirements) {
+    assert monitoringExporter != null : "May not set resources without configuration";
+
+    monitoringExporter.setResources(resourceRequirements);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/MonitoringExporterSpecification.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/MonitoringExporterSpecification.java
@@ -109,14 +109,6 @@ public class MonitoringExporterSpecification {
     return Optional.ofNullable(imagePullPolicy).orElse(CommonUtils.getInferredImagePullPolicy(getImage()));
   }
 
-  void setImagePullPolicy(@Nullable V1Container.ImagePullPolicyEnum imagePullPolicy) {
-    this.imagePullPolicy = imagePullPolicy;
-  }
-
-  Integer getPort() {
-    return port;
-  }
-
   void setPort(Integer port) {
     this.port = port;
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/MonitoringExporterSpecification.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/MonitoringExporterSpecification.java
@@ -9,6 +9,7 @@ import javax.annotation.Nullable;
 
 import com.google.gson.Gson;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import oracle.kubernetes.common.utils.CommonUtils;
 import oracle.kubernetes.json.Default;
 import oracle.kubernetes.json.Description;
@@ -43,6 +44,15 @@ public class MonitoringExporterSpecification {
           + "Legal values are Always, Never, and IfNotPresent. "
           + "Defaults to Always if image ends in :latest; IfNotPresent, otherwise.")
   private V1Container.ImagePullPolicyEnum imagePullPolicy;
+
+  /**
+   * Defines the requirements and limits for the monitoring exporter sidecar.
+   *
+   * @since 4.0
+   */
+  @Description("Memory and CPU minimum requirements and limits for the Monitoring exporter sidecar. "
+      + "See `kubectl explain pods.spec.containers.resources`.")
+  private V1ResourceRequirements resources;
 
   @Description(
       "The port exposed by the WebLogic Monitoring Exporter running in the sidecar container. "
@@ -79,6 +89,14 @@ public class MonitoringExporterSpecification {
     return new Yaml().load(yaml);
   }
 
+  public V1ResourceRequirements getResources() {
+    return resources;
+  }
+
+  public void setResources(V1ResourceRequirements resources) {
+    this.resources = resources;
+  }
+
   String getImage() {
     return Optional.ofNullable(image).orElse(DEFAULT_EXPORTER_IMAGE);
   }
@@ -107,6 +125,7 @@ public class MonitoringExporterSpecification {
   public String toString() {
     return new ToStringBuilder(this)
           .append("configuration", configuration)
+          .append("resources", resources)
           .append("image", image)
           .append("imagePullPolicy", imagePullPolicy)
           .append("port", port)
@@ -122,6 +141,7 @@ public class MonitoringExporterSpecification {
   private boolean equals(MonitoringExporterSpecification that) {
     return new EqualsBuilder()
           .append(configuration, that.configuration)
+          .append(resources, that.resources)
           .append(image, that.image)
           .append(imagePullPolicy, that.imagePullPolicy)
           .append(port, that.port)
@@ -132,6 +152,7 @@ public class MonitoringExporterSpecification {
   public int hashCode() {
     return new HashCodeBuilder(17, 37)
           .append(configuration)
+          .append(resources)
           .append(image)
           .append(imagePullPolicy)
           .append(port)

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/DomainConfigurator.java
@@ -16,6 +16,7 @@ import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Toleration;
 import io.kubernetes.client.openapi.models.V1Volume;
@@ -362,6 +363,8 @@ public abstract class DomainConfigurator {
   public abstract DomainConfigurator withPodAnnotation(String name, String value);
 
   public abstract DomainConfigurator withMonitoringExporterConfiguration(String configuration);
+
+  public abstract DomainConfigurator withMonitoringExporterResources(V1ResourceRequirements resourceRequirements);
 
   public abstract DomainConfigurator withMonitoringExporterImage(String imageName);
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainCommonConfigurator.java
@@ -16,6 +16,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodReadinessGate;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Toleration;
 import io.kubernetes.client.openapi.models.V1Volume;
@@ -189,6 +190,12 @@ public class DomainCommonConfigurator extends DomainConfigurator {
   @Override
   public DomainConfigurator withMonitoringExporterConfiguration(String configuration) {
     getDomainSpec().createMonitoringExporterConfiguration(configuration);
+    return this;
+  }
+
+  @Override
+  public DomainConfigurator withMonitoringExporterResources(V1ResourceRequirements resourceRequirements) {
+    getDomainSpec().setMonitoringExporterResources(resourceRequirements);
     return this;
   }
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
@@ -29,6 +29,7 @@ import oracle.kubernetes.operator.ServerStartPolicy;
 import oracle.kubernetes.operator.ShutdownType;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.processing.EffectiveServerSpec;
+import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DomainV2Test extends DomainTestBase {
 
@@ -1676,5 +1678,14 @@ class DomainV2Test extends DomainTestBase {
     configureDomain(domain).withConfigOverrideDistributionStrategy(OverrideDistributionStrategy.ON_RESTART);
 
     assertThat(domain.getOverrideDistributionStrategy(), equalTo(OverrideDistributionStrategy.ON_RESTART));
+  }
+
+  @Test
+  void whenNoMonitoringExporterConfigurationDefined_refuseAttemptToSetResourceRequirements() {
+    final DomainConfigurator domainConfigurator = configureDomain(domain);
+    final V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();
+    
+    assertThrows(AssertionError.class,
+        () -> domainConfigurator.withMonitoringExporterResources(resourceRequirements));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainV2Test.java
@@ -1681,6 +1681,17 @@ class DomainV2Test extends DomainTestBase {
   }
 
   @Test
+  void whenReadFromYaml_MonitoringExporterSpecificationSupportsBasicOperations() throws IOException {
+    List<KubernetesObject> resources = readFromYaml(DOMAIN_V2_SAMPLE_YAML_3);
+    DomainResource domain = (DomainResource) resources.get(0);
+
+    final MonitoringExporterSpecification specification = domain.getSpec().getMonitoringExporterSpecification();
+    assertThat(specification.toString(), containsString("monexp:latest"));
+    assertThat(specification, not(equalTo(new MonitoringExporterSpecification())));
+    assertThat(specification.hashCode(), not(equalTo(new MonitoringExporterSpecification().hashCode())));
+  }
+
+  @Test
   void whenNoMonitoringExporterConfigurationDefined_refuseAttemptToSetResourceRequirements() {
     final DomainConfigurator domainConfigurator = configureDomain(domain);
     final V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();


### PR DESCRIPTION
The monitoring exporter specification now supports resource requirements. For example:

```
  monitoringExporter:
    image: monexp:latest
    imagePullPolicy: IfNotPresent
    resources:
      limits:
        cpu: "0.25"
    configuration:
      queries:
```
