### PR TITLE
Reintegrate cluster content earlier during webhook conversion to v8

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
+++ b/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
@@ -119,6 +119,9 @@ public class SchemaConversionUtils {
     LOGGER.fine("Converting domain " + domain + " to " + targetAPIVersion + " apiVersion.");
 
     String apiVersion = (String) domain.get(API_VERSION);
+
+    integrateClusters(spec, resourceLookup);
+
     adjustAdminPortForwardingDefault(spec, apiVersion);
     convertLegacyAuxiliaryImages(spec);
     convertDomainStatus(domain);
@@ -133,8 +136,6 @@ public class SchemaConversionUtils {
     removeAndPreserveAllowReplicasBelowMinDynClusterSize(spec, toBePreserved);
     removeAndPreserveServerStartState(spec, toBePreserved);
     removeAndPreserveIstio(spec, toBePreserved);
-
-    integrateClusters(spec, resourceLookup);
 
     try {
       preserve(domain, toBePreserved, apiVersion);

--- a/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
+++ b/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class SchemaConversionUtilsTest {
@@ -151,7 +151,7 @@ class SchemaConversionUtilsTest {
     Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
     List<Object> convertedClusters = (List<Object>) getDomainSpec(converterv8.getDomain()).get("clusters");
     List<Object> origClusters = (List<Object>) getDomainSpec(v8Domain).get("clusters");
-    assertNotNull(convertedClusters);
+    assertThat(convertedClusters, notNullValue());
     assertThat(convertedClusters, equalTo(origClusters));
   }
 

--- a/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
+++ b/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class SchemaConversionUtilsTest {
@@ -148,7 +149,10 @@ class SchemaConversionUtilsTest {
     converterv8.convert(domain, clusters);
 
     Map<String, Object> v8Domain = readAsYaml(DOMAIN_V8_AUX_IMAGE30_YAML);
-    assertThat(converterv8.getDomain().get("clusters"), equalTo(v8Domain.get("clusters")));
+    List<Object> convertedClusters = (List<Object>) getDomainSpec(converterv8.getDomain()).get("clusters");
+    List<Object> origClusters = (List<Object>) getDomainSpec(v8Domain).get("clusters");
+    assertNotNull(convertedClusters);
+    assertThat(convertedClusters, equalTo(origClusters));
   }
 
   @Test

--- a/common/src/test/resources/oracle/kubernetes/common/utils/aux-image-30-sample.yaml
+++ b/common/src/test/resources/oracle/kubernetes/common/utils/aux-image-30-sample.yaml
@@ -111,6 +111,7 @@ spec:
   clusters:
   - clusterName: cluster-1
     serverStartState: "RUNNING"
+    serverStartPolicy: ALWAYS
     serverPod:
       # Instructs Kubernetes scheduler to prefer nodes for new cluster members where there are not
       # already members of the same cluster.

--- a/common/src/test/resources/oracle/kubernetes/common/utils/converted-domain-sample.yaml
+++ b/common/src/test/resources/oracle/kubernetes/common/utils/converted-domain-sample.yaml
@@ -85,6 +85,7 @@ metadata:
     weblogic.createdByOperator: "true"
 spec:
     clusterName: cluster-1
+    serverStartPolicy: Always
     serverPod:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
During conversion from v9 to v8, cluster resources are reintegrated into the domain content. There is a unit-test that was meant to ensure that this cluster content was properly downgraded to v8, such as having the v8 versions of enumeration values.

That unit-test was, unfortunately, broken. This change corrects the unit-test and moves the reintegration of cluster resources earlier in the flow of the webhook such that the other methods that modify constants and other content work correctly.