### PR TITLE
Owls102321 - provide more details in POD_CYCLE_STARTING event message

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -91,6 +91,7 @@ import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE_SUCCESS;
 import static oracle.kubernetes.operator.helpers.AnnotationHelper.SHA256_ANNOTATION;
 import static oracle.kubernetes.operator.helpers.CompatibilityCheck.CompatibilityScope.DOMAIN;
+import static oracle.kubernetes.operator.helpers.CompatibilityCheck.CompatibilityScope.POD;
 import static oracle.kubernetes.operator.helpers.CompatibilityCheck.CompatibilityScope.UNKNOWN;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.DOMAIN_ROLL_STARTING;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.POD_CYCLE_STARTING;
@@ -689,6 +690,14 @@ public abstract class PodStepContext extends BasePodStepContext {
     return compatibility.getScopedIncompatibility(scope);
   }
 
+  protected String getReasonToRecycle(V1Pod pod) {
+    String message = getReasonToRecycle(pod, POD);
+    if (message == null || message.length() == 0) {
+      message = getDomainIncompatibility(pod);
+    }
+    return message;
+  }
+
   private ResponseStep<V1Pod> createResponse(Step next) {
     return new CreateResponseStep(next);
   }
@@ -1199,7 +1208,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     }
 
     private Step createCyclePodEventStep(Step next) {
-      String reason = Optional.ofNullable(message).orElse(getReasonToRecycle(pod, CompatibilityScope.POD));
+      String reason = Optional.ofNullable(message).orElse(getReasonToRecycle(pod));
       LOGGER.info(
           MessageKeys.CYCLING_POD,
           Objects.requireNonNull(pod.getMetadata()).getName(),


### PR DESCRIPTION
When the reason of rolling a server pod is not because of pod spec changes, the event does not provide any details.
The change is to use domain level rolling reason in this case. 

Before:
{"timestamp":"2022-09-21T13:53:00.340716483Z","thread":35,"fiber":"engine-operator-thread-6-fiber-108","namespace":"ns-tdbrni","domainUID":"domain1","level":"INFO","class":"oracle.kubernetes.operator.helpers.PodStepContext$CyclePodStep","method":"createCyclePodEventStep","timeInMillis":1663768380340,"message":"Replacing pod domain1-admin-server because: null","exception":"","code":"","headers":{},"body":""}

After:
{"timestamp":"2022-09-21T18:35:19.822776863Z","thread":23,"fiber":"engine-operator-thread-1-fiber-104","namespace":"ns-cgjcth","domainUID":"domain1","level":"INFO","class":"oracle.kubernetes.operator.helpers.PodStepContext$CyclePodStep","method":"createCyclePodEventStep","timeInMillis":1663785319822,"message":"Replacing pod domain1-admin-server because: WebLogic domain configuration changed due to a Model in Image model update","exception":"","code":"","headers":{},"body":""}