### PR TITLE
OWLS-102533 - override the default YAML size limit to accomodate the SnakeYAML change

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -379,4 +379,5 @@ public interface TestConstants {
   //Defaulting to 1440 minutes (24 hours)
   public static final Long FAILURE_RETRY_LIMIT_MINUTES =
       Long.valueOf(getNonEmptySystemProperty("failure.retry.limit.minutes", "10"));
+  String YAML_MAX_FILE_SIZE_PROPERTY = "-Dwdt.config.yaml.max.file.size=20000000";
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/WebLogicImageTool.java
@@ -12,6 +12,7 @@ import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.FMWINFRA_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OKE_CLUSTER;
+import static oracle.weblogic.kubernetes.TestConstants.YAML_MAX_FILE_SIZE_PROPERTY;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.DOWNLOAD_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.IMAGE_TOOL;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WDT_DOWNLOAD_FILENAME_DEFAULT;
@@ -168,6 +169,7 @@ public class WebLogicImageTool {
         + " --tag " + params.modelImageName() + ":" + params.modelImageTag()
         + " --fromImage " + params.baseImageName() + ":" + params.baseImageTag()
         + " --wdtDomainType " + params.domainType()
+        + " --wdtJavaOptions " + YAML_MAX_FILE_SIZE_PROPERTY
         + ownership;
 
     if (params.wdtModelOnly()) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FmwUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FmwUtils.java
@@ -28,6 +28,7 @@ import static oracle.weblogic.kubernetes.TestConstants.FAILURE_RETRY_INTERVAL_SE
 import static oracle.weblogic.kubernetes.TestConstants.FAILURE_RETRY_LIMIT_MINUTES;
 import static oracle.weblogic.kubernetes.TestConstants.FMWINFRA_IMAGE_TO_USE_IN_SPEC;
 import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
+import static oracle.weblogic.kubernetes.TestConstants.YAML_MAX_FILE_SIZE_PROPERTY;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.utils.ApplicationUtils.callWebAppAndWaitTillReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Common utility methods for FMW Domain.
  */
 public class FmwUtils {
+
   /**
    * Construct a domain object with the given parameters that can be used to create a domain resource.
    * @param domainUid unique Uid of the domain
@@ -86,7 +88,10 @@ public class FmwUtils {
                     .value("-Dweblogic.StdoutDebugEnabled=false"))
                 .addEnvItem(new V1EnvVar()
                     .name("USER_MEM_ARGS")
-                    .value("-Djava.security.egd=file:/dev/./urandom ")))
+                    .value("-Djava.security.egd=file:/dev/./urandom "))
+                .addEnvItem(new V1EnvVar()
+                    .name("WLSDEPLOY_PROPERTIES")
+                    .value(YAML_MAX_FILE_SIZE_PROPERTY)))
             .adminServer(new AdminServer()
                 .adminService(new AdminService()
                     .addChannelsItem(new Channel()


### PR DESCRIPTION
OWLS-102533 - Change to the FMW integration tests to override the default YAML size limit to accomodate the change in latest version of SnakeYAML to limit the incoming data.
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13146/