### PR TITLE
Remove 3.2.x Upgrade Test 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModelsWithLoadBalancer.java
@@ -136,7 +136,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @DisplayName("Verify scaling the clusters in the domain with different domain types, "
         + "rolling restart behavior in a multi-cluster MII domain and "
         + "the sample application can be accessed via NGINX ingress controller")
-@Tag("kind-parallel")
+@Tag("kind-sequential")
 @Tag("oke-sequential")
 @IntegrationTest
 @Tag("olcne")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorFmwUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorFmwUpgrade.java
@@ -194,24 +194,6 @@ class ItOperatorFmwUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.1.4 to current with a FMW Domain.
-   */
-  @Test
-  @DisplayName("Upgrade Operator from 3.1.4 to current")
-  void testOperatorFmwUpgradeFrom314ToCurrent() {
-    installAndUpgradeOperator("3.1.4", "v8", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
-  }
-
-  /**
-   * Operator upgrade from 3.2.5 to current with a FMW Domain.
-   */
-  @Test
-  @DisplayName("Upgrade Operator from 3.2.5 to current")
-  void testOperatorFmwUpgradeFrom325ToCurrent() {
-    installAndUpgradeOperator("3.2.5", "v8", DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
-  }
-
-  /**
    * Operator upgrade from 3.3.8 to current with a FMW Domain.
    */
   @Test

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItOperatorWlsUpgrade.java
@@ -164,31 +164,6 @@ class ItOperatorWlsUpgrade {
   }
 
   /**
-   * Operator upgrade from 3.1.4 to current.
-   * Currently from 3.1.4 to WKO 4.0, v9 cluster reference doesn't work
-   * Temporarily disabled
-   */
-  @Disabled
-  @ParameterizedTest
-  @DisplayName("Upgrade Operator from 3.1.4 to current")
-  @ValueSource(strings = { "Image", "FromModel" })
-  void testOperatorWlsUpgradeFrom314ToCurrent(String domainType) {
-    logger.info("Starting test testOperatorWlsUpgradeFrom314ToCurrent with domain type {0}", domainType);
-    installAndUpgradeOperator(domainType, "3.1.4", OLD_DOMAIN_VERSION, DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
-  }
-
-  /**
-   * Operator upgrade from 3.2.5 to current.
-   */
-  @ParameterizedTest
-  @DisplayName("Upgrade Operator from 3.2.5 to current")
-  @ValueSource(strings = { "Image", "FromModel" })
-  void testOperatorWlsUpgradeFrom325ToCurrent(String domainType) {
-    logger.info("Starting test testOperatorWlsUpgradeFrom325ToCurrent with domain type {0}", domainType);
-    installAndUpgradeOperator(domainType, "3.2.5", OLD_DOMAIN_VERSION, DEFAULT_EXTERNAL_SERVICE_NAME_SUFFIX);
-  }
-
-  /**
    * Operator upgrade from 3.3.8 to current.
    */
   @ParameterizedTest


### PR DESCRIPTION
Jenkins Results

(a) Remove 3.2.x Upgrade Tests
(b) Move the ItMultiDomainModelsWithLoadBalancer class into sequential run

https://build.weblogick8s.org:8443/job/wko-kind-nightly-seqential/819