### PR TITLE
Owls 102818 - Changes to the lifecycle scripts to explicitly use v8 so they work correctly even when v9 is installed

### DIFF
--- a/kubernetes/samples/scripts/domain-lifecycle/clusterStatus.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/clusterStatus.sh
@@ -70,7 +70,7 @@ function clusterStatus() {
 
     local __val
     for __val in \
-      $($__kubernetes_cli $__ns_filter get domains \
+      $($__kubernetes_cli $__ns_filter get domains.v8.weblogic.oracle \
         -o=jsonpath='{range .items[*]}{.metadata.namespace}{","}{.metadata.name}{","}{.spec.domainUID}{"\n"}{end}')
     do
       local __ns_cur=$(  echo $__val | cut -d ',' -f 1)
@@ -97,7 +97,7 @@ function clusterStatus() {
       __jp+='{"\n"}'
       __jp+='{end}'
 
-      $__kubernetes_cli -n "$__ns_cur" get domain "$__uid_cur" -o=jsonpath="$__jp"
+      $__kubernetes_cli -n "$__ns_cur" get domain.v8.weblogic.oracle "$__uid_cur" -o=jsonpath="$__jp"
 
     done | sed 's/~!\([0-9][0-9]*\)/\1/g'\
          | sed 's/~!/0/g' \

--- a/kubernetes/samples/scripts/domain-lifecycle/helper.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/helper.sh
@@ -1004,10 +1004,10 @@ executePatchCommand() {
   local verboseMode=$5
 
   if [ "${verboseMode}" == "true" ]; then
-    printInfo "Executing command --> ${kubernetesCli} patch domain ${domainUid} \
+    printInfo "Executing command --> ${kubernetesCli} patch domain.v8.weblogic.oracle ${domainUid} \
       -n ${domainNamespace} --type=merge --patch \"${patchJson}\""
   fi
-  ${kubernetesCli} patch domain ${domainUid} -n ${domainNamespace} --type=merge --patch "${patchJson}"
+  ${kubernetesCli} patch domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} --type=merge --patch "${patchJson}"
 }
 
 # timestamp

--- a/kubernetes/samples/scripts/domain-lifecycle/introspectDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/introspectDomain.sh
@@ -86,7 +86,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/restartServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/restartServer.sh
@@ -82,7 +82,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/rollCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/rollCluster.sh
@@ -97,7 +97,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/rollDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/rollDomain.sh
@@ -86,7 +86,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/scaleCluster.sh
@@ -95,7 +95,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startCluster.sh
@@ -89,7 +89,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startDomain.sh
@@ -74,7 +74,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 
 if [ -z "${domainJson}" ]; then
   printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. Exiting."

--- a/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/startServer.sh
@@ -138,7 +138,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopCluster.sh
@@ -86,7 +86,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1

--- a/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopDomain.sh
@@ -72,7 +72,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 
 if [ -z "${domainJson}" ]; then
   printError "Domain resource for domain '${domainUid}' not found in namespace '${domainNamespace}'. Exiting."

--- a/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/stopServer.sh
@@ -135,7 +135,7 @@ function initialize {
 initialize
 
 # Get the domain in json format
-domainJson=$(${kubernetesCli} get domain ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
+domainJson=$(${kubernetesCli} get domain.v8.weblogic.oracle ${domainUid} -n ${domainNamespace} -o json --ignore-not-found)
 if [ -z "${domainJson}" ]; then
   printError "Unable to get domain resource for domain '${domainUid}' in namespace '${domainNamespace}'. Please make sure the 'domain_uid' and 'namespace' specified by the '-d' and '-n' arguments are correct. Exiting."
   exit 1


### PR DESCRIPTION
Owls 102818 - Changes to the lifecycle scripts to explicitly use v8 API version so that they work correctly even when v9 is installed.

Integration test runs -
https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/47/
https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/45/
https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/44/
https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/43/