### PR TITLE
OWLS-101725 - Grep Review: grep for "compatibilityModeInitContainerLogs" 

### DIFF
--- a/operator/src/main/resources/scripts/auxImage.sh
+++ b/operator/src/main/resources/scripts/auxImage.sh
@@ -42,8 +42,8 @@ elif [[ "$AUXILIARY_IMAGE_CONTAINER_NAME" == "compatibility-mode-operator-aux-co
   initCompatibilityModeInitContainersWithLegacyAuxImages > /tmp/compatibilityModeInitContainers.out 2>&1
   cat /tmp/compatibilityModeInitContainers.out
 
-  mkdir -p ${AUXILIARY_IMAGE_TARGET_PATH}/compatibilityModeInitContainerLogs
-  cp /tmp/compatibilityModeInitContainers.out ${AUXILIARY_IMAGE_TARGET_PATH}/compatibilityModeInitContainerLogs/${AUXILIARY_IMAGE_CONTAINER_NAME}.out
+  mkdir -p "${AUXILIARY_IMAGE_TARGET_PATH}"/"${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"
+  cp /tmp/compatibilityModeInitContainers.out "${AUXILIARY_IMAGE_TARGET_PATH}"/"${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"/"${AUXILIARY_IMAGE_CONTAINER_NAME}".out
 else
   trace SEVERE "Invalid auxiliary image container name '$AUXILIARY_IMAGE_CONTAINER_NAME'. " \
                "The auxiliary image container name must start with either 'operator-aux-container' " \

--- a/operator/src/main/resources/scripts/auxImage.sh
+++ b/operator/src/main/resources/scripts/auxImage.sh
@@ -42,8 +42,8 @@ elif [[ "$AUXILIARY_IMAGE_CONTAINER_NAME" == "compatibility-mode-operator-aux-co
   initCompatibilityModeInitContainersWithLegacyAuxImages > /tmp/compatibilityModeInitContainers.out 2>&1
   cat /tmp/compatibilityModeInitContainers.out
 
-  mkdir -p "${AUXILIARY_IMAGE_TARGET_PATH}"/"${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"
-  cp /tmp/compatibilityModeInitContainers.out "${AUXILIARY_IMAGE_TARGET_PATH}"/"${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"/"${AUXILIARY_IMAGE_CONTAINER_NAME}".out
+  mkdir -p "${AUXILIARY_IMAGE_TARGET_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"
+  cp /tmp/compatibilityModeInitContainers.out "${AUXILIARY_IMAGE_TARGET_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}/${AUXILIARY_IMAGE_CONTAINER_NAME}.out"
 else
   trace SEVERE "Invalid auxiliary image container name '$AUXILIARY_IMAGE_CONTAINER_NAME'. " \
                "The auxiliary image container name must start with either 'operator-aux-container' " \

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -764,8 +764,8 @@ checkAuxiliaryImage() {
 #
 # checkCompatibilityModeInitContainersWithLegacyAuxImages
 #   purpose: If the AUXILIARY_IMAGE_PATH directory exists, it echoes the contents of output files
-#            in ${AUXILIARY_IMAGE_PATH}/compatibilityModeInitContainerLogs dir. It returns 1 if a SEVERE message
-#            is found in any of the output files in ${AUXILIARY_IMAGE_PATH}/compatibilityModeInitContainerLogs
+#            in ${AUXILIARY_IMAGE_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR} dir. It returns 1 if a SEVERE message
+#            is found in any of the output files in ${AUXILIARY_IMAGE_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}
 #            dirs. It also returns 1 if 'successfully' message is not found in the output files
 #            or if the AUXILIARY_IMAGE_PATH directory is empty. Otherwise it returns 0 (success).
 #            See also 'auxImage.sh'.
@@ -791,9 +791,9 @@ checkCompatibilityModeInitContainersWithLegacyAuxImages() {
     rm -f ${AUXILIARY_IMAGE_PATH}/testaccess.tmp || return 1
 
     # The container .out files embed their container name, the names will sort in the same order in which the containers ran
-    out_files=$(ls -1 $AUXILIARY_IMAGE_PATH/compatibilityModeInitContainerLogs/*.out 2>/dev/null | sort --version-sort)
+    out_files=$(ls -1 "${AUXILIARY_IMAGE_PATH}"/"${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"/*.out 2>/dev/null | sort --version-sort)
     if [ -z "${out_files}" ]; then
-      trace SEVERE "Compatibility Auxiliary Image: Assertion failure. No files found in '$AUXILIARY_IMAGE_PATH/compatibilityModeInitContainerLogs/*.out'"
+      trace SEVERE "Compatibility Auxiliary Image: Assertion failure. No files found in '$AUXILIARY_IMAGE_PATH/$AUXILIARY_IMAGE_COMMAND_LOGS_DIR/*.out'"
       return 1
     fi
     severe_found=false
@@ -813,7 +813,7 @@ checkCompatibilityModeInitContainersWithLegacyAuxImages() {
       trace "Compatibility Auxiliary Image: End of '${out_file}' contents"
     done
     [ "${severe_found}" = "true" ] && return 1
-    [ -z "$(ls -A $AUXILIARY_IMAGE_PATH 2>/dev/null | grep -v compatibilityModeInitContainerLogs)" ] \
+    [ -z "$(ls -A "${AUXILIARY_IMAGE_PATH}" 2>/dev/null | grep -v "${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}")" ] \
       && trace SEVERE "Compatibility Auxiliary Image: No files found in '$AUXILIARY_IMAGE_PATH'. " \
        "Do your auxiliary images have files in their '$AUXILIARY_IMAGE_PATH' directories? " \
       && return 1

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -791,7 +791,7 @@ checkCompatibilityModeInitContainersWithLegacyAuxImages() {
     rm -f ${AUXILIARY_IMAGE_PATH}/testaccess.tmp || return 1
 
     # The container .out files embed their container name, the names will sort in the same order in which the containers ran
-    out_files=$(ls -1 "${AUXILIARY_IMAGE_PATH}"/"${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"/*.out 2>/dev/null | sort --version-sort)
+    out_files=$(ls -1 "${AUXILIARY_IMAGE_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}/*.out" 2>/dev/null | sort --version-sort)
     if [ -z "${out_files}" ]; then
       trace SEVERE "Compatibility Auxiliary Image: Assertion failure. No files found in '$AUXILIARY_IMAGE_PATH/$AUXILIARY_IMAGE_COMMAND_LOGS_DIR/*.out'"
       return 1

--- a/operator/src/main/resources/scripts/utils_base.sh
+++ b/operator/src/main/resources/scripts/utils_base.sh
@@ -47,6 +47,8 @@
 #
 #   Set TRACE_INCLUDE_FILE env var to false to suppress file name and line number.
 #
+export AUXILIARY_IMAGE_COMMAND_LOGS_DIR="${AUXILIARY_IMAGE_COMMAND_LOGS_DIR:-compatibilityModeInitContainerLogs}"
+
 trace() {
   (
   set +x


### PR DESCRIPTION
Introduce variable `AUXILIARY_IMAGE_COMMAND_LOGS_DIR` to shell scripts for name of directory containing output from running the `AUXILIARY_IMAGE_COMMAND`. Defaults to `compatibilityModeInitContainerLogs`.

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13183/