### PR TITLE
Add top level 'explain' descriptions for Domain and Cluster resources…

### DIFF
--- a/documentation/domains/Cluster.json
+++ b/documentation/domains/Cluster.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A Cluster resource describes the lifecycle options for all of the Managed Server members of a WebLogic cluster, including Java options, environment variables, additional Pod content, and the ability to explicitly start, stop, or restart cluster members. It must describe a cluster that already exists in the WebLogic domain configuration. See also `domain.spec.clusters`.",
   "type": "object",
   "definitions": {
     "AdminServer": {
@@ -157,6 +158,7 @@
       }
     },
     "ClusterSpec": {
+      "description": "The specification of the operation of the WebLogic cluster. Required.",
       "type": "object",
       "properties": {
         "serverService": {

--- a/documentation/domains/Cluster.md
+++ b/documentation/domains/Cluster.md
@@ -1,5 +1,7 @@
 ### Cluster
 
+A Cluster resource describes the lifecycle options for all of the Managed Server members of a WebLogic cluster, including Java options, environment variables, additional Pod content, and the ability to explicitly start, stop, or restart cluster members. It must describe a cluster that already exists in the WebLogic domain configuration. See also `domain.spec.clusters`.
+
 | Name | Type | Description |
 | --- | --- | --- |
 | `apiVersion` | string | The API version defines the versioned schema of this cluster. |
@@ -9,6 +11,8 @@
 | `status` | [Cluster Status](#cluster-status) | The current status of the operation of the WebLogic cluster. Updated automatically by the operator. |
 
 ### Cluster Spec
+
+The specification of the operation of the WebLogic cluster. Required.
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A Domain resource describes the configuration, logging, images, and lifecycle of a WebLogic domain, including Java options, environment variables, additional Pod content, and the ability to explicitly start, stop, or restart its members. The Domain resource references its Cluster resources using `.spec.clusters`.",
   "type": "object",
   "definitions": {
     "AdminServer": {

--- a/documentation/domains/Domain.md
+++ b/documentation/domains/Domain.md
@@ -1,5 +1,7 @@
 ### Domain
 
+A Domain resource describes the configuration, logging, images, and lifecycle of a WebLogic domain, including Java options, environment variables, additional Pod content, and the ability to explicitly start, stop, or restart its members. The Domain resource references its Cluster resources using `.spec.clusters`.
+
 | Name | Type | Description |
 | --- | --- | --- |
 | `apiVersion` | string | The API version defines the versioned schema of this Domain. Required. |

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1280,7 +1280,7 @@ window.onload = function() {
           "type": "boolean"
         },
         "clusters": {
-          "description": "References to Cluster resources that describe the lifecycle options for all of the Managed Server members of a WebLogic cluster, including Java options, environment variables, additional Pod content, and the ability to explicitly start, stop, or restart cluster members. The Cluster resource must describe a cluster that already exists in the WebLogic domain configuration.",
+          "description": "References to Cluster resources that describe the lifecycle options for all of the Managed Server members of a WebLogic cluster, including Java options, environment variables, additional Pod content, the ability to explicitly start, stop, or restart cluster members. The Cluster resource must describe a cluster that already exists in the WebLogic domain configuration.",
           "type": "array",
           "items": {
             "$ref": "https://github.com/garethr/kubernetes-json-schema/blob/master/v1.13.5/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"

--- a/kubernetes/crd/cluster-crd.yaml
+++ b/kubernetes/crd/cluster-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: e2f9fdbfd207554ee57037b88a5a0704b9f39dda969f9c5e791c820e291376c9
+    weblogic.sha256: c5705fa9410721155ee88e195303da6f7630f2732ed48911926732d1731d5d4c
   name: clusters.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -25,8 +25,15 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: A Cluster resource describes the lifecycle options for all of
+          the Managed Server members of a WebLogic cluster, including Java options,
+          environment variables, additional Pod content, and the ability to explicitly
+          start, stop, or restart cluster members. It must describe a cluster that
+          already exists in the WebLogic domain configuration. See also `domain.spec.clusters`.
         properties:
           spec:
+            description: The specification of the operation of the WebLogic cluster.
+              Required.
             properties:
               serverService:
                 description: Customization affecting the generation of ClusterIP Services

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 4d3978c01ddf8b9f9ba477576355f57ecf2a7df320b4a7ae848210d3d5b21703
+    weblogic.sha256: 0f19892c1da0e97279730097ec59a037a108c805a99b6489a7d0d44bb99149cb
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -25,6 +25,11 @@ spec:
   - name: v9
     schema:
       openAPIV3Schema:
+        description: A Domain resource describes the configuration, logging, images,
+          and lifecycle of a WebLogic domain, including Java options, environment
+          variables, additional Pod content, and the ability to explicitly start,
+          stop, or restart its members. The Domain resource references its Cluster
+          resources using `.spec.clusters`.
         properties:
           spec:
             description: The specification of the operation of the WebLogic domain.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -43,6 +43,7 @@ import io.kubernetes.client.openapi.models.V1WebhookConversion;
 import io.kubernetes.client.util.Yaml;
 import okhttp3.internal.http2.StreamResetException;
 import oracle.kubernetes.common.logging.MessageKeys;
+import oracle.kubernetes.json.Description;
 import oracle.kubernetes.operator.KubernetesConstants;
 import oracle.kubernetes.operator.LabelConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
@@ -54,8 +55,10 @@ import oracle.kubernetes.operator.utils.PathSupport;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.ClusterSpec;
 import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import org.apache.commons.codec.binary.Base64;
@@ -276,6 +279,11 @@ public class CrdHelper {
     abstract Class<?> getStatusClass();
 
     /**
+     * Returns the class that represents the resource.
+     */
+    abstract Class<?> getResourceClass();
+
+    /**
      * Returns a prefix which identifies the CRD schema files for this type of resource.
      */
     abstract String getPrefix();
@@ -416,12 +424,18 @@ public class CrdHelper {
       GsonBuilder gsonBuilder = new GsonBuilder();
       gsonBuilder.setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE);
       Gson gson = gsonBuilder.create();
+
       JsonElement jsonElementSpec = gson.toJsonTree(createCrdSchemaGenerator().generate(getSpecClass()));
       V1JSONSchemaProps spec = gson.fromJson(jsonElementSpec, V1JSONSchemaProps.class);
+
       JsonElement jsonElementStatus = gson.toJsonTree(createCrdSchemaGenerator().generate(getStatusClass()));
       V1JSONSchemaProps status = gson.fromJson(jsonElementStatus, V1JSONSchemaProps.class);
+
+      String description = getResourceClass().getAnnotation(Description.class).value();
+
       return new V1JSONSchemaProps()
           .type("object")
+          .description(description)
           .putPropertiesItem("spec", spec)
           .putPropertiesItem("status", status);
     }
@@ -639,6 +653,11 @@ public class CrdHelper {
     }
 
     @Override
+    Class<?> getResourceClass() {
+      return DomainResource.class;
+    }
+
+    @Override
     protected String getSingularName() {
       return KubernetesConstants.DOMAIN_SINGULAR;
     }
@@ -691,6 +710,11 @@ public class CrdHelper {
     @Override
     Class<?> getStatusClass() {
       return ClusterStatus.class;
+    }
+
+    @Override
+    Class<?> getResourceClass() {
+      return ClusterResource.class;
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterResource.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterResource.java
@@ -22,6 +22,14 @@ import org.jetbrains.annotations.NotNull;
  *
  * @since 4.0
  */
+@Description(
+    "A Cluster resource describes the lifecycle options for all "
+    + "of the Managed Server members of a WebLogic cluster, including Java "
+    + "options, environment variables, additional Pod content, and the ability to "
+    + "explicitly start, stop, or restart cluster members. "
+    + "It must describe a cluster that already exists in the WebLogic domain "
+    + "configuration. See also `domain.spec.clusters`."
+)
 public class ClusterResource implements KubernetesObject {
   /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpec.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @since 2.0
  */
+@Description("The specification of the operation of the WebLogic cluster. Required.")
 public class ClusterSpec extends BaseConfiguration implements Comparable<ClusterSpec> {
   /** The name of the cluster. Required. */
   @Description("The name of the cluster. This value must match the name of a WebLogic cluster already defined "

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainResource.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainResource.java
@@ -64,6 +64,13 @@ import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_AUXILIARY_IM
 /**
  * Domain represents a WebLogic domain and how it will be realized in the Kubernetes cluster.
  */
+@Description(
+    "A Domain resource describes the configuration, logging, images, and lifecycle "
+    + "of a WebLogic domain, including Java "
+    + "options, environment variables, additional Pod content, and the ability to "
+    + "explicitly start, stop, or restart its members. The Domain resource "
+    + "references its Cluster resources using `.spec.clusters`."
+)
 public class DomainResource implements KubernetesObject, RetryMessageFactory {
   /**
    * The starting marker of a token that needs to be substituted with a matching env var.


### PR DESCRIPTION
…, plus modify schema generation to capture the description annotations on said resources.

```
$ kubectl explain domain
KIND:     Domain
VERSION:  weblogic.oracle/v9

DESCRIPTION:
     A Domain resource describes the configuration, logging, images, and
     lifecycle of a WebLogic domain, including Java options, environment
     variables, additional Pod content, and the ability to explicitly start,
     stop, or restart its members. The Domain resource references its Cluster
     resources using `.spec.clusters`.

FIELDS:
<snip>
```

```
$ kubectl explain cluster
KIND:     Cluster
VERSION:  weblogic.oracle/v1

DESCRIPTION:
     A Cluster resource describes the lifecycle options for all of the Managed
     Server members of a WebLogic cluster, including Java options, environment
     variables, additional Pod content, and the ability to explicitly start,
     stop, or restart cluster members. It must describe a cluster that already
     exists in the WebLogic domain configuration. See also
     `domain.spec.clusters`.

FIELDS:
<snip>
```