### PR TITLE
OWLS-102533 - increase the WDT YAML max file size to 25MB in integration tests.

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -380,5 +380,5 @@ public interface TestConstants {
   //Defaulting to 1440 minutes (24 hours)
   public static final Long FAILURE_RETRY_LIMIT_MINUTES =
       Long.valueOf(getNonEmptySystemProperty("failure.retry.limit.minutes", "10"));
-  String YAML_MAX_FILE_SIZE_PROPERTY = "-Dwdt.config.yaml.max.file.size=20000000";
+  String YAML_MAX_FILE_SIZE_PROPERTY = "-Dwdt.config.yaml.max.file.size=25000000";
 }


### PR DESCRIPTION
OWLS-102533 - Increase the WDT YAML max file size to 25MB (from 20MB) as one of the test creates a file bigger than 20MB .

Integration test run results at - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13243/console