### PR TITLE
OWLS-102367: WKO 4.0 bug: Cluster resource 'Observed Generation' status goes missing after a few minutes idle time

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -946,11 +946,11 @@ public class DomainStatusUpdater {
 
         void addClusterConditions() {
           clusterStatus.addCondition(
-                  new ClusterCondition(ClusterConditionType.AVAILABLE)
-                          .withStatus(isAvailable()));
+              new ClusterCondition(ClusterConditionType.AVAILABLE)
+                  .withStatus(isAvailable()));
           clusterStatus.addCondition(
-                  new ClusterCondition(ClusterConditionType.COMPLETED)
-                          .withStatus(isProcessingCompleted()));
+              new ClusterCondition(ClusterConditionType.COMPLETED)
+                  .withStatus(isProcessingCompleted()));
         }
 
         private String createNotReadyMessage() {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -945,19 +945,12 @@ public class DomainStatusUpdater {
         }
 
         void addClusterConditions() {
-          addClusterConditionIfNeeded(clusterStatus.getCondition(ClusterConditionType.AVAILABLE),
-                  new ClusterCondition(ClusterConditionType.AVAILABLE).withStatus(isAvailable()));
-
-          addClusterConditionIfNeeded(clusterStatus.getCondition(ClusterConditionType.COMPLETED),
-                  new ClusterCondition(ClusterConditionType.COMPLETED).withStatus(isProcessingCompleted()));
-
-        }
-
-        private void addClusterConditionIfNeeded(ClusterCondition currentCondition, ClusterCondition newCondition) {
-          if (currentCondition == null
-                  || !currentCondition.equals(newCondition)) {
-            clusterStatus.addCondition(newCondition);
-          }
+          clusterStatus.addCondition(
+                  new ClusterCondition(ClusterConditionType.AVAILABLE)
+                          .withStatus(isAvailable()));
+          clusterStatus.addCondition(
+                  new ClusterCondition(ClusterConditionType.COMPLETED)
+                          .withStatus(isProcessingCompleted()));
         }
 
         private String createNotReadyMessage() {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -1362,13 +1362,18 @@ public class DomainStatusUpdater {
           .withLabelSelector(DOMAINUID_LABEL + "=" + info.getDomainUid() + "," + CLUSTERNAME_LABEL + "=" + clusterName)
           .withMaximumReplicas(clusterConfig.getClusterSize())
           .withMinimumReplicas(MINIMUM_CLUSTER_COUNT)
-          .withReplicasGoal(getClusterSizeGoal(clusterName));
+          .withReplicasGoal(getClusterSizeGoal(clusterName))
+          .withObservedGeneration(getClusterObservedGeneration(clusterName));
     }
 
     private Integer getClusterSizeGoal(String clusterName) {
       return info.getReplicaCount(clusterName);
     }
 
+    private Long getClusterObservedGeneration(String clusterName) {
+      return Optional.ofNullable(info.getClusterResource(clusterName)).map(c -> c.getStatus())
+              .map(s -> s.getObservedGeneration()).orElse(1L);
+    }
   }
 
   static class FailureStep extends DomainStatusUpdaterStep implements StepWithRetryCount {

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
@@ -201,11 +201,6 @@ public class ClusterStatus implements Comparable<ClusterStatus>, PatchableCompon
     return conditions;
   }
 
-  public ClusterCondition getCondition(ClusterConditionType type) {
-    return getConditions().stream().filter(condition -> condition.getType().equals(type))
-            .findFirst().orElse(null);
-  }
-
   @Override
   public String toString() {
     return new ToStringBuilder(this)

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
@@ -174,6 +174,20 @@ public class ClusterStatus implements Comparable<ClusterStatus>, PatchableCompon
     return observedGeneration;
   }
 
+  /**
+   * The observedGeneration attribute is defined as an integer type in the Cluster Resource
+   * schema, hence convert to integer when publishing the status.
+   * @return integer value of the observedGeneration, if set, otherwise -1.
+   */
+  private Integer getObservedGenerationAsInteger() {
+    return observedGeneration != null ? observedGeneration.intValue() : -1;
+  }
+
+  public ClusterStatus withObservedGeneration(Long observedGeneration) {
+    this.observedGeneration = observedGeneration;
+    return this;
+  }
+
   public void setObservedGeneration(Long observedGeneration) {
     this.observedGeneration = observedGeneration;
   }
@@ -249,13 +263,15 @@ public class ClusterStatus implements Comparable<ClusterStatus>, PatchableCompon
     return other.getClusterName() != null && other.getClusterName().equals(clusterName);
   }
 
-  private static final ObjectPatch<ClusterStatus> clusterPatch = createObjectPatch(ClusterStatus.class)
-        .withStringField("clusterName", ClusterStatus::getClusterName)
-        .withIntegerField("maximumReplicas", ClusterStatus::getMaximumReplicas)
-        .withIntegerField("minimumReplicas", ClusterStatus::getMinimumReplicas)
-        .withIntegerField("readyReplicas", ClusterStatus::getReadyReplicas)
-        .withIntegerField("replicas", ClusterStatus::getReplicas)
-        .withIntegerField("replicasGoal", ClusterStatus::getReplicasGoal);
+  private static final ObjectPatch<ClusterStatus> clusterPatch =
+      createObjectPatch(ClusterStatus.class)
+          .withStringField("clusterName", ClusterStatus::getClusterName)
+          .withIntegerField("maximumReplicas", ClusterStatus::getMaximumReplicas)
+          .withIntegerField("minimumReplicas", ClusterStatus::getMinimumReplicas)
+          .withIntegerField("observedGeneration", ClusterStatus::getObservedGenerationAsInteger)
+          .withIntegerField("readyReplicas", ClusterStatus::getReadyReplicas)
+          .withIntegerField("replicas", ClusterStatus::getReplicas)
+          .withIntegerField("replicasGoal", ClusterStatus::getReplicasGoal);
 
   static ObjectPatch<ClusterStatus> getObjectPatch() {
     return clusterPatch;

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
@@ -201,6 +201,11 @@ public class ClusterStatus implements Comparable<ClusterStatus>, PatchableCompon
     return conditions;
   }
 
+  public ClusterCondition getCondition(ClusterConditionType type) {
+    return getConditions().stream().filter(condition -> condition.getType().equals(type))
+            .findFirst().orElse(null);
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterStatus.java
@@ -177,10 +177,10 @@ public class ClusterStatus implements Comparable<ClusterStatus>, PatchableCompon
   /**
    * The observedGeneration attribute is defined as an integer type in the Cluster Resource
    * schema, hence convert to integer when publishing the status.
-   * @return integer value of the observedGeneration, if set, otherwise -1.
+   * @return integer value of the observedGeneration, if set, otherwise defaults to 1.
    */
   private Integer getObservedGenerationAsInteger() {
-    return observedGeneration != null ? observedGeneration.intValue() : -1;
+    return observedGeneration != null ? observedGeneration.intValue() : 1;
   }
 
   public ClusterStatus withObservedGeneration(Long observedGeneration) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -214,7 +214,7 @@ class DomainStatusPatchTest {
     DomainStatus status1 = new DomainStatus();
     DomainStatus status2 = new DomainStatus()
           .addCluster(new ClusterStatus()
-              .withClusterName("cluster1").withReplicas(2).withReadyReplicas(4)
+              .withClusterName("cluster1").withReplicas(2).withReadyReplicas(4).withObservedGeneration(1L)
               .withMaximumReplicas(10).withReplicasGoal(10).withMinimumReplicas(2))
           .addCluster(new ClusterStatus()
               .withClusterName("cluster2").withReplicas(4).withMaximumReplicas(8).withMinimumReplicas(1));
@@ -224,8 +224,9 @@ class DomainStatusPatchTest {
     assertThat(builder.getPatches(),
           hasItemsInOrder(
                 "ADD /status/clusters/- {'clusterName':'cluster1','maximumReplicas':10,'minimumReplicas':2,"
-                    + "'readyReplicas':4,'replicas':2,'replicasGoal':10}",
-                "ADD /status/clusters/- {'clusterName':'cluster2','maximumReplicas':8,'minimumReplicas':1,'replicas':4}"
+                    + "'observedGeneration':1,'readyReplicas':4,'replicas':2,'replicasGoal':10}",
+                "ADD /status/clusters/- {'clusterName':'cluster2','maximumReplicas':8,'minimumReplicas':1,"
+                    + "'observedGeneration':-1,'replicas':4}"
                 ));
   }
 
@@ -261,7 +262,8 @@ class DomainStatusPatchTest {
           .addCluster(new ClusterStatus()
               .withClusterName("cluster2").withReplicas(2).withMaximumReplicas(8).withMinimumReplicas(3))
           .addCluster(new ClusterStatus()
-              .withClusterName("cluster4").withReplicas(4).withMaximumReplicas(8).withMinimumReplicas(2));
+              .withClusterName("cluster4").withReplicas(4).withMaximumReplicas(8).withMinimumReplicas(2)
+              .withObservedGeneration(2L));
 
     computePatch(status1, status2);
 
@@ -271,7 +273,7 @@ class DomainStatusPatchTest {
                 "REPLACE /status/clusters/1/replicas 2",
                 "REMOVE /status/clusters/2",
                 "ADD /status/clusters/- {'clusterName':'cluster4','maximumReplicas':8,"
-                        + "'minimumReplicas':2,'replicas':4}"
+                        + "'minimumReplicas':2,'observedGeneration':2,'replicas':4}"
                 ));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainStatusPatchTest.java
@@ -226,7 +226,7 @@ class DomainStatusPatchTest {
                 "ADD /status/clusters/- {'clusterName':'cluster1','maximumReplicas':10,'minimumReplicas':2,"
                     + "'observedGeneration':1,'readyReplicas':4,'replicas':2,'replicasGoal':10}",
                 "ADD /status/clusters/- {'clusterName':'cluster2','maximumReplicas':8,'minimumReplicas':1,"
-                    + "'observedGeneration':-1,'replicas':4}"
+                    + "'observedGeneration':1,'replicas':4}"
                 ));
   }
 


### PR DESCRIPTION
Although the the 'Observed Generation' attribute is reported in the Cluster status initially, it disappears when the Domain Status is updated.