### PR TITLE
Added tests for WKO Retry Improvements: Implement the handling of Fatal and Warning Failures

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
@@ -195,12 +195,13 @@ class ItRetryImprovements {
    * Create a domain-in-image domain with an invalid domain resource that has duplicate server names
    * the domain should fail to start with SEVERE error and FatalDomainInvalidError
    * the Operator should stop retrying immediately.
-   * Also log a clear message in Operator logs and the domain Failed condition with the cause,
-   * actions to fix the problem.
+   * Also a message is logged into Operator Log indicating FatalDomainInvalidError
+   * and the domain Failed condition with the cause, actions to fix the problem.
    * Verify that retry resume after the issue is fixed and the domain starts successfully.
    */
   @Test
-  @DisplayName("Create a domain duplicate server names. Verify that retry stopped and handles FATAL error as designed.")
+  @DisplayName("Create a domain with duplicate server names."
+       + "Verify that retry stopped and handles FATAL error as designed.")
   void testRetryOccursAsExpectedAndThrowFatalFailures() {
     int replicaCount = 2;
     String duplicateServerName = "managed-server1";
@@ -251,7 +252,8 @@ class ItRetryImprovements {
    * Also log a clear message in Operator logs and the domain with the cause.
    */
   @Test
-  @DisplayName("Create a domain duplicate server names. Verify that retry stopped and handles Waring as designed.")
+  @DisplayName("Create a domain with replica count = 6 that exceeds the maximum cluster size "
+      + "Verify domain starts and WARNING message is logged")
   void testRetryOccursAsExpectedAndThrowWarning() {
     int replicaMaxCount = 5;
     int replicaCount = 6;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
@@ -69,7 +69,6 @@ class ItRetryImprovements {
 
   // domain constants
   private static final String clusterName = "cluster-1";
-  //private static final int replicaCount = 2;
   private static final String wlSecretName = "weblogic-credentials";
   private static final String domainUid = "domaininimage";
   private static final String wdtModelFileForDomainInImage = "wdt-singlecluster-sampleapp-usingprop-wls.yaml";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
@@ -7,7 +7,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import io.kubernetes.client.custom.V1Patch;
 import oracle.weblogic.domain.DomainResource;
+import oracle.weblogic.domain.ManagedServer;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -22,6 +24,7 @@ import static oracle.weblogic.kubernetes.TestConstants.ADMIN_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.ADMIN_USERNAME_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.DOMAIN_VERSION;
 import static oracle.weblogic.kubernetes.TestConstants.FAILURE_RETRY_INTERVAL_SECONDS;
+import static oracle.weblogic.kubernetes.TestConstants.FAILURE_RETRY_LIMIT_MINUTES;
 import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WDT_BASIC_MODEL_PROPERTIES_FILE;
@@ -30,6 +33,9 @@ import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.WLS_DOMAIN_TYPE;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.createDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.deleteSecret;
+import static oracle.weblogic.kubernetes.actions.TestActions.getNextIntrospectVersion;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchClusterCustomResourceReturnResponse;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.domainExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
@@ -41,6 +47,7 @@ import static oracle.weblogic.kubernetes.utils.ImageUtils.createTestRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.findStringInOperatorLog;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.PatchDomainUtils.patchDomainResource;
 import static oracle.weblogic.kubernetes.utils.SecretUtils.createSecretWithUsernamePassword;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -62,7 +69,7 @@ class ItRetryImprovements {
 
   // domain constants
   private static final String clusterName = "cluster-1";
-  private static final int replicaCount = 2;
+  //private static final int replicaCount = 2;
   private static final String wlSecretName = "weblogic-credentials";
   private static final String domainUid = "domaininimage";
   private static final String wdtModelFileForDomainInImage = "wdt-singlecluster-sampleapp-usingprop-wls.yaml";
@@ -101,6 +108,7 @@ class ItRetryImprovements {
   // This method is needed in this test class to delete uncompleted domain to restore the env
   @AfterEach
   public void tearDown() {
+    deleteSecret(wlSecretName, domainNamespace);
     deleteDomainResource(domainNamespace, domainUid);
   }
 
@@ -114,10 +122,12 @@ class ItRetryImprovements {
   @Test
   @DisplayName("Create a domain without WLS secret. Verify that retry occurs and handles SEVERE error as designed.")
   void testRetryOccursAsExpectedAndThrowSevereFailures() {
+    int replicaCount = 2;
     // verify that the operator starts retrying in the intervals specified in domain.spec.failureRetryIntervalSeconds
     // when a SEVERE error occurs and clear message is logged.
     Long failureRetryLimitMinutes = Long.valueOf("1");
-    createDomainWithoutWlsSecret(failureRetryLimitMinutes);
+    DomainResource domain = createDomainResourceForRetryTest(failureRetryLimitMinutes, replicaCount, false);
+    createDomainForRetryTest(domain);
 
     String retryOccurRegex = new StringBuffer(".*WebLogicCredentials.*\\s*secret.*")
         .append(wlSecretName)
@@ -157,9 +167,11 @@ class ItRetryImprovements {
   @Test
   @DisplayName("Verify that retry stops after the issue is fixed and the domain starts successfully.")
   void testRetryStoppedAfterIssueFixed() {
+    int replicaCount = 2;
     // verify that the operator starts retrying when a SEVERE error occurs
     Long failureRetryLimitMinutes = Long.valueOf("5");
-    createDomainWithoutWlsSecret(failureRetryLimitMinutes);
+    DomainResource domain = createDomainResourceForRetryTest(failureRetryLimitMinutes, replicaCount,false);
+    createDomainForRetryTest(domain);
 
     String retryOccurRegex = new StringBuffer(".*WebLogicCredentials.*\\s*secret.*")
         .append(wlSecretName)
@@ -176,12 +188,132 @@ class ItRetryImprovements {
     logger.info("Create secret for admin credentials");
     createSecretWithUsernamePassword(wlSecretName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
 
+    verifyDomainExistsAndServerStarted(replicaCount);
+  }
+
+  /**
+   * Create a domain-in-image domain with an invalid domain resource that has duplicate server names
+   * the domain should fail to start with SEVERE error and FatalDomainInvalidError
+   * the Operator should stop retrying immediately.
+   * Also log a clear message in Operator logs and the domain Failed condition with the cause,
+   * actions to fix the problem.
+   * Verify that retry resume after the issue is fixed and the domain starts successfully.
+   */
+  @Test
+  @DisplayName("Create a domain duplicate server names. Verify that retry stopped and handles FATAL error as designed.")
+  void testRetryOccursAsExpectedAndThrowFatalFailures() {
+    int replicaCount = 2;
+    String duplicateServerName = "managed-server1";
+    // verify that the operator stops retrying immediately when a FATAL error occurs and clear message is logged.
+    DomainResource domain = createDomainResourceForRetryTest(FAILURE_RETRY_LIMIT_MINUTES, replicaCount, true);
+
+    // create an invalid domain resource with duplicate server names
+    domain.getSpec().addManagedServersItem(new ManagedServer().serverName(duplicateServerName));
+    domain.getSpec().addManagedServersItem(new ManagedServer().serverName(duplicateServerName));
+    createDomainForRetryTest(domain);
+
+    String fatalDomainInvalidErrorRegex =
+        new StringBuffer(".*FatalDomainInvalidError.*More than one.*spec.managedServers.*")
+          .append(duplicateServerName)
+          .append(".*").toString();
+
+    // verify that FatalDomainInvalidError message found in domain status message
+    testUntil(() -> findStringInDomainStatusMessage(domainNamespace, domainUid, fatalDomainInvalidErrorRegex),
+        logger, "FatalDomainInvalidError is found in domain status message");
+
+    // verify that FatalDomainInvalidError message found in Operator log
+    testUntil(() -> findStringInOperatorLog(opNamespace, fatalDomainInvalidErrorRegex),
+        logger, "FatalDomainInvalidError is found in Operator log");
+
+    // patch domain CR to delete duplicate server and have Operator retry
+    int introspectVersion = 0;
+    if (domain.getSpec().getIntrospectVersion() != null) {
+      introspectVersion = Integer.parseInt(domain.getSpec().getIntrospectVersion()) + 1;
+    }
+
+    StringBuffer patchStr = new StringBuffer("[{");
+    patchStr.append("\"op\": \"remove\",")
+        .append(" \"path\": \"/spec/managedServers/0\"},")
+        .append("{\"op\": \"replace\", \"path\": \"/spec/introspectVersion\", \"value\": \"")
+        .append(introspectVersion)
+        .append("\"}]");
+    logger.info("PatchStr for : {0}", patchStr.toString());
+
+    boolean cmPatched = patchDomainResource(domainUid, domainNamespace, patchStr);
+    assertTrue(cmPatched, "Patch domain CR to delete duplicate server failed");
+
+    verifyDomainExistsAndServerStarted(replicaCount);
+  }
+
+  /**
+   * Create a domain-in-image domain with replica count = 6 that exceeds the maximum cluster size
+   * of 5. The domain should start but with WARNING message.
+   * Also log a clear message in Operator logs and the domain with the cause.
+   */
+  @Test
+  @DisplayName("Create a domain duplicate server names. Verify that retry stopped and handles Waring as designed.")
+  void testRetryOccursAsExpectedAndThrowWarning() {
+    int replicaMaxCount = 5;
+    int replicaCount = 6;
+    // create a domain with replicas = 6 that exceeds the maximum cluster size of 5
+    DomainResource domain = createDomainResourceForRetryTest(FAILURE_RETRY_LIMIT_MINUTES, replicaCount, true);
+    createDomainForRetryTest(domain);
+
+    String warningMsgRegex = new StringBuffer(".*")
+        .append(replicaCount)
+        .append("\\s*replicas.*")
+        .append(clusterName)
+        .append(".*maximum.*size.*")
+        .append(replicaMaxCount)
+        .append(".*").toString();
+
+    // verify that warningMsgRegex message found in domain status message
+    testUntil(() -> findStringInDomainStatusMessage(domainNamespace, domainUid, warningMsgRegex),
+        logger, "warningMsgRegex is found in domain status message");
+
+    // verify that WARNING and warningMsgRegex message found in Operator log
+    testUntil(() -> findStringInOperatorLog(opNamespace, ".*WARNING" + warningMsgRegex),
+        logger, "warningMsgRegex is found in Operator log");
+
+    // verify that the cluster is up and running
+    verifyDomainExistsAndServerStarted(replicaMaxCount);
+
+    // reduce replicas back to the maximum cluster size
+    StringBuffer patchStr =
+        new StringBuffer("[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": ")
+            .append(replicaMaxCount).append("}]");
+    V1Patch patch = new V1Patch(patchStr.toString());
+    logger.info("Patching the cluster resource using patching string {0}", patchStr);
+    String response = patchClusterCustomResourceReturnResponse(clusterName, domainNamespace, patch,
+        V1Patch.PATCH_FORMAT_JSON_PATCH);
+    assertTrue(response.contains("Succeeded with response code: 200"),
+        String.format("patching cluster %s in namespace %s failed with error msg: %s",
+            clusterName, domainNamespace, response));
+
+    // update introspectVersion to have Operator start retry
+    String introspectVersion = assertDoesNotThrow(() -> getNextIntrospectVersion(domainUid, domainNamespace));
+    patchStr = new StringBuffer("[{\"op\": \"add\", \"path\": \"/spec/introspectVersion\", \"value\": \"")
+        .append(introspectVersion)
+        .append("\"}]");
+    logger.info("Updating introspectVersion in domain resource using patch string: {0}", patchStr);
+
+    boolean cmPatched = patchDomainResource(domainUid, domainNamespace, patchStr);
+    assertTrue(cmPatched, "Patch domain CR to update introspectVersion in domain resource failed");
+
+    // verify that warningMsgRegex message is gone in domain status message
+    testUntil(() -> ! findStringInDomainStatusMessage(domainNamespace, domainUid, warningMsgRegex),
+        logger, "warningMsgRegex is not found in domain status message");
+
+    // verify that the cluster is still up and running
+    verifyDomainExistsAndServerStarted(replicaMaxCount);
+  }
+
+  private void verifyDomainExistsAndServerStarted(int replicaCount) {
     // wait for the domain to exist
     logger.info("Checking for domain custom resource in namespace {0}", domainNamespace);
     testUntil(
         domainExists(domainUid, DOMAIN_VERSION, domainNamespace),
-        logger,
-        "domain {0} to be created in namespace {1}",
+        logger, "domain {0} to be created in namespace {1}",
         domainUid,
         domainNamespace);
 
@@ -202,7 +334,15 @@ class ItRetryImprovements {
     }
   }
 
-  private static DomainResource createDomainWithoutWlsSecret(Long failureRetryLimitMinutes) {
+  private static DomainResource createDomainResourceForRetryTest(Long failureRetryLimitMinutes,
+                                                                 int replicaCount,
+                                                                 boolean createSecret) {
+    if (createSecret) {
+      // create secret for admin credentials
+      logger.info("Create secret for admin credentials");
+      createSecretWithUsernamePassword(wlSecretName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
+    }
+
     // create image with model files
     logger.info("Creating image with model file and verify");
     List<String> appSrcDirList = new ArrayList<>();
@@ -223,10 +363,12 @@ class ItRetryImprovements {
     // create the domain custom resource
     DomainResource domain = createDomainResourceForDomainInImage(domainUid, domainNamespace,
         domainInImageWithWdtImage, wlSecretName, clusterName, replicaCount, failureRetryLimitMinutes);
-
-    // create the domain CR
     assertNotNull(domain, "domain is null");
 
+    return domain;
+  }
+
+  private static void createDomainForRetryTest(DomainResource domain) {
     logger.info("Creating domain custom resource for domainUid {0} in namespace {1}",
         domainUid, domainNamespace);
     assertTrue(assertDoesNotThrow(() -> createDomainCustomResource(domain, DOMAIN_VERSION),
@@ -234,7 +376,5 @@ class ItRetryImprovements {
             domainUid, domainNamespace)),
         String.format("Create domain custom resource failed with ApiException for %s in namespace %s",
             domainUid, domainNamespace));
-
-    return domain;
   }
 }


### PR DESCRIPTION
use case for FATAL error:

1. create a domain and specifying the same server name twice.
2. check FatalDomainInvalidError msg in both domain status and Operator log
3. Operator with stop retry immediately
4. After duplicated server is removed and introspectVersion is changed, the Operator will start retry automatically

use case for WARNING error:

1. create a domain-in-image domain with replica count = 6 that exceeds the maximum cluster size of 5. The domain should  start but with WARNING message.
2. verify that a clear message is logged in Operator logs and the domain with the cause.
3. reduce replicas back to the maximum cluster size
4. verify that WARNING message is gone in domain status message


Jenkins:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13333/ (new) 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13231
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13232
