### PR TITLE
OWLS-102819 - Update the DPI cache with the live domain resource at the beginning of make-right.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -358,8 +358,13 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
 
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<DomainResource> callResponse) {
-      DomainPresenceInfo.fromPacket(packet).ifPresent(info -> info.setDeleting(false));
+      DomainPresenceInfo.fromPacket(packet).ifPresent(info -> updateCache(info, callResponse.getResult()));
       return doNext(packet);
+    }
+
+    private void updateCache(DomainPresenceInfo info, DomainResource domain) {
+      info.setDeleting(false);
+      info.setDomain(domain);
     }
 
     @Override


### PR DESCRIPTION
OWLS-102819 - Fix for the issue of two introspector jobs created when applying the domain and the cluster resource at the same time. When the make-right is triggered due to added cluster, the DPI cache has stale domain resource and introspector Job is created with the wrong owner reference. This causes the first introspector job to be deleted by the "k8s garbage collector" as part of the garbage collection of stale domain.

This change updates the DPI cache with the live domain resource read at the beginning of make-right cycle. 

Integration test results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13254/