### PR TITLE
OWLS-102929 - [wko-nightly] Fix ItAuxV8DomainImplicitUpgrade test, OWLS-101724 Grep Review: grep for "successfully"

### DIFF
--- a/operator/src/main/resources/scripts/auxImage.sh
+++ b/operator/src/main/resources/scripts/auxImage.sh
@@ -34,16 +34,28 @@ checkEnv AUXILIARY_IMAGE_TARGET_PATH AUXILIARY_IMAGE_CONTAINER_NAME || exit 1
 
 if [[ "$AUXILIARY_IMAGE_CONTAINER_NAME" == "operator-aux-container"* ]]; then
   initAuxiliaryImage > /tmp/auxiliaryImage.out 2>&1
+  retval=$?
   cat /tmp/auxiliaryImage.out
 
   mkdir -p ${AUXILIARY_IMAGE_TARGET_PATH}/auxiliaryImageLogs
   cp /tmp/auxiliaryImage.out ${AUXILIARY_IMAGE_TARGET_PATH}/auxiliaryImageLogs/${AUXILIARY_IMAGE_CONTAINER_NAME}.out
+  sucFile="${AUXILIARY_IMAGE_TARGET_PATH}/auxiliaryImageLogs/${AUXILIARY_IMAGE_CONTAINER_NAME}.suc"
+  rm -f "$sucFile"
+  if [ $retval -eq 0 ]; then
+    echo $retval > "$sucFile"
+  fi
 elif [[ "$AUXILIARY_IMAGE_CONTAINER_NAME" == "compatibility-mode-operator-aux-container"* ]]; then
   initCompatibilityModeInitContainersWithLegacyAuxImages > /tmp/compatibilityModeInitContainers.out 2>&1
+  retval=$?
   cat /tmp/compatibilityModeInitContainers.out
 
   mkdir -p "${AUXILIARY_IMAGE_TARGET_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}"
   cp /tmp/compatibilityModeInitContainers.out "${AUXILIARY_IMAGE_TARGET_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}/${AUXILIARY_IMAGE_CONTAINER_NAME}.out"
+  sucFile="${AUXILIARY_IMAGE_TARGET_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}/${AUXILIARY_IMAGE_CONTAINER_NAME}.suc"
+  rm -f "$sucFile"
+  if [ $retval -eq 0 ]; then
+    echo $retval > "$sucFile"
+  fi
 else
   trace SEVERE "Invalid auxiliary image container name '$AUXILIARY_IMAGE_CONTAINER_NAME'. " \
                "The auxiliary image container name must start with either 'operator-aux-container' " \

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -743,10 +743,11 @@ checkAuxiliaryImage() {
   fi
   local severe_found=false
   for out_file in $out_files; do
+    sucFile="${out_file/%.out/.suc}"
     if [ "$(grep -c SEVERE $out_file)" != "0" ]; then
       trace FINE "Auxiliary Image: Error found in file '${out_file}' while initializing auxiliaryImage."
       severe_found=true
-    elif [ "$(grep -c successfully $out_file)" = "0" ]; then
+    elif [ ! -f "$sucFile" ]; then
       trace SEVERE "Auxiliary Image: Command execution was unsuccessful in file '${out_file}' while initializing auxiliaryImage. " \
                    "Contents of '${out_file}':"
       cat $out_file
@@ -798,10 +799,11 @@ checkCompatibilityModeInitContainersWithLegacyAuxImages() {
     fi
     severe_found=false
     for out_file in $out_files; do
+      sucFile="${out_file/%.out/.suc}"
       if [ "$(grep -c SEVERE $out_file)" != "0" ]; then
         trace FINE "Compatibility Auxiliary Image: Error found in file '${out_file}' while initializing auxiliaryImage."
         severe_found=true
-      elif [ "$(grep -c successfully $out_file)" = "0" ]; then
+      elif [ ! -f "$sucFile" ]; then
         trace SEVERE "Compatibility Auxiliary Image: Command execution was unsuccessful in file '${out_file}' while initializing auxiliaryImage. " \
                      "Contents of '${out_file}':"
         cat $out_file

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -792,7 +792,7 @@ checkCompatibilityModeInitContainersWithLegacyAuxImages() {
     rm -f ${AUXILIARY_IMAGE_PATH}/testaccess.tmp || return 1
 
     # The container .out files embed their container name, the names will sort in the same order in which the containers ran
-    out_files=$(ls -1 "${AUXILIARY_IMAGE_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}/*.out" 2>/dev/null | sort --version-sort)
+    out_files=$(ls -1 "${AUXILIARY_IMAGE_PATH}/${AUXILIARY_IMAGE_COMMAND_LOGS_DIR}/"*.out 2>/dev/null | sort --version-sort)
     if [ -z "${out_files}" ]; then
       trace SEVERE "Compatibility Auxiliary Image: Assertion failure. No files found in '$AUXILIARY_IMAGE_PATH/$AUXILIARY_IMAGE_COMMAND_LOGS_DIR/*.out'"
       return 1

--- a/operator/src/main/resources/scripts/utils_base.sh
+++ b/operator/src/main/resources/scripts/utils_base.sh
@@ -374,7 +374,7 @@ initCompatibilityModeInitContainersWithLegacyAuxImages() {
   if [ -z "${AUXILIARY_IMAGE_COMMAND}" ]; then
     trace SEVERE "Compatibility Auxiliary Image: The 'serverPod.auxiliaryImages.command' is empty for the " \
                 "container image='$AUXILIARY_IMAGE_CONTAINER_IMAGE'. Exiting."
-    return
+    return 1
   fi
 
   trace FINE "Compatibility Auxiliary Image: About to execute command '$AUXILIARY_IMAGE_COMMAND' in container image='$AUXILIARY_IMAGE_CONTAINER_IMAGE'. " \
@@ -386,6 +386,7 @@ initCompatibilityModeInitContainersWithLegacyAuxImages() {
   if [ $? -ne 0 ]; then
     trace SEVERE "Compatibility Auxiliary Image: Command '$AUXILIARY_IMAGE_COMMAND' execution failed in container image='$AUXILIARY_IMAGE_CONTAINER_IMAGE' " \
                 "with AUXILIARY_IMAGE_PATH=$AUXILIARY_IMAGE_PATH. Error -> '$results' ."
+    return 1
   else
     trace FINE "Compatibility Auxiliary Image: Command '$AUXILIARY_IMAGE_COMMAND' executed successfully. Output -> '$results'."
   fi


### PR DESCRIPTION
- ItAuxV8DomainImplicitUpgrade tests failed due to misplaced double quote in checkCompatibilityModeInitContainersWithLegacyAuxImages() function. This is now fixed.
- Updated scripts to check for successful auxiliary image command execution using existence of `.suc` file instead of searching for `successfully` string in output 

ItAuxV8DomainImplicitUpgrade pases: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13293/
jenkins (still running): https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13296/