### PR TITLE
Fix to retain existing init containers under serverPod when adding the init containers for the auxiliary images.

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
+++ b/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
@@ -450,7 +450,8 @@ public class SchemaConversionUtils {
   private void addInitContainersVolumeAndMountsToServerPod(Map<String, Object> serverPod, List<Object> auxiliaryImages,
                                                                          List<Object> auxiliaryImageVolumes) {
     addEmptyDirVolume(serverPod, auxiliaryImageVolumes);
-    List<Object> initContainers = new ArrayList<>();
+    List<Object> initContainers = Optional.ofNullable((List<Object>) serverPod.get("initContainers"))
+        .orElse(new ArrayList<>());
     for (Object auxiliaryImage : auxiliaryImages) {
       initContainers.add(
           createInitContainerForAuxiliaryImage((Map<String, Object>) auxiliaryImage, containerIndex.get(),


### PR DESCRIPTION
Fix for `ItInitContainers` integration test failures in the interop environment. This change ensures that the conversion webhook doesn't overrride the existing init containers under `serverPod` stanza when creating and adding the init containers for the auxiliary images.

Integration test run results - https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/114/