### PR TITLE
Owls102830 - report errors for all invalid clusters

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
+++ b/common/src/main/java/oracle/kubernetes/common/logging/MessageKeys.java
@@ -274,6 +274,8 @@ public class MessageKeys {
   public static final String DOMAIN_INTROSPECTION_TRIGGER_CHANGED = "WLSWH-0017";
   public static final String WEBHOOK_STARTUP_FAILED = "WLSWH-0018";
   public static final String CLUSTER_REPLICAS_CANNOT_BE_HONORED = "WLSWH-0019";
+  public static final String DOMAIN_REPLICAS_CANNOT_BE_HONORED_MULTIPLE_CLUSTERS = "WLSWH-0020";
+  public static final String DOMAIN_REPLICAS_TOO_HIGH_MULTIPLE_CLUSTERS = "WLSWH-0021";
 
   private MessageKeys() {
   }

--- a/common/src/main/resources/Operator.properties
+++ b/common/src/main/resources/Operator.properties
@@ -314,7 +314,7 @@ WLSWH-0011=Validating webhook failed to perform validation due to ''{0}''
 WLSWH-0012=Validating Webhook configuration ''{0}'' has been updated
 WLSWH-0013=Validating Webhook configuration ''{0}'' has not been updated due to ''{1}''
 WLSWH-0014=Cannot read validating Webhook configuration ''{0}'' due to ''{1}''
-WLSWH-0015=Change request to domain resource ''{0}'' cannot be honored because the replica count for cluster ''{1}'' \
+WLSWH-0015=Change request to domain resource ''{0}'' cannot be honored because the replica count of cluster ''{1}'' \
   would exceed the cluster size ''{2}''
 WLSWH-0016=Change request to domain resource ''{0}'' causes the replica count of cluster ''{1}'' to exceed the cluster \
   size ''{2}''
@@ -323,3 +323,7 @@ WLSWH-0017=The request is allowed because ''{0}'' also changed, which will lead 
 WLSWH-0018=WebLogic Operator webhook ''{0}'' failed to start up due to ''{1}''
 WLSWH-0019=Change request to cluster resource ''{0}'' cannot be honored because the replica count would exceed the \
   cluster size ''{1}''
+WLSWH-0020=Change request to domain resource ''{0}'' cannot be honored because the replica count of each cluster in ''{1}'' \
+  would exceed its cluster size ''{2}'' respectively
+WLSWH-0021=Change request to domain resource ''{0}'' causes the replica count of each cluster in ''{1}'' to exceed its cluster \
+  size ''{2}'' respectively

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItValidateWebhookReplicas.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItValidateWebhookReplicas.java
@@ -114,7 +114,6 @@ class ItValidateWebhookReplicas {
   private static int externalRestHttpsPort = 0;
 
   private String clusterName = "cluster-1";
-  private String clusterName2 = "cluster-2";
 
   /**
    * Perform initialization for all the tests in this class.
@@ -180,9 +179,9 @@ class ItValidateWebhookReplicas {
     }
 
     // check managed servers are up and running for domain2
-    for (int i = 1; i <= domain2NumCluster; i++) {
-      for (int j = 1; j <= replicaCount; j++) {
-        checkPodReadyAndServiceExists(domainUid2 + "-cluster-" + i + "-" + MANAGED_SERVER_NAME_BASE + j,
+    for (int i = 1; i <= replicaCount; i++) {
+      for (int j = 1; j <= domain2NumCluster; j++) {
+        checkPodReadyAndServiceExists(domainUid2 + "-cluster-" + j + "-" + MANAGED_SERVER_NAME_BASE + i,
             domainUid2, domainNamespace2);
       }
     }
@@ -262,7 +261,7 @@ class ItValidateWebhookReplicas {
     String expectedErrorMsg =
         "admission webhook \"weblogic.validating.webhook\" denied the request: Change request to domain resource '"
             + domainUid
-            + "' cannot be honored because the replica count for cluster '"
+            + "' cannot be honored because the replica count of cluster '"
             + clusterName
             + "' would exceed the cluster size '5' when patching "
             + domainUid
@@ -443,7 +442,7 @@ class ItValidateWebhookReplicas {
     String expectedErrorMsg =
         "admission webhook \"weblogic.validating.webhook\" denied the request: Change request to domain resource '"
             + domainUid2
-            + "' cannot be honored because the replica count for cluster 'cluster-2' "
+            + "' cannot be honored because the replica count of cluster 'cluster-2' "
             + "would exceed the cluster size '5' when patching "
             + domainUid2
             + " in namespace "
@@ -489,12 +488,8 @@ class ItValidateWebhookReplicas {
     String expectedErrorMsg =
         "admission webhook \"weblogic.validating.webhook\" denied the request: Change request to domain resource '"
             + domainUid2
-            + "' cannot be honored because the replica count for cluster 'cluster-1' "
-            + "would exceed the cluster size '5' \n"
-            + "Change request to domain resource '" + domainUid2
-            + "' cannot be honored because the replica count for cluster 'cluster-2' "
-            + "would exceed the cluster size '5'"
-            + "when patching "
+            + "' cannot be honored because the replica count of each cluster in 'cluster-1, cluster-2' "
+            + "would exceed its cluster size '5, 5' respectively when patching "
             + domainUid2
             + " in namespace "
             + domainNamespace2;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItValidateWebhookReplicas.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItValidateWebhookReplicas.java
@@ -114,6 +114,7 @@ class ItValidateWebhookReplicas {
   private static int externalRestHttpsPort = 0;
 
   private String clusterName = "cluster-1";
+  private String clusterName2 = "cluster-2";
 
   /**
    * Perform initialization for all the tests in this class.
@@ -179,9 +180,9 @@ class ItValidateWebhookReplicas {
     }
 
     // check managed servers are up and running for domain2
-    for (int i = 1; i <= replicaCount; i++) {
-      for (int j = 1; j <= domain2NumCluster; j++) {
-        checkPodReadyAndServiceExists(domainUid2 + "-cluster-" + j + "-" + MANAGED_SERVER_NAME_BASE + i,
+    for (int i = 1; i <= domain2NumCluster; i++) {
+      for (int j = 1; j <= replicaCount; j++) {
+        checkPodReadyAndServiceExists(domainUid2 + "-cluster-" + i + "-" + MANAGED_SERVER_NAME_BASE + j,
             domainUid2, domainNamespace2);
       }
     }
@@ -488,8 +489,12 @@ class ItValidateWebhookReplicas {
     String expectedErrorMsg =
         "admission webhook \"weblogic.validating.webhook\" denied the request: Change request to domain resource '"
             + domainUid2
-            + "' cannot be honored because the replica count for cluster 'cluster-1' and 'cluster-2' "
-            + "would exceed the cluster size '5' when patching "
+            + "' cannot be honored because the replica count for cluster 'cluster-1' "
+            + "would exceed the cluster size '5' \n"
+            + "Change request to domain resource '" + domainUid2
+            + "' cannot be honored because the replica count for cluster 'cluster-2' "
+            + "would exceed the cluster size '5'"
+            + "when patching "
             + domainUid2
             + " in namespace "
             + domainNamespace2;

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainUpdateAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainUpdateAdmissionChecker.java
@@ -112,7 +112,13 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
   }
 
   boolean areAllClusterReplicaCountsValid(DomainResource domain) {
-    return getClusterStatusList(domain).stream().allMatch(c -> isReplicaCountValid(domain, c));
+    boolean allValid = true;
+    for (ClusterStatus status : getClusterStatusList(domain)) {
+      if (!isReplicaCountValid(domain, status)) {
+        allValid = false;
+      }
+    }
+    return allValid;
   }
 
   @NotNull

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/AdmissionCheckerTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/AdmissionCheckerTestBase.java
@@ -32,6 +32,7 @@ import static oracle.kubernetes.operator.KubernetesConstants.WLS_CONTAINER_NAME;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.AUX_IMAGE_1;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.AUX_IMAGE_2;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.BAD_REPLICAS;
+import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.CLUSTER_NAME_2;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.NEW_IMAGE_NAME;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.createAuxiliaryImage;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.createCluster;
@@ -68,6 +69,8 @@ abstract class AdmissionCheckerTestBase {
   final DomainResource proposedDomain2 = createDomainWithoutCluster();
   final ClusterResource existingCluster = createCluster();
   final ClusterResource proposedCluster = createCluster();
+  final ClusterResource proposedCluster2 = createCluster(CLUSTER_NAME_2);
+
   AdmissionChecker domainChecker;
   AdmissionChecker clusterChecker;
 

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/AdmissionWebhookTestSetUp.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/AdmissionWebhookTestSetUp.java
@@ -27,7 +27,7 @@ import static oracle.kubernetes.operator.DomainProcessorTestSetup.createTestDoma
  */
 class AdmissionWebhookTestSetUp {
   static final String CLUSTER_NAME_1 = "C1";
-  private static final String CLUSTER_NAME_2 = "C2";
+  static final String CLUSTER_NAME_2 = "C2";
   public static final String ORIGINAL_IMAGE_NAME = "abcd";
   public static final int ORIGINAL_REPLICAS = 2;
   public static final String ORIGINAL_INTROSPECT_VERSION = "1234";
@@ -71,6 +71,24 @@ class AdmissionWebhookTestSetUp {
   /**
    * Create a Cluster resource model that contains the cluster configuration and status for WebhookRestTest
    * and ValidationUtilsTest.
+   *
+   * @param clusterName the name of the cluster resource
+   * @return the cluster resource created
+   */
+  public static ClusterResource createCluster(String clusterName) {
+    ClusterResource clusterResource =
+        new ClusterResource().withMetadata(new V1ObjectMeta().name(clusterName).namespace(NS))
+            .spec(createClusterSpec(clusterName));
+    clusterResource.setApiVersion((KubernetesConstants.DOMAIN_GROUP + "/" + KubernetesConstants.CLUSTER_VERSION));
+    clusterResource.setStatus(createClusterStatus(clusterName));
+    return clusterResource;
+  }
+
+  /**
+   * Create a Cluster resource model that contains the cluster configuration and status for WebhookRestTest
+   * and ValidationUtilsTest.
+   *
+   * @return the cluster resource created
    */
   public static ClusterResource createCluster() {
     ClusterResource clusterResource =

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/ResourceUpdateAdmissionCheckerTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/ResourceUpdateAdmissionCheckerTest.java
@@ -10,6 +10,7 @@ import oracle.kubernetes.operator.DomainSourceType;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.webhooks.resource.ClusterUpdateAdmissionChecker;
 import oracle.kubernetes.operator.webhooks.resource.DomainUpdateAdmissionChecker;
+import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +24,7 @@ import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.BAD_
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.GOOD_REPLICAS;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.NEW_IMAGE_NAME;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.NEW_INTROSPECT_VERSION;
+import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.ORIGINAL_REPLICAS;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.createAuxiliaryImage;
 import static oracle.kubernetes.operator.webhooks.AdmissionWebhookTestSetUp.setAuxiliaryImages;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,6 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ResourceUpdateAdmissionCheckerTest extends AdmissionCheckerTestBase {
+  private static final String WARN_MESSAGE_PATTERN_DOMAIN =
+      "Change request to domain resource '%s' causes the replica count of each cluster in '%s' to exceed its cluster "
+          + "size '%s' respectively";
 
   @Override
   void setupCheckers() {
@@ -208,7 +213,7 @@ class ResourceUpdateAdmissionCheckerTest extends AdmissionCheckerTestBase {
   }
 
   @Test
-  void whenDomainSourceTypeBothMIIAuxImgDifferentAndDomainImageChangedReplicasInvalid_returnTrue() {
+  void whenDomainSourceTypeBothMIIAuxImgDifferentAndDomainImageChangedReplicasInvalid_returnTrueWithWarnings() {
     proposedDomain.getSpec().withReplicas(BAD_REPLICAS);
     proposedDomain.getSpec().withImage(NEW_IMAGE_NAME);
     setAuxiliaryImages(existingDomain, Collections.singletonList(createAuxiliaryImage(AUX_IMAGE_1)));
@@ -217,10 +222,19 @@ class ResourceUpdateAdmissionCheckerTest extends AdmissionCheckerTestBase {
     proposedDomain.getSpec().withDomainHomeSourceType(DomainSourceType.FROM_MODEL);
 
     assertThat(domainChecker.isProposedChangeAllowed(), equalTo(true));
+    assertThat(((DomainUpdateAdmissionChecker)domainChecker).hasWarnings(), equalTo(true));
+    assertThat(((DomainUpdateAdmissionChecker)domainChecker).getWarnings().get(0),
+        equalTo(getWarningMessageForDomainResource(proposedDomain, proposedCluster, proposedCluster2)));
+
+  }
+
+  private Object getWarningMessageForDomainResource(DomainResource domain, ClusterResource c1, ClusterResource c2) {
+    return String.format(WARN_MESSAGE_PATTERN_DOMAIN, domain.getDomainUid(),
+        c1.getMetadata().getName() + ", " + c2.getMetadata().getName(), ORIGINAL_REPLICAS + ", " + ORIGINAL_REPLICAS);
   }
 
   @Test
-  void whenDomainCheckerClusterReplicasChangedToUnsetAndReadClusterSucceed_returnTrueWithoutException() {
+  void whenDomainCheckerClusterReplicasChangedToUnsetAndReadClusterSucceed_returnFalseWithoutException() {
     testSupport.defineResources(proposedDomain);
     proposedDomain.getSpec().withReplicas(BAD_REPLICAS);
     existingCluster.getSpec().withReplicas(2);

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
@@ -88,7 +88,10 @@ class WebhookRestTest extends RestTestBase {
   private static final String VALIDATING_WEBHOOK_HREF = "/admission";
   private static final String RESPONSE_UID = "705ab4f5-6393-11e8-b7cc-42010a800002";
   private static final String REJECT_MESSAGE_PATTERN_DOMAIN = "Change request to domain resource '%s' cannot be honored"
-          + " because the replica count for cluster '%s' would exceed the cluster size '%s'";
+          + " because the replica count of cluster '%s' would exceed the cluster size '%s'";
+  private static final String REJECT_MESSAGE_PATTERN_DOMAIN_MULTIPLE_CLUSTERS =
+      "Change request to domain resource '%s' cannot be honored"
+      + " because the replica count of each cluster in '%s' would exceed its cluster size '%s' respectively";
   private static final String REJECT_MESSAGE_PATTERN_CLUSTER = "Change request to cluster resource '%s' cannot be "
       + "honored because the replica count would exceed the cluster size '%s'";
 
@@ -558,11 +561,8 @@ class WebhookRestTest extends RestTestBase {
   }
 
   private Object getRejectMessageForDomainResource(DomainResource domain, ClusterResource c1, ClusterResource c2) {
-    return String.format(REJECT_MESSAGE_PATTERN_DOMAIN,
-        domain.getDomainUid(), c1.getMetadata().getName(), ORIGINAL_REPLICAS)
-        + "\n"
-        + String.format(REJECT_MESSAGE_PATTERN_DOMAIN,
-            domain.getDomainUid(), c2.getMetadata().getName(), ORIGINAL_REPLICAS);
+    return String.format(REJECT_MESSAGE_PATTERN_DOMAIN_MULTIPLE_CLUSTERS, domain.getDomainUid(),
+        c1.getMetadata().getName() + ", " + c2.getMetadata().getName(), ORIGINAL_REPLICAS + ", " + ORIGINAL_REPLICAS);
   }
 
   private Object getRejectMessageForClusterResource(ClusterResource cluster) {


### PR DESCRIPTION
The validating webhook currently only reports the first invalid cluster when the domain's replicas is changed to a value that exceeds the cluster size of more clusters in a domain. 

The changes in this PR reports all invalid clusters. 

Full integration test run had one failure, which is the same as nightly run. 
This branch: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13364/
Nightly: https://build.weblogick8s.org:8443/job/wko-kind-nightly-parallel/1069/
