### PR TITLE
Use down plan when domain has deletionTimestamp

### DIFF
--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -796,6 +796,20 @@ class DomainProcessorTest {
   }
 
   @Test
+  void whenDomainMarkedForDeletion_removeAllPodsServicesAndPodDisruptionBudgets() {
+    defineServerResources(ADMIN_NAME);
+    Arrays.stream(MANAGED_SERVER_NAMES).forEach(this::defineServerResources);
+
+    domain.getMetadata().setDeletionTimestamp(OffsetDateTime.now());
+    // MakeRightOperation is created without forDeletion() similar to list or MODIFIED watch
+    processor.createMakeRightOperation(originalInfo).interrupt().withExplicitRecheck().execute();
+
+    assertThat(getRunningServices(), empty());
+    assertThat(getRunningPods(), empty());
+    assertThat(getRunningPDBs(), empty());
+  }
+
+  @Test
   void whenDomainShutDown_ignoreNonOperatorServices() {
     defineServerResources(ADMIN_NAME);
     Arrays.stream(MANAGED_SERVER_NAMES).forEach(this::defineServerResources);


### PR DESCRIPTION
Use the domain down plan when the domain has a metadata.deletionTimestamp. Once we merge this to main I'll work on a backport to release/3.4.

This should resolve the deadlock we discussed in the scrum.