### PR TITLE
OWLS-103230 - [wko-nightly] Mii samples failed with MII sample domain resources in git do not align with integration test templates

### DIFF
--- a/operator/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-JRF-AI
+++ b/operator/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-JRF-AI
@@ -20,6 +20,13 @@ spec:
   domainHome: /u01/domains/@@DOMAIN_UID@@
 
   # The WebLogic Server image that the Operator uses to start the domain
+  # **NOTE**:
+  # This sample uses General Availability (GA) images. GA images are suitable for demonstration and
+  # development purposes only where the environments are not available from the public Internet;
+  # they are not acceptable for production use. In production, you should always use CPU (patched)
+  # images from OCR or create your images using the WebLogic Image Tool.
+  # Please refer to the `OCR` and `Manage FMW infrastructure domains` pages in the WebLogic
+  # Kubernetes Operator documentation for details.
   image: "@@BASE_IMAGE_NAME@@:@@BASE_IMAGE_TAG@@"
 
   # Defaults to "Always" if image tag (version) is ':latest'

--- a/operator/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-WLS-AI
+++ b/operator/integration-tests/model-in-image/mii-sample-wrapper/mii-domain.yaml.template-WLS-AI
@@ -20,6 +20,13 @@ spec:
   domainHome: /u01/domains/@@DOMAIN_UID@@
 
   # The WebLogic Server image that the Operator uses to start the domain
+  # **NOTE**:
+  # This sample uses General Availability (GA) images. GA images are suitable for demonstration and
+  # development purposes only where the environments are not available from the public Internet;
+  # they are not acceptable for production use. In production, you should always use CPU (patched)
+  # images from OCR or create your images using the WebLogic Image Tool.
+  # Please refer to the `OCR` and `WebLogic Images` pages in the WebLogic Kubernetes Operator
+  # documentation for details.
   image: "@@BASE_IMAGE_NAME@@:@@BASE_IMAGE_TAG@@"
 
   # Defaults to "Always" if image tag (version) is ':latest'


### PR DESCRIPTION
Add changes to MII samples domain resource templates that were missed by [PR 3485](https://github.com/oracle/weblogic-kubernetes-operator/pull/3485).

ItMiiSample* tests passed: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13455/testReport/oracle.weblogic.kubernetes/