### PR TITLE
Openshift mesh 3.4 update

### DIFF
--- a/documentation/3.4/content/userguide/istio/istio.md
+++ b/documentation/3.4/content/userguide/istio/istio.md
@@ -203,9 +203,9 @@ See the following description of each `spec.configuration.istio` attribute:
   |1.10 and later|`true`|Not supported.|
   |1.10 and later|`false`|Supported.|
 
-  **For Red Hat OpenShift Service Mesh**
-  
+
   |Red Hat OpenShift version|localhostBindingsEnabled|Notes|
+        |----|----|----|
   |Pre 4.11|`true` or not set|Supported|
   |Pre 4.11|`false` or not set|Not Supported|
   |4.11 and later|`true`|Not Supported|

--- a/documentation/3.4/content/userguide/istio/istio.md
+++ b/documentation/3.4/content/userguide/istio/istio.md
@@ -207,6 +207,8 @@ See the following description of each `spec.configuration.istio` attribute:
   
   |Red Hat OpenShift version|localhostBindingsEnabled|Notes|
   |Pre 4.11|`true` or not set|Supported|
+  |Pre 4.11|`false` or not set|Not Supported|
+  |4.11 and later|`true`|Not Supported|
   |4.11 and later|`false`|Supported|
 
 __Note__: If the `localhostBindingsEnabled` is set incorrectly for the Istio version running in a domain,

--- a/documentation/3.4/content/userguide/istio/istio.md
+++ b/documentation/3.4/content/userguide/istio/istio.md
@@ -203,7 +203,11 @@ See the following description of each `spec.configuration.istio` attribute:
   |1.10 and later|`true`|Not supported.|
   |1.10 and later|`false`|Supported.|
 
-  **For Red Hat OpenShift Service Mesh**,  you do not need to set `istioLocalhostBindingsEnabled` or if set, it must be set to `true` if you are using Red Hat OpenShift version 4.10.x or below.  If you are using Red Hat OpenShift version 4.11.x or above, set `istioLocalhostBindingsEnabled` to `true`.
+  **For Red Hat OpenShift Service Mesh**
+  
+  |Red Hat OpenShift version|localhostBindingsEnabled|Notes|
+  |Pre 4.11|`true` or not set|Supported|
+  |4.11 and later|`false`|Supported|
 
 __Note__: If the `localhostBindingsEnabled` is set incorrectly for the Istio version running in a domain,
 then:

--- a/documentation/3.4/content/userguide/istio/istio.md
+++ b/documentation/3.4/content/userguide/istio/istio.md
@@ -203,7 +203,7 @@ See the following description of each `spec.configuration.istio` attribute:
   |1.10 and later|`true`|Not supported.|
   |1.10 and later|`false`|Supported.|
 
-  **For Red Hat OpenShift Service Mesh**,  you do not need to set `istioLocalhostBindingsEnabled` or if set, it must be set to `true`.
+  **For Red Hat OpenShift Service Mesh**,  you do not need to set `istioLocalhostBindingsEnabled` or if set, it must be set to `true` if you are using Red Hat OpenShift version 4.10.x or below.  If you are using Red Hat OpenShift version 4.11.x or above, set `istioLocalhostBindingsEnabled` to `true`.
 
 __Note__: If the `localhostBindingsEnabled` is set incorrectly for the Istio version running in a domain,
 then:

--- a/documentation/3.4/content/userguide/istio/istio.md
+++ b/documentation/3.4/content/userguide/istio/istio.md
@@ -206,10 +206,10 @@ See the following description of each `spec.configuration.istio` attribute:
 
   |Red Hat OpenShift version|localhostBindingsEnabled|Notes|
         |----|----|----|
-  |Pre 4.11|`true` or not set|Supported|
-  |Pre 4.11|`false` or not set|Not Supported|
-  |4.11 and later|`true`|Not Supported|
-  |4.11 and later|`false`|Supported|
+  |Pre 4.11|`true` or not set|Supported.|
+  |Pre 4.11|`false` or not set|Not Supported.|
+  |4.11 and later|`true`|Not Supported.|
+  |4.11 and later|`false`|Supported.|
 
 __Note__: If the `localhostBindingsEnabled` is set incorrectly for the Istio version running in a domain,
 then:


### PR DESCRIPTION
This update the OpenShift 3.4 settings for `localHostBindingEnabled` in the Istio use case for the updated OpenShift version.