### PR TITLE
Owls 103231 - Changes to retry the failed patch operation in ItKubernetesDomainEvents tests and explicitly get the v8 version of domain

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -460,7 +460,7 @@ class ItKubernetesDomainEvents {
           + "]";
       logger.info("Updating replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
       V1Patch patch = new V1Patch(patchStr);
-      assertTrue(patchDomainCustomResource(domainUid, domainNamespace3, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
+      assertTrue(patchDomainCustomResource(domainUid, domainNamespace3, patch, V1Patch.PATCH_FORMAT_JSON_PATCH, 5),
           "Failed to patch domain");
 
       // No event will be created for this
@@ -476,7 +476,7 @@ class ItKubernetesDomainEvents {
           + "]";
       logger.info("Updating replicas in cluster {0} using patch string: {1}", cluster1Name, patchStr);
       V1Patch patch = new V1Patch(patchStr);
-      assertTrue(patchDomainCustomResource(domainUid, domainNamespace3, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
+      assertTrue(patchDomainCustomResource(domainUid, domainNamespace3, patch, V1Patch.PATCH_FORMAT_JSON_PATCH, 5),
           "Failed to patch domain");
     }
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/Domain.java
@@ -192,7 +192,23 @@ public class Domain {
    */
   public static boolean patchDomainCustomResource(String domainUid, String namespace, V1Patch patch,
                                                   String patchFormat) {
-    return Kubernetes.patchDomainCustomResource(domainUid, namespace, patch, patchFormat);
+    return Kubernetes.patchDomainCustomResource(domainUid, namespace, patch, patchFormat, 0);
+  }
+
+  /**
+   * Patch the Domain Custom Resource.
+   *
+   * @param domainUid unique domain identifier
+   * @param namespace name of namespace
+   * @param patch patch data in format matching the specified media type
+   * @param patchFormat one of the following types used to identify patch document:
+   *     "application/json-patch+json", "application/merge-patch+json",
+   * @param maxRetryCount Max retry count.
+   * @return true if successful, false otherwise
+   */
+  public static boolean patchDomainCustomResource(String domainUid, String namespace, V1Patch patch,
+                                                  String patchFormat, int maxRetryCount) {
+    return Kubernetes.patchDomainCustomResource(domainUid, namespace, patch, patchFormat, maxRetryCount);
   }
 
   /**

--- a/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/utils/wl-pod-wait.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/model-in-image/utils/wl-pod-wait.sh
@@ -179,7 +179,7 @@ function getDomainValue() {
   local ljpath="{$1}"
   local __retvar=$2
   set +e
-  attvalue=$(kubectl -n ${DOMAIN_NAMESPACE} get domain ${DOMAIN_UID} -o=jsonpath="$ljpath" 2>&1)
+  attvalue=$(kubectl -n ${DOMAIN_NAMESPACE} get domain.v8.weblogic.oracle ${DOMAIN_UID} -o=jsonpath="$ljpath" 2>&1)
   if [ $? -ne 0 ]; then
     if [ $expected -ne 0 ]; then
       echo "@@ Error: Could not obtain '$1' from '${DOMAIN_UID}' in namespace '${DOMAIN_NAMESPACE}'. Is your domain resource deployed? Err='$attvalue'"
@@ -202,7 +202,7 @@ function getDomainAIImages() {
   set +e
   attvalue=$(
     kubectl \
-      get domain ${DOMAIN_UID} \
+      get domain.v8.weblogic.oracle ${DOMAIN_UID} \
       -n ${DOMAIN_NAMESPACE} \
       -o=jsonpath="{range .spec.serverPod.auxiliaryImages[*]}{.image}{','}{end}" \
       2>&1


### PR DESCRIPTION
Owls 103231 - Following changes to support the interop environments with 3.4 operator and 4.0 webhook.
- Changes to retry the failed domain custom resource patch operation in ItKubernetesDomainEvents tests to prevent failures in interop branch. 
- Change to remove setting of FOREGROUND propagation policy in delete options.
- Change to wl-pod-wait.sh script to explicitly get the v8 version of the domain.

Integration test results - https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/195/