### PR TITLE
OWLS-103314 - Fix for the ItMiiSample tests failures by renaming and restoring unsupported available condition reason.

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
+++ b/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
@@ -58,12 +58,13 @@ public class SchemaConversionUtils {
   private static final String DOLLAR_SPEC_SERVERPOD = "$.spec.serverPod";
   private static final String DOLLAR_SPEC_AS_SERVERPOD = "$.spec.adminServer.serverPod";
 
+  public static final String INTERNAL = "Internal";
   /**
    * The list of failure reason strings. Hard-coded here to match the values in DomainFailureReason.
    * Validated in tests in the operator.
    */
   public static final List<String> SUPPORTED_FAILURE_REASONS = List.of(
-        "Aborted", "Internal", "TopologyMismatch", "ReplicasTooHigh",
+        "Aborted", INTERNAL, "TopologyMismatch", "ReplicasTooHigh",
         "ServerPod", "Kubernetes", "Introspection", "DomainInvalid");
 
   private static final String VOLUME_MOUNTS = "volumeMounts";
@@ -337,7 +338,7 @@ public class SchemaConversionUtils {
         Map<String, Object> annotations = (Map<String, Object>) meta.computeIfAbsent(
             ANNOTATIONS, k -> new LinkedHashMap<>());
         annotations.put(FAILED_REASON, currentReason);
-        condition.put(REASON, "Internal");
+        condition.put(REASON, INTERNAL);
       }
     }
   }
@@ -350,7 +351,7 @@ public class SchemaConversionUtils {
         Map<String, Object> annotations = (Map<String, Object>) meta.computeIfAbsent(
             ANNOTATIONS, k -> new LinkedHashMap<>());
         annotations.put(AVAILABLE_REASON, currentReason);
-        condition.put(REASON, "Internal");
+        condition.put(REASON, INTERNAL);
       }
     }
   }

--- a/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
+++ b/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
@@ -346,7 +346,7 @@ public class SchemaConversionUtils {
   private void renameAvailableReasonIfUnsupported(Map<String, Object> domain, Map<String, String> condition) {
     if ("Available".equals(condition.get(TYPE))) {
       String currentReason = condition.get(REASON);
-      if (isUnsupportedReason(currentReason)) {
+      if (currentReason != null && isUnsupportedReason(currentReason)) {
         Map<String, Object> meta = getMetadata(domain);
         Map<String, Object> annotations = (Map<String, Object>) meta.computeIfAbsent(
             ANNOTATIONS, k -> new LinkedHashMap<>());

--- a/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
+++ b/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
@@ -233,6 +233,15 @@ class SchemaConversionUtilsTest {
   }
 
   @Test
+  void whenOldDomainHasNullAvailableConditionReason_dontPreserve() {
+    addStatusCondition("Available", "True", null, "Ready");
+
+    converter.convert(v8Domain);
+
+    assertThat(converter.getDomain(), hasNoJsonPath("$.metadata.annotations.['weblogic.v8.available.reason']"));
+  }
+
+  @Test
   void testV9DomainFailedConditionReason_restored() throws IOException {
     Map<String, Object> v9Domain = readAsYaml(DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML);
     getMapAtPath(v9Domain, "metadata.annotations")

--- a/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
+++ b/common/src/test/java/oracle/kubernetes/common/utils/SchemaConversionUtilsTest.java
@@ -221,6 +221,18 @@ class SchemaConversionUtilsTest {
   }
 
   @Test
+  void whenOldDomainHasUnsupportedAvailableConditionReason_replaceAndPreserve() {
+    addStatusCondition("Available", "True", "ServersReady", "Ready");
+
+    converter.convert(v8Domain);
+
+    assertThat(converter.getDomain(),
+        hasJsonPath("$.status.conditions[?(@.type=='Available')].reason", contains("Internal")));
+    assertThat(converter.getDomain(), hasJsonPath("$.metadata.annotations.['weblogic.v8.available.reason']",
+        equalTo("ServersReady")));
+  }
+
+  @Test
   void testV9DomainFailedConditionReason_restored() throws IOException {
     Map<String, Object> v9Domain = readAsYaml(DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML);
     getMapAtPath(v9Domain, "metadata.annotations")
@@ -232,6 +244,20 @@ class SchemaConversionUtilsTest {
     assertThat(converterv8.getDomain(), hasNoJsonPath("$.metadata.annotations.['weblogic.v8.failed.reason']"));
     assertThat(converterv8.getDomain(),
             hasJsonPath("$.status.conditions[?(@.type=='Failed')].reason", contains("Danger")));
+  }
+
+  @Test
+  void testV9DomainAvailableConditionReason_restored() throws IOException {
+    Map<String, Object> v9Domain = readAsYaml(DOMAIN_V9_CONVERTED_LEGACY_AUX_IMAGE_YAML);
+    getMapAtPath(v9Domain, "metadata.annotations")
+        .put("weblogic.v8.available.reason", "ServersReady");
+    addStatusCondition(v9Domain, "Available", "True", "Internal", "Ready");
+
+    converterv8.convert(v9Domain);
+
+    assertThat(converterv8.getDomain(), hasNoJsonPath("$.metadata.annotations.['weblogic.v8.available.reason']"));
+    assertThat(converterv8.getDomain(),
+        hasJsonPath("$.status.conditions[?(@.type=='Available')].reason", contains("ServersReady")));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
OWLS-103314 - The ItMiiSample tests are failing since the `V8` domain has an unsupported reason "ServersReady" for the "Available" condition in the domain status. This change renames the reason when converting domain from `v8` to `v9` and then restores the reason when converting the domain back from `v9` to `v8`. @rjeberhard Presently the reason is renamed from "ServersReady" to "Internal", please let me know if it should be renamed to something else.

Integration test results - https://build.weblogick8s.org:8443/job/wko-kind-34-with-webhook/195/