### PR TITLE
Use the doEnd method instead of returning null next action

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -35,6 +35,7 @@ import oracle.kubernetes.operator.watcher.WatchListener;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.EXECUTE_MAKE_RIGHT_DOMAIN;
 import static oracle.kubernetes.common.logging.MessageKeys.LOG_WAITING_COUNT;
@@ -201,6 +202,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
     protected ResponseStep<V1Pod> resumeIfReady(Callback callback) {
       return new DefaultResponseStep<>(getNext()) {
+        @NotNull
         @Override
         public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
 
@@ -220,7 +222,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
             if (isReady(callResponse.getResult()) || callback.didResumeFiber()) {
               callback.proceedFromWait(callResponse.getResult());
-              return null;
+              return doEnd(packet);
             }
           }
 
@@ -371,11 +373,12 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
         this.callback = callback;
       }
 
+      @NotNull
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
         if (callResponse.getResult() == null || callback.didResumeFiber()) {
           callback.proceedFromWait(callResponse.getResult());
-          return null;
+          return doEnd(packet);
         } else {
           return doDelay(createReadAndIfReadyCheckStep(callback), packet,
               getWatchBackstopRecheckDelaySeconds(), TimeUnit.SECONDS);

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -35,7 +35,6 @@ import oracle.kubernetes.operator.watcher.WatchListener;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.EXECUTE_MAKE_RIGHT_DOMAIN;
 import static oracle.kubernetes.common.logging.MessageKeys.LOG_WAITING_COUNT;
@@ -202,7 +201,6 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
     protected ResponseStep<V1Pod> resumeIfReady(Callback callback) {
       return new DefaultResponseStep<>(getNext()) {
-        @NotNull
         @Override
         public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
 
@@ -373,7 +371,6 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
         this.callback = callback;
       }
 
-      @NotNull
       @Override
       public NextAction onSuccess(Packet packet, CallResponse<V1Pod> callResponse) {
         if (callResponse.getResult() == null || callback.didResumeFiber()) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -25,6 +25,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
+import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_FORBIDDEN;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
@@ -297,7 +298,7 @@ public abstract class ResponseStep<T> extends Step {
    * @param callResponse the result of the call
    * @return Next action for fiber processing
    */
-  public NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
+  public @NotNull NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
     throw new IllegalStateException("Must be overridden, if called");
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -25,7 +25,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_FORBIDDEN;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
@@ -298,7 +297,7 @@ public abstract class ResponseStep<T> extends Step {
    * @param callResponse the result of the call
    * @return Next action for fiber processing
    */
-  public @NotNull NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
+  public NextAction onSuccess(Packet packet, CallResponse<T> callResponse) {
     throw new IllegalStateException("Must be overridden, if called");
   }
 }


### PR DESCRIPTION
Use the doEnd(packet) method to end the fiber processing instead of returning "null" next action. With "null" next action, the `doPotentialRetry` method of ResponseStep logs a ASYNC_NO_RETRY message since the RetryStrategy in the packet is null.

Integration test results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13488/