### PR TITLE
Various code cleanup

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/CoreDelegateImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/CoreDelegateImpl.java
@@ -29,10 +29,10 @@ import static oracle.kubernetes.operator.BaseMain.probesHome;
 
 public class CoreDelegateImpl implements CoreDelegate {
 
-  protected String buildVersion;
-  protected SemanticVersion productVersion;
-  protected KubernetesVersion kubernetesVersion;
-  protected Engine engine;
+  protected final String buildVersion;
+  protected final SemanticVersion productVersion;
+  protected final KubernetesVersion kubernetesVersion;
+  protected final Engine engine;
   protected final String deploymentImpl;
   protected final String deploymentBuildTime;
 

--- a/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
@@ -41,7 +41,7 @@ public class WebhookMain extends BaseMain {
 
   private final WebhookMainDelegate conversionWebhookMainDelegate;
   private boolean warnedOfCrdAbsence;
-  private AtomicInteger crdPresenceCheckCount = new AtomicInteger(0);
+  private final AtomicInteger crdPresenceCheckCount = new AtomicInteger(0);
   private final RestConfig restConfig = new RestConfigImpl(new Certificates(delegate));
   @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"})
   private static NextStepFactory nextStepFactory = WebhookMain::createInitializeWebhookIdentityStep;

--- a/operator/src/main/java/oracle/kubernetes/operator/authentication/Helpers.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/authentication/Helpers.java
@@ -98,7 +98,7 @@ public class Helpers {
    */
   protected V1ServiceAccountList getAllServiceAccounts() throws ApiException {
 
-    V1ServiceAccountList serviceAccountList = null;
+    V1ServiceAccountList serviceAccountList;
 
     String cont = "";
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -35,6 +35,7 @@ import oracle.kubernetes.weblogic.domain.model.AuxiliaryImage;
 import static oracle.kubernetes.common.AuxiliaryImageConstants.AUXILIARY_IMAGE_INIT_CONTAINER_NAME_PREFIX;
 import static oracle.kubernetes.common.AuxiliaryImageConstants.AUXILIARY_IMAGE_INIT_CONTAINER_WRAPPER_SCRIPT;
 import static oracle.kubernetes.common.AuxiliaryImageConstants.AUXILIARY_IMAGE_TARGET_PATH;
+import static oracle.kubernetes.common.CommonConstants.COMPATIBILITY_MODE;
 import static oracle.kubernetes.common.CommonConstants.SCRIPTS_MOUNTS_PATH;
 import static oracle.kubernetes.common.CommonConstants.SCRIPTS_VOLUME;
 import static oracle.kubernetes.common.helpers.AuxiliaryImageEnvVars.AUXILIARY_IMAGE_PATHS;
@@ -159,6 +160,17 @@ public abstract class BasePodStepContext extends StepContextBase {
     addEnvVar(vars, AuxiliaryImageEnvVars.AUXILIARY_IMAGE_CONTAINER_IMAGE, auxiliaryImage.getImage());
     addEnvVar(vars, AuxiliaryImageEnvVars.AUXILIARY_IMAGE_CONTAINER_NAME, name);
     return vars;
+  }
+
+  protected List<V1EnvVar> createEnv(V1Container c) {
+    List<V1EnvVar> initContainerEnvVars = new ArrayList<>();
+    Optional.ofNullable(c.getEnv()).ifPresent(initContainerEnvVars::addAll);
+    if (!c.getName().startsWith(COMPATIBILITY_MODE)) {
+      getEnvironmentVariables()
+          .forEach(envVar -> addIfMissing(initContainerEnvVars,
+              envVar.getName(), envVar.getValue(), envVar.getValueFrom()));
+    }
+    return initContainerEnvVars;
   }
 
   protected V1ResourceRequirements createResources() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -265,6 +265,7 @@ public class DomainValidationSteps {
           .or(() -> Optional.ofNullable((List<ClusterResource>) packet.get(CLUSTERS))).orElse(Collections.emptyList());
     }
 
+    @SuppressWarnings("unchecked")
     private List<ClusterResource> getClustersInNamespace(Packet packet) {
       return Optional.ofNullable((List<ClusterResource>) packet.get(CLUSTERS)).orElse(Collections.emptyList());
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -271,8 +271,8 @@ public class EventHelper {
     }
 
     private class ReplaceEventResponseStep extends ResponseStep<CoreV1Event> {
-      Step replaceEventStep;
-      CoreV1Event existingEvent;
+      final Step replaceEventStep;
+      final CoreV1Event existingEvent;
 
       ReplaceEventResponseStep(Step replaceEventStep, CoreV1Event existingEvent, Step next) {
         super(next);
@@ -1202,8 +1202,8 @@ public class EventHelper {
     }
 
     private class ReplaceClusterResourceEventResponseStep extends ResponseStep<CoreV1Event> {
-      Step replaceClusterEventStep;
-      CoreV1Event existingClusterEvent;
+      final Step replaceClusterEventStep;
+      final CoreV1Event existingClusterEvent;
 
       ReplaceClusterResourceEventResponseStep(Step replaceClusterEventStep, CoreV1Event existingClusterEvent,
           Step next) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/FluentdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/FluentdHelper.java
@@ -268,10 +268,7 @@ public class FluentdHelper {
   private static void addFluentdContainerELSCredEnv(FluentdSpecification fluentdSpecification,
                                                     V1Container fluentdContainer, String envName, String keyName) {
     if (!hasFluentdContainerEnv(fluentdSpecification, envName)) {
-      boolean isOptional = false;
-      if (envName.equals("ELASTICSEARCH_USER") || envName.equals("ELASTICSEARCH_PASSWORD")) {
-        isOptional = true;
-      }
+      boolean isOptional = envName.equals("ELASTICSEARCH_USER") || envName.equals("ELASTICSEARCH_PASSWORD");
       V1SecretKeySelector keySelector = new V1SecretKeySelector()
           .key(keyName)
           .optional(isOptional)

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -384,17 +384,6 @@ public class JobStepContext extends BasePodStepContext {
             initContainers.add(createInitContainerForAuxiliaryImage(auxiliaryImages.get(idx), idx)));
   }
 
-  protected List<V1EnvVar> createEnv(V1Container c) {
-    List<V1EnvVar> initContainerEnvVars = new ArrayList<>();
-    Optional.ofNullable(c.getEnv()).ifPresent(initContainerEnvVars::addAll);
-    if (!c.getName().startsWith(COMPATIBILITY_MODE)) {
-      getEnvironmentVariables()
-              .forEach(envVar -> addIfMissing(initContainerEnvVars,
-                  envVar.getName(), envVar.getValue(), envVar.getValueFrom()));
-    }
-    return initContainerEnvVars;
-  }
-
   @Override
   protected V1PodSpec createPodSpec() {
     V1PodSpec podSpec = super.createPodSpec()
@@ -431,7 +420,7 @@ public class JobStepContext extends BasePodStepContext {
       addWdtSecretVolume(podSpec);
     }
 
-    if (podSpec.getAffinity().equals(getDefaultAntiAffinity())) {
+    if (getDefaultAntiAffinity().equals(podSpec.getAffinity())) {
       podSpec.affinity(null);
     }
     return podSpec;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -184,8 +184,8 @@ public class ServiceHelper {
   }
 
   static String getAppProtocol(String protocol) {
-    List<String> httpProtocols = new ArrayList<>(Arrays.asList(PROTOCOL_HTTP));
-    List<String> httpsProtocols = new ArrayList<>(Arrays.asList(PROTOCOL_HTTPS));
+    List<String> httpProtocols = new ArrayList<>(List.of(PROTOCOL_HTTP));
+    List<String> httpsProtocols = new ArrayList<>(List.of(PROTOCOL_HTTPS));
     List<String> tlsProtocols = new ArrayList<>(Arrays.asList("t3s", "ldaps", "iiops", "cbts", "sips", PROTOCOL_ADMIN));
 
     String appProtocol = PROTOCOL_TCP;

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/RequestDebugLoggingFilter.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/RequestDebugLoggingFilter.java
@@ -74,7 +74,7 @@ public class RequestDebugLoggingFilter extends BaseDebugLoggingFilter
     // This should be OK since JSON input shouldn't be monstrously big
     try (BufferedReader ir = new BufferedReader(new InputStreamReader(req.getEntityStream()))) {
       StringBuilder sb = new StringBuilder();
-      String line = null;
+      String line;
       Charset cs = MessageUtils.getCharset(req.getMediaType());
       // TBD - is all the Charset handling correct?
       do {

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/model/DomainActionType.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/model/DomainActionType.java
@@ -4,5 +4,5 @@
 package oracle.kubernetes.operator.http.rest.model;
 
 public enum DomainActionType {
-  UNKNOWN, INTROSPECT, RESTART;
+  UNKNOWN, INTROSPECT, RESTART
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/InitializeWebhookIdentityStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/InitializeWebhookIdentityStep.java
@@ -237,7 +237,7 @@ public class InitializeWebhookIdentityStep extends Step {
     }
   }
 
-  protected static final V1Secret createModel(V1Secret secret, WebhookIdentity webhookIdentity) {
+  protected static V1Secret createModel(V1Secret secret, WebhookIdentity webhookIdentity) {
     if (secret == null) {
       Map<String, byte[]> data = new HashMap<>();
       data.put(WEBHOOK_KEY, webhookIdentity.getWebhookKey().getBytes());
@@ -260,8 +260,8 @@ public class InitializeWebhookIdentityStep extends Step {
 
   final class WebhookIdentity {
 
-    private String webhookKey;
-    private byte[] webhookCert;
+    private final String webhookKey;
+    private final byte[] webhookCert;
 
     public WebhookIdentity(String webhookKey, byte[] webhookCert) {
       this.webhookKey = webhookKey;

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -54,8 +54,8 @@ import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 public class ShutdownManagedServerStep extends Step {
 
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
-  private String serverName;
-  private V1Pod pod;
+  private final String serverName;
+  private final V1Pod pod;
 
   private ShutdownManagedServerStep(Step next, String serverName, V1Pod pod) {
     super(next);
@@ -360,7 +360,7 @@ public class ShutdownManagedServerStep extends Step {
 
   static final class ShutdownManagedServerResponseStep extends HttpResponseStep {
     private static final String SHUTDOWN_REQUEST_RETRY_COUNT = "shutdownRequestRetryCount";
-    private String serverName;
+    private final String serverName;
     private HttpAsyncRequestStep requestStep;
 
     ShutdownManagedServerResponseStep(String serverName, Step next) {

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/utils/GsonBuilderUtils.java
@@ -70,6 +70,7 @@ public class GsonBuilderUtils {
     return getGsonBuilder().toJson(map, Map.class);
   }
 
+  @SuppressWarnings("unchecked")
   public static Map<String, Object> readMap(String map) {
     return getGsonBuilder().fromJson(map, Map.class);
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/FluentdSpecification.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/FluentdSpecification.java
@@ -57,7 +57,7 @@ public class FluentdSpecification {
       new V1ResourceRequirements().limits(new HashMap<>()).requests(new HashMap<>());
 
   @Description("Volume mounts for fluentd container")
-  private List<V1VolumeMount> volumeMounts = new ArrayList<>();
+  private final List<V1VolumeMount> volumeMounts = new ArrayList<>();
 
   @Description("Fluentd elastic search credentials. A Kubernetes secret in the same namespace of the domain."
       + " It must contains 4 keys: elasticsearchhost - ElasticSearch Host Service Address,"

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -76,7 +76,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   private final KubernetesTestSupport testSupport = new KubernetesTestSupport();
   private final DomainProcessorStub dp = createStub(DomainProcessorStub.class);
   private final DomainNamespaces domainNamespaces = new DomainNamespaces(null);
-  DomainResource domain = createDomain(UID1, NS);
+  final DomainResource domain = createDomain(UID1, NS);
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/operator/src/test/java/oracle/kubernetes/operator/EventTestUtils.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/EventTestUtils.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -295,7 +296,7 @@ public class EventTestUtils {
 
   public static boolean isDomainFailedAbortedEvent(CoreV1Event e) {
     return DOMAIN_FAILED_EVENT.equals(e.getReason())
-        && e.getMessage().contains(getLocalizedString(ABORTED_EVENT_ERROR));
+        && Objects.requireNonNull(e.getMessage()).contains(getLocalizedString(ABORTED_EVENT_ERROR));
   }
 
   public static String getLocalizedString(String msgId) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ManagedPodHelperTest.java
@@ -1236,8 +1236,7 @@ class ManagedPodHelperTest extends PodHelperTestBase {
 
     V1Affinity expectedValue = new V1Affinity().podAntiAffinity(
         new V1PodAntiAffinity().preferredDuringSchedulingIgnoredDuringExecution(
-            Arrays.asList(
-                createWeightedPodAffinityTerm("weblogic.domainUID", UID))));
+            List.of(createWeightedPodAffinityTerm("weblogic.domainUID", UID))));
 
     assertThat(getCreatePodAffinity(), is(expectedValue));
   }
@@ -1260,8 +1259,7 @@ class ManagedPodHelperTest extends PodHelperTestBase {
 
     V1Affinity expectedValue = new V1Affinity().podAntiAffinity(
         new V1PodAntiAffinity().preferredDuringSchedulingIgnoredDuringExecution(
-            Arrays.asList(
-                createWeightedPodAffinityTerm("weblogic.clusterName", CLUSTER_NAME))));
+            List.of(createWeightedPodAffinityTerm("weblogic.clusterName", CLUSTER_NAME))));
 
     assertThat(getCreatePodAffinity(), is(expectedValue));
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ResourceVersionTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ResourceVersionTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
@@ -242,8 +242,7 @@ class RollingHelperTest {
     CLUSTERED_SERVER_NAMES.forEach(s -> rolling.put(s, createRollingStepAndPacket(s)));
     configureDomain().configureCluster(domainPresenceInfo, CLUSTER_NAME).withReplicas(3);
 
-    ConcurrentLinkedQueue<StepAndPacket> stepAndPackets = new ConcurrentLinkedQueue<>();
-    stepAndPackets.addAll(rolling.values());
+    ConcurrentLinkedQueue<StepAndPacket> stepAndPackets = new ConcurrentLinkedQueue<>(rolling.values());
     Step rollSpecificClusterStep = new RollingHelper.RollSpecificClusterStep(CLUSTER_NAME, stepAndPackets);
 
     rollSpecificClusterStep.apply(testSupport.getPacket());

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
@@ -108,6 +108,9 @@ class WebhookRestTest extends RestTestBase {
   private static final String REJECT_MESSAGE_CLUSTER_NOT_FOUND =
       "Exception: io.kubernetes.client.openapi.ApiException: Cluster %s not found";
 
+  public static final String KIND_ADMISSION_REVIEW = "AdmissionReview";
+
+
   private final AdmissionReview domainReview = createDomainAdmissionReview();
   private final AdmissionReview clusterReview = createClusterAdmissionReview();
   private final AdmissionReview scaleReview = createScaleAdmissionReview();
@@ -123,8 +126,12 @@ class WebhookRestTest extends RestTestBase {
 
   private final ConversionReviewModel conversionReview = createConversionReview();
 
+  private AdmissionReview createAdmissionReview() {
+    return new AdmissionReview().apiVersion(V1).kind(KIND_ADMISSION_REVIEW);
+  }
+
   private AdmissionReview createDomainAdmissionReview() {
-    return new AdmissionReview().apiVersion(V1).kind("AdmissionReview").request(createDomainAdmissionRequest());
+    return createAdmissionReview().request(createDomainAdmissionRequest());
   }
 
   private AdmissionRequest createDomainAdmissionRequest() {
@@ -148,7 +155,7 @@ class WebhookRestTest extends RestTestBase {
   }
 
   private AdmissionReview createClusterAdmissionReview() {
-    return new AdmissionReview().apiVersion(V1).kind("AdmissionReview").request(createClusterAdmissionRequest());
+    return createAdmissionReview().request(createClusterAdmissionRequest());
   }
 
   private AdmissionRequest createClusterAdmissionRequest() {
@@ -172,7 +179,7 @@ class WebhookRestTest extends RestTestBase {
   }
 
   private AdmissionReview createScaleAdmissionReview() {
-    return new AdmissionReview().apiVersion(V1).kind("AdmissionReview").request(createScaleAdmissionRequest());
+    return createAdmissionReview().request(createScaleAdmissionRequest());
   }
 
   private AdmissionRequest createScaleAdmissionRequest() {
@@ -744,7 +751,7 @@ class WebhookRestTest extends RestTestBase {
     AdmissionReview review = createScaleAdmissionReview();
     AdmissionRequest request = review.getRequest();
     Map<String, String> kind = new HashMap<>();
-    kind.put("kind", "blabal");
+    kind.put("kind", "blabla");
     request.setKind(kind);
     testSupport.defineResources(validScale);
     setProposedScale(validScale);

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/WebhookRestTest.java
@@ -39,7 +39,6 @@ import oracle.kubernetes.operator.webhooks.model.Scale;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
@@ -673,14 +672,13 @@ class WebhookRestTest extends RestTestBase {
   }
 
   @Test
-  @Disabled("Cluster replicas are no longer included in Domain specification")
-  void whenClusterReplicasChangedUnsetAndReadDomainFailed404_rejectItWithException() {
+  void whenClusterReplicasChangedUnsetAndListDomainFailed404_rejectItWithException() {
     testSupport.defineResources(proposedDomain);
     existingCluster.getSpec().withReplicas(GOOD_REPLICAS);
     proposedCluster.getSpec().withReplicas(null);
     setExistingAndProposedCluster();
 
-    testSupport.failOnRead(KubernetesTestSupport.DOMAIN, UID, NS, HTTP_FORBIDDEN);
+    testSupport.failOnList(KubernetesTestSupport.DOMAIN, NS, HTTP_FORBIDDEN);
 
     AdmissionReview responseReview = sendValidatingRequestAsAdmissionReview(clusterReview);
 

--- a/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfigTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfigTest.java
@@ -42,7 +42,7 @@ class WlsDomainConfigTest {
   };
   private final List<LogRecord> logRecords = new ArrayList<>();
   private final List<Memento> mementos = new ArrayList<>();
-  private WlsDomainConfig wlsDomainConfig = new WlsDomainConfig("test-domain");
+  private final WlsDomainConfig wlsDomainConfig = new WlsDomainConfig("test-domain");
   private final WlsDomainConfigSupport support = new WlsDomainConfigSupport("test-domain");
 
   @BeforeEach

--- a/operator/src/test/java/oracle/kubernetes/operator/work/TerminalStep.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/work/TerminalStep.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /** A do-nothing step that can be used as a base for testing. It has no next step. */
 public class TerminalStep extends Step {
   private boolean executed;
-  private AtomicInteger executionCount = new AtomicInteger(0);
+  private final AtomicInteger executionCount = new AtomicInteger(0);
 
   public TerminalStep() {
     super(null);

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainResourceSpecTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainResourceSpecTest.java
@@ -101,7 +101,6 @@ class DomainResourceSpecTest {
   private String getLatestDefaultImage() {
     String defaultImageName = KubernetesConstants.DEFAULT_IMAGE
         .substring(0, KubernetesConstants.DEFAULT_IMAGE.indexOf(':'));
-    String latestImage = defaultImageName + KubernetesConstants.LATEST_IMAGE_SUFFIX;
-    return latestImage;
+    return defaultImageName + KubernetesConstants.LATEST_IMAGE_SUFFIX;
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -22,7 +22,6 @@ import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.NS;
@@ -37,8 +36,10 @@ import static oracle.kubernetes.operator.helpers.PodHelperTestBase.getAuxiliaryI
 import static oracle.kubernetes.weblogic.domain.model.Model.DEFAULT_AUXILIARY_IMAGE_MOUNT_PATH;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DomainValidationTest extends DomainValidationTestBase {
 
@@ -196,13 +197,12 @@ class DomainValidationTest extends DomainValidationTestBase {
   }
 
   @Test
-  @Disabled("Domain validation doesn't read cluster resources")
   void whenClusterSpecsHaveDuplicateNames_reportError() {
     addClusterWithName("cluster1");
     addClusterWithName("cluster1");
 
-    assertThat(domain.getValidationFailures(resourceLookup),
-          contains(stringContainsInOrder("clusters", "cluster1")));
+    assertThat(domain.getValidationFailures(resourceLookup), hasSize(2));
+    assertTrue(domain.getValidationFailures(resourceLookup).get(0).contains("cluster1"));
   }
 
   private void addClusterWithName(String clusterName) {


### PR DESCRIPTION
- Fix and enable some unit test cases that were commented out when cluster resource was integrated.
- Move a duplicate method createEnv() into a common base class.
- Fix some IntelliJ warnings.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13609/