### PR TITLE
backport MonitoringExporter Test change into release/3.4

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporterWebApp.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMonitoringExporterWebApp.java
@@ -510,7 +510,7 @@ class ItMonitoringExporterWebApp {
       page1 = webClient.getPage(exporterUrl);
     }
     assertNotNull(page1, "can't retrieve exporter dashboard page");
-    assertTrue((page1.asNormalizedText()).contains("This is the WebLogic Monitoring Exporter."));
+    assertTrue((page1.asNormalizedText()).contains("Oracle WebLogic Monitoring Exporter"));
 
     // Get the form that we are dealing with and within that form,
     // find the submit button and the field that we want to change.Generated form for cluster had


### PR DESCRIPTION
Backport the (https://github.com/oracle/weblogic-kubernetes-operator/pull/3532) 
    test change due to WebLogicMonitoring Exporter header change 


https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13612