### PR TITLE
Support wdt app module deployment

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1105,7 +1105,8 @@ class MII_DomainConfigGenerator(Generator):
     # all the many policies files
     packcmd = "tar -pczf /tmp/domain.tar.gz %s/config/config.xml %s/config/jdbc/ %s/config/jms %s/config/coherence " \
               "%s/config/diagnostics %s/config/startup %s/config/configCache %s/config/nodemanager " \
-              "%s/config/security %s/config/fmwconfig/servers/*/logging.xml" % (
+              "%s/wlsdeploy/applications/*.xml " \
+              "%s/config/security %s/config/fmwconfig/servers/*/logging.xml" % ( self.domain_home,
               self.domain_home, self.domain_home, self.domain_home, self.domain_home, self.domain_home,
               self.domain_home, self.domain_home, self.domain_home, self.domain_home, self.domain_home)
     os.system(packcmd)

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -1327,9 +1327,10 @@ prepareMIIServer() {
 
         # expand the archive apps and shared lib to the wlsdeploy/* directories
         # the config.xml is referencing them from that path
-
+        # exclude standalone app module in wlsdeploy/applications/*.xml since it is included int zipped up domain config
+        # zip, the original xml in the archive may have wdt tokenized notations.
         cd ${DOMAIN_HOME} || return 1
-        ${JAVA_HOME}/bin/jar xf ${IMG_ARCHIVES_ROOTDIR}/${file} wlsdeploy/
+        unzip ${IMG_ARCHIVES_ROOTDIR}/${file} -x "wlsdeploy/applications/*.xml" -x "wlsdeploy/domainBin/*"
         if [ $? -ne 0 ] ; then
           trace SEVERE "Domain Source Type is FromModel, error in extracting application archive ${IMG_ARCHIVES_ROOTDIR}/${file}"
           return 1

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -1330,15 +1330,12 @@ prepareMIIServer() {
         # exclude standalone app module in wlsdeploy/applications/*.xml since it is included int zipped up domain config
         # zip, the original xml in the archive may have wdt tokenized notations.
         cd ${DOMAIN_HOME} || return 1
-        unzip ${IMG_ARCHIVES_ROOTDIR}/${file} -x "wlsdeploy/applications/*.xml" -x "wlsdeploy/domainBin/*"
+        unzip ${IMG_ARCHIVES_ROOTDIR}/${file} -x "wlsdeploy/applications/./*.xml" -x "wlsdeploy/domainBin/*"
         if [ $? -ne 0 ] ; then
           trace SEVERE "Domain Source Type is FromModel, error in extracting application archive ${IMG_ARCHIVES_ROOTDIR}/${file}"
           return 1
         fi
     done
-    echo "-----------------------------------------------"
-    cat ${DOMAIN_HOME}/config/config.xml
-    ls -lR ${DOMAIN_HOME}/wlsdeploy
 
   return 0
 }

--- a/operator/src/main/resources/scripts/modelInImage.sh
+++ b/operator/src/main/resources/scripts/modelInImage.sh
@@ -1335,9 +1335,11 @@ prepareMIIServer() {
           trace SEVERE "Domain Source Type is FromModel, error in extracting application archive ${IMG_ARCHIVES_ROOTDIR}/${file}"
           return 1
         fi
-        # No need to have domainLibraries in domain home
-        rm -fr ${WLSDEPLOY_DOMAINLIB}
     done
+    echo "-----------------------------------------------"
+    cat ${DOMAIN_HOME}/config/config.xml
+    ls -lR ${DOMAIN_HOME}/wlsdeploy
+
   return 0
 }
 


### PR DESCRIPTION
This PR is to add support for the standalone app deployment in WDT which include archive jms, jdbc, wldf modules xml.   The operator will store any standalone xml file deployed in the domain in the domain config zip and restore them before starting the server. 