### PR TITLE
OWLS-103643 - Change to the quick start cluster resource name to include domain-uid and cluster-name validation

### DIFF
--- a/documentation/domains/Cluster.json
+++ b/documentation/domains/Cluster.json
@@ -200,7 +200,10 @@
           "description": "Changes to this field cause the operator to restart WebLogic Server instances. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle/startup/#restarting-servers.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "clusterName"
+      ]
     },
     "ClusterStatus": {
       "type": "object",

--- a/kubernetes/crd/cluster-crd.yaml
+++ b/kubernetes/crd/cluster-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 70bafec24ec0f378000f5916e91ad27c6aa400bdff77526f4dee9be54898eea2
+    weblogic.sha256: 3c1dd670396edaa66773c2de84ea6d50a05f4618c2515d1005dc2c4029790d17
   name: clusters.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -2913,6 +2913,8 @@ spec:
                 description: 'Changes to this field cause the operator to restart
                   WebLogic Server instances. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle/startup/#restarting-servers.'
                 type: string
+            required:
+            - clusterName
             type: object
           status:
             properties:

--- a/kubernetes/samples/quick-start/domain-resource.yaml
+++ b/kubernetes/samples/quick-start/domain-resource.yaml
@@ -114,7 +114,7 @@ spec:
 
   # The desired behavior for starting a specific cluster's member servers
   clusters:
-  - name: cluster-1
+  - name: sample-domain1-cluster-1
 
   # Change the restartVersion to force the introspector job to rerun
   # and apply any new model configuration, to also force a subsequent
@@ -135,7 +135,7 @@ spec:
 apiVersion: "weblogic.oracle/v1"
 kind: Cluster
 metadata:
-  name: cluster-1
+  name: sample-domain1-cluster-1
   # Update this with the namespace your domain will run in:
   namespace: sample-domain1-ns
   labels:
@@ -144,3 +144,4 @@ metadata:
 
 spec:
   replicas: 2
+  clusterName: cluster-1

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterSpec.java
@@ -16,7 +16,6 @@ import oracle.kubernetes.operator.ServerStartPolicy;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An element representing a cluster in the domain configuration.
@@ -28,7 +27,7 @@ public class ClusterSpec extends BaseConfiguration implements Comparable<Cluster
   /** The name of the cluster. Required. */
   @Description("The name of the cluster. This value must match the name of a WebLogic cluster already defined "
       + "in the WebLogic domain configuration. Required.")
-  @NotNull
+  @Nonnull
   private String clusterName;
 
   /** The number of replicas to run in the cluster, if specified. */


### PR DESCRIPTION
OWLS-103643 part 1
 - Change to the quick start cluster resource name to include domain-uid to follow the best practice.
 - Added valiation for the ClusterSpec.ClusterName to be non-null.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13628/console