### PR TITLE
Standardize on javax.annotation annotations

### DIFF
--- a/documentation/domains/Cluster.json
+++ b/documentation/domains/Cluster.json
@@ -654,7 +654,10 @@
           "description": "Changes to this field cause the operator to restart WebLogic Server instances. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle/startup/#restarting-servers.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "serverName"
+      ]
     },
     "Map": {
       "type": "object"
@@ -1143,5 +1146,8 @@
       "description": "The current status of the operation of the WebLogic cluster. Updated automatically by the operator.",
       "$ref": "#/definitions/ClusterStatus"
     }
-  }
+  },
+  "required": [
+    "spec"
+  ]
 }

--- a/documentation/domains/Domain.json
+++ b/documentation/domains/Domain.json
@@ -573,7 +573,10 @@
           "description": "Changes to this field cause the operator to restart WebLogic Server instances. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle/startup/#restarting-servers.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "serverName"
+      ]
     },
     "Map": {
       "type": "object"

--- a/documentation/domains/index.html
+++ b/documentation/domains/index.html
@@ -1489,7 +1489,10 @@ window.onload = function() {
           "description": "Changes to this field cause the operator to restart WebLogic Server instances. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle/startup/#restarting-servers.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "serverName"
+      ]
     },
     "Map": {
       "type": "object"

--- a/integration-tests/src/test/java/oracle/weblogic/domain/ClusterResource.java
+++ b/integration-tests/src/test/java/oracle/weblogic/domain/ClusterResource.java
@@ -4,6 +4,7 @@
 package oracle.weblogic.domain;
 
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -11,7 +12,6 @@ import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An element representing a cluster in the domain configuration.
@@ -206,7 +206,7 @@ public class ClusterResource implements KubernetesObject {
     return this;
   }
 
-  @NotNull
+  @Nonnull
   public ClusterSpec getSpec() {
     return spec;
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsFailedCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsFailedCondition.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.models.V1EnvVar;
@@ -35,7 +36,6 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.FmwUtils;
 import oracle.weblogic.kubernetes.utils.LoggingUtil;
 import oracle.weblogic.kubernetes.utils.PodUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -295,7 +295,7 @@ class ItDiagnosticsFailedCondition {
     }
   }
 
-  @NotNull
+  @Nonnull
   private String getClusterResName(String domainName) {
     return domainName + "-" + this.wlClusterName;
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItLivenessProbeCustomization.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItLivenessProbeCustomization.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiException;
@@ -27,7 +28,6 @@ import oracle.weblogic.domain.ServerPod;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -465,7 +465,7 @@ class ItLivenessProbeCustomization {
     return exception != null && exception.getResponseBody().contains(expectedMsg);
   }
 
-  @NotNull
+  @Nonnull
   private static DomainResource createDomainResource(String domainName) {
 
     // create the domain CR

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -54,7 +55,6 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.Command;
 import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.assertions.impl.Cluster;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.jetbrains.annotations.NotNull;
 
 import static java.io.File.createTempFile;
 import static java.nio.file.Files.copy;
@@ -1191,7 +1191,7 @@ public class DomainUtils {
    * @param domainNamespace the namespace
    * @param domainUid the UID
    */
-  @NotNull
+  @Nonnull
   public static DomainResource getAndValidateInitialDomain(String domainNamespace, String domainUid) {
     DomainResource domain = assertDoesNotThrow(() -> getDomainCustomResource(domainUid, domainNamespace),
         String.format("getDomainCustomResource failed with ApiException when tried to get domain %s in namespace %s",
@@ -1210,7 +1210,7 @@ public class DomainUtils {
    * @param regex check string
    * @return true if regex found, false otherwise.
    */
-  @NotNull
+  @Nonnull
   public static boolean findStringInDomainStatusMessage(String domainNamespace, String domainUid, String regex) {
     // get the domain status message
     StringBuffer getDomainInfoCmd = new StringBuffer("kubectl get domain/");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PersistentVolumeUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PersistentVolumeUtils.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -26,7 +27,6 @@ import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
-import org.jetbrains.annotations.NotNull;
 
 import static java.nio.file.Files.createDirectories;
 import static oracle.weblogic.kubernetes.TestConstants.FSS_DIR;
@@ -225,7 +225,7 @@ public class PersistentVolumeUtils {
     }
   }
 
-  @NotNull
+  @Nonnull
   private static Path createPVHostPathDir(String pvName, String className) {
     Path pvHostPath = null;
     LoggingFacade logger = getLogger();

--- a/kubernetes/crd/domain-crd.yaml
+++ b/kubernetes/crd/domain-crd.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    weblogic.sha256: 6c271191a86ea2a5ff138c7772075e2867ac7cbb6c04ab4133f94e6a69508662
+    weblogic.sha256: 869d5b8e0c547afc1f704e7a4a37ff8623be6606ec8c5e51c9555304835a6464
   name: domains.weblogic.oracle
 spec:
   group: weblogic.oracle
@@ -9186,6 +9186,8 @@ spec:
                       description: 'Changes to this field cause the operator to restart
                         WebLogic Server instances. More info: https://oracle.github.io/weblogic-kubernetes-operator/userguide/managing-domains/domain-lifecycle/startup/#restarting-servers.'
                       type: string
+                  required:
+                  - serverName
                 type: array
             type: object
           status:

--- a/operator-build-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/JsonSchemaMojo.java
+++ b/operator-build-maven-plugin/src/main/java/oracle/kubernetes/json/mojo/JsonSchemaMojo.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import oracle.kubernetes.mojosupport.FileSystem;
 import org.apache.maven.plugin.AbstractMojo;
@@ -19,7 +20,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.jetbrains.annotations.NotNull;
 
 @Mojo(
     name = "generate",
@@ -87,7 +87,7 @@ public class JsonSchemaMojo extends AbstractMojo {
     }
   }
 
-  @NotNull
+  @Nonnull
   String getRootName() {
     return new File(getOutputFile()).getName().split("\\.")[0];
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorDelegate.java
@@ -3,10 +3,11 @@
 
 package oracle.kubernetes.operator;
 
+import javax.annotation.Nonnull;
+
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.makeright.MakeRightDomainOperationImpl;
 import oracle.kubernetes.operator.work.FiberGate;
-import org.jetbrains.annotations.NotNull;
 
 /** A set of underlying services required during domain processing. */
 public interface DomainProcessorDelegate extends CoreDelegate {
@@ -42,7 +43,7 @@ public interface DomainProcessorDelegate extends CoreDelegate {
    */
   FiberGate createFiberGate();
 
-  @NotNull
+  @Nonnull
   default MakeRightDomainOperation createMakeRightOperation(MakeRightExecutor executor, DomainPresenceInfo info) {
     return new MakeRightDomainOperationImpl(executor, this, info);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -62,7 +62,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.DomainStatusUpdater.createInternalFailureSteps;
 import static oracle.kubernetes.operator.DomainStatusUpdater.createIntrospectionFailureSteps;
@@ -1004,7 +1003,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
       return domainUid;
     }
 
-    @NotNull
+    @Nonnull
     private Packet createPacket() {
       Packet packet = new Packet();
       packet

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -66,7 +66,6 @@ import oracle.kubernetes.weblogic.domain.model.Model;
 import oracle.kubernetes.weblogic.domain.model.OnlineUpdate;
 import oracle.kubernetes.weblogic.domain.model.ServerHealth;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_NOT_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_FATAL_ERROR;
@@ -799,7 +798,7 @@ public class DomainStatusUpdater {
               CLUSTER_MESSAGE_LIMIT, createUnavailableClustersMessage(unavailableClusters));
         }
 
-        @NotNull
+        @Nonnull
         private List<String> createUnavailableClustersMessage(List<ClusterCheck> unavailableClusters) {
           return unavailableClusters.stream().map(ClusterCheck::createNotReadyMessage).collect(Collectors.toList());
         }

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ContainerState;
@@ -43,8 +44,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.SystemClock;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static oracle.kubernetes.operator.ProcessingConstants.JOB_POD_INTROSPECT_CONTAINER_TERMINATED;
 import static oracle.kubernetes.operator.ProcessingConstants.JOB_POD_INTROSPECT_CONTAINER_TERMINATED_MARKER;
@@ -369,7 +368,7 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
           }
         }
 
-        private boolean isJobTerminated(@NotNull V1Pod jobPod) {
+        private boolean isJobTerminated(@Nonnull V1Pod jobPod) {
           return Optional.of(jobPod)
               .map(V1Pod::getStatus)
               .map(V1PodStatus::getContainerStatuses).orElseGet(Collections::emptyList).stream()

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CrdHelper.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -62,7 +63,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import org.apache.commons.codec.binary.Base64;
-import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -373,7 +373,7 @@ public class CrdHelper {
       return versions;
     }
 
-    @NotNull
+    @Nonnull
     private List<V1CustomResourceDefinitionVersion> getExistingVersions() {
       final Map<String, String> schemas = schemaReader.loadFilesFromClasspath();
       return schemas.entrySet().stream()

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainValidationSteps.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
@@ -29,7 +30,6 @@ import oracle.kubernetes.weblogic.domain.model.ClusterList;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.KubernetesResourceLookup;
-import org.jetbrains.annotations.NotNull;
 
 import static java.lang.System.lineSeparator;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_VALIDATION_FAILED;
@@ -148,7 +148,7 @@ public class DomainValidationSteps {
       }
     }
 
-    @NotNull
+    @Nonnull
     private String getErrorMessage(List<String> fatalValidationFailures, List<String> validationFailures) {
       String errorMsg;
       if (fatalValidationFailures.isEmpty()) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -53,7 +53,6 @@ import oracle.kubernetes.weblogic.domain.model.ClusterSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.Server;
-import org.jetbrains.annotations.NotNull;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_INTROSPECTION_INCOMPLETE;
@@ -536,7 +535,7 @@ public class JobHelper {
         }
       }
 
-      @NotNull
+      @Nonnull
       private Boolean isDomainIntrospectionComplete(CallResponse<String> callResponse) {
         return Optional.ofNullable(callResponse).map(CallResponse::getResult)
             .map(r -> r.contains(DOMAIN_INTROSPECTION_COMPLETE)).orElse(false);
@@ -754,7 +753,7 @@ public class JobHelper {
           return jobName.equals(status.getName()) && getTerminatedExitCode(status) == 0;
         }
 
-        @NotNull
+        @Nonnull
         private Integer getTerminatedExitCode(V1ContainerStatus status) {
           return Optional.ofNullable(status.getState())
               .map(V1ContainerState::getTerminated)

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -49,8 +50,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
 import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static oracle.kubernetes.common.CommonConstants.COMPATIBILITY_MODE;
 import static oracle.kubernetes.common.CommonConstants.SCRIPTS_MOUNTS_PATH;
@@ -325,7 +324,7 @@ public class JobStepContext extends BasePodStepContext {
         .orElse(TuningParameters.getInstance().getActiveJobInitialDeadlineSeconds());
   }
 
-  @NotNull
+  @Nonnull
   private Long getNumDeadlineIncreases() {
     return Math.min(TuningParameters.getInstance().getActiveDeadlineMaxNumIncrements(), info.getNumDeadlineIncreases());
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -80,7 +80,6 @@ import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.CommonConstants.COMPATIBILITY_MODE;
 import static oracle.kubernetes.common.helpers.AuxiliaryImageEnvVars.AUXILIARY_IMAGE_MOUNT_PATH;
@@ -355,7 +354,7 @@ public abstract class PodStepContext extends BasePodStepContext {
     return  name;
   }
 
-  @NotNull
+  @Nonnull
   private String getPortNamePrefix(String name) {
     // Use first 12 characters of port name as prefix due to 15 character port name limit
     return name.substring(0, 12);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/RollingHelper.java
@@ -30,7 +30,6 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.Step.StepAndPacket;
 import oracle.kubernetes.utils.OperatorUtils;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 
@@ -171,12 +170,12 @@ public class RollingHelper {
         return work;
       }
 
-      @NotNull
+      @Nonnull
       private Step createServersStep(Collection<StepAndPacket> serverRestarts) {
         return new ServersThatCanRestartNowStep(serverRestarts);
       }
 
-      @NotNull
+      @Nonnull
       private RollSpecificClusterStep createPerClusterStep(Map.Entry<String, Queue<StepAndPacket>> entry) {
         return new RollSpecificClusterStep(entry.getKey(), entry.getValue());
       }
@@ -273,7 +272,7 @@ public class RollingHelper {
         return getInfo().getMinAvailable(clusterName);
       }
 
-      @NotNull
+      @Nonnull
       private List<String> getReadyServers(WlsDomainConfig config) {
         return Optional.ofNullable(config)
               .map(this::getClusterConfig)

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/WebhookHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/WebhookHelper.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.models.AdmissionregistrationV1ServiceReference;
 import io.kubernetes.client.openapi.models.AdmissionregistrationV1WebhookClientConfig;
@@ -26,8 +28,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import org.apache.commons.codec.binary.Base64;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static oracle.kubernetes.common.logging.MessageKeys.VALIDATING_WEBHOOK_CONFIGURATION_CREATED;
 import static oracle.kubernetes.operator.KubernetesConstants.CLUSTER_PLURAL;
@@ -142,7 +142,7 @@ public class WebhookHelper {
       return createRule().apiVersions(createList(DOMAIN_VERSION)).resources(createList(DOMAIN_RESOURCES));
     }
 
-    @NotNull
+    @Nonnull
     private List<String> createList(String item) {
       return Collections.singletonList(item);
     }
@@ -157,7 +157,7 @@ public class WebhookHelper {
     }
 
     @Nullable
-    private byte[] getCaBundle(@NotNull Certificates certificates) {
+    private byte[] getCaBundle(@Nonnull Certificates certificates) {
       return Optional.of(certificates).map(Certificates::getWebhookCertificateData)
           .map(Base64::decodeBase64).orElse(null);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/WlsConfigValidator.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/WlsConfigValidator.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import oracle.kubernetes.operator.DomainFailureMessages;
 import oracle.kubernetes.operator.ProcessingConstants;
@@ -25,7 +26,6 @@ import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.ClusterSpec;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import oracle.kubernetes.weblogic.domain.model.MonitoringExporterSpecification;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.ILLEGAL_CLUSTER_SERVICE_NAME_LENGTH;
 import static oracle.kubernetes.common.logging.MessageKeys.ILLEGAL_EXTERNAL_SERVICE_NAME_LENGTH;
@@ -255,7 +255,7 @@ public class WlsConfigValidator {
     }
   }
 
-  @NotNull
+  @Nonnull
   private Boolean isPortInUseByDynamicServer(int exporterPort, WlsClusterConfig cluster) {
     return Optional.ofNullable(cluster.getDynamicServersConfig())
           .map(WlsDynamicServersConfig::getServerTemplate)
@@ -320,7 +320,7 @@ public class WlsConfigValidator {
 
   }
 
-  @NotNull
+  @Nonnull
   private String[] getTopologyClusterNames() {
     return Optional.ofNullable(domainConfig).map(WlsDomainConfig::getClusterNames).orElse(new String[0]);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/DomainPresenceStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/DomainPresenceStep.java
@@ -3,12 +3,13 @@
 
 package oracle.kubernetes.operator.makeright;
 
+import javax.annotation.Nonnull;
+
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
-import org.jetbrains.annotations.NotNull;
 
 public class DomainPresenceStep extends Step {
 
@@ -36,7 +37,7 @@ public class DomainPresenceStep extends Step {
     return Step.chain(next, getNext());
   }
 
-  @NotNull
+  @Nonnull
   private Boolean isDomainShuttingDown(Packet packet) {
     return DomainPresenceInfo.fromPacket(packet)
         .map(DomainPresenceInfo::getDomain)

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/InitializeWebhookIdentityStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/InitializeWebhookIdentityStep.java
@@ -17,6 +17,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Secret;
@@ -38,7 +39,6 @@ import org.apache.commons.io.FileUtils;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.OperatorCreationException;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.WEBHOOK_IDENTITY_INITIALIZATION_FAILED;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getWebhookNamespace;
@@ -197,7 +197,7 @@ public class InitializeWebhookIdentityStep extends Step {
   private static class SslIdentityFactoryImpl implements SslIdentityFactory {
 
     @Override
-    @NotNull
+    @Nonnull
     public KeyPair createKeyPair() throws NoSuchAlgorithmException, InvalidKeySpecException {
       return SelfSignedCertUtils.createKeyPair();
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -3,6 +3,8 @@
 
 package oracle.kubernetes.operator.steps;
 
+import javax.annotation.Nonnull;
+
 import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.operator.PodAwaiterStepFactory;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
@@ -11,7 +13,6 @@ import oracle.kubernetes.operator.helpers.ServiceHelper;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownWithHttpStep;
 
@@ -49,7 +50,7 @@ public class ServerDownStep extends Step {
     return doNext(oldPod != null ? createShutdownManagedServerStep(oldPod, next) : next, packet);
   }
 
-  @NotNull
+  @Nonnull
   private Step createShutdownManagedServerStep(V1Pod oldPod, Step next) {
     return ShutdownManagedServerStep
         .createShutdownManagedServerStep(createWaitForServerShutdownWithHttpStep(

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -42,7 +42,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.KubernetesConstants.WLS_CONTAINER_NAME;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
@@ -339,12 +338,12 @@ public class ShutdownManagedServerStep extends Step {
       return doNext(packet);
     }
 
-    @NotNull
+    @Nonnull
     private Boolean shutdownAttemptSucceeded(Packet packet) {
       return Optional.ofNullable((Boolean)packet.get(SHUTDOWN_WITH_HTTP_SUCCEEDED)).orElse(false);
     }
 
-    @NotNull
+    @Nonnull
     private Boolean serverNotShutdown(String serverState) {
       return Optional.ofNullable(serverState).map(s -> !s.equals(SHUTDOWN_STATE)).orElse(false);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/SslIdentityFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/SslIdentityFactory.java
@@ -9,14 +9,14 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
+import javax.annotation.Nonnull;
 
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.operator.OperatorCreationException;
-import org.jetbrains.annotations.NotNull;
 
 public interface SslIdentityFactory {
 
-  @NotNull
+  @Nonnull
   KeyPair createKeyPair() throws NoSuchAlgorithmException, InvalidKeySpecException;
 
   String convertToPEM(Object object) throws IOException;

--- a/operator/src/main/java/oracle/kubernetes/operator/utils/SelfSignedCertUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/utils/SelfSignedCertUtils.java
@@ -18,6 +18,7 @@ import java.security.spec.RSAPublicKeySpec;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import javax.annotation.Nonnull;
 
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
@@ -39,7 +40,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorNamespace;
 import static oracle.kubernetes.operator.helpers.NamespaceHelper.getWebhookNamespace;
@@ -125,7 +125,7 @@ public final class SelfSignedCertUtils {
             .setProvider(new BouncyCastleProvider()).getCertificate(certificateBuilder.build(contentSigner));
   }
 
-  @NotNull
+  @Nonnull
   private static GeneralNames getSAN(String cert) {
     String host = INTERNAL_WEBLOGIC_OPERATOR_SVC;
     String namespace = getOperatorNamespace();

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionChecker.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.ApiException;
 import oracle.kubernetes.operator.helpers.CallBuilder;
@@ -16,7 +17,6 @@ import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
-import org.jetbrains.annotations.NotNull;
 
 import static java.lang.System.lineSeparator;
 
@@ -72,7 +72,7 @@ public abstract class AdmissionChecker {
     return getClusterSizeOptional(clusterStatus).orElse(0);
   }
 
-  int getDomainReplicaCount(@NotNull DomainResource domain) {
+  int getDomainReplicaCount(@Nonnull DomainResource domain) {
     return Optional.of(domain).map(DomainResource::getSpec).map(DomainSpec::getReplicas).orElse(1);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionWebhookResource.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/AdmissionWebhookResource.java
@@ -4,6 +4,8 @@
 package oracle.kubernetes.operator.webhooks.resource;
 
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.ApiException;
 import jakarta.ws.rs.Consumes;
@@ -17,8 +19,6 @@ import oracle.kubernetes.operator.webhooks.model.AdmissionRequest;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponseStatus;
 import oracle.kubernetes.operator.webhooks.model.AdmissionReview;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static oracle.kubernetes.common.logging.MessageKeys.VALIDATION_FAILED;
 import static oracle.kubernetes.operator.webhooks.utils.GsonBuilderUtils.readAdmissionReview;
@@ -117,15 +117,15 @@ public class AdmissionWebhookResource extends BaseResource {
     return validate(request);
   }
 
-  private AdmissionResponse validate(@NotNull AdmissionRequest request) throws ApiException {
+  private AdmissionResponse validate(@Nonnull AdmissionRequest request) throws ApiException {
     LOGGER.fine("Validating " +  request.getObject() + " against " + request.getOldObject()
         + " Kind = " + request.getKind() + " uid = " + request.getUid() + " resource = " + request.getResource()
         + " subResource = " + request.getSubResource());
     return getAdmissionChecker(request).validate().uid(getUid(request));
   }
 
-  @NotNull
-  private AdmissionChecker getAdmissionChecker(@NotNull AdmissionRequest request) throws ApiException {
+  @Nonnull
+  private AdmissionChecker getAdmissionChecker(@Nonnull AdmissionRequest request) throws ApiException {
     return request.getRequestKind().getAdmissionChecker(request);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/ClusterCreateAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/ClusterCreateAdmissionChecker.java
@@ -4,13 +4,13 @@
 package oracle.kubernetes.operator.webhooks.resource;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponseStatus;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * ClusterCreateAdmissionChecker provides the validation functionality for the validating webhook. It takes a
@@ -28,7 +28,7 @@ public class ClusterCreateAdmissionChecker extends AdmissionChecker {
   private final AdmissionResponse response = new AdmissionResponse();
 
   /** Construct a ClusterCreateAdmissionChecker. */
-  public ClusterCreateAdmissionChecker(@NotNull ClusterResource proposedCluster) {
+  public ClusterCreateAdmissionChecker(@Nonnull ClusterResource proposedCluster) {
     this.proposedCluster = proposedCluster;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/ClusterScaleAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/ClusterScaleAdmissionChecker.java
@@ -3,9 +3,10 @@
 
 package oracle.kubernetes.operator.webhooks.resource;
 
+import javax.annotation.Nonnull;
+
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_SCALE_REPLICAS_TOO_HIGH;
 
@@ -25,7 +26,7 @@ import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_SCALE_REPLICA
 public class ClusterScaleAdmissionChecker extends ClusterAdmissionChecker {
 
   /** Construct a ClusterUpdateAdmissionChecker. */
-  public ClusterScaleAdmissionChecker(@NotNull ClusterResource proposedCluster) {
+  public ClusterScaleAdmissionChecker(@Nonnull ClusterResource proposedCluster) {
     this.proposedCluster = proposedCluster;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/ClusterUpdateAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/ClusterUpdateAdmissionChecker.java
@@ -5,13 +5,13 @@ package oracle.kubernetes.operator.webhooks.resource;
 
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.ClusterSpec;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_REPLICAS_CANNOT_BE_HONORED;
 
@@ -34,8 +34,8 @@ public class ClusterUpdateAdmissionChecker extends ClusterScaleAdmissionChecker 
   private final ClusterResource existingCluster;
 
   /** Construct a ClusterUpdateAdmissionChecker. */
-  public ClusterUpdateAdmissionChecker(@NotNull ClusterResource existingCluster,
-                                       @NotNull ClusterResource proposedCluster) {
+  public ClusterUpdateAdmissionChecker(@Nonnull ClusterResource existingCluster,
+                                       @Nonnull ClusterResource proposedCluster) {
     super(proposedCluster);
     this.existingCluster = existingCluster;
   }
@@ -68,7 +68,7 @@ public class ClusterUpdateAdmissionChecker extends ClusterScaleAdmissionChecker 
         .orElse(false);
   }
 
-  private boolean isProposedSpecUnchanged(@NotNull ClusterSpec existingSpec) {
+  private boolean isProposedSpecUnchanged(@Nonnull ClusterSpec existingSpec) {
     return Objects.equals(existingSpec, proposedCluster.getSpec());
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainCreateAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainCreateAdmissionChecker.java
@@ -3,12 +3,13 @@
 
 package oracle.kubernetes.operator.webhooks.resource;
 
+import javax.annotation.Nonnull;
+
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponse;
 import oracle.kubernetes.operator.webhooks.model.AdmissionResponseStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * DomainCreateAdmissionChecker provides the validation functionality for the validating webhook. It takes
@@ -31,7 +32,7 @@ public class DomainCreateAdmissionChecker extends AdmissionChecker {
   /**
    * Construct a DomainCreateAdmissionChecker.
    */
-  public DomainCreateAdmissionChecker(@NotNull DomainResource proposedDomain) {
+  public DomainCreateAdmissionChecker(@Nonnull DomainResource proposedDomain) {
     this.proposedDomain = proposedDomain;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainUpdateAdmissionChecker.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/webhooks/resource/DomainUpdateAdmissionChecker.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -22,7 +23,6 @@ import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
-import org.jetbrains.annotations.NotNull;
 
 import static java.lang.Boolean.FALSE;
 import static oracle.kubernetes.common.logging.MessageKeys.DOMAIN_INTROSPECTION_TRIGGER_CHANGED;
@@ -60,7 +60,7 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
   private Exception exception;
 
   /** Construct a DomainAdmissionChecker. */
-  public DomainUpdateAdmissionChecker(@NotNull DomainResource existingDomain, @NotNull DomainResource proposedDomain) {
+  public DomainUpdateAdmissionChecker(@Nonnull DomainResource existingDomain, @Nonnull DomainResource proposedDomain) {
     this.existingDomain = existingDomain;
     this.proposedDomain = proposedDomain;
   }
@@ -98,7 +98,7 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
         .orElse(false);
   }
 
-  private boolean isProposedSpecUnchanged(@NotNull DomainSpec existingSpec) {
+  private boolean isProposedSpecUnchanged(@Nonnull DomainSpec existingSpec) {
     return Objects.equals(existingSpec, proposedDomain.getSpec());
   }
 
@@ -136,25 +136,25 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
     return allValid;
   }
 
-  @NotNull
+  @Nonnull
   private String getDomainReplicasTooHighMsg(List<String> list) {
     return list.size() > 1 ? DOMAIN_REPLICAS_TOO_HIGH_MULTIPLE_CLUSTERS : DOMAIN_REPLICAS_TOO_HIGH;
   }
 
-  @NotNull
+  @Nonnull
   private String getDomainReplicasCannotBeHonoredMsg(List<String> list) {
     return list.size() > 1 ? DOMAIN_REPLICAS_CANNOT_BE_HONORED_MULTIPLE_CLUSTERS : DOMAIN_REPLICAS_CANNOT_BE_HONORED;
   }
 
-  @NotNull
-  private List<ClusterStatus> getClusterStatusList(@NotNull DomainResource domain) {
+  @Nonnull
+  private List<ClusterStatus> getClusterStatusList(@Nonnull DomainResource domain) {
     return Optional.of(domain)
         .map(DomainResource::getStatus)
         .map(DomainStatus::getClusters)
         .orElse(Collections.emptyList());
   }
 
-  private Boolean isReplicaCountValid(@NotNull DomainResource domain, @NotNull ClusterStatus status) {
+  private Boolean isReplicaCountValid(@Nonnull DomainResource domain, @Nonnull ClusterStatus status) {
     boolean isValid = false;
     try {
       isValid = getProposedReplicaCount(domain, getCluster(domain, status.getClusterName())) <= getClusterSize(status);
@@ -167,7 +167,7 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
     return isValid;
   }
 
-  private int getProposedReplicaCount(@NotNull DomainResource domain, ClusterSpec clusterSpec) {
+  private int getProposedReplicaCount(@Nonnull DomainResource domain, ClusterSpec clusterSpec) {
     return Optional.ofNullable(clusterSpec).map(ClusterSpec::getReplicas).orElse(getDomainReplicaCount(domain));
   }
 
@@ -200,13 +200,13 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
     return warnings;
   }
 
-  private ClusterSpec getCluster(@NotNull DomainResource domain, String clusterName) throws ApiException {
+  private ClusterSpec getCluster(@Nonnull DomainResource domain, String clusterName) throws ApiException {
     List<ClusterResource> clusters = getClusters(domain.getNamespace());
     return clusters.stream().filter(cluster -> clusterName.equals(cluster.getClusterName())
         && isReferenced(domain, cluster)).findFirst().map(ClusterResource::getSpec).orElse(null);
   }
 
-  private boolean isReferenced(@NotNull DomainResource domain, ClusterResource cluster) {
+  private boolean isReferenced(@Nonnull DomainResource domain, ClusterResource cluster) {
     String name = Optional.ofNullable(cluster).map(ClusterResource::getMetadata).map(V1ObjectMeta::getName).orElse("");
     return Optional.of(domain).map(DomainResource::getSpec).map(DomainSpec::getClusters)
         .orElse(Collections.emptyList()).stream().anyMatch(ref -> name.equals(ref.getName()));
@@ -252,11 +252,11 @@ public class DomainUpdateAdmissionChecker extends AdmissionChecker {
     return !isEqualCollection(existingDomain.getAuxiliaryImages(), proposedDomain.getAuxiliaryImages());
   }
 
-  private String getImage(@NotNull DomainResource existingDomain) {
+  private String getImage(@Nonnull DomainResource existingDomain) {
     return Optional.of(existingDomain).map(DomainResource::getSpec).map(DomainSpec::getImage).orElse(null);
   }
 
-  private boolean noAuxiliaryImagesConfigured(@NotNull DomainResource domain) {
+  private boolean noAuxiliaryImagesConfigured(@Nonnull DomainResource domain) {
     return domain.getAuxiliaryImages() == null;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterResource.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ClusterResource.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.weblogic.domain.model;
 
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
@@ -17,7 +18,6 @@ import oracle.kubernetes.operator.KubernetesConstants;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An element representing a cluster in the domain configuration.
@@ -66,7 +66,7 @@ public class ClusterResource implements KubernetesObject {
   @Expose
   @Valid
   @Description("The specification of the operation of the WebLogic cluster. Required.")
-  @NotNull
+  @Nonnull
   private ClusterSpec spec = new ClusterSpec();
 
   /**
@@ -240,7 +240,7 @@ public class ClusterResource implements KubernetesObject {
     return this;
   }
 
-  @NotNull
+  @Nonnull
   public ClusterSpec getSpec() {
     return spec;
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainStatus.java
@@ -28,7 +28,6 @@ import oracle.kubernetes.utils.SystemClock;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.ProcessingConstants.FATAL_INTROSPECTOR_ERROR;
 import static oracle.kubernetes.operator.ProcessingConstants.FATAL_INTROSPECTOR_ERROR_MSG;
@@ -209,7 +208,7 @@ public class DomainStatus {
    * reason, message and retry information. Since failures are sorted first, a failure will always be returned
    * if one is present.
    */
-  @NotNull
+  @Nonnull
   public DomainCondition getSummaryCondition() {
     return conditions.stream()
           .filter(this::maySupplyStatusMessage)
@@ -217,7 +216,7 @@ public class DomainStatus {
   }
 
   // Returns a condition with null reason, message and retry information.
-  @NotNull
+  @Nonnull
   private DomainCondition createEmptyCondition() {
     return new DomainCondition(AVAILABLE);
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ManagedServer.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/ManagedServer.java
@@ -11,7 +11,6 @@ import oracle.kubernetes.json.Description;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jetbrains.annotations.NotNull;
 
 public class ManagedServer extends Server implements Comparable<ManagedServer> {
   /** The name of the Managed Server. Required. */
@@ -20,10 +19,10 @@ public class ManagedServer extends Server implements Comparable<ManagedServer> {
   @Description("The name of the Managed Server. This name must match the name of a Managed Server instance or of a "
       + "dynamic cluster member name from a server template already defined in the WebLogic domain configuration. "
       + "Required.")
-  @NotNull
+  @Nonnull
   private String serverName;
 
-  @NotNull
+  @Nonnull
   public String getServerName() {
     return serverName;
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/KubernetesExecFactoryFake.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/KubernetesExecFactoryFake.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -14,7 +15,6 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.utils.KubernetesExec;
 import oracle.kubernetes.operator.utils.KubernetesExecFactory;
-import org.jetbrains.annotations.NotNull;
 
 import static com.meterware.simplestub.Stub.createStub;
 import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
@@ -23,7 +23,7 @@ class KubernetesExecFactoryFake implements KubernetesExecFactory {
   private final Map<String, String> responses = new HashMap<>();
   private final Map<String, Integer> exitCodes = new HashMap<>();
 
-  @NotNull
+  @Nonnull
   public Memento install() throws NoSuchFieldException {
     return StaticStubSupport.install(ServerStatusReader.class, "execFactory", this);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/NamespaceTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.Stub;
@@ -29,7 +30,6 @@ import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.hamcrest.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +64,7 @@ public class NamespaceTest {
   private final Set<String> currentNamespaces = new HashSet<>();
   private final DomainNamespaces domainNamespaces = createDomainNamespaces();
 
-  @NotNull
+  @Nonnull
   public static DomainNamespaces createDomainNamespaces() {
     return new DomainNamespaces(null);
   }
@@ -134,7 +134,7 @@ public class NamespaceTest {
     return new DomainResource().withMetadata(new V1ObjectMeta().namespace(ns).name(createUid(ns)));
   }
 
-  @NotNull
+  @Nonnull
   private String createUid(String ns) {
     return "uid-" + ns;
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/OperatorEventProcessingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/OperatorEventProcessingTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -22,7 +23,6 @@ import oracle.kubernetes.operator.helpers.KubernetesEventObjects;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.utils.TestUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -328,7 +328,7 @@ class OperatorEventProcessingTest {
     return getEventName(found).equals(getEventName(event)) ? found : null;
   }
 
-  @NotNull
+  @Nonnull
   private String getEventName(CoreV1Event event) {
     return Optional.ofNullable(event).map(CoreV1Event::getMetadata).map(V1ObjectMeta::getName).orElse("");
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/OperatorMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/OperatorMainTest.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -60,7 +61,6 @@ import org.glassfish.grizzly.http.server.HttpHandlerRegistration;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -463,7 +463,7 @@ class OperatorMainTest extends ThreadFactoryTestBase {
     return Arrays.stream(namespaces).filter(domainNamespaces::isStarting).collect(Collectors.toList());
   }
 
-  @NotNull
+  @Nonnull
   DomainRecheck createDomainRecheck() {
     return new DomainRecheck(delegate);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
@@ -20,6 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -49,8 +50,6 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.ThreadFactorySingleton;
 import oracle.kubernetes.utils.TestUtils;
 import org.hamcrest.junit.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -645,7 +644,7 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
     return getMatchRules(configuration, resource).size() == 1;
   }
 
-  @NotNull
+  @Nonnull
   private List<V1RuleWithOperations> getMatchRules(V1ValidatingWebhookConfiguration configuration, String resource) {
     return getRules(configuration).stream().filter(r -> isResourceEquals(resource, r)).collect(Collectors.toList());
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/builders/StubWatchFactory.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/builders/StubWatchFactory.java
@@ -22,7 +22,6 @@ import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watch.Response;
 import io.kubernetes.client.util.Watchable;
 import okhttp3.Call;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A test-time replacement for the factory that creates Watch objects, allowing tests to specify
@@ -97,7 +96,7 @@ public class StubWatchFactory<T> implements WatchFactory<T> {
    * @return a test double for the requested watch
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
-  @NotNull
+  @Nonnull
   public Watchable<T> createWatch(ApiClient client, Call call, Type type) {
     try {
       addRecordedParameters(getParameters(call));
@@ -119,7 +118,7 @@ public class StubWatchFactory<T> implements WatchFactory<T> {
     }
   }
 
-  @NotNull
+  @Nonnull
   private Map<String, String> getParameters(Call call) {
     final Matcher matcher = URL_PARAMETERS.matcher(call.request().url().toString());
     final Map<String, String> recordedParams = new HashMap<>();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/CrdHelperTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1CustomResourceConversion;
@@ -31,8 +32,6 @@ import oracle.kubernetes.operator.utils.InMemoryFileSystem;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.operator.work.TerminalStep;
 import oracle.kubernetes.utils.TestUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,12 +100,12 @@ class CrdHelperTest {
   enum TestSubject {
     DOMAIN {
       @Override
-      @NotNull
+      @Nonnull
       protected String getExpectedCrdName() {
         return KubernetesConstants.DOMAIN_CRD_NAME;
       }
 
-      @NotNull
+      @Nonnull
       @Override
       String getLatestCrdVersion() {
         return KubernetesConstants.DOMAIN_VERSION;
@@ -125,12 +124,12 @@ class CrdHelperTest {
       }
     }, CLUSTER {
       @Override
-      @NotNull
+      @Nonnull
       protected String getExpectedCrdName() {
         return KubernetesConstants.CLUSTER_CRD_NAME;
       }
 
-      @NotNull
+      @Nonnull
       @Override
       String getLatestCrdVersion() {
         return KubernetesConstants.CLUSTER_VERSION;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainIntrospectorJobTest.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.meterware.simplestub.Memento;
@@ -72,8 +74,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainTestUtils;
 import oracle.kubernetes.weblogic.domain.model.Model;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -461,14 +461,14 @@ class DomainIntrospectorJobTest extends DomainTestUtils {
     return getJobPodSpec(jobs.get(0)).getContainers();
   }
 
-  @NotNull
+  @Nonnull
   private List<AuxiliaryImage> getAuxiliaryImages(String...images) {
     List<AuxiliaryImage> auxiliaryImageList = new ArrayList<>();
     Arrays.stream(images).forEach(image -> auxiliaryImageList.add(getAuxiliaryImage(image)));
     return auxiliaryImageList;
   }
 
-  @NotNull
+  @Nonnull
   public static AuxiliaryImage getAuxiliaryImage(String image) {
     return new AuxiliaryImage().image(image);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/DomainValidationStepTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.LogRecord;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -31,7 +32,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import oracle.kubernetes.weblogic.domain.model.Model;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -205,7 +205,7 @@ class DomainValidationStepTest {
         .orElse(null);
   }
 
-  @NotNull
+  @Nonnull
   private Stream<DomainCondition> getConditions(DomainResource updatedDomain) {
     return Optional.ofNullable(updatedDomain).map(DomainResource::getStatus).map(DomainStatus::getConditions)
         .orElse(Collections.emptyList()).stream();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesTestSupport.java
@@ -87,7 +87,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainList;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jetbrains.annotations.NotNull;
 
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -1198,7 +1197,7 @@ public class KubernetesTestSupport extends FiberTestSupport {
       }
     }
 
-    @NotNull
+    @Nonnull
     private Operation getOperation(RequestParams requestParams) {
       return requestParams.call.equals("getVersion")
             ? Operation.getVersion

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -93,7 +93,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainValidationTestBase;
 import oracle.kubernetes.weblogic.domain.model.ServerEnvVars;
 import org.hamcrest.junit.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1148,22 +1147,22 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
                     .mountPath(DEFAULT_LEGACY_AUXILIARY_IMAGE_MOUNT_PATH)));
   }
 
-  @NotNull
+  @Nonnull
   protected String getAuxiliaryImageVolumeName() {
     return getAuxiliaryImageVolumeName(TEST_VOLUME_NAME);
   }
 
-  @NotNull
+  @Nonnull
   protected static String getAuxiliaryImageVolumeName(String testVolumeName) {
     return AUXILIARY_IMAGE_VOLUME_NAME_PREFIX + testVolumeName;
   }
 
-  @NotNull
+  @Nonnull
   protected static String getLegacyAuxiliaryImageVolumeName() {
     return COMPATIBILITY_MODE + getAuxiliaryImageVolumeName(TEST_VOLUME_NAME);
   }
 
-  @NotNull
+  @Nonnull
   protected String getLegacyAuxiliaryImageVolumeName(String testVolumeName) {
     return COMPATIBILITY_MODE + AUXILIARY_IMAGE_VOLUME_NAME_PREFIX + testVolumeName;
   }
@@ -1346,14 +1345,14 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     return ImmutableMap.of("serverPod", createServerPod(auxiliaryImages));
   }
 
-  @NotNull
+  @Nonnull
   private static Map<String, Object> createServerPod(List<Object> auxiliaryImages) {
     Map<String, Object> serverPod = new LinkedHashMap<>();
     serverPod.put("auxiliaryImages", auxiliaryImages);
     return serverPod;
   }
 
-  @NotNull
+  @Nonnull
   private static Map<String, Object> createServerPod(List<Object> auxiliaryImages, Map<String, Object> resources) {
     Map<String, Object> serverPod = new LinkedHashMap<>();
     serverPod.put("auxiliaryImages", auxiliaryImages);
@@ -1361,14 +1360,14 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     return serverPod;
   }
 
-  @NotNull
+  @Nonnull
   private static Map<String, Object> createWebLogicCredentialsSecret() {
     Map<String, Object> webLogicCredentialsSecret = new LinkedHashMap<>();
     webLogicCredentialsSecret.put("name", "webLogicCredentialsSecretName");
     return webLogicCredentialsSecret;
   }
 
-  @NotNull
+  @Nonnull
   static Map<String, Object> createMetadata() {
     Map<String, Object> metadata = new LinkedHashMap<>();
     metadata.put("name", "domain1");
@@ -1388,7 +1387,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
             TEST_VOLUME_NAME);
   }
 
-  @NotNull
+  @Nonnull
   private static Map<String, Object> createAuxiliaryImage(String image, String imagePullPolicy,
                                                           String command, String volume) {
     Map<String, Object> auxiliaryImage = new LinkedHashMap<>();
@@ -1410,7 +1409,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     return createAuxiliaryImageVolume(TEST_VOLUME_NAME, mountPath);
   }
 
-  @NotNull
+  @Nonnull
   static Map<String, Object> createAuxiliaryImageVolume(String name, String mountPath) {
     Map<String, Object> auxiliaryImageVolumes = new LinkedHashMap<>();
     auxiliaryImageVolumes.put("name", name);
@@ -1418,7 +1417,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     return auxiliaryImageVolumes;
   }
 
-  @NotNull
+  @Nonnull
   static Map<String, Object> createAuxiliaryImageVolume(String name, String mountPath, String sizeLimit,
                                                                 String medium) {
     Map<String, Object> auxiliaryImageVolume = new LinkedHashMap<>();
@@ -1489,7 +1488,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
                     .mountPath(DEFAULT_LEGACY_AUXILIARY_IMAGE_MOUNT_PATH)));
   }
 
-  @NotNull
+  @Nonnull
   List<AuxiliaryImage> getAuxiliaryImages(String... images) {
     List<AuxiliaryImage> auxiliaryImageList = new ArrayList<>();
     Arrays.stream(images).forEach(image -> auxiliaryImageList
@@ -1497,7 +1496,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     return auxiliaryImageList;
   }
 
-  @NotNull
+  @Nonnull
   public static AuxiliaryImage getAuxiliaryImage(String image) {
     return new AuxiliaryImage().image(image);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/RollingHelperTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -42,7 +43,6 @@ import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -201,7 +201,7 @@ class RollingHelperTest {
     logRecords.clear();
   }
 
-  @NotNull
+  @Nonnull
   private List<String> getAllServerNames() {
     List<String> allServerNames = new ArrayList<>(Collections.singletonList(NONCLUSTERED_SERVER));
     allServerNames.addAll(CLUSTERED_SERVER_NAMES);
@@ -386,7 +386,7 @@ class RollingHelperTest {
     return pod;
   }
 
-  @NotNull
+  @Nonnull
   private List<V1EnvVar> getEnvList(V1Pod pod) {
     return Optional.ofNullable(pod.getSpec())
           .map(V1PodSpec::getContainers)

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/TopologyValidationStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/TopologyValidationStepTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -37,7 +38,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -257,7 +257,7 @@ class TopologyValidationStepTest {
       }
     }
 
-    @NotNull
+    @Nonnull
     private WlsServerConfig createServerWithNoPorts() {
       WlsServerConfig server = new WlsServerConfig(MANAGED_SERVER1, LISTEN_ADDRESS, 0);
       server.setListenPort(null);
@@ -389,7 +389,7 @@ class TopologyValidationStepTest {
       ensureNoClustersAreEmpty();
     }
 
-    @NotNull
+    @Nonnull
     private String createName() {
       return createdName = createNameWithLength(totalLength - domain.getDomainUid().length());
     }

--- a/operator/src/test/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/client/HttpAsyncRequestStepTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -28,7 +29,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.TestUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,7 +93,7 @@ class HttpAsyncRequestStepTest {
     assertThat(requestStep.getNext(), sameInstance(responseStep));
   }
 
-  @NotNull
+  @Nonnull
   private HttpAsyncRequestStep createStep() {
     return HttpAsyncRequestStep.createGetRequest("http://localhost/nothing", responseStep);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/introspection/IntrospectionStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/introspection/IntrospectionStatusTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.logging.LogRecord;
+import javax.annotation.Nullable;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -35,7 +36,6 @@ import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.utils.TestUtils;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/FailureReportingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/FailureReportingTest.java
@@ -49,7 +49,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainValidationMessages;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -414,7 +413,7 @@ class FailureReportingTest {
       return getMatchingConditions(nextAction.getPacket());
     }
 
-    @NotNull
+    @Nonnull
     private Set<DomainCondition> getMatchingConditions(Packet packet) {
       return DomainPresenceInfo.fromPacket(packet)
           .map(DomainPresenceInfo::getDomain)

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/BeforeAdminServiceStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/BeforeAdminServiceStepTest.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.steps;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -20,7 +21,6 @@ import oracle.kubernetes.weblogic.domain.DomainConfigurator;
 import oracle.kubernetes.weblogic.domain.DomainConfiguratorFactory;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/InitializeWebhookIdentityStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/InitializeWebhookIdentityStepTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -32,7 +33,6 @@ import oracle.kubernetes.utils.SystemClockTestSupport;
 import oracle.kubernetes.utils.TestUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.junit.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -178,7 +178,7 @@ class InitializeWebhookIdentityStepTest {
           InitializeWebhookIdentityStep.class, "identityFactory", new SSlIdentityFactoryStub());
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public KeyPair createKeyPair() {
       return new KeyPair(Stub.createNiceStub(PublicKey.class), Stub.createNiceStub(PrivateKey.class));

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -47,7 +48,6 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -199,7 +199,7 @@ class ShutdownManagedServerStepTest {
     return new V1Pod().metadata(createManagedPodMetadata(serverName)).spec(podSpec);
   }
 
-  @NotNull
+  @Nonnull
   private List<V1Container> addEnvToWLSContainer(List<V1EnvVar> env) {
     List<V1Container> containers = new ArrayList<>();
     V1Container container = new V1Container().name(KubernetesConstants.WLS_CONTAINER_NAME).env(env);
@@ -207,7 +207,7 @@ class ShutdownManagedServerStepTest {
     return containers;
   }
 
-  @NotNull
+  @Nonnull
   private List<V1EnvVar> addShutdownEnvVars() {
     List<V1EnvVar> env = new ArrayList<>();
     addEnvVar(env, "SHUTDOWN_TYPE", ShutdownType.GRACEFUL.toString());

--- a/operator/src/test/java/oracle/kubernetes/operator/utils/InMemoryFileSystem.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/utils/InMemoryFileSystem.java
@@ -29,10 +29,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
-import org.jetbrains.annotations.Nullable;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
 

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/ClusterCreateAdmissionCheckerTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/ClusterCreateAdmissionCheckerTest.java
@@ -5,13 +5,13 @@ package oracle.kubernetes.operator.webhooks;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import oracle.kubernetes.operator.webhooks.resource.ClusterCreateAdmissionChecker;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static oracle.kubernetes.operator.KubernetesConstants.WLS_CONTAINER_NAME;
@@ -98,7 +98,7 @@ class ClusterCreateAdmissionCheckerTest extends AdmissionCheckerTestBase {
     assertThat(clusterChecker.isProposedChangeAllowed(), equalTo(false));
   }
 
-  @NotNull
+  @Nonnull
   private List<V1EnvVar> createEnvVarListWithReservedName() {
     List<V1EnvVar> list = new ArrayList<>();
     list.add(new V1EnvVar().name(SERVER_NAME).value("haha"));

--- a/operator/src/test/java/oracle/kubernetes/operator/webhooks/DomainAdmissionCheckerTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/webhooks/DomainAdmissionCheckerTestBase.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator.webhooks;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerPort;
@@ -16,7 +17,6 @@ import oracle.kubernetes.weblogic.domain.model.AuxiliaryImage;
 import oracle.kubernetes.weblogic.domain.model.Configuration;
 import oracle.kubernetes.weblogic.domain.model.ManagedServer;
 import oracle.kubernetes.weblogic.domain.model.Model;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
@@ -125,7 +125,7 @@ abstract class DomainAdmissionCheckerTestBase extends AdmissionCheckerTestBase {
     assertThat(domainChecker.isProposedChangeAllowed(), equalTo(false));
   }
 
-  @NotNull
+  @Nonnull
   private List<V1EnvVar> createEnvVarListWithReservedName() {
     List<V1EnvVar> list = new ArrayList<>();
     list.add(new V1EnvVar().name(SERVER_NAME).value("haha"));

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusConditionMatcher.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainStatusConditionMatcher.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import oracle.kubernetes.utils.OperatorUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unused")
 public class DomainStatusConditionMatcher extends TypeSafeDiagnosingMatcher<DomainStatus> {
@@ -22,7 +21,7 @@ public class DomainStatusConditionMatcher extends TypeSafeDiagnosingMatcher<Doma
   private String expectedMessage;
   private OffsetDateTime expectedTransitionTime;
 
-  private DomainStatusConditionMatcher(@NotNull DomainConditionType expectedType) {
+  private DomainStatusConditionMatcher(@Nonnull DomainConditionType expectedType) {
     this.expectedType = expectedType;
   }
 
@@ -35,7 +34,7 @@ public class DomainStatusConditionMatcher extends TypeSafeDiagnosingMatcher<Doma
     return this;
   }
 
-  DomainStatusConditionMatcher withReason(@NotNull DomainFailureReason reason) {
+  DomainStatusConditionMatcher withReason(@Nonnull DomainFailureReason reason) {
     expectedReason = reason;
     return this;
   }


### PR DESCRIPTION
We were using a mixture of javax.annotation and JetBrains annotations. Let's standardize on the versions provided by Java.