### PR TITLE
Skip status initialization during domain recheck and rename SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED flag

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -1012,7 +1012,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
               ProcessingConstants.DOMAIN_COMPONENT_NAME,
               Component.createFor(delegate.getKubernetesVersion()));
       packet.put(LoggingFilter.LOGGING_FILTER_PACKET_KEY, loggingFilter);
-      packet.put(ProcessingConstants.SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED, Boolean.TRUE);
+      packet.put(ProcessingConstants.DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE, Boolean.TRUE);
       return packet;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -185,8 +185,7 @@ class DomainResourcesValidation {
 
   private static void activateDomain(DomainProcessor dp, DomainPresenceInfo info) {
     info.setPopulated(true);
-    MakeRightDomainOperation makeRight = dp.createMakeRightOperation(info).withExplicitRecheck()
-            .skipUpdateDomainStatusIfNeeded();
+    MakeRightDomainOperation makeRight = dp.createMakeRightOperation(info).withExplicitRecheck();
     if (info.getDomain().getStatus() == null) {
       makeRight = makeRight.withEventData(new EventData(DOMAIN_CREATED)).interrupt();
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -83,12 +83,12 @@ import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.TO_BE_ROLLED_LABEL;
 import static oracle.kubernetes.operator.MIINonDynamicChangesMethod.COMMIT_UPDATE_ONLY;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE_RESTART_REQUIRED;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_STATE_MAP;
-import static oracle.kubernetes.operator.ProcessingConstants.SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTTING_DOWN_STATE;
@@ -578,10 +578,10 @@ public class DomainStatusUpdater {
     }
 
     private boolean shouldSkipDomainStatusUpdate(Packet packet) {
-      boolean isSkipUpdateDomainStatusIfNeeded =
-              (Boolean) packet.getOrDefault(SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED, Boolean.FALSE);
+      boolean domainRecheckOrScheduledStatusUpdate =
+              (Boolean) packet.getOrDefault(DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE, Boolean.FALSE);
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
-      return (isSkipUpdateDomainStatusIfNeeded)
+      return (domainRecheckOrScheduledStatusUpdate)
               && info.getServerStartupInfo() == null;
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -64,5 +64,5 @@ public interface ProcessingConstants {
 
   String SHUTDOWN_WITH_HTTP_SUCCEEDED = "SHUTDOWN_WITH_HTTP_SUCCEEDED";
   String DOMAIN_INTROSPECTION_COMPLETE = "Domain introspection complete";
-  String SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED = "skipUpdateDomainStatusIfNeeded";
+  String DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE = "domainRecheckOrScheduledStatusUpdate";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -234,7 +234,9 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
 
     result.add(Optional.ofNullable(eventData).map(EventHelper::createEventStep).orElse(null));
     result.add(new DomainProcessorImpl.PopulatePacketServerMapsStep());
-    result.add(createStatusInitializationStep());
+    if (wasStartedFromEvent()) {
+      result.add(createStatusInitializationStep());
+    }
     if (deleting) {
       result.add(new StartPlanStep(liveInfo, createDomainDownPlan()));
     } else {

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -68,8 +68,6 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
   private boolean willInterrupt;
   private boolean inspectionRun;
   private EventHelper.EventData eventData;
-  private boolean skipUpdateDomainStatusIfNeeded;
-
 
   /**
    * Create the operation.
@@ -116,12 +114,6 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
    */
   public MakeRightDomainOperation withEventData(EventHelper.EventData eventData) {
     this.eventData = eventData;
-    return this;
-  }
-
-  @Override
-  public MakeRightDomainOperation skipUpdateDomainStatusIfNeeded() {
-    this.skipUpdateDomainStatusIfNeeded = true;
     return this;
   }
 
@@ -194,7 +186,6 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
     this.deleting = false;
     this.willInterrupt = false;
     this.inspectionRun = false;
-    this.skipUpdateDomainStatusIfNeeded = false;
   }
 
 
@@ -214,8 +205,8 @@ public class MakeRightDomainOperationImpl implements MakeRightDomainOperation {
             Component.createFor(delegate.getKubernetesVersion(),
                 PodAwaiterStepFactory.class, delegate.getPodAwaiterStepFactory(getNamespace()),
                 JobAwaiterStepFactory.class, delegate.getJobAwaiterStepFactory(getNamespace())));
-    if (skipUpdateDomainStatusIfNeeded) {
-      packet.put(ProcessingConstants.SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED, Boolean.TRUE);
+    if (!wasStartedFromEvent()) {
+      packet.put(ProcessingConstants.DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE, Boolean.TRUE);
     }
     return packet;
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -2201,7 +2201,8 @@ class DomainProcessorTest {
   void whenDomainIsNotValid_dontBringUpServers() {
     defineDuplicateServerNames();
 
-    processor.createMakeRightOperation(originalInfo).withExplicitRecheck().execute();
+    processor.createMakeRightOperation(originalInfo)
+        .withEventData(new EventHelper.EventData(DOMAIN_CHANGED)).withExplicitRecheck().execute();
 
     assertServerPodAndServiceNotPresent(originalInfo, ADMIN_NAME);
     for (String serverName : MANAGED_SERVER_NAMES) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -76,12 +76,12 @@ import static oracle.kubernetes.operator.EventConstants.DOMAIN_ROLL_COMPLETED_EV
 import static oracle.kubernetes.operator.EventMatcher.hasEvent;
 import static oracle.kubernetes.operator.EventTestUtils.getLocalizedString;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
+import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_TOPOLOGY;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE_RESTART_REQUIRED;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_HEALTH_MAP;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_STATE_MAP;
-import static oracle.kubernetes.operator.ProcessingConstants.SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTTING_DOWN_STATE;
@@ -1675,7 +1675,7 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
-  void whenSkipUpdateDomainStatusTrueAndSSINotConstructedDuringMakeRight_verifyDomainStatusNotUpdated() {
+  void whenDomainRecheckOrScheduledStatusUpdateAndSSINotConstructed_verifyDomainStatusNotUpdated() {
     configureDomain().configureCluster(info, "cluster1").withReplicas(2).withMaxUnavailable(1);
     ScenarioBuilder scenarioBuilder = defineScenario();
     scenarioBuilder.withCluster("cluster1", "server1", "server2")
@@ -1688,7 +1688,7 @@ abstract class DomainStatusUpdateTestBase {
     assertThat(getRecordedDomain(), hasCondition(COMPLETED).withStatus(FALSE));
 
     scenarioBuilder.withServersReachingState(RUNNING_STATE, "server1", "server2").build();
-    testSupport.addToPacket(SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED, Boolean.TRUE);
+    testSupport.addToPacket(DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE, Boolean.TRUE);
     info.setServerStartupInfo(null);
 
     updateDomainStatus();
@@ -1697,22 +1697,22 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
-  void whenSkipUpdateDomainStatusTrueAndAdminOnly_availableIsTrue() {
+  void whenDomainRecheckOrScheduleStatusUpdateAndAdminOnly_availableIsTrue() {
     configureDomain().withDefaultServerStartPolicy(ServerStartPolicy.ADMIN_ONLY);
     defineScenario().build();
 
-    testSupport.addToPacket(SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED, Boolean.TRUE);
+    testSupport.addToPacket(DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE, Boolean.TRUE);
     updateDomainStatus();
 
     assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(TRUE));
   }
 
   @Test
-  void whenSkipUpdateDomainStatusTrueAdminOnlyAndAdminServerIsNotReady_availableIsFalse() {
+  void whenDomainRecheckOrScheduleStatusUpdateAndAdminOnlyAndAdminServerIsNotReady_availableIsFalse() {
     configureDomain().withDefaultServerStartPolicy(ServerStartPolicy.ADMIN_ONLY);
     defineScenario().withServersReachingState(STARTING_STATE, "admin").build();
 
-    testSupport.addToPacket(SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED, Boolean.TRUE);
+    testSupport.addToPacket(DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE, Boolean.TRUE);
     updateDomainStatus();
 
     assertThat(getRecordedDomain(), hasCondition(AVAILABLE).withStatus(FALSE));

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/FailureReportingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/FailureReportingTest.java
@@ -26,6 +26,7 @@ import oracle.kubernetes.operator.Processors;
 import oracle.kubernetes.operator.ServerStartPolicy;
 import oracle.kubernetes.operator.calls.SimulatedStep;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.EventHelper;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.SecretType;
 import oracle.kubernetes.operator.helpers.UnitTestHash;
@@ -94,7 +95,8 @@ class FailureReportingTest {
   private final MakeRightExecutorStub executor = Stub.createNiceStub(MakeRightExecutorStub.class);
   private final DomainProcessorDelegateStub delegate
       = Stub.createStrictStub(DomainProcessorDelegateStub.class, testSupport);
-  private final MakeRightDomainOperation makeRight = new MakeRightDomainOperationImpl(executor, delegate, info);
+  private final MakeRightDomainOperation makeRight = new MakeRightDomainOperationImpl(executor, delegate, info)
+      .withEventData(new EventHelper.EventData(EventHelper.EventItem.DOMAIN_CHANGED));
   private final TerminalStep terminalStep = new TerminalStep();
   private String introspectionString = INFO_MESSAGE;
   private Step steps;


### PR DESCRIPTION
This PR skips the status initialization during domain recheck and renames the packet flag SKIP_UPDATE_DOMAIN_STATUS_IF_NEEDED to DOMAIN_RECHECK_OR_SCHEDULED_STATUS_UPDATE.

It also removes `skipUpdateDomainStatusIfNeeded` flag from the MakeRightDomainOperationImpl and instead uses `wasStartedFromEvent` method to identify if make-right is started by the explicit domain recheck. 

Integration test run results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13636/console.