### PR TITLE
backport [wko-nightly] NullPointerException in TestAssertions#domainStatusReasonMatches to release/3.4

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -292,7 +292,7 @@ class ItMultiDomainModels {
     unzipWDTInstallationFile(auxiliaryImageDir.toString());
 
     // create image1 with model and wdt installation files
-    String miiAuxiliaryImage1 = MII_AUXILIARY_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG + "1";
+    String miiAuxiliaryImage1 = MII_AUXILIARY_IMAGE_NAME + ":" + MII_BASIC_IMAGE_TAG + "mdmauxi";
     createAuxiliaryImage(auxiliaryImageDir.toString(),
         Paths.get(RESOURCE_DIR, "auxiliaryimage", "Dockerfile").toString(), miiAuxiliaryImage1);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/assertions/TestAssertions.java
@@ -396,9 +396,11 @@ public class TestAssertions {
                                                             String statusReason) {
     LoggingFacade logger = getLogger();
     return () -> {
-      if (domain != null && domain.getStatus() != null && domain.getStatus().getReason() != null) {
-        logger.info("domain status reason: {0}", domain.getStatus().getReason());
-        return domain.getStatus().getReason().equalsIgnoreCase(statusReason);
+      if (domain != null && domain.getStatus() != null && domain.getStatus().getConditions() != null
+          && !domain.getStatus().getConditions().isEmpty()) {
+        boolean match = domain.getStatus().getConditions().stream()
+            .anyMatch(condition -> condition.getReason() != null && condition.getReason().contains(statusReason));
+        return match;
       } else {
         if (domain == null) {
           logger.info("domain is null");


### PR DESCRIPTION
backport [wko-nightly] NullPointerException in TestAssertions#domainStatusReasonMatches to release/3.4

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13665/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13671/