### PR TITLE
owls 103828 - Integration test changes to match the new behavior of Domain Available condition

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDiagnosticsCompleteAvailableCondition.java
@@ -254,7 +254,7 @@ class ItDiagnosticsCompleteAvailableCondition {
    * Verify all the cluster servers pods will be shutdown.
    * Verify the following conditions are generated:
    * type: Completed, status: true
-   * type: Available, status: False
+   * type: Available, status: true
    * Verify no Failed type condition generated.
    */
   @Test
@@ -289,7 +289,7 @@ class ItDiagnosticsCompleteAvailableCondition {
           DOMAIN_STATUS_CONDITION_COMPLETED_TYPE, "True");
       // verify the condition Available type has status True
       checkDomainStatusConditionTypeHasExpectedStatus(domainUid, domainNamespace1,
-          DOMAIN_STATUS_CONDITION_AVAILABLE_TYPE, "False");
+          DOMAIN_STATUS_CONDITION_AVAILABLE_TYPE, "True");
       // verify there is no status condition type Failed
       verifyDomainStatusConditionTypeDoesNotExist(domainUid, domainNamespace1, DOMAIN_STATUS_CONDITION_FAILED_TYPE);
 
@@ -303,7 +303,7 @@ class ItDiagnosticsCompleteAvailableCondition {
    * Verify all the cluster servers pods will be shutdown.
    * Verify the following conditions are generated:
    * type: Completed, status: true
-   * type: Available, status: False
+   * type: Available, status: true
    * Verify no Failed type condition generated.
    */
   @Test
@@ -337,7 +337,7 @@ class ItDiagnosticsCompleteAvailableCondition {
           DOMAIN_STATUS_CONDITION_COMPLETED_TYPE, "True");
       // verify the condition Available type has status True
       checkDomainStatusConditionTypeHasExpectedStatus(domainUid, domainNamespace1,
-          DOMAIN_STATUS_CONDITION_AVAILABLE_TYPE, "False");
+          DOMAIN_STATUS_CONDITION_AVAILABLE_TYPE, "True");
       // verify there is no status condition type Failed
       verifyDomainStatusConditionTypeDoesNotExist(domainUid, domainNamespace1, DOMAIN_STATUS_CONDITION_FAILED_TYPE);
     } finally {


### PR DESCRIPTION
Integration test changes to match the new behavior of Domain Available condition status set to `True` when admin server is running and cluster is intentionally shut down.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13706/