### PR TITLE
OWLS-103910 - Create the webhook deployment if the existing webhook is from the same namespace.

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -192,7 +192,8 @@ spec:
 {{- end }}
 ---
   {{ $chartVersion := .Chart.Version }}
-  {{ $webhookExists := include "utils.verifyExistingWebhookDeployment" (list $chartVersion) | trim }}
+  {{ $releaseNamespace := .Release.Namespace }}
+  {{ $webhookExists := include "utils.verifyExistingWebhookDeployment" (list $chartVersion $releaseNamespace) | trim }}
   {{- if and (ne $webhookExists "true") (not .operatorOnly) }}
     # webhook does not exist or chart version is newer, create a new webhook
     apiVersion: "v1"

--- a/kubernetes/charts/weblogic-operator/templates/_utils.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_utils.tpl
@@ -498,12 +498,16 @@ Return true if there's an existing webhook deployment and chart version is less 
 */}}
 {{- define "utils.verifyExistingWebhookDeployment" -}}
 {{- $chartVersion := index . 0 -}}
+{{- $releaseNamespace := index . 1 -}}
 {{- range $deployment := (lookup "apps/v1" "Deployment" "" "").items }}
 {{-   if not $deployment.metadata.labels }}
 {{-    $ignore := set $deployment.metadata "labels" (dict) }}
 {{-   end }}
 {{-   if and (eq $deployment.metadata.name "weblogic-operator-webhook") (hasKey $deployment.metadata.labels "weblogic.webhookVersion") }}
 {{      $webhookVersion := get $deployment.metadata.labels "weblogic.webhookVersion" }}
+{{-     if (eq $deployment.metadata.namespace $releaseNamespace) }}
+{{-       print "false" }}
+{{-     end -}}
 {{-     if le $chartVersion $webhookVersion }}
 {{-       print "true" }}
 {{-     end -}}


### PR DESCRIPTION
OWLS-103910 - Fix for the issue with "helm upgrade" deleting existing webhook deployment. This change re-creates the webhook deployment if the existing webhook deployment is from the same namespace.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13720/