### PR TITLE
Add support for tolerations to operator's Helm chart

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -46,6 +46,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: "weblogic-operator"
         image: {{ .image | quote }}

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -182,6 +182,11 @@ preserveWebhook: false
 # for more information on affinity and anti-affinity.
 #affinity:
 
+# tolerations and taints work together to ensure that pods are not scheduled on inappropriate nodes. If the tolerations value is specified,
+# then this content will be added to teh operator's deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# for more information on tolerations and taints.
+#tolerations:
+
 # Values related to debugging the operator.
 # Customers should not need to use the following properties
 

--- a/kubernetes/charts/weblogic-operator/values.yaml
+++ b/kubernetes/charts/weblogic-operator/values.yaml
@@ -183,7 +183,7 @@ preserveWebhook: false
 #affinity:
 
 # tolerations and taints work together to ensure that pods are not scheduled on inappropriate nodes. If the tolerations value is specified,
-# then this content will be added to teh operator's deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# then this content will be added to the operator's deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 # for more information on tolerations and taints.
 #tolerations:
 


### PR DESCRIPTION
Requested by a customer who has been editing the Helm chart as a workaround. Will backport this to 4.0 and 3.4 once merged to main.