### PR TITLE
OWLS-103645 - Add domain and cluster 4.0 'observedGeneration' to pod labels.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/LabelConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/LabelConstants.java
@@ -25,8 +25,8 @@ public interface LabelConstants {
   String MII_UPDATED_RESTART_REQUIRED_LABEL = "weblogic.configChangesPendingRestart";
   String INTROSPECTION_DOMAIN_SPEC_GENERATION = "weblogic.domainSpecGeneration";
   String TO_BE_ROLLED_LABEL = "weblogic.awaitingPodRoll";
-  String OBSERVED_DOMAIN_GENERATION_LABEL = "weblogic.observedDomainGeneration";
-  String OBSERVED_CLUSTER_GENERATION_LABEL = "weblogic.observedClusterGeneration";
+  String DOMAIN_OBSERVED_GENERATION_LABEL = "weblogic.domainObservedGeneration";
+  String CLUSTER_OBSERVED_GENERATION_LABEL = "weblogic.clusterObservedGeneration";
 
   static String forDomainUidSelector(String uid) {
     return String.format("%s=%s", DOMAINUID_LABEL, uid);

--- a/operator/src/main/java/oracle/kubernetes/operator/LabelConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/LabelConstants.java
@@ -25,6 +25,8 @@ public interface LabelConstants {
   String MII_UPDATED_RESTART_REQUIRED_LABEL = "weblogic.configChangesPendingRestart";
   String INTROSPECTION_DOMAIN_SPEC_GENERATION = "weblogic.domainSpecGeneration";
   String TO_BE_ROLLED_LABEL = "weblogic.awaitingPodRoll";
+  String OBSERVED_DOMAIN_GENERATION_LABEL = "weblogic.observedDomainGeneration";
+  String OBSERVED_CLUSTER_GENERATION_LABEL = "weblogic.observedClusterGeneration";
 
   static String forDomainUidSelector(String uid) {
     return String.format("%s=%s", DOMAINUID_LABEL, uid);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -73,6 +73,7 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.AuxiliaryImage;
+import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.IntrospectorJobEnvVars;
 import oracle.kubernetes.weblogic.domain.model.MonitoringExporterSpecification;
@@ -93,6 +94,8 @@ import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.MODEL_IN_IMAGE_DOMAINZIP_HASH;
+import static oracle.kubernetes.operator.LabelConstants.OBSERVED_CLUSTER_GENERATION_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.OBSERVED_DOMAIN_GENERATION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.OPERATOR_VERSION;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE_SUCCESS;
@@ -147,8 +150,9 @@ public abstract class PodStepContext extends BasePodStepContext {
     return isCustomerItem(entry) || PATCHABLE_OPERATOR_KEYS.contains(entry.getKey());
   }
 
-  private static final Set<String> PATCHABLE_OPERATOR_KEYS
-        = Set.of(INTROSPECTION_STATE_LABEL, OPERATOR_VERSION, MODEL_IN_IMAGE_DOMAINZIP_HASH, SHA256_ANNOTATION);
+  private static final Set<String> PATCHABLE_OPERATOR_KEYS = Set.of(INTROSPECTION_STATE_LABEL, OPERATOR_VERSION,
+      MODEL_IN_IMAGE_DOMAINZIP_HASH, SHA256_ANNOTATION, OBSERVED_DOMAIN_GENERATION_LABEL,
+      OBSERVED_CLUSTER_GENERATION_LABEL);
 
   private static boolean isCustomerItem(Map.Entry<String, String> entry) {
     return !entry.getKey().startsWith("weblogic.");
@@ -212,6 +216,10 @@ public abstract class PodStepContext extends BasePodStepContext {
 
   DomainResource getDomain() {
     return info.getDomain();
+  }
+
+  ClusterResource getCluster(String clusterName) {
+    return info.getClusterResource(clusterName);
   }
 
   private String getDomainName() {
@@ -443,6 +451,10 @@ public abstract class PodStepContext extends BasePodStepContext {
         .ifPresent(version -> result.put(INTROSPECTION_STATE_LABEL, version));
     Optional.ofNullable(productVersion)
           .ifPresent(pv -> result.put(LabelConstants.OPERATOR_VERSION, pv));
+    Optional.ofNullable(getDomain().getMetadata()).map(m -> m.getGeneration())
+        .ifPresent(generation -> result.put(OBSERVED_DOMAIN_GENERATION_LABEL, String.valueOf(generation)));
+    Optional.ofNullable(getCluster(getClusterName())).map(c -> c.getMetadata()).map(m -> m.getGeneration())
+        .ifPresent(generation -> result.put(OBSERVED_CLUSTER_GENERATION_LABEL, String.valueOf(generation)));
 
     if (addRestartRequiredLabel) {
       result.put(MII_UPDATED_RESTART_REQUIRED_LABEL, "true");

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -91,11 +91,11 @@ import static oracle.kubernetes.operator.IntrospectorConfigMapConstants.NUM_CONF
 import static oracle.kubernetes.operator.KubernetesConstants.DEFAULT_EXPORTER_SIDECAR_PORT;
 import static oracle.kubernetes.operator.KubernetesConstants.EXPORTER_CONTAINER_NAME;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
+import static oracle.kubernetes.operator.LabelConstants.CLUSTER_OBSERVED_GENERATION_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAIN_OBSERVED_GENERATION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.MII_UPDATED_RESTART_REQUIRED_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.MODEL_IN_IMAGE_DOMAINZIP_HASH;
-import static oracle.kubernetes.operator.LabelConstants.OBSERVED_CLUSTER_GENERATION_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.OBSERVED_DOMAIN_GENERATION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.OPERATOR_VERSION;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE;
 import static oracle.kubernetes.operator.ProcessingConstants.MII_DYNAMIC_UPDATE_SUCCESS;
@@ -151,8 +151,8 @@ public abstract class PodStepContext extends BasePodStepContext {
   }
 
   private static final Set<String> PATCHABLE_OPERATOR_KEYS = Set.of(INTROSPECTION_STATE_LABEL, OPERATOR_VERSION,
-      MODEL_IN_IMAGE_DOMAINZIP_HASH, SHA256_ANNOTATION, OBSERVED_DOMAIN_GENERATION_LABEL,
-      OBSERVED_CLUSTER_GENERATION_LABEL);
+      MODEL_IN_IMAGE_DOMAINZIP_HASH, SHA256_ANNOTATION, DOMAIN_OBSERVED_GENERATION_LABEL,
+      CLUSTER_OBSERVED_GENERATION_LABEL);
 
   private static boolean isCustomerItem(Map.Entry<String, String> entry) {
     return !entry.getKey().startsWith("weblogic.");
@@ -452,9 +452,9 @@ public abstract class PodStepContext extends BasePodStepContext {
     Optional.ofNullable(productVersion)
           .ifPresent(pv -> result.put(LabelConstants.OPERATOR_VERSION, pv));
     Optional.ofNullable(getDomain().getMetadata()).map(V1ObjectMeta::getGeneration)
-        .ifPresent(generation -> result.put(OBSERVED_DOMAIN_GENERATION_LABEL, String.valueOf(generation)));
+        .ifPresent(generation -> result.put(DOMAIN_OBSERVED_GENERATION_LABEL, String.valueOf(generation)));
     Optional.ofNullable(getCluster(getClusterName())).map(ClusterResource::getMetadata).map(V1ObjectMeta::getGeneration)
-        .ifPresent(generation -> result.put(OBSERVED_CLUSTER_GENERATION_LABEL, String.valueOf(generation)));
+        .ifPresent(generation -> result.put(CLUSTER_OBSERVED_GENERATION_LABEL, String.valueOf(generation)));
 
     if (addRestartRequiredLabel) {
       result.put(MII_UPDATED_RESTART_REQUIRED_LABEL, "true");

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -451,9 +451,9 @@ public abstract class PodStepContext extends BasePodStepContext {
         .ifPresent(version -> result.put(INTROSPECTION_STATE_LABEL, version));
     Optional.ofNullable(productVersion)
           .ifPresent(pv -> result.put(LabelConstants.OPERATOR_VERSION, pv));
-    Optional.ofNullable(getDomain().getMetadata()).map(m -> m.getGeneration())
+    Optional.ofNullable(getDomain().getMetadata()).map(V1ObjectMeta::getGeneration)
         .ifPresent(generation -> result.put(OBSERVED_DOMAIN_GENERATION_LABEL, String.valueOf(generation)));
-    Optional.ofNullable(getCluster(getClusterName())).map(c -> c.getMetadata()).map(m -> m.getGeneration())
+    Optional.ofNullable(getCluster(getClusterName())).map(ClusterResource::getMetadata).map(V1ObjectMeta::getGeneration)
         .ifPresent(generation -> result.put(OBSERVED_CLUSTER_GENERATION_LABEL, String.valueOf(generation)));
 
     if (addRestartRequiredLabel) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -119,12 +119,12 @@ import static oracle.kubernetes.operator.KubernetesConstants.HTTP_BAD_REQUEST;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_OK;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.CLUSTER_OBSERVED_GENERATION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
+import static oracle.kubernetes.operator.LabelConstants.DOMAIN_OBSERVED_GENERATION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.INTROSPECTION_STATE_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.OBSERVED_CLUSTER_GENERATION_LABEL;
-import static oracle.kubernetes.operator.LabelConstants.OBSERVED_DOMAIN_GENERATION_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTION_COMPLETE;
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR_JOB;
@@ -513,8 +513,8 @@ class DomainProcessorTest {
   }
 
   private String getObservedGeneration(String name, String generationType) {
-    return generationType.equals("DOMAIN") ? getPodLabels(name).get(OBSERVED_DOMAIN_GENERATION_LABEL)
-        : getPodLabels(name).get(OBSERVED_CLUSTER_GENERATION_LABEL);
+    return generationType.equals("DOMAIN") ? getPodLabels(name).get(DOMAIN_OBSERVED_GENERATION_LABEL)
+        : getPodLabels(name).get(CLUSTER_OBSERVED_GENERATION_LABEL);
   }
 
   private Map<String, String> getPodLabels(String name) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -488,7 +488,7 @@ class DomainProcessorTest {
   }
 
   @Test
-  void whenMakeRightRun_updateDomainStatusAndObservedDomainGeneration() {
+  void whenMakeRightRun_updateDomainStatusAndDomainObservedGeneration() {
     domainConfigurator.configureCluster(newInfo, CLUSTER).withReplicas(MIN_REPLICAS);
     newInfo.getReferencedClusters().forEach(testSupport::defineResources);
 
@@ -503,12 +503,12 @@ class DomainProcessorTest {
     assertThat(getStateGoal(updatedDomain, MANAGED_SERVER_NAMES[4]), equalTo(SHUTDOWN_STATE));
     assertThat(getResourceVersion(updatedDomain), not(getResourceVersion(domain)));
     assertThat(updatedDomain.getStatus().getObservedGeneration(), equalTo(2L));
-    assertThat(getObservedDomainGeneration(ADMIN_NAME), is("2"));
-    assertThat(getObservedDomainGeneration(getManagedServerName(1)), is("2"));
-    assertThat(getObservedDomainGeneration(getManagedServerName(2)), is("2"));
+    assertThat(getDomainObservedGeneration(ADMIN_NAME), is("2"));
+    assertThat(getDomainObservedGeneration(getManagedServerName(1)), is("2"));
+    assertThat(getDomainObservedGeneration(getManagedServerName(2)), is("2"));
   }
 
-  private String getObservedDomainGeneration(String name) {
+  private String getDomainObservedGeneration(String name) {
     return getObservedGeneration(name, "DOMAIN");
   }
 
@@ -522,7 +522,7 @@ class DomainProcessorTest {
   }
 
   @Test
-  void whenMakeRightRun_updateClusterResourceStatusAndObservedClusterGeneration() {
+  void whenMakeRightRun_updateClusterResourceStatusAndClusterObservedGeneration() {
     ClusterResource clusterResource = createClusterResource(NS, CLUSTER);
     clusterResource.getMetadata().generation(2L);
     testSupport.defineResources(clusterResource);


### PR DESCRIPTION
OWLS-103645 - Add `observedDomainGeneration` and `observedClusterGeneration` information to the pods labels to simplify the determination of the progress of all significant resource changes as they flow through a domain.

Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13784/