### PR TITLE
OWLS-103768 WKO: Replace all usages of `egrep` with `grep -E`

### DIFF
--- a/integration-tests/src/test/resources/bash-scripts/discover_domain.sh
+++ b/integration-tests/src/test/resources/bash-scripts/discover_domain.sh
@@ -164,7 +164,7 @@ run_wdt() {
   local domain_home_dir="/u01/$domain_src"
   if [ -z "${domain_home_dir}" ]; then
     local domain_dir="/shared/domains"
-    local domain_uid=`egrep 'domainUID' $inputs_orig | awk '{print $2}'`
+    local domain_uid=`grep -E 'domainUID' $inputs_orig | awk '{print $2}'`
     local domain_home_dir=$domain_dir/$domain_uid
   fi 
 

--- a/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
+++ b/integration-tests/src/test/resources/bash-scripts/setup_wdt.sh
@@ -187,7 +187,7 @@ run_wdt() {
   local domain_home_dir="$DOMAIN_HOME_DIR"
   if [ -z "${domain_home_dir}" ]; then
     local domain_dir="/shared/domains"
-    local domain_uid=`egrep 'domainUID' $inputs_orig | awk '{print $2}'`
+    local domain_uid=`grep -E 'domainUID' $inputs_orig | awk '{print $2}'`
     local domain_home_dir=$domain_dir/$domain_uid
   fi 
 

--- a/integration-tests/src/test/resources/bash-scripts/syncTestImagesRepo.sh
+++ b/integration-tests/src/test/resources/bash-scripts/syncTestImagesRepo.sh
@@ -49,7 +49,7 @@ dockerPullPushImage() {
 
 dockerPullPushImages() {
  file="images.properties"
- egrep -v '^#' $file | grep -v "^$" |
+ grep -E -v '^#' $file | grep -v "^$" |
    while IFS=";" read -r f1 f2 
    do
      # printf 'Source Location : [%s], Target: [%s] \n' "$f1" "$f2"

--- a/kubernetes/samples/scripts/common/wdt-and-wit-utility.sh
+++ b/kubernetes/samples/scripts/common/wdt-and-wit-utility.sh
@@ -138,7 +138,7 @@ run_wdt() {
   local domain_home_dir="$DOMAIN_HOME_DIR"
   if [ -z "${domain_home_dir}" ]; then
     local domain_dir="/shared/domains"
-    local domain_uid=`egrep 'domainUID' $inputs_orig | awk '{print $2}'`
+    local domain_uid=`grep -E 'domainUID' $inputs_orig | awk '{print $2}'`
     local domain_home_dir=$domain_dir/$domain_uid
   fi 
 

--- a/kubernetes/samples/scripts/delete-domain/delete-weblogic-domain-resources.sh
+++ b/kubernetes/samples/scripts/delete-domain/delete-weblogic-domain-resources.sh
@@ -97,7 +97,7 @@ getDomainResources() {
   if [ $? -eq 0 ]; then
     kubectl get domain \
             -o=jsonpath='{range .items[*]}{.kind}{" "}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}{end}' \
-            --all-namespaces=true | egrep "$domain_regex" >> $2
+            --all-namespaces=true | grep -E "$domain_regex" >> $2
   fi
 
   # now, get all non-namespaced types with -l $LABEL_SELECTOR

--- a/operator/integration-tests/bash/cleanup.sh
+++ b/operator/integration-tests/bash/cleanup.sh
@@ -483,7 +483,7 @@ genericDelete() {
     kubectl get pvc \
       -o=jsonpath='{range .items[*]}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}{end}' \
       --all-namespaces=true \
-      | egrep -e "($3)" | patchPVCFinalizer
+      | grep -E -e "($3)" | patchPVCFinalizer
   fi
 
   while : ; do
@@ -494,14 +494,14 @@ genericDelete() {
     kubectl get $1 \
         -o=jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.kind}{"/"}{.metadata.name}{"\n"}{end}' \
         --all-namespaces=true 2>&1 \
-        | egrep -e "($3)" | sort > $resfile_yes 2>&1
+        | grep -E -e "($3)" | sort > $resfile_yes 2>&1
     artcount_yes="`cat $resfile_yes | wc -l`"
 
     # leftover non-namespaced artifacts
     kubectl get $2 \
         -o=jsonpath='{range .items[*]}{.kind}{"/"}{.metadata.name}{"\n"}{end}' \
         --all-namespaces=true 2>&1 \
-        | egrep -e "($3)" | sort > $resfile_no 2>&1
+        | grep -E -e "($3)" | sort > $resfile_no 2>&1
     artcount_no="`cat $resfile_no | wc -l`"
 
     artcount_total=$((artcount_yes + artcount_no))

--- a/operator/integration-tests/introspector/introspectTest.sh
+++ b/operator/integration-tests/introspector/introspectTest.sh
@@ -603,7 +603,7 @@ waitForPod() {
     fi
     echo -n "."
     sleep 1
-    status=`kubectl -n $NAMESPACE get pods 2>&1 | egrep $pod_name | awk '{print $2}'`
+    status=`kubectl -n $NAMESPACE get pods 2>&1 | grep -E $pod_name | awk '{print $2}'`
   done
   echo "  ($((SECONDS - startsecs)) seconds)"
 }

--- a/validateScripts.sh
+++ b/validateScripts.sh
@@ -15,6 +15,11 @@ validate_script() {
   if [ -n "$result" ]; then
    printf "Please remove usages of 'function' keyword from %s:\n%s\n" "$1" "$result"
   fi
+
+  result=$(grep "egrep" "$1")
+  if [ -n "$result" ]; then
+   printf "Please replace usages of 'egrep' with 'grep -E' in %s:\n%s\n" "$1" "$result"
+  fi
 }
 
 


### PR DESCRIPTION
Also added validation to build to check for usages of `egrep` and fail build with error such as:

```
[INFO] --- exec-maven-plugin:3.1.0:exec (validate-shell-scripts) @ weblogic-kubernetes-operator ---
Please replace usages of 'egrep' with 'grep -E' in /Users/alai/github/weblogic-kubernetes-operator/operator/integration-tests/introspector/introspectTest.sh:
    status=`kubectl -n $NAMESPACE get pods 2>&1 | egrep $pod_name | awk '{print $2}'`
[ERROR] Command execution failed.
```

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13814/