### PR TITLE
Fix create ingress failed with default ingressClass

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManagedCoherence.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItManagedCoherence.java
@@ -151,9 +151,6 @@ class ItManagedCoherence {
   @Test
   @DisplayName("Two cluster domain with a Coherence cluster and test interaction with cache data")
   void testMultiClusterCoherenceDomain() {
-    String ingressName = domainUid + "-ingress-host-routing";
-    String channelName = "tcp-80";
-
     // create a DomainHomeInImage image using WebLogic Image Tool
     String domImage = createAndVerifyDomainImage();
 
@@ -162,11 +159,8 @@ class ItManagedCoherence {
 
     if (OKD) {
       String cluster1HostName = domainUid + "-cluster-cluster-1";
-      String cluster2HostName = domainUid + "-cluster-cluster-2";
 
       final String cluster1IngressHost = createRouteForOKD(cluster1HostName, domainNamespace);
-      final String cluster2IngressHost = createRouteForOKD(cluster2HostName, domainNamespace);
-
 
       // test adding data to the cache and retrieving them from the cache
       boolean testCompletedSuccessfully = assertDoesNotThrow(()
@@ -180,7 +174,8 @@ class ItManagedCoherence {
       }
       // clusterNameMsPortMap.put(clusterName, managedServerPort);
       logger.info("Creating ingress for domain {0} in namespace {1}", domainUid, domainNamespace);
-      createTraefikIngressForDomainAndVerify(domainUid, domainNamespace, 0, clusterNameMsPortMap, true, null);
+      createTraefikIngressForDomainAndVerify(domainUid, domainNamespace, 0, clusterNameMsPortMap, true, null,
+          traefikHelmParams.getReleaseName());
 
       String clusterHostname = domainUid + "." + domainNamespace + ".cluster-1.test";
       // get ingress service Nodeport

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
@@ -672,6 +672,7 @@ public class LoadBalancerUtils {
    * @param clusterNameMSPortMap the map with key as cluster name and the value as managed server port of the cluster
    * @param setIngressHost if false does not set ingress host
    * @param tlsSecret name of the TLS secret if any
+   * @param ingressTraefikClass the ingressClass for Traefik
    * @return list of ingress hosts
    */
   public static List<String> createTraefikIngressForDomainAndVerify(
@@ -680,11 +681,11 @@ public class LoadBalancerUtils {
       int nodeport,
       Map<String, Integer> clusterNameMSPortMap,
       boolean setIngressHost,
-      String tlsSecret) {
+      String tlsSecret,
+      String ingressTraefikClass) {
 
     LoggingFacade logger = getLogger();
     // create an ingress in domain namespace
-    final String ingressTraefikClass = null;
     String ingressName = domainUid + "-" + ingressTraefikClass;
 
     List<String> ingressHostList =


### PR DESCRIPTION
Fix create ingress failed with default ingressClass
Add the ingressClass when creating the ingress.

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/13826/