### PR TITLE
OWLS-104087 fix an intermittent failure in nightly Jenkins

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -669,8 +669,13 @@ class ItKubernetesDomainEvents {
   void testK8SEventsDelete() {
     OffsetDateTime timestamp = now();
     createDomain(domainNamespace2, domainUid, pvName2, pvcName2);
-    deleteDomainCustomResource(domainUid, domainNamespace2);
+
+    // Delete the cluster resource before deleting the containing domain resource in order
+    // to make sure that ClusterDeleted event is logged. The operator ignores all K8S events
+    // for a cluster if it is not referenced by a domain that is managed by the operator.
     deleteClusterCustomResource(cluster1Name, domainNamespace2);
+    deleteDomainCustomResource(domainUid, domainNamespace2);
+
     checkPodDoesNotExist(adminServerPodName, domainUid, domainNamespace2);
     checkPodDoesNotExist(managedServerPodNamePrefix + 1, domainUid, domainNamespace2);
     checkPodDoesNotExist(managedServerPodNamePrefix + 2, domainUid, domainNamespace2);


### PR DESCRIPTION
The ItKubernetesDomainEvents.testK8SEventsDelete fails intermittently in nightlies for both main and release/4.0 branches because the expected ClusterDeleted event is not logged by the operator after a cluster resource and its containing domain resource are deleted.

The K8S server notifies the operator when a cluster is deleted, and the operator, upon receipt of the notification, logs a ClusterDeleted event if the cluster is referenced by a domain that is managed by the operator. 

The test code deletes the domain resource before deleting the cluster resource. If the domain deletion is completed when the operator is notified that the cluster is deleted, the operator knows nothing about the cluster and therefore will not log any event. Thus the test intermittently fails.

The fix is to delete the cluster first.