### PR TITLE
Fixed ItMiiDynamicUpdatePart1.testMiiUpdateDynamicClusterSize failed intermittently on nightly

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiDynamicUpdatePart1.java
@@ -383,7 +383,9 @@ class ItMiiDynamicUpdatePart1 {
     assertTrue(p2Success,
         String.format("replica patching to 1 failed for cluster %s in namespace %s",
             clusterName, helper.domainNamespace));
-    checkPodReadyAndServiceExists(helper.managedServerPrefix + "1", domainUid, helper.domainNamespace);
+    for (int i = 1; i <= helper.replicaCount; i++) {
+      checkPodReadyAndServiceExists(helper.managedServerPrefix + i, domainUid, helper.domainNamespace);
+    }
 
     // get the creation time of the server pods before patching
     LinkedHashMap<String, OffsetDateTime> pods = new LinkedHashMap<>();


### PR DESCRIPTION
From https://build.weblogick8s.org:8443/job/wko34-kind-nightly-parallel/266/artifact/logdir/jenkins-wko34-kind-nightly-parallel-266/wl_k8s_test_results/diagnostics/ItMiiDynamicUpdatePart1/ItMiiDynamicUpdatePart1.out/*view*/,

the error is:
--------------------
<11-08-2022 13:32:48> <INFO> <oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes getPodCreationTimestamp> <Pod doesn't exist or pod metadata is null>
<11-08-2022 13:32:48> <SEVERE> <oracle.weblogic.kubernetes.extensions.IntegrationTestWatcher handleTestExecutionException> <org.opentest4j.AssertionFailedError: Got null PodCreationTimestamp ==> expected: not <null>

at oracle.weblogic.kubernetes.ItMiiDynamicUpdatePart1.testMiiUpdateDynamicClusterSize(ItMiiDynamicUpdatePart1.java:397)

Analysis:
--------------
In the line 386, we only check whether one ms pod is up and running but we have two ms servers in the cluster
checkPodReadyAndServiceExists(helper.managedServerPrefix + "1", domainUid, helper.domainNamespace);

Changes made:
-----------------------
Check both ms pods and make sure they are all up and running

for (int i = 1; i <= helper.replicaCount; i++)
{ checkPodReadyAndServiceExists(helper.managedServerPrefix + i, domainUid, helper.domainNamespace); } 

Jenkins:

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14152
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14154