### PR TITLE
improve OKD cleanup script

### DIFF
--- a/okdtest.sh
+++ b/okdtest.sh
@@ -133,6 +133,8 @@ kubectl delete pv pv-testalertmanagertest3 --wait=false || true
 kubectl delete pv pv-testgrafanatest3 --wait=false || true
 kubectl delete pv pv-testprometheustest3 --wait=false || true
 
+kubectl delete crd $(kubectl get crd | grep weblogic) || true
+
 kubectl get ingressroutes -A --no-headers | awk '/tdlbs-/{print $2}' | xargs kubectl delete ingressroute || true
 kubectl get clusterroles --no-headers | awk '/ns-/{print $1}' | xargs kubectl delete clusterroles || true
 kubectl get clusterroles --no-headers | awk '/appscode/{print $1}' | xargs kubectl delete clusterroles || true


### PR DESCRIPTION
OKD test run:
https://build.weblogick8s.org:8443/job/wko34-okd/66/consoleFull

++ kubectl get crd
++ grep weblogic
+ kubectl delete crd clusters.weblogic.oracle 2022-11-21T17:38:43Z domains.weblogic.oracle 2022-11-21T17:38:42Z
customresourcedefinition.apiextensions.k8s.io "clusters.weblogic.oracle" deleted
customresourcedefinition.apiextensions.k8s.io "domains.weblogic.oracle" deleted