### PR TITLE
Add specific securityContext for containers in OpenShift environment.

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -114,7 +114,7 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-        {{-   end }}            
+        {{- end }}            
         volumeMounts:
         - name: "weblogic-operator-cm-volume"
           mountPath: "/deployment/config"

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -106,6 +106,15 @@ spec:
             {{- if .memoryLimits}}
             memory: {{ .memoryLimits }}
             {{- end }}
+        {{- if (eq ( .kubernetesPlatform | default "Generic" ) "OpenShift") }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        {{-   end }}            
         volumeMounts:
         - name: "weblogic-operator-cm-volume"
           mountPath: "/deployment/config"
@@ -306,6 +315,15 @@ spec:
                 {{- if .memoryLimits}}
                 memory: {{ .memoryLimits }}
                 {{- end }}
+            {{- if (eq ( .kubernetesPlatform | default "Generic") "OpenShift") }}
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                 drop: ["ALL"]
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            {{- end }}
             volumeMounts:
             - name: "weblogic-webhook-cm-volume"
               mountPath: "/deployment/config"


### PR DESCRIPTION
Add specific containers.securityContext entries in the helm chart when installing in the OpenShift environment;  without these entries, OpenShift responds with warnings,  although everything seems to work fine.