### PR TITLE
watcher: stop parsing resource version

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Watcher.java
@@ -4,7 +4,6 @@
 package oracle.kubernetes.operator;
 
 import java.lang.reflect.Method;
-import java.math.BigInteger;
 import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,14 +17,12 @@ import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
 import oracle.kubernetes.common.logging.MessageKeys;
 import oracle.kubernetes.operator.builders.WatchBuilder;
-import oracle.kubernetes.operator.helpers.KubernetesUtils;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.logging.ThreadLoggingContext;
 import oracle.kubernetes.operator.watcher.WatchListener;
 
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_GONE;
-import static oracle.kubernetes.utils.OperatorUtils.isNullOrEmpty;
 
 /**
  * This class handles the Watching interface and drives the watch support for a specific type of
@@ -233,7 +230,7 @@ abstract class Watcher<T> {
 
   private void handleRegularUpdate(Watch.Response<T> item) {
     LOGGER.finer(MessageKeys.WATCH_EVENT, item.type, item.object);
-    trackResourceVersion(item.type, item.object);
+    trackResourceVersion(item.object);
     if (listener != null) {
       listener.receivedResponse(item);
     }
@@ -253,26 +250,14 @@ abstract class Watcher<T> {
   }
 
   /**
-   * Track resourceVersion and keep highest one for next watch iteration. The resourceVersion is
+   * Track resourceVersion and keep the latest one for next watch iteration. The resourceVersion is
    * extracted from the metadata in the class by a getter written to return that information. If the
    * getter is not defined then the user will get all watches repeatedly.
    *
-   * @param type the type of operation
    * @param object the object that is returned
    */
-  private void trackResourceVersion(String type, Object object) {
-    updateResourceVersion(getNewResourceVersion(type, object));
-  }
-
-  private String getNewResourceVersion(String type, Object object) {
-    String newResourceVersion = getResourceVersionFromMetadata(object);
-    if (type.equalsIgnoreCase("DELETED")) {
-      BigInteger biResourceVersion = KubernetesUtils.getResourceVersion(newResourceVersion);
-      if (biResourceVersion.compareTo(BigInteger.ZERO) > 0) {
-        return biResourceVersion.add(BigInteger.ONE).toString();
-      }
-    }
-    return newResourceVersion;
+  private void trackResourceVersion(Object object) {
+    resourceVersion = getResourceVersionFromMetadata(object);
   }
 
   private String getResourceVersionFromMetadata(Object object) {
@@ -283,18 +268,6 @@ abstract class Watcher<T> {
     } catch (Exception e) {
       LOGGER.warning(MessageKeys.EXCEPTION, e);
       return IGNORED;
-    }
-  }
-
-  private void updateResourceVersion(String newResourceVersion) {
-    if (isNullOrEmpty(resourceVersion) || resourceVersion.equals(IGNORED)) {
-      resourceVersion = newResourceVersion;
-    } else {
-      BigInteger biNewResourceVersion = KubernetesUtils.getResourceVersion(newResourceVersion);
-      BigInteger biResourceVersion = KubernetesUtils.getResourceVersion(resourceVersion);
-      if (biNewResourceVersion.compareTo(biResourceVersion) > 0) {
-        resourceVersion = newResourceVersion;
-      }
     }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
@@ -145,7 +145,7 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase implements A
   }
 
   private Watch.Response<Object> createHttpGoneErrorResponse(BigInteger nextResourceVersion) {
-    return WatchEvent.createErrorEvent(HTTP_GONE, nextResourceVersion).toWatchResponse();
+    return WatchEvent.createErrorEvent(HTTP_GONE, nextResourceVersion.toString()).toWatchResponse();
   }
 
   private Watch.Response<Object> createHttpGoneErrorWithoutResourceVersionResponse() {

--- a/operator/src/test/java/oracle/kubernetes/operator/builders/WatchEvent.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/builders/WatchEvent.java
@@ -5,7 +5,6 @@ package oracle.kubernetes.operator.builders;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
 
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1Status;
@@ -61,13 +60,13 @@ public class WatchEvent<T> {
     return new WatchEvent<>(new V1Status().code(statusCode).message("Oops"));
   }
 
-  public static <S> WatchEvent<S> createErrorEvent(int statusCode, BigInteger resourceVersion) {
+  public static <S> WatchEvent<S> createErrorEvent(int statusCode, String resourceVersion) {
     return new WatchEvent<>(
         new V1Status().code(statusCode).message(createMessageWithResourceVersion(resourceVersion)));
   }
 
-  private static String createMessageWithResourceVersion(BigInteger resourceVersion) {
-    return String.format("Something wrong: continue from (%d)", resourceVersion);
+  private static String createMessageWithResourceVersion(String resourceVersion) {
+    return String.format("Something wrong: continue from (%s)", resourceVersion);
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
@@ -29,18 +29,18 @@ class KubernetesUtilsTest {
   }
 
   @Test
-  void whenCreationTimesMatch_metadataWithHigherResourceVersionIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("1");
+  void whenCreationTimesMatch_metadataWithLowerNameIsNewer() {
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).name("a");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).name("b");
 
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(true));
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
   }
 
   @Test
-  void whenCreationTimesAndResourceVersionsMatch_neitherIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
+  void whenCreationTimesAndNamesMatch_neitherIsNewer() {
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).name("a");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).name("a");
 
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(false));
@@ -50,48 +50,9 @@ class KubernetesUtilsTest {
   void whenHaveLargeResourceVersionsAndSameTime_succeedIsFirstNewer() {
     OffsetDateTime now = SystemClock.now();
 
-    // This needs to be a value bigger than 2147483647
-    String resVersion = "2733280673";
-    String evenBiggerResVersion = "2733280673000";
-
-    V1ObjectMeta first = new V1ObjectMeta().creationTimestamp(now).resourceVersion(resVersion);
-    V1ObjectMeta second = new V1ObjectMeta().creationTimestamp(now).resourceVersion(evenBiggerResVersion);
+    V1ObjectMeta first = new V1ObjectMeta().creationTimestamp(now).name("b");
+    V1ObjectMeta second = new V1ObjectMeta().creationTimestamp(now).name("a");
 
     assertThat(KubernetesUtils.isFirstNewer(first, second), is(false));
-  }
-
-  @Test
-  void whenHaveNonParsableResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    OffsetDateTime now = SystemClock.now();
-
-    String resVersion = "ThisIsNotANumber";
-    String differentResVersion = "SomeOtherValueAlsoNotANumber";
-
-    V1ObjectMeta first = new V1ObjectMeta().creationTimestamp(now).resourceVersion(resVersion);
-    V1ObjectMeta second = new V1ObjectMeta().creationTimestamp(now).resourceVersion(differentResVersion);
-
-    assertThat(KubernetesUtils.isFirstNewer(first, second), is(false));
-  }
-
-  @Test
-  void whenHaveSmallResourceVersion_parseCorrectly() {
-    String resVersion = "1";
-
-    BigInteger bigInteger = KubernetesUtils.getResourceVersion(resVersion);
-    assertThat(bigInteger, is(BigInteger.ONE));
-  }
-
-  @Test
-  void whenHaveNullResourceVersion_parseCorrectly() {
-    BigInteger bigInteger = KubernetesUtils.getResourceVersion((String) null);
-    assertThat(bigInteger, is(BigInteger.ZERO));
-  }
-
-  @Test
-  void whenHaveOpaqueResourceVersion_parseCorrectly() {
-    String resVersion = "123NotANumber456";
-
-    BigInteger bigInteger = KubernetesUtils.getResourceVersion(resVersion);
-    assertThat(bigInteger, is(BigInteger.ZERO));
   }
 }


### PR DESCRIPTION
As noted in the documentation for the utility methods, parsing the resource version is explicitly disallowed by the Kubernetes API. The Kubernetes API server ensures that watch event streams deliver events once and only once, and always in a total order. This is the critical feature of the system that allows for users to resume a watch from the latest resource version they have seen without requiring them to do any parsing or comparison. This change removes the parsing logic from the codebase and simplifies the reousrce version tracking routine.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>