### PR TITLE
update helm version to 3.10.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,7 +231,7 @@ pipeline {
         )
         string(name: 'HELM_VERSION',
                description: 'Helm version',
-               defaultValue: '3.7.2'
+               defaultValue: '3.10.2'
         )
         choice(name: 'ISTIO_VERSION',
                description: 'Istio version',

--- a/Jenkinsfile.kindnightly
+++ b/Jenkinsfile.kindnightly
@@ -206,7 +206,7 @@ pipeline {
         )
         string(name: 'HELM_VERSION',
                description: 'Helm version',
-               defaultValue: '3.8.1'
+               defaultValue: '3.10.2'
         )
         choice(name: 'ISTIO_VERSION',
                description: 'Istio version',

--- a/Jenkinsfile.oke
+++ b/Jenkinsfile.oke
@@ -74,7 +74,7 @@ pipeline {
                 )
         string(name: 'HELM_VERSION',
                description: 'Helm version',
-               defaultValue: '3.7.2'
+               defaultValue: '3.10.2'
         )
         string(name: 'ISTIO_VERSION',
                description: 'Other Possible Values 1.7.3, 1.8.1, 1.7.6',


### PR DESCRIPTION
Updating helm version to latest 3.10.2 to fix this failure.

<11-28-2022 13:09:32> <INFO> <oracle.weblogic.kubernetes.actions.impl.primitive.Helm exec> <Command failed with errors Error: INSTALLATION FAILED: execution error at (traefik/templates/deployment.yaml:3:8): ERROR: Helm >= 3.9.0 is required
>