### PR TITLE
OWLS-102744 [wko-nightly] testErrorPathDomainWithFailCustomMountCommand failure 3.4

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -69,6 +69,7 @@ import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.actions.TestActions.now;
 import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.patchDomainResourceWithNewIntrospectVersion;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.secretExists;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.verifyRollingRestartOccurred;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createDomainResource;
@@ -518,6 +519,7 @@ class ItMiiAuxiliaryImage {
             patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
         "patchDomainCustomResource(Auxiliary Image)  failed ");
     assertTrue(aiPatched, "patchDomainCustomResource(auxiliary image) failed");
+    patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
     // check the introspector pod log contains the expected error message
     String expectedErrorMsg = "Auxiliary Image: Command 'exit 1' execution failed in container";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiAuxiliaryImage.java
@@ -519,6 +519,8 @@ class ItMiiAuxiliaryImage {
             patchDomainCustomResource(domainUid, domainNamespace, patch, "application/json-patch+json"),
         "patchDomainCustomResource(Auxiliary Image)  failed ");
     assertTrue(aiPatched, "patchDomainCustomResource(auxiliary image) failed");
+    // update introspectVersion to ensure that any introspection started before
+    // auxiliary image was patched, if there is any still running, would be aborted.
     patchDomainResourceWithNewIntrospectVersion(domainUid, domainNamespace);
 
     // check the introspector pod log contains the expected error message


### PR DESCRIPTION
MII domain resource is patched with a change that would cause introspection to fail, and the test expects no server pods should be rolled. If there is an existing introspector job running for the pre-patched version of the domain resource, the introspector job could complete successfully and proceed to start rolling server pods.

Update test to also patch introspectVersion so operator would abort the current introspection if there is one.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14264/