### PR TITLE
Nightly 4.0 ItWlsSamples failures fix

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -53,6 +53,7 @@ import static oracle.weblogic.kubernetes.TestConstants.TEST_IMAGES_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.TEST_IMAGES_REPO_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.TEST_NGINX_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
@@ -227,7 +228,7 @@ class ItWlsSamples {
     // update domainHomeImageBase with right values in create-domain-inputs.yaml
     assertDoesNotThrow(() -> {
       replaceStringInFile(get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
-              "domainHomeImageBase: container-registry.oracle.com/middleware/weblogic:" + WEBLOGIC_IMAGE_TAG,
+              "domainHomeImageBase: container-registry.oracle.com/middleware/weblogic:" + WEBLOGIC_IMAGE_TAG_DEFAULT,
               "domainHomeImageBase: " + WEBLOGIC_IMAGE_TO_USE_IN_SPEC);
       replaceStringInFile(get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
               "#image:",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -626,7 +626,6 @@ class ItWlsSamples {
   }
 
   private void updateDomainInputsFile(String domainUid, Path sampleBase, String pvcName) {
-    
     // change namespace from default to custom, domain name, and t3PublicAddress
     assertDoesNotThrow(() -> {
       replaceStringInFile(get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -5,6 +5,7 @@ package oracle.weblogic.kubernetes;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -626,6 +627,8 @@ class ItWlsSamples {
   }
 
   private void updateDomainInputsFile(String domainUid, Path sampleBase, String pvcName) {
+    assertDoesNotThrow(() -> logger.info(Files.readString(get(sampleBase.toString(), "create-domain-inputs.yaml"))));
+    
     // change namespace from default to custom, domain name, and t3PublicAddress
     assertDoesNotThrow(() -> {
       replaceStringInFile(get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -5,7 +5,6 @@ package oracle.weblogic.kubernetes;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -627,7 +626,6 @@ class ItWlsSamples {
   }
 
   private void updateDomainInputsFile(String domainUid, Path sampleBase, String pvcName) {
-    assertDoesNotThrow(() -> logger.info(Files.readString(get(sampleBase.toString(), "create-domain-inputs.yaml"))));
     
     // change namespace from default to custom, domain name, and t3PublicAddress
     assertDoesNotThrow(() -> {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -304,7 +304,7 @@ class ItWlsSamples {
               "createDomainFilesDir: wlst", "createDomainFilesDir: "
                       +  script);
       replaceStringInFile(get(sampleBase.toString(), "create-domain-inputs.yaml").toString(),
-              "image: container-registry.oracle.com/middleware/weblogic:" + WEBLOGIC_IMAGE_TAG,
+              "image: container-registry.oracle.com/middleware/weblogic:" + WEBLOGIC_IMAGE_TAG_DEFAULT,
               "image: " + WEBLOGIC_IMAGE_TO_USE_IN_SPEC);
     });
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/FileUtils.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -469,15 +468,16 @@ public class FileUtils {
       throws IOException {
     LoggingFacade logger = getLogger();
     Path src = Paths.get(filePath);
-    logger.info("Replacing {0} in {1}", regex, src.toString());
-    Charset charset = StandardCharsets.UTF_8;
-    String content = new String(Files.readAllBytes(src), charset);
-    String newcontent = content.replaceAll(regex, replacement);
-    logger.info("with {0}", replacement);
-    if (content.equals(newcontent)) {
+    logger.info("Replacing {0} in {1} with {2}", regex, src.toString(), replacement);    
+    String content = new String(Files.readAllBytes(src), StandardCharsets.UTF_8);
+    if (!content.contains(regex)) {
       logger.info("search string {0} not found to replace with {1}", regex, replacement);
     }
-    Files.write(src, newcontent.getBytes(charset));
+    long oldModified = src.toFile().lastModified();
+    Files.write(src, content.replaceAll(regex, replacement).getBytes(StandardCharsets.UTF_8));
+    if (oldModified == src.toFile().lastModified()) {
+      logger.info("No modification was done to the file");
+    }
   }
 
   /**

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -x
+#!/usr/bin/env bash
 # Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain/domain-home-in-image/create-domain.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -x
 # Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #


### PR DESCRIPTION
Change in the image in Jenkins causing the domain in image tests to fail. We have to use the DEFAULT TAG when trying to replace the image in domain-inputs file.

https://build.weblogick8s.org:8443/job/wko40-kind-nightly-parallel/34/