### PR TITLE
Added test for retry improvements to cover introspect failure retry count exceeded error msg to domain status failure msg

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovements.java
@@ -404,10 +404,14 @@ class ItRetryImprovements {
     testUntil(() -> checkPodLogContainsRegex(createDomainFailedMsgRegex, operatorPodName, opNamespace),
         logger, "{0} is found in Operator log", createDomainFailedMsgRegex);
 
-    // verify that SEVERE and createDomainFailedMsgRegex message found in Operator log
+    // verify that SEVERE and createDomainFailedMsgRegex message found in introspector log
     testUntil(() -> checkInUncompletedIntroPodLogContainsRegex(createDomainFailedMsgRegex,
         domainUid, domainNamespace),
         logger, "{0} is found in introspector log", createDomainFailedMsgRegex);
+
+    // verify that SEVERE and createDomainFailedMsgRegex message found in domain status
+    testUntil(() -> findStringInDomainStatusMessage(domainNamespace, domainUid, createDomainFailedMsgRegex, "true"),
+        logger, "{0} is found in domain status message", createDomainFailedMsgRegex);
 
     Callable<Boolean> configMapExist = assertDoesNotThrow(() -> configMapExist(domainNamespace, badModelFileCm));
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -1211,14 +1211,24 @@ public class DomainUtils {
    * @return true if regex found, false otherwise.
    */
   @Nonnull
-  public static boolean findStringInDomainStatusMessage(String domainNamespace, String domainUid, String regex) {
-    // get the domain status message
+  public static boolean findStringInDomainStatusMessage(String domainNamespace,
+                                                        String domainUid,
+                                                        String regex,
+                                                        String... multupleMessage) {
     StringBuffer getDomainInfoCmd = new StringBuffer("kubectl get domain/");
     getDomainInfoCmd
         .append(domainUid)
         .append(" -n ")
-        .append(domainNamespace)
-        .append(" -o jsonpath='{.status.message}' --ignore-not-found");
+        .append(domainNamespace);
+
+    if (multupleMessage.length == 0) {
+      // get single field of domain message
+      getDomainInfoCmd.append(" -o jsonpath='{.status.message}' --ignore-not-found");
+    } else {
+      // use [,] to get side by side multiple fields of the domain status message
+      getDomainInfoCmd.append(" -o jsonpath=\"{.status.conditions[*]['status', 'message']}\" --ignore-not-found");
+    }
+
     getLogger().info("Command to get domain status message: " + getDomainInfoCmd);
 
     CommandParams params = new CommandParams().defaults();


### PR DESCRIPTION
Added new test to cover New feature: https://jira.oraclecorp.com/jira/browse/OWLS-93072 - WKO 4.0 Retry: Add "introspect failure retry count exceeded error" msg to domain status failure msg 

Jenkins:

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14297
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14299