### PR TITLE
Add more files in validateCLI.sh exception .dat file

### DIFF
--- a/validateCLI.docker.dat
+++ b/validateCLI.docker.dat
@@ -41,3 +41,7 @@ docker-istio-secret
 DB_IMAGE_PULL_SECRET:-docker-secret
 SOURCEDIR:-ai-docker-file
 create-domain-on-aks.sh:.*
+wlsDockerContainer
+wls-docker-container-imag
+dii-docker-container
+DockerCluster


### PR DESCRIPTION
After pulling the latest main branch, the operator build started to fail on my Mac laptop with the following error.

ERROR: The 'validateCLI.sh' in directory '/Users/dongboxiao/weblogic-kubernetes-operator' detected invalid direct uses of the Kubernetes or image builder CLIs. Kubernetes CLI calls should use the KUBERNETES_CLI env var or java constant instead of directly using 'kubectl'. And image builder CLI calls should use the WLSIMG_BUILDER env var or java constant instead of directly using 'docker'. To add usage exceptions, add a sed regex expression in ./validateCLI.kubectl.dat or ./validateCLI.docker.dat for 'kubectl' and 'docker' exceptions respectively. Please fix the following:
integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java:1228:    final String containerName = "wlsDockerContainer";
integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java:1233:    final String diiImageName = "wls-docker-container-image";
integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java:1234:    final String diiModelFileName = "dii-docker-container.yaml";
integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java:1235:    final String diiModelPropFileName = "dii-docker-container.properties";
operator/src/test/java/oracle/kubernetes/operator/wlsconfig/WlsDomainConfigTest.java:66:    WlsClusterConfig wlsClusterConfig = wlsDomainConfig.getClusterConfig("DockerCluster");
[ERROR] Command execution failed.

Having checked with Tom, I am adding the files that the script complains to the exception .dat file. With this change, the build problem disappeared on Mac and the build continues working on my Linux OCI VM. 
