### PR TITLE
pass bash as executable and rest of the parameters as arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,10 +189,11 @@
                 <goal>exec</goal>
               </goals>
               <configuration>
-                <executable>../validateCLI.sh</executable>
-                <arguments>
-                  <argument>..</argument>
-                </arguments>
+	      <executable>bash</executable>
+	      <arguments>
+		  <argument>../validateCLI.sh</argument>
+		  <argument>..</argument>
+	      </arguments>
               </configuration>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -190,10 +190,10 @@
               </goals>
               <configuration>
 	      <executable>bash</executable>
-	      <arguments>
+	        <arguments>
 		  <argument>../validateCLI.sh</argument>
 		  <argument>..</argument>
-	      </arguments>
+	        </arguments>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
pass bash as executable and rest of the parameters as arguments, otherwise this fails when running targets in windows OS

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14400/