### PR TITLE
pass bash as executable and rest of the parameters as arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,11 +188,12 @@
               <goals>
                 <goal>exec</goal>
               </goals>
-              <configuration>
-                <executable>../validateCLI.sh</executable>
-                <arguments>
-                  <argument>..</argument>
-                </arguments>
+	      <configuration>
+	        <executable>bash</executable>
+	          <arguments>
+		    <argument>../validateCLI.sh</argument>
+		    <argument>..</argument>
+	          </arguments>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
pass bash as executable and rest of the parameters as arguments, otherwise this fails when running targets in windows OS

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14401