### PR TITLE
Introduce custom condition factory

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiClusterResource.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiClusterResource.java
@@ -256,7 +256,7 @@ class ItMiiClusterResource {
 
     //verify the introspector pod is created and runs
     String introspectPodNameBase2 = getIntrospectJobName(domainUid);
-    ConditionFactory customConditionFactory = createCustomConditionFactory(0, 2, 5);
+    ConditionFactory customConditionFactory = createCustomConditionFactory(0, 1, 5);
     checkPodExists(customConditionFactory, introspectPodNameBase2, domainUid, domainNamespace);    
     checkPodDoesNotExist(introspectPodNameBase2, domainUid, domainNamespace);
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiClusterResource.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiClusterResource.java
@@ -257,7 +257,7 @@ class ItMiiClusterResource {
     //verify the introspector pod is created and runs
     String introspectPodNameBase2 = getIntrospectJobName(domainUid);
     ConditionFactory customConditionFactory = createCustomConditionFactory(0, 1, 5);
-    checkPodExists(customConditionFactory, introspectPodNameBase2, domainUid, domainNamespace);    
+    checkPodExists(customConditionFactory, introspectPodNameBase2, domainUid, domainNamespace);
     checkPodDoesNotExist(introspectPodNameBase2, domainUid, domainNamespace);
 
     // check managed server pods from cluster-1 are shutdown
@@ -366,7 +366,8 @@ class ItMiiClusterResource {
 
     //verify the introspector pod is created and runs
     String introspectPodNameBase2 = getIntrospectJobName(domainUid);
-    checkPodExists(introspectPodNameBase2, domainUid, domainNamespace);
+    ConditionFactory customConditionFactory = createCustomConditionFactory(0, 1, 5);
+    checkPodExists(customConditionFactory, introspectPodNameBase2, domainUid, domainNamespace);
     checkPodDoesNotExist(introspectPodNameBase2, domainUid, domainNamespace);
 
     // check managed server pods from cluster-1 are shutdown

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiClusterResource.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiClusterResource.java
@@ -32,6 +32,7 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.CommandParams;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -67,6 +68,7 @@ import static oracle.weblogic.kubernetes.utils.ClusterUtils.startCluster;
 import static oracle.weblogic.kubernetes.utils.ClusterUtils.stopCluster;
 import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.verifyPodsNotRolled;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.createCustomConditionFactory;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getNextFreePort;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
@@ -254,7 +256,8 @@ class ItMiiClusterResource {
 
     //verify the introspector pod is created and runs
     String introspectPodNameBase2 = getIntrospectJobName(domainUid);
-    checkPodExists(introspectPodNameBase2, domainUid, domainNamespace);
+    ConditionFactory customConditionFactory = createCustomConditionFactory(0, 2, 5);
+    checkPodExists(customConditionFactory, introspectPodNameBase2, domainUid, domainNamespace);    
     checkPodDoesNotExist(introspectPodNameBase2, domainUid, domainNamespace);
 
     // check managed server pods from cluster-1 are shutdown

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -130,7 +130,7 @@ public class CommonTestUtils {
   private static final String TMP_FILE_NAME = "temp-download-file.out";
 
   /**
-   * Create a custom condition factory with custom values for pollDelay, pollInterval and atMost time.
+   * Create a condition factory with custom values for pollDelay, pollInterval and atMost time.
    *
    * @param polldelay starting delay before checking for the condition in seconds
    * @param pollInterval interval time between checking for the condition in seconds

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -129,6 +129,19 @@ public class CommonTestUtils {
 
   private static final String TMP_FILE_NAME = "temp-download-file.out";
 
+  /**
+   * Create a custom condition factory with custom values for pollDelay, pollInterval and atMost time.
+   *
+   * @param polldelay starting delay before checking for the condition in seconds
+   * @param pollInterval interval time between checking for the condition in seconds
+   * @param atMostMinutes how long should it wait for the condition becomes true in minutes
+   * @return ConditionFactory custom condition factory
+   */
+  public static ConditionFactory createCustomConditionFactory(int polldelay, int pollInterval, int atMostMinutes) {
+    return with().pollDelay(polldelay, SECONDS)
+        .and().with().pollInterval(pollInterval, SECONDS)
+        .atMost(atMostMinutes, MINUTES).await();
+  }
 
   /**
    * Test assertion using standard retry policy over time until it passes or the timeout expires.

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PodUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PodUtils.java
@@ -95,6 +95,27 @@ public class PodUtils {
   }
 
   /**
+   * Check pod exists in the specified namespace.
+   *
+   * @param conditionFactory Configuration for Awaitility condition factory
+   * @param podName pod name to check
+   * @param domainUid the label the pod is decorated with
+   * @param domainNamespace the domain namespace in which the domain exists
+   */
+  public static void checkPodExists(ConditionFactory conditionFactory, String podName,
+      String domainUid, String domainNamespace) {
+    LoggingFacade logger = getLogger();
+    testUntil(conditionFactory,
+        assertDoesNotThrow(() -> podExists(podName, domainUid, domainNamespace),
+            String.format("podExists failed with ApiException for pod %s in namespace %s",
+                podName, domainNamespace)),
+        logger,
+        "pod {0} to be created in namespace {1}",
+        podName,
+        domainNamespace);
+  }
+  
+  /**
    * Check pod is ready.
    *
    * @param podName pod name to check


### PR DESCRIPTION
Since introspector pod is created and deleted within seconds, the existing conditionfactory objects are not useful to catch the introspector pod lifecycle. Introducing this custom condition factory to start the checking right away.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14526/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14527/