### PR TITLE
Consistently manage domain resources using name rather than domainUid

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -34,7 +34,7 @@ abstract class WaitForReadyStep<T> extends Step {
 
   protected static Step createMakeDomainRightStep(WaitForReadyStep<?>.Callback callback,
                                            DomainPresenceInfo info, Step next) {
-    return new CallBuilder().readDomainAsync(info.getDomainUid(),
+    return new CallBuilder().readDomainAsync(info.getDomainName(),
             info.getNamespace(), new MakeRightDomainStep<>(callback, null));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/CallBuilder.java
@@ -800,7 +800,7 @@ public class CallBuilder {
   /**
    * Patch cluster.
    *
-   * @param name the domain uid (unique within the k8s cluster)
+   * @param name the domain name
    * @param namespace the namespace containing the domain
    * @param patchBody the patch to apply
    * @return Updated cluster
@@ -921,41 +921,41 @@ public class CallBuilder {
   /**
    * Read domain synchronously.
    *
-   * @param uid the domain uid (unique within the k8s cluster)
+   * @param name the domain name
    * @param namespace Namespace
    * @return Replaced domain
    * @throws ApiException APIException
    */
-  public DomainResource readDomain(String uid, String namespace) throws ApiException {
-    RequestParams requestParams = new RequestParams("readDomain", namespace, uid, null, (String)null);
+  public DomainResource readDomain(String name, String namespace) throws ApiException {
+    RequestParams requestParams = new RequestParams("readDomain", namespace, name, null, (String)null);
     return executeSynchronousCall(requestParams, readDomainCall);
   }
 
   /**
    * Replace domain.
    *
-   * @param uid the domain uid (unique within the k8s cluster)
+   * @param name the domain name
    * @param namespace Namespace
    * @param body Body
    * @return Replaced domain
    * @throws ApiException APIException
    */
-  public DomainResource replaceDomain(String uid, String namespace, DomainResource body) throws ApiException {
-    RequestParams requestParams = new RequestParams("replaceDomain", namespace, uid, body, uid);
+  public DomainResource replaceDomain(String name, String namespace, DomainResource body) throws ApiException {
+    RequestParams requestParams = new RequestParams("replaceDomain", namespace, name, body, name);
     return executeSynchronousCall(requestParams, replaceDomainCall);
   }
 
   /**
    * Replace domain status.
    *
-   * @param uid the domain uid (unique within the k8s cluster)
+   * @param name the domain name
    * @param namespace Namespace
    * @param body Body
    * @return Replaced domain
    * @throws ApiException APIException
    */
-  public DomainResource replaceDomainStatus(String uid, String namespace, DomainResource body) throws ApiException {
-    RequestParams requestParams = new RequestParams("replaceDomainStatus", namespace, uid, body, uid);
+  public DomainResource replaceDomainStatus(String name, String namespace, DomainResource body) throws ApiException {
+    RequestParams requestParams = new RequestParams("replaceDomainStatus", namespace, name, body, name);
     return executeSynchronousCall(requestParams, replaceDomainStatusCall);
   }
 
@@ -984,15 +984,15 @@ public class CallBuilder {
   /**
    * Patch domain.
    *
-   * @param uid the domain uid (unique within the k8s cluster)
+   * @param name the domain name
    * @param namespace the namespace containing the domain
    * @param patchBody the patch to apply
    * @return Updated domain
    * @throws ApiException APIException
    */
-  public DomainResource patchDomain(String uid, String namespace, V1Patch patchBody) throws ApiException {
+  public DomainResource patchDomain(String name, String namespace, V1Patch patchBody) throws ApiException {
     RequestParams requestParams =
-        new RequestParams("patchDomain", namespace, uid, patchBody, uid);
+        new RequestParams("patchDomain", namespace, name, patchBody, name);
     return executeSynchronousCall(requestParams, patchDomainCall);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -741,6 +741,15 @@ public class DomainPresenceInfo extends ResourcePresenceInfo {
     return domainUid;
   }
 
+  /**
+   * Gets the Domain name.
+   *
+   * @return Domain name
+   */
+  public String getDomainName() {
+    return getDomain().getMetadata().getName();
+  }
+
   @Override
   public String getResourceName() {
     return getDomainUid();

--- a/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/rest/RestBackendImpl.java
@@ -457,7 +457,7 @@ public class RestBackendImpl implements RestBackend {
     try {
       callBuilder
           .patchDomain(
-              domain.getDomainUid(), domain.getMetadata().getNamespace(),
+              domain.getMetadata().getName(), domain.getMetadata().getNamespace(),
               new V1Patch(patchBuilder.build().toString()));
     } catch (ApiException e) {
       throw handleApiException(e);

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -348,7 +348,7 @@ public class MakeRightDomainOperationImpl extends MakeRightOperationImpl<DomainP
     @Override
     public NextAction apply(Packet packet) {
       DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
-      return doNext(new CallBuilder().readDomainAsync(info.getDomainUid(), info.getNamespace(),
+      return doNext(new CallBuilder().readDomainAsync(info.getDomainName(), info.getNamespace(),
           new ReadDomainResponseStep(getNext())), packet);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainResource.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainResource.java
@@ -611,7 +611,8 @@ public class DomainResource implements KubernetesObject, RetryMessageFactory {
    * @return domain home
    */
   public String getDomainHome() {
-    return emptyToNull(spec.getDomainHome());
+    return emptyToNull(Optional.ofNullable(spec.getDomainHome())
+            .orElse(getDomainHomeSourceType().getDefaultDomainHome(getDomainUid())));
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/DomainSpec.java
@@ -518,7 +518,7 @@ public class DomainSpec extends BaseConfiguration {
    * @return domain home
    */
   String getDomainHome() {
-    return Optional.ofNullable(domainHome).orElse(getDomainHomeSourceType().getDefaultDomainHome(getDomainUid()));
+    return domainHome;
   }
 
   public String getLivenessProbeCustomScript() {


### PR DESCRIPTION
Several code points were using the domainUid rather than the domain resource name (metadata.name) when attempting to read or update the domain resource. 

Cleaned-up the parameters and JavaDoc in CallBuilder to make it clear that the name is required rather than the domainUID.

Finally, observed another bug in DomainResource where the domainHome default was calculated based on the value of `spec.domainUID` rather than on the value of the domainUid (which might default to `metadata.name`)