### PR TITLE
make sure webhook does not inject istio sidecar

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -246,8 +246,11 @@ spec:
           annotations:
             prometheus.io/port: '8083'
             prometheus.io/scrape: 'true'
+            sidecar.istio.io/inject: 'false'
           {{- range $key, $value := .annotations }}
-            {{ $key }}: {{ $value | quote }}
+            {{- if ne $key "sidecar.istio.io/inject" }}
+              {{ $key }}: {{ $value | quote }}
+            {{- end }}          
           {{- end }}
           labels:
             weblogic.webhookName: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
Adding an annotation to the webhook pod to make sure the Istio sidecar will not be injected into the pod,  otherwise, in the OpenShift mesh environment, we will get a certificate validation error when deploying a domain.