### PR TITLE
Changes from PR 3700 to stop parsing the resource version.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
@@ -132,16 +132,6 @@ public class KubernetesUtils {
   }
 
   /**
-   * Returns the resource version associated with the specified object metadata.
-   *
-   * @param metadata Meta data containing resource version
-   * @return Resource version
-   */
-  public static String getResourceVersion(V1ObjectMeta metadata) {
-    return Optional.ofNullable(metadata).map(V1ObjectMeta::getResourceVersion).orElse("");
-  }
-
-  /**
    * Returns the resource version associated with the specified list.
    *
    * @param list the result of a Kubernetes list operation.

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/KubernetesUtils.java
@@ -117,8 +117,7 @@ public class KubernetesUtils {
 
   /**
    * Returns true if the first metadata indicates a newer resource than does the second. 'Newer'
-   * indicates that the creation time is later. If two items have the same creation time, a lexographic
-   * sort of the names indicates the newer resource.
+   * indicates that the creation time is later.
    *
    * @param m1 the first item to compare
    * @param m2 the second item to compare

--- a/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WatcherTestBase.java
@@ -146,7 +146,7 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase implements A
   }
 
   private Watch.Response<Object> createHttpGoneErrorResponse(BigInteger nextResourceVersion) {
-    return WatchEvent.createErrorEvent(HTTP_GONE, nextResourceVersion).toWatchResponse();
+    return WatchEvent.createErrorEvent(HTTP_GONE, nextResourceVersion.toString()).toWatchResponse();
   }
 
   private Watch.Response<Object> createHttpGoneErrorWithoutResourceVersionResponse() {
@@ -239,18 +239,6 @@ public abstract class WatcherTestBase extends ThreadFactoryTestBase implements A
     createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
 
     assertThat(StubWatchFactory.getRequestParameters().get(1), hasEntry("resourceVersion", "0"));
-  }
-
-  @Test
-  void afterDelete_nextRequestSendsIncrementedResourceVersion() {
-    scheduleDeleteResponse(createObjectWithMetaData());
-    scheduleAddResponse(createObjectWithMetaData());
-
-    createAndRunWatcher(NAMESPACE, stopping, INITIAL_RESOURCE_VERSION);
-
-    assertThat(
-        StubWatchFactory.getRequestParameters().get(1),
-        hasEntry("resourceVersion", INITIAL_RESOURCE_VERSION.add(BigInteger.ONE).toString()));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/builders/WatchEvent.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/builders/WatchEvent.java
@@ -5,7 +5,6 @@ package oracle.kubernetes.operator.builders;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
 
 import com.google.gson.annotations.SerializedName;
 import io.kubernetes.client.openapi.models.V1Status;
@@ -61,13 +60,13 @@ public class WatchEvent<T> {
     return new WatchEvent<>(new V1Status().code(statusCode).message("Oops"));
   }
 
-  public static <S> WatchEvent<S> createErrorEvent(int statusCode, BigInteger resourceVersion) {
+  public static <S> WatchEvent<S> createErrorEvent(int statusCode, String resourceVersion) {
     return new WatchEvent<>(
         new V1Status().code(statusCode).message(createMessageWithResourceVersion(resourceVersion)));
   }
 
-  private static String createMessageWithResourceVersion(BigInteger resourceVersion) {
-    return String.format("Something wrong: continue from (%d)", resourceVersion);
+  private static String createMessageWithResourceVersion(String resourceVersion) {
+    return String.format("Something wrong: continue from (%s)", resourceVersion);
   }
 
   /**

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
@@ -3,7 +3,6 @@
 
 package oracle.kubernetes.operator.helpers;
 
-import java.math.BigInteger;
 import java.time.OffsetDateTime;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -29,69 +28,11 @@ class KubernetesUtilsTest {
   }
 
   @Test
-  void whenCreationTimesMatch_metadataWithHigherResourceVersionIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("1");
-
-    assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(true));
-    assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
-  }
-
-  @Test
-  void whenCreationTimesAndResourceVersionsMatch_neitherIsNewer() {
-    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
-    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).resourceVersion("2");
+  void whenCreationTimes_neitherIsNewer() {
+    V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).name("a");
+    V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).name("b");
 
     assertThat(KubernetesUtils.isFirstNewer(meta2, meta1), is(false));
     assertThat(KubernetesUtils.isFirstNewer(meta1, meta2), is(false));
-  }
-
-  @Test
-  void whenHaveLargeResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    OffsetDateTime now = SystemClock.now();
-
-    // This needs to be a value bigger than 2147483647
-    String resVersion = "2733280673";
-    String evenBiggerResVersion = "2733280673000";
-
-    V1ObjectMeta first = new V1ObjectMeta().creationTimestamp(now).resourceVersion(resVersion);
-    V1ObjectMeta second = new V1ObjectMeta().creationTimestamp(now).resourceVersion(evenBiggerResVersion);
-
-    assertThat(KubernetesUtils.isFirstNewer(first, second), is(false));
-  }
-
-  @Test
-  void whenHaveNonParsableResourceVersionsAndSameTime_succeedIsFirstNewer() {
-    OffsetDateTime now = SystemClock.now();
-
-    String resVersion = "ThisIsNotANumber";
-    String differentResVersion = "SomeOtherValueAlsoNotANumber";
-
-    V1ObjectMeta first = new V1ObjectMeta().creationTimestamp(now).resourceVersion(resVersion);
-    V1ObjectMeta second = new V1ObjectMeta().creationTimestamp(now).resourceVersion(differentResVersion);
-
-    assertThat(KubernetesUtils.isFirstNewer(first, second), is(false));
-  }
-
-  @Test
-  void whenHaveSmallResourceVersion_parseCorrectly() {
-    String resVersion = "1";
-
-    BigInteger bigInteger = KubernetesUtils.getResourceVersion(resVersion);
-    assertThat(bigInteger, is(BigInteger.ONE));
-  }
-
-  @Test
-  void whenHaveNullResourceVersion_parseCorrectly() {
-    BigInteger bigInteger = KubernetesUtils.getResourceVersion((String) null);
-    assertThat(bigInteger, is(BigInteger.ZERO));
-  }
-
-  @Test
-  void whenHaveOpaqueResourceVersion_parseCorrectly() {
-    String resVersion = "123NotANumber456";
-
-    BigInteger bigInteger = KubernetesUtils.getResourceVersion(resVersion);
-    assertThat(bigInteger, is(BigInteger.ZERO));
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/KubernetesUtilsTest.java
@@ -28,7 +28,7 @@ class KubernetesUtilsTest {
   }
 
   @Test
-  void whenCreationTimes_neitherIsNewer() {
+  void whenCreationTimesMatch_neitherIsNewer() {
     V1ObjectMeta meta1 = new V1ObjectMeta().creationTimestamp(time1).name("a");
     V1ObjectMeta meta2 = new V1ObjectMeta().creationTimestamp(time1).name("b");
 


### PR DESCRIPTION
Merge the changes from PR 3700 to stop parsing the resource version in the existing PR to pause the watches during periodic list and resume with new resourceVersion.

Integration test results - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14648/