### PR TITLE
disable istio mii tests for 12.2.1.3 images

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItIstioMiiDomain.java
@@ -22,6 +22,7 @@ import oracle.weblogic.domain.DomainSpec;
 import oracle.weblogic.domain.Model;
 import oracle.weblogic.domain.OnlineUpdate;
 import oracle.weblogic.domain.ServerPod;
+import oracle.weblogic.kubernetes.annotations.DisabledOn12213Image;
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
@@ -151,6 +152,7 @@ class ItIstioMiiDomain {
   @DisplayName("Create WebLogic Domain with mii model with istio")
   @Tag("gate")
   @Tag("crio")
+  @DisabledOn12213Image
   void testIstioModelInImageDomain() {
 
     // Create the repo secret to pull the image

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -335,7 +335,8 @@ public interface TestConstants {
       "-Dweblogic.security.SSL.ignoreHostnameVerification=true -Dweblogic.security.TrustKeyStore=DemoTrust";
 
   public static final boolean WEBLOGIC_SLIM = WEBLOGIC_IMAGE_TAG.contains("slim");
-  public static final boolean WEBLOGIC_12213 = WEBLOGIC_IMAGE_TAG.contains("12.2.1.3");
+  public static final boolean WEBLOGIC_12213 = WEBLOGIC_IMAGE_TAG.contains("12.2.1.3") &&
+          !WEBLOGIC_IMAGE_TAG.toLowerCase().contains("cpu");
 
   public static final String WEBLOGIC_VERSION = "12.2.1.4.0";
   public static final String HTTP_PROXY =

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -335,8 +335,8 @@ public interface TestConstants {
       "-Dweblogic.security.SSL.ignoreHostnameVerification=true -Dweblogic.security.TrustKeyStore=DemoTrust";
 
   public static final boolean WEBLOGIC_SLIM = WEBLOGIC_IMAGE_TAG.contains("slim");
-  public static final boolean WEBLOGIC_12213 = WEBLOGIC_IMAGE_TAG.contains("12.2.1.3") &&
-          !WEBLOGIC_IMAGE_TAG.toLowerCase().contains("cpu");
+  public static final boolean WEBLOGIC_12213 = WEBLOGIC_IMAGE_TAG.contains("12.2.1.3") 
+          && !WEBLOGIC_IMAGE_TAG.toLowerCase().contains("cpu");
 
   public static final String WEBLOGIC_VERSION = "12.2.1.4.0";
   public static final String HTTP_PROXY =

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -335,6 +335,7 @@ public interface TestConstants {
       "-Dweblogic.security.SSL.ignoreHostnameVerification=true -Dweblogic.security.TrustKeyStore=DemoTrust";
 
   public static final boolean WEBLOGIC_SLIM = WEBLOGIC_IMAGE_TAG.contains("slim");
+  public static final boolean WEBLOGIC_12213 = WEBLOGIC_IMAGE_TAG.contains("12.2.1.3");
 
   public static final String WEBLOGIC_VERSION = "12.2.1.4.0";
   public static final String HTTP_PROXY =

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/annotations/DisabledOn12213Image.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/annotations/DisabledOn12213Image.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import oracle.weblogic.kubernetes.extensions.DisabledOn12213ImageCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOn12213ImageCondition.class)
+public @interface DisabledOn12213Image {
+
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/DisabledOn12213ImageCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/DisabledOn12213ImageCondition.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes.extensions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_12213;
+
+public class DisabledOn12213ImageCondition implements ExecutionCondition {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (WEBLOGIC_12213) {
+      return ConditionEvaluationResult.disabled("Test disabled on WebLogic 12.2.1.3 image");
+    } else {
+      return ConditionEvaluationResult.enabled("Test enabled on non-12.2.1.3 WebLogic image");
+    }
+  }
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/DisabledOn12213ImageCondition.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/DisabledOn12213ImageCondition.java
@@ -13,6 +13,8 @@ public class DisabledOn12213ImageCondition implements ExecutionCondition {
 
   @Override
   public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    // disable the test because of application deployment through REST interface issue
+    // and is included in WebLogic 12.2.1.3.0 CPU's"
     if (WEBLOGIC_12213) {
       return ConditionEvaluationResult.disabled("Test disabled on WebLogic 12.2.1.3 image");
     } else {


### PR DESCRIPTION
Jenkins - 

https://build.weblogick8s.org:8443/job/wko-kind-weekly-multiconfig/ - tests were failing on 12.2.1.3 images before, now they pass as istio mii tests are disabled for 12.2.1.3 images because of known issue.

latest jenkins - 
https://build.weblogick8s.org:8443/job/wko-kind-weekly-multiconfig/80/