### PR TITLE
owls-104622  domain status cluster condition Complete type is always True when the cluster replicas changed to 0

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovementMisc.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRetryImprovementMisc.java
@@ -342,10 +342,9 @@ class ItRetryImprovementMisc {
     checkDomainStatusConditionTypeHasExpectedStatus(shortRetryPolicy, domainUid, domainNamespace,
         DOMAIN_STATUS_CONDITION_COMPLETED_TYPE, "False", DOMAIN_VERSION);
 
-    // Enable this check when the bug is fixed
     // check the cluster status condition Complete becomes false
-    //checkDomainStatusClusterConditionTypeHasExpectedStatus(shortRetryPolicy, domainUid, domainNamespace,
-    //    clusterName, DOMAIN_STATUS_CONDITION_COMPLETED_TYPE, "False", DOMAIN_VERSION);
+    checkDomainStatusClusterConditionTypeHasExpectedStatus(shortRetryPolicy, domainUid, domainNamespace,
+        clusterName, DOMAIN_STATUS_CONDITION_COMPLETED_TYPE, "False", DOMAIN_VERSION);
 
     // verify Cluster status condition Available becomes false and stay false when the server pod is deleting
     checkDomainStatusClusterConditionTypeHasExpectedStatus(withQuickRetryPolicy, domainUid, domainNamespace,

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -135,7 +135,7 @@ public class DomainStatusUpdater {
    * @return the new step
    */
   public static Step createStatusUpdateStep(Step next) {
-    return new StatusUpdateStep(createClusterResourceStatusUpdaterStep(next));
+    return new StatusUpdateStep(next);
   }
 
 
@@ -360,7 +360,7 @@ public class DomainStatusUpdater {
       if (callResponse.getResult() != null) {
         packet.getSpi(DomainPresenceInfo.class).setDomain(callResponse.getResult());
       }
-      return doNext(packet);
+      return doNext(createClusterResourceStatusUpdaterStep(getNext()), packet);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -936,9 +936,15 @@ public class DomainStatusUpdater {
         }
 
         private boolean allIntendedClusterServersReady() {
-          return isClusterIntentionallyShutDown() || (allStartedClusterServersAreComplete()
+          return isClusterIntentionallyShutDown()
+              ? allNonStartedClusterServersAreShutdown()
+              : isClusterStartupCompleted();
+        }
+
+        private boolean isClusterStartupCompleted() {
+          return allStartedClusterServersAreComplete()
               && allNonStartedClusterServersAreShutdown()
-              && clusteredServersMarkedForRoll().isEmpty());
+              && clusteredServersMarkedForRoll().isEmpty();
         }
 
         private boolean allStartedClusterServersAreComplete() {


### PR DESCRIPTION
- When Cluster resource replicas decreases to 0, Cluster resource Completed condition should remain False until all server pods have completed shutdown.
- Ensure cluster status is updated after domain status updated successfully
- Re-enables domain status conditions check in ItRetryImprovementMisc.testClusterReplicasToZero

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14650/
