### PR TITLE
Proper shut down for operator and webhook; Have webhook delete VWC 

### DIFF
--- a/deployment/scripts/operator.sh
+++ b/deployment/scripts/operator.sh
@@ -70,3 +70,7 @@ HEAP="-XshowSettings:vm"
 java $HEAP $MOCKING_WLS $DEBUG $LOGGING -jar /operator/weblogic-kubernetes-operator.jar &
 PID=$!
 wait $PID
+
+SHUTDOWN_COMPLETE_MARKER_FILE="${DEPLOYMENT_DIR}/marker.shutdown-complete"
+
+touch ${SHUTDOWN_COMPLETE_MARKER_FILE}

--- a/deployment/scripts/stop.sh
+++ b/deployment/scripts/stop.sh
@@ -6,5 +6,13 @@ echo "Setting stop signal"
 
 DEPLOYMENT_DIR="/deployment"
 SHUTDOWN_MARKER_FILE="${DEPLOYMENT_DIR}/marker.shutdown"
+SHUTDOWN_COMPLETE_MARKER_FILE="${DEPLOYMENT_DIR}/marker.shutdown-complete"
 
 touch ${SHUTDOWN_MARKER_FILE}
+
+while true; do
+  if [ -e ${SHUTDOWN_COMPLETE_MARKER_FILE} ] ; then
+    exit 0
+  fi
+  sleep 1
+done

--- a/deployment/scripts/stop.sh
+++ b/deployment/scripts/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+echo "Setting stop signal"
+
+DEPLOYMENT_DIR="/deployment"
+SHUTDOWN_MARKER_FILE="${DEPLOYMENT_DIR}/marker.shutdown"
+
+touch ${SHUTDOWN_MARKER_FILE}

--- a/deployment/scripts/webhook.sh
+++ b/deployment/scripts/webhook.sh
@@ -63,3 +63,8 @@ HEAP="-XshowSettings:vm"
 java -cp /operator/weblogic-kubernetes-operator.jar $HEAP $MOCKING_WLS $DEBUG $LOGGING oracle.kubernetes.operator.WebhookMain &
 PID=$!
 wait $PID
+
+DEPLOYMENT_DIR="/deployment"
+SHUTDOWN_COMPLETE_MARKER_FILE="${DEPLOYMENT_DIR}/marker.shutdown-complete"
+
+touch ${SHUTDOWN_COMPLETE_MARKER_FILE}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-general.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-clusterrole-general.tpl
@@ -38,5 +38,5 @@ rules:
   verbs: ["create"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create", "update", "patch"]
+  verbs: ["get", "create", "update", "patch", "delete"]
 {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -135,7 +135,6 @@ spec:
         livenessProbe:
           exec:
             command:
-            - "bash"
             - "/probes/livenessProbe.sh"
           initialDelaySeconds: 40
           periodSeconds: 10
@@ -143,7 +142,6 @@ spec:
         readinessProbe:
           exec:
             command:
-            - "bash"
             - "/probes/readinessProbe.sh"
           initialDelaySeconds: 2
           periodSeconds: 10
@@ -348,14 +346,12 @@ spec:
             livenessProbe:
               exec:
                 command:
-                - "bash"
                 - "/probes/livenessProbe.sh"
               initialDelaySeconds: 40
               periodSeconds: 5
             readinessProbe:
               exec:
                 command:
-                - "bash"
                 - "/probes/readinessProbe.sh"
               initialDelaySeconds: 2
               periodSeconds: 10

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -54,8 +54,11 @@ spec:
       - name: "weblogic-operator"
         image: {{ .image | quote }}
         imagePullPolicy: {{ .imagePullPolicy | quote }}
-        command: ["bash"]
-        args: ["/deployment/operator.sh"]
+        command: ["/deployment/operator.sh"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/deployment/stop.sh"]
         env:
         - name: "OPERATOR_NAMESPACE"
           valueFrom:
@@ -276,8 +279,11 @@ spec:
           - name: "weblogic-operator-webhook"
             image: {{ .image | quote }}
             imagePullPolicy: {{ .imagePullPolicy | quote }}
-            command: ["bash"]
-            args: ["/deployment/webhook.sh"]
+            command: ["/deployment/webhook.sh"]
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/deployment/stop.sh"]
             env:
             - name: "WEBHOOK_NAMESPACE"
               valueFrom:

--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -134,15 +134,13 @@ spec:
         {{- if not .remoteDebugNodePortEnabled }}
         livenessProbe:
           exec:
-            command:
-            - "/probes/livenessProbe.sh"
+            command: ["/probes/livenessProbe.sh"]
           initialDelaySeconds: 40
           periodSeconds: 10
           failureThreshold: 5
         readinessProbe:
           exec:
-            command:
-            - "/probes/readinessProbe.sh"
+            command: ["/probes/readinessProbe.sh"]
           initialDelaySeconds: 2
           periodSeconds: 10
         {{- end }}
@@ -345,14 +343,12 @@ spec:
             {{- if not .remoteDebugNodePortEnabled }}
             livenessProbe:
               exec:
-                command:
-                - "/probes/livenessProbe.sh"
+                command: ["/probes/livenessProbe.sh"]
               initialDelaySeconds: 40
               periodSeconds: 5
             readinessProbe:
               exec:
-                command:
-                - "/probes/readinessProbe.sh"
+                command: ["/probes/readinessProbe.sh"]
               initialDelaySeconds: 2
               periodSeconds: 10
             {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
@@ -16,5 +16,5 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create", "update", "patch"]
+  verbs: ["get", "create", "update", "patch", "delete]
 {{- end }}

--- a/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-role.tpl
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- define "operator.operatorRole" }}
@@ -16,5 +16,5 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
-  verbs: ["get", "create", "update", "patch", "delete]
+  verbs: ["get", "create", "update", "patch", "delete"]
 {{- end }}

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -13,7 +13,10 @@ import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentStrategy;
 import io.kubernetes.client.openapi.models.V1EnvVarSource;
+import io.kubernetes.client.openapi.models.V1ExecAction;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
+import io.kubernetes.client.openapi.models.V1Lifecycle;
+import io.kubernetes.client.openapi.models.V1LifecycleHandler;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1PolicyRule;
 import io.kubernetes.client.openapi.models.V1Probe;
@@ -218,8 +221,10 @@ abstract class CreateOperatorGeneratedFilesTestBase {
                                         .image(getInputs().getWeblogicOperatorImage())
                                         .imagePullPolicy(
                                             getInputs().getWeblogicOperatorImagePullPolicy())
-                                        .addCommandItem("bash")
-                                        .addArgsItem("/deployment/operator.sh")
+                                        .addCommandItem("/deployment/operator.sh")
+                                        .lifecycle(
+                                            new V1Lifecycle().preStop(new V1LifecycleHandler().exec(
+                                                new V1ExecAction().addCommandItem("/deployment/stop.sh"))))
                                         .addEnvItem(
                                             newEnvVar()
                                                 .name("OPERATOR_NAMESPACE")

--- a/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
+++ b/kubernetes/src/test/java/oracle/kubernetes/operator/create/CreateOperatorGeneratedFilesTestBase.java
@@ -310,7 +310,7 @@ abstract class CreateOperatorGeneratedFilesTestBase {
         .initialDelaySeconds(initialDelaySeconds)
         .periodSeconds(periodSeconds)
         .failureThreshold(failureThreshold)
-        .exec(newExecAction().addCommandItem("bash").addCommandItem(shellScript));
+        .exec(newExecAction().addCommandItem(shellScript));
   }
 
   @Test
@@ -763,7 +763,8 @@ abstract class CreateOperatorGeneratedFilesTestBase {
                 "get",
                 "create",
                 "update",
-                "patch"));
+                "patch",
+                "delete"));
   }
 
   @Test

--- a/operator/src/main/java/oracle/kubernetes/operator/BaseMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/BaseMain.java
@@ -189,6 +189,7 @@ public abstract class BaseMain {
 
   void waitForDeath() {
     Runtime.getRuntime().addShutdownHook(new Thread(shutdownSignal::release));
+    scheduleCheckForShutdownMarker();
 
     try {
       shutdownSignal.acquire();
@@ -197,6 +198,16 @@ public abstract class BaseMain {
     }
 
     stopAllWatchers();
+  }
+
+  void scheduleCheckForShutdownMarker() {
+    wrappedExecutorService.scheduleWithFixedDelay(
+        () -> {
+          File marker = new File(delegate.getDeploymentHome(), "marker.shutdown");
+          if (marker.exists()) {
+            shutdownSignal.release();
+          }
+        }, 5, 2, TimeUnit.SECONDS);
   }
 
   static Packet createPacketWithLoggingContext(String ns) {

--- a/operator/src/main/java/oracle/kubernetes/operator/BaseMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/BaseMain.java
@@ -153,10 +153,10 @@ public abstract class BaseMain {
 
     @Override
     public void run() {
-      releaseShutdownSignal();
       if (inner != null) {
         inner.run();
       }
+      releaseShutdownSignal();
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/BaseMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/BaseMain.java
@@ -185,6 +185,11 @@ public abstract class BaseMain {
 
   abstract BaseRestServer createRestServer();
 
+  // For test
+  AtomicReference<BaseServer> getRestServer() {
+    return restServer;
+  }
+
   void stopRestServer() {
     Optional.ofNullable(restServer.getAndSet(null)).ifPresent(BaseServer::stop);
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/OperatorMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/OperatorMain.java
@@ -172,8 +172,7 @@ public class OperatorMain extends BaseMain {
       // now we just wait until the pod is terminated
       operatorMain.waitForDeath();
 
-      operatorMain.stopRestServer();
-      operatorMain.stopMetricsServer();
+      operatorMain.stopDeployment(operatorMain::completeStop);
     } finally {
       LOGGER.info(MessageKeys.OPERATOR_SHUTTING_DOWN);
     }
@@ -284,6 +283,11 @@ public class OperatorMain extends BaseMain {
     } catch (Throwable e) {
       LOGGER.warning(MessageKeys.EXCEPTION, e);
     }
+  }
+
+  private void completeStop() {
+    stopRestServer();
+    stopMetricsServer();
   }
 
   NamespaceWatcher getNamespaceWatcher() {

--- a/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WebhookMain.java
@@ -84,8 +84,7 @@ public class WebhookMain extends BaseMain {
       // now we just wait until the pod is terminated
       main.waitForDeath();
 
-      main.stopRestServer();
-      main.stopMetricsServer();
+      main.stopDeployment(main::completeStop);
     } finally {
       LOGGER.info(MessageKeys.WEBHOOK_SHUTTING_DOWN);
     }
@@ -115,6 +114,11 @@ public class WebhookMain extends BaseMain {
             WebhookHelper.createValidatingWebhookConfigurationStep(certs)));
   }
 
+  @Override
+  protected Step createShutdownSteps() {
+    return WebhookHelper.deleteValidatingWebhookConfigurationStep();
+  }
+
   private static Step createInitializeWebhookIdentityStep(WebhookMainDelegate delegate, Step next) {
     return new InitializeWebhookIdentityStep(delegate, next);
   }
@@ -137,6 +141,11 @@ public class WebhookMain extends BaseMain {
       createConversionWebhookEvent(eventData);
 
     }
+  }
+
+  void completeStop() {
+    stopRestServer();
+    stopMetricsServer();
   }
 
   Runnable recheckCrd() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/WebhookHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/WebhookHelper.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 
 import io.kubernetes.client.openapi.models.AdmissionregistrationV1ServiceReference;
 import io.kubernetes.client.openapi.models.AdmissionregistrationV1WebhookClientConfig;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1RuleWithOperations;
 import io.kubernetes.client.openapi.models.V1ValidatingWebhook;
@@ -23,6 +24,7 @@ import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.calls.UnrecoverableErrorBuilder;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
+import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.utils.Certificates;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
@@ -337,6 +339,24 @@ public class WebhookHelper {
         return isNotAuthorizedOrForbidden(callResponse)
             ? doNext(packet) : super.onFailureNoRetry(packet, callResponse);
       }
+    }
+  }
+
+  public static Step deleteValidatingWebhookConfigurationStep() {
+    return new DeleteValidatingWebhookConfigurationStep();
+  }
+
+  private static class DeleteValidatingWebhookConfigurationStep extends Step {
+    @Override
+    public NextAction apply(Packet packet) {
+      return doNext(createActionStep(), packet);
+    }
+
+    private Step createActionStep() {
+      V1DeleteOptions deleteOptions = new V1DeleteOptions();
+      return new CallBuilder()
+          .deleteValidatingWebhookConfigurationAsync(VALIDATING_WEBHOOK_NAME, deleteOptions,
+              new DefaultResponseStep<>(getNext()));
     }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/OperatorMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/OperatorMainTest.java
@@ -108,6 +108,7 @@ import static oracle.kubernetes.operator.helpers.NamespaceHelper.getOperatorName
 import static oracle.kubernetes.operator.tuning.TuningParameters.DEFAULT_CALL_LIMIT;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -322,6 +323,15 @@ class OperatorMainTest extends ThreadFactoryTestBase {
     testSupport.defineResources(event1, event2);
     operatorMain.startDeployment(null);
     assertThat(getNSEventMapSize(), equalTo(2));
+  }
+
+  @Test
+  void whenOperatorShutdown_completionCallbackOccursBeforeFollowingLogic() {
+    final List<String> callOrder = Collections.synchronizedList(new ArrayList<>());
+    operatorMain.stopDeployment(() -> callOrder.add("completionCallback"));
+    callOrder.add("afterStoppedDeployment");
+
+    assertThat(callOrder, hasItems("completionCallback", "afterStoppedDeployment"));
   }
 
   private int getNSEventMapSize() {

--- a/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
@@ -107,6 +107,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class WebhookMainTest extends ThreadFactoryTestBase {
@@ -579,6 +580,20 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
     assertThat(logRecords,
         not(containsInfo(REPLACE_VALIDATING_WEBHOOK_CONFIGURATION_FAILED).withParams(VALIDATING_WEBHOOK_NAME)));
     testSupport.verifyCompletionThrowable(UnrecoverableCallException.class);
+  }
+
+  @Test
+  void whenWebhookShutdown_deleteValidatingWebhookConfiguration() {
+    setServiceCaBundle(testCaBundle);
+    setServiceNamespace(testNamespace);
+    testSupport.defineResources(testValidatingWebhookConfig);
+
+    testSupport.runSteps(main.createShutdownSteps());
+
+    logRecords.clear();
+    V1ValidatingWebhookConfiguration generatedConfiguration = getCreatedValidatingWebhookConfiguration();
+
+    assertThat(generatedConfiguration, nullValue());
   }
 
   private V1ObjectMeta createNameOnlyMetadata() {

--- a/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
@@ -104,6 +104,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -594,6 +595,15 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
     V1ValidatingWebhookConfiguration generatedConfiguration = getCreatedValidatingWebhookConfiguration();
 
     assertThat(generatedConfiguration, nullValue());
+  }
+
+  @Test
+  void whenWebhookShutdown_completionCallbackOccursBeforeFollowingLogic() {
+    final List<String> callOrder = Collections.synchronizedList(new ArrayList<>());
+    main.stopDeployment(() -> callOrder.add("completionCallback"));
+    callOrder.add("afterStoppedDeployment");
+
+    assertThat(callOrder, hasItems("completionCallback", "afterStoppedDeployment"));
   }
 
   private V1ObjectMeta createNameOnlyMetadata() {

--- a/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/WebhookMainTest.java
@@ -606,6 +606,13 @@ public class WebhookMainTest extends ThreadFactoryTestBase {
     assertThat(callOrder, hasItems("completionCallback", "afterStoppedDeployment"));
   }
 
+  @Test
+  void whenShutdownMarkerIsCreate_stopWebhook() {
+    inMemoryFileSystem.defineFile("/deployment/marker.shutdown", "shutdown");
+    main.waitForDeath();
+    assertThat(main.getShutdownSignalAvailablePermits(), equalTo(0));
+  }
+
   private V1ObjectMeta createNameOnlyMetadata() {
     return new V1ObjectMeta().name(VALIDATING_WEBHOOK_NAME);
   }


### PR DESCRIPTION
The initial idea was that the webhook should delete the ValidatingWebhookConfiguration during its shutdown so that this resource would not be stranded. 

While working on that, I discovered that neither the webhook or operator were really cleanly shutting down -- that is, the runtime signal handler was never being called. Therefore, I put in a preStop handler and added handling to make sure that either process would get to complete its shutdown behavior before exiting.

Then, I added the handling to the webhook to delete the VWC.