### PR TITLE
Owls 105072 - Changes to generate cluster deleted event when deleted cluster found during explicit LIST

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -15,6 +15,7 @@ import io.kubernetes.client.openapi.models.V1PodDisruptionBudget;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watch.Response;
+import oracle.kubernetes.operator.helpers.ClusterPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.EventHelper.EventItem;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
@@ -108,6 +109,14 @@ public interface DomainProcessor {
    * @return Map of cached domain presence infos.
    */
   default Map<String, Map<String,DomainPresenceInfo>>  getDomainPresenceInfoMap() {
+    return new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Get the map of cluster presence infos.
+   * @return Map of cached cluster presence infos.
+   */
+  default Map<String, Map<String, ClusterPresenceInfo>>  getClusterPresenceInfoMap() {
     return new ConcurrentHashMap<>();
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -35,6 +35,7 @@ import oracle.kubernetes.operator.calls.UnrecoverableCallException;
 import oracle.kubernetes.operator.helpers.ClusterPresenceInfo;
 import oracle.kubernetes.operator.helpers.ConfigMapHelper;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.EventHelper;
 import oracle.kubernetes.operator.helpers.EventHelper.ClusterResourceEventData;
 import oracle.kubernetes.operator.helpers.EventHelper.EventData;
 import oracle.kubernetes.operator.helpers.EventHelper.EventItem;
@@ -1011,8 +1012,13 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
 
     @Override
     protected void cacheResourcePresenceInfo(ResourcePresenceInfo presenceInfo) {
-      clusters.computeIfAbsent(presenceInfo.getNamespace(), c -> new ConcurrentHashMap<>())
-          .computeIfAbsent(presenceInfo.getResourceName(), k -> (ClusterPresenceInfo) presenceInfo);
+      if (operation.getEventData().getItem() == EventHelper.EventItem.CLUSTER_DELETED) {
+        Optional.ofNullable(clusters.get(presenceInfo.getNamespace()))
+            .ifPresent(m -> m.remove(presenceInfo.getResourceName()));
+      } else {
+        clusters.computeIfAbsent(presenceInfo.getNamespace(), c -> new ConcurrentHashMap<>())
+            .computeIfAbsent(presenceInfo.getResourceName(), k -> (ClusterPresenceInfo) presenceInfo);
+      }
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -105,7 +105,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   @SuppressWarnings("FieldMayBeFinal")
   private static Map<String, Map<String, ScheduledFuture<?>>> statusUpdaters = new ConcurrentHashMap<>();
 
-  // List of clusters in a domain.
+  // List of clusters in a namespace.
   private static Map<String, Map<String, ClusterPresenceInfo>> clusters = new ConcurrentHashMap<>();
 
   private final DomainProcessorDelegate delegate;
@@ -920,6 +920,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
 
     @Override
     protected void cacheResourcePresenceInfo(ResourcePresenceInfo presenceInfo) {
+      //No-op.
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -234,7 +234,6 @@ class DomainResourcesValidation {
   }
 
   private void deActivateCluster(DomainProcessor dp, ClusterPresenceInfo info) {
-    getClusterPresenceInfoMap().remove(info.getResourceName());
     dp.createMakeRightOperationForClusterEvent(EventHelper.EventItem.CLUSTER_DELETED, info.getResource()).execute();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -97,11 +97,11 @@ class DomainResourcesValidation {
   }
 
   private void executeMakeRightForDeletedClusters(DomainProcessor dp) {
-    List<String> clusterNamesFromList = Optional.ofNullable(activeClusterResources).map(c -> c.getItems())
+    List<String> clusterNamesFromList = Optional.ofNullable(activeClusterResources).map(ClusterList::getItems)
         .orElse(new ArrayList<>()).stream().map(ClusterResource::getMetadata).map(V1ObjectMeta::getName)
         .collect(Collectors.toList());
     getClusterPresenceInfoMap().values().stream()
-        .filter(i -> !clusterNamesFromList.contains(i.getResourceName())).collect(Collectors.toList())
+        .filter(cpi -> !clusterNamesFromList.contains(cpi.getResourceName())).collect(Collectors.toList())
         .forEach(info -> deActivateCluster(dp, info));
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -233,7 +233,8 @@ class DomainResourcesValidation {
     makeRight.execute();
   }
 
-  private static void deActivateCluster(DomainProcessor dp, ClusterPresenceInfo info) {
+  private void deActivateCluster(DomainProcessor dp, ClusterPresenceInfo info) {
+    getClusterPresenceInfoMap().remove(info.getResourceName());
     dp.createMakeRightOperationForClusterEvent(EventHelper.EventItem.CLUSTER_DELETED, info.getResource()).execute();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightClusterOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightClusterOperation.java
@@ -25,4 +25,11 @@ public interface MakeRightClusterOperation extends MakeRightOperation<ClusterPre
    */
   MakeRightClusterOperation interrupt();
 
+  /**
+   * Get the event data associated with this make-right operation.
+   *
+   * @return the event data.
+   */
+  EventHelper.EventData getEventData();
+
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ClusterPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ClusterPresenceInfo.java
@@ -33,6 +33,10 @@ public class ClusterPresenceInfo extends ResourcePresenceInfo {
     return Optional.of(cluster).map(ClusterResource::getMetadata).map(V1ObjectMeta::getName).orElse(null);
   }
 
+  public ClusterResource getResource() {
+    return cluster;
+  }
+
   @Override
   public void addToPacket(Packet packet) {
     packet.getComponents().put(COMPONENT_KEY, Component.createFor(this));

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightClusterOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightClusterOperationImpl.java
@@ -86,4 +86,9 @@ public class MakeRightClusterOperationImpl extends MakeRightOperationImpl<Cluste
   public ClusterPresenceInfo getPresenceInfo() {
     return liveInfo;
   }
+
+  @Override
+  public EventHelper.EventData getEventData() {
+    return eventData;
+  }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -217,6 +217,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
     MatcherAssert.assertThat(getDeletedClusterEvents(dp, CLUSTER_1), nullValue());
     MatcherAssert.assertThat(getDeletedClusterEvents(dp, CLUSTER_2), notNullValue());
     MatcherAssert.assertThat(getDeletedClusterEvents(dp, CLUSTER_3), nullValue());
+    MatcherAssert.assertThat(clusterPresenceInfoMap.size(), equalTo(2));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -196,7 +196,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenClusterResourceDeletedAndNotReferencedByDomain_triggerClusterMakeRightToGenerateClusterDeletedEvent() {
+  void whenUnreferencedClusterResourceDeleted_triggerClusterMakeRightToGenerateClusterDeletedEvent() {
     testSupport.addComponent("DP", DomainProcessor.class, dp);
     Map<String,ClusterPresenceInfo> clusterPresenceInfoMap = new ConcurrentHashMap<>();
     for (String clusterName : List.of(CLUSTER_1, CLUSTER_2, CLUSTER_3)) {
@@ -209,9 +209,9 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
 
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
     testSupport.deleteResources(
-        testSupport.<ClusterResource>getResourceWithName(CLUSTER, CLUSTER_2));
-    testSupport.deleteResources(
         testSupport.<DomainResource>getResourceWithName(DOMAIN, domain.getDomainUid()));
+    testSupport.deleteResources(
+        testSupport.<ClusterResource>getResourceWithName(CLUSTER, CLUSTER_2));
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
 
     MatcherAssert.assertThat(getDeletedClusterEvents(dp, CLUSTER_1), nullValue());


### PR DESCRIPTION
Owls 105072 - If the watch event notification is missed when a cluster resource is deleted, trigger the make-right to generate cluster DELETE event during explicit LIST. This PR caches the ClusterResourceInfo during the initial make-right and then checks for the delta during the explicit listing. If the cluster is present in the ClusterResourceInfo cache but is missing from the returned list, then it triggers  make-right to generate the event.

Integration test runs - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14875/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/14874/


