### PR TITLE
OWLS-105263 - Fix for missing domain deletion event in integration test run.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -213,7 +213,8 @@ class DomainResourcesValidation {
   private static void removeStrandedDomainPresenceInfo(DomainProcessor dp, DomainPresenceInfo info) {
     info.setDeleting(true);
     info.setPopulated(true);
-    dp.createMakeRightOperation(info).withExplicitRecheck().forDeletion().execute();
+    dp.createMakeRightOperation(info).withExplicitRecheck().forDeletion().withEventData(new EventData(
+        EventHelper.EventItem.DOMAIN_DELETED)).execute();
   }
 
   private Stream<DomainPresenceInfo> getActiveDomainPresenceInfos() {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -464,6 +464,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
       private final Map<String, DomainPresenceInfo> dpis;
       private boolean explicitRecheck;
       private boolean deleting;
+      private EventHelper.EventData eventData;
 
       MakeRightDomainOperationStub(DomainPresenceInfo info, Map<String, DomainPresenceInfo> dpis) {
         this.info = info;
@@ -491,6 +492,12 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
       @Override
       public MakeRightDomainOperation forDeletion() {
         deleting = true;
+        return this;
+      }
+
+      @Override
+      public MakeRightDomainOperation withEventData(EventHelper.EventData eventData) {
+        this.eventData = eventData;
         return this;
       }
 


### PR DESCRIPTION
OWLS-105263 - Generate a DOMAIN delete event when domain is deleted but is already present in the DomainPrecenseInfo cache. 