### PR TITLE
Fix intermittent test issue when scaling down the cluster in ItMultiDomainModels.testScaleClustersAndAdminConsoleLogin

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMultiDomainModels.java
@@ -176,17 +176,17 @@ class ItMultiDomainModels {
     }
 
     Callable<Boolean> isDynRestarted =
-        assertDoesNotThrow(() -> isPodRestarted(dynamicServerPodName,
-            domainNamespace, dynTs));
+        assertDoesNotThrow(() -> isPodRestarted(dynamicServerPodName, domainNamespace, dynTs));
     assertFalse(assertDoesNotThrow(isDynRestarted::call),
-
         "Dynamic managed server pod must not be restated");
+
     // then scale cluster back to 1 server
     logger.info("Scaling back cluster {0} of domain {1} in namespace {2} from {3} servers to {4} servers.",
         clusterName, domainUid, domainNamespace,numberOfServers,replicaCount);
     assertDoesNotThrow(() -> scaleCluster(clusterName, domainNamespace,
         replicaCount), "Could not scale down the cluster");
-    for (int i = (replicaCount + 1); i <= numberOfServers; i++) {
+
+    for (int i = numberOfServers; i > replicaCount; i--) {
       logger.info("Wait for managed server pod {0} to be deleted in namespace {1}",
           managedServerPrefix + i, domainNamespace);
       checkPodDeleted(managedServerPrefix + i, domainUid, domainNamespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PodUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/PodUtils.java
@@ -333,7 +333,7 @@ public class PodUtils {
    */
   public static void checkPodDeleted(String podName, String domainUid, String domNamespace) {
     final LoggingFacade logger = getLogger();
-    testUntil(
+    testUntil(withLongRetryPolicy,
         assertDoesNotThrow(() -> podDoesNotExist(podName, domainUid, domNamespace),
           String.format("podDoesNotExist failed with ApiException for %s in namespace in %s",
             podName, domNamespace)),


### PR DESCRIPTION
Fix intermittent test issue when scaling down the cluster in ItMultiDomainModels.testScaleClustersAndAdminConsoleLogin.

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15016/