### PR TITLE
Resolve upgrade issue based on change to logHomeLayout

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -288,6 +289,16 @@ public abstract class BasePodStepContext extends StepContextBase {
       }
     }
     return null;
+  }
+
+  protected void removeEnvVar(List<V1EnvVar> vars, String name) {
+    Iterator<V1EnvVar> it = vars.iterator();
+    while (it.hasNext()) {
+      if (name.equals(it.next().getName())) {
+        it.remove();
+        break;
+      }
+    }
   }
 
   protected void addOrReplaceEnvVar(List<V1EnvVar> vars, String name, String value) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -1318,9 +1318,6 @@ public abstract class PodStepContext extends BasePodStepContext {
     }
 
     private void restoreLogHomeLayoutEnvVar(V1Pod recipe, V1Pod currentPod) {
-      // currentPod = NoEnvVar -> recipe = FLAT
-      // currentPod = ByServers -> recipe = NoEnvVar
-
       getContainer(recipe).map(V1Container::getEnv).ifPresent(envVars ->
           Optional.ofNullable(findEnvVar(envVars, ServerEnvVars.LOG_HOME_LAYOUT)).ifPresent(ev -> {
             if (LogHomeLayoutType.FLAT.toString().equals(ev.getValue())) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -1327,15 +1327,6 @@ public abstract class PodStepContext extends BasePodStepContext {
               }
             }
           }));
-      getContainer(currentPod).map(V1Container::getEnv).ifPresent(envVars ->
-          Optional.ofNullable(findEnvVar(envVars, ServerEnvVars.LOG_HOME_LAYOUT)).ifPresent(ev -> {
-            if (!LogHomeLayoutType.FLAT.toString().equals(ev.getValue())) {
-              List<V1EnvVar> recipeEVs = getContainer(recipe).map(V1Container::getEnv).orElse(new ArrayList<>());
-              if (findEnvVar(recipeEVs, ServerEnvVars.LOG_HOME_LAYOUT) == null) {
-                addEnvVar(recipeEVs, ServerEnvVars.LOG_HOME_LAYOUT, ev.getValue());
-              }
-            }
-          }));
     }
 
     private boolean canAdjustRecentOperatorMajorVersion3HashToMatch(V1Pod currentPod, String requiredHash) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -603,6 +603,33 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
   void afterUpgradeIstioMonitoringExporterPodWithResourceRequirements_replacePod() {
     useProductionHash();
     defineExporterConfigurationWithResourceRequirements();
+
+    initializeExistingPod(loadPodModel(getReferenceIstioMonitoringExporterTcpProtocol()));
+
+    verifyPodReplaced();
+  }
+
+  @Test
+  void afterUpgradeLogHomeLayoutStillFlat_dontReplacePod() {
+    useProductionHash();
+    defineExporterConfiguration();
+
+    configurator.withLogHomeLayout(LogHomeLayoutType.FLAT);
+
+    initializeExistingPod(loadPodModel(getReferenceIstioMonitoringExporterTcpProtocol()));
+
+    // Surprisingly, verifyPodPatched() is the correct assertion -- because the logic to adjust the recipe and
+    // generate hashes for pre-existing pods works correctly, the existing pod will not be replaced; however,
+    // it will be patched to update the weblogic.operatorVersion label and the annotation with the hash.
+    verifyPodPatched();
+  }
+
+  @Test
+  void afterUpgradeLogHomeLayoutByServers_replacePod() {
+    useProductionHash();
+    defineExporterConfigurationWithResourceRequirements();
+
+    configurator.withLogHomeLayout(LogHomeLayoutType.BY_SERVERS);
 
     initializeExistingPod(loadPodModel(getReferenceIstioMonitoringExporterTcpProtocol()));
 


### PR DESCRIPTION
This adds another potential adjustment to recipe pods to match historical pods. In this case, pods created with 3.4.x have a default logHomeLayout of Flat while the default for 4.0.x is ByServers. Because of this, the recipe would not default to having a "LOG_HOME_LAYOUT" environment variable where it did not previously have one. 