### PR TITLE
Owls 105422 - periodically read the domain resource while waiting for the server to shut down.

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -253,11 +253,6 @@ public class JobWatcher extends Watcher<V1Job> implements WatchListener<V1Job>, 
       return isComplete(job) || isFailed(job);
     }
 
-    @Override
-    boolean onReadNotFoundForCachedResource(V1Job cachedJob, boolean isNotFoundOnRead) {
-      return false;
-    }
-
     // Ignore modified callbacks from different jobs (identified by having different creation times) or those
     // where the job is not yet ready.
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
@@ -36,11 +36,11 @@ public interface PodAwaiterStepFactory {
   Step waitForDelete(V1Pod pod, Step next);
 
   /**
-   * Waits until the Pod is unready.
+   * Waits until the Pod server is shut down.
    *
-   * @param serverName Server to watch
-   * @param domain Domain name
-   * @param next Next processing step once Pod is unready
+   * @param serverName Pod Server name to watch
+   * @param domain Domain resource
+   * @param next Next processing step once Pod is shut down
    * @return Asynchronous step
    */
   Step waitForServerShutdown(String serverName, DomainResource domain, Step next);

--- a/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
@@ -5,6 +5,7 @@ package oracle.kubernetes.operator;
 
 import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
 public interface PodAwaiterStepFactory {
   /**
@@ -37,9 +38,10 @@ public interface PodAwaiterStepFactory {
   /**
    * Waits until the Pod is unready.
    *
-   * @param pod Pod to watch
+   * @param serverName Server to watch
+   * @param domain Domain name
    * @param next Next processing step once Pod is unready
    * @return Asynchronous step
    */
-  Step waitForUnready(V1Pod pod, Step next);
+  Step waitForUnready(String serverName, DomainResource domain, Step next);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
@@ -43,5 +43,5 @@ public interface PodAwaiterStepFactory {
    * @param next Next processing step once Pod is unready
    * @return Asynchronous step
    */
-  Step waitForUnready(String serverName, DomainResource domain, Step next);
+  Step waitForServerShutdown(String serverName, DomainResource domain, Step next);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodAwaiterStepFactory.java
@@ -33,4 +33,13 @@ public interface PodAwaiterStepFactory {
    * @return Asynchronous step
    */
   Step waitForDelete(V1Pod pod, Step next);
+
+  /**
+   * Waits until the Pod is unready.
+   *
+   * @param pod Pod to watch
+   * @param next Next processing step once Pod is unready
+   * @return Asynchronous step
+   */
+  Step waitForUnready(V1Pod pod, Step next);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -427,7 +427,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
     @Override
     Step createReadAsyncStep(String name, String namespace, String domainUid,
                              ResponseStep<DomainResource> responseStep) {
-      return new CallBuilder().readDomainAsync(domainUid, namespace, responseStep);
+      return new CallBuilder().readDomainAsync(name, namespace, responseStep);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -409,10 +409,12 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
     @Override
     void addCallback(String name, Consumer<DomainResource> callback) {
+      // Ignore
     }
 
     @Override
     void removeCallback(String name, Consumer<DomainResource> callback) {
+      // Ignore
     }
 
     @Override
@@ -431,7 +433,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
       private final WaitForReadyStep<DomainResource>.Callback callback;
       private final String serverName;
 
-      WaitForServerShutdownResponseStep(WaitForReadyStep.Callback callback, String serverName) {
+      WaitForServerShutdownResponseStep(WaitForReadyStep<DomainResource>.Callback callback, String serverName) {
         super(WaitForServerShutdownStep.this.getNext());
         this.callback = callback;
         this.serverName = serverName;

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -83,7 +83,9 @@ abstract class WaitForReadyStep<T> extends Step {
    *
    * @return true if cached resource not found on read
    */
-  abstract boolean onReadNotFoundForCachedResource(T cachedResource, boolean isNotFoundOnRead);
+  boolean onReadNotFoundForCachedResource(T cachedResource, boolean isNotFoundOnRead) {
+    return false;
+  }
 
   /**
    * Returns true if the callback for this resource should be processed. This is typically used to exclude

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -167,6 +167,21 @@ public class PodHelper {
   }
 
   /**
+   * get if pod is in ready state.
+   * @param pod pod
+   * @return true, if pod is ready
+   */
+  public static boolean hasContainersReadyStatus(V1Pod pod) {
+    return Optional.ofNullable(pod)
+        .map(V1Pod::getStatus)
+        .filter(PodHelper::isRunning)
+        .map(V1PodStatus::getConditions)
+        .orElse(Collections.emptyList())
+        .stream()
+        .anyMatch(PodHelper::isContainersReadyCondition);
+  }
+
+  /**
    * Get pod's Ready condition if the pod is in Running phase.
    * @param pod pod
    * @return V1PodCondition, if exists, otherwise null.
@@ -209,6 +224,10 @@ public class PodHelper {
 
   private static boolean isReadyCondition(V1PodCondition condition) {
     return "Ready".equals(condition.getType()) && "True".equals(condition.getStatus());
+  }
+
+  private static boolean isContainersReadyCondition(V1PodCondition condition) {
+    return "ContainersReady".equals(condition.getType()) && "True".equals(condition.getStatus());
   }
 
   private static boolean isReadyNotTrueCondition(V1PodCondition condition) {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -183,8 +183,8 @@ public class PodHelper {
   }
 
   /**
-   * Get the server state From DPI or the domain resource.
-   * @param domain domain resource
+   * Get the server state From the domain resource.
+   * @param domain domain resource.
    * @param serverName Name of the server.
    * @return server state, if exists, otherwise null.
    */

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -51,6 +51,7 @@ import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVERS_TO_ROLL;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
+import static oracle.kubernetes.operator.WebLogicConstants.UNKNOWN_STATE;
 
 @SuppressWarnings("ConstantConditions")
 public class PodHelper {
@@ -741,6 +742,7 @@ public class PodHelper {
         if (isServerShutdown(getServerStateFromInfo(info, serverName))) {
           gracePeriodSeconds = 0;
         }
+
         return doNext(
             deletePod(name, info.getNamespace(), getPodDomainUid(oldPod), gracePeriodSeconds, getNext()),
             packet);
@@ -749,7 +751,8 @@ public class PodHelper {
 
     @Nonnull
     private Boolean isServerShutdown(String serverState) {
-      return Optional.ofNullable(serverState).map(SHUTDOWN_STATE::equals).orElse(false);
+      return Optional.ofNullable(serverState).map(s -> SHUTDOWN_STATE.equals(s) || UNKNOWN_STATE.equals(s))
+          .orElse(false);
     }
 
     @Nullable

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -51,7 +51,6 @@ import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.SERVERNAME_LABEL;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVERS_TO_ROLL;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
-import static oracle.kubernetes.operator.WebLogicConstants.UNKNOWN_STATE;
 
 @SuppressWarnings("ConstantConditions")
 public class PodHelper {
@@ -741,10 +740,6 @@ public class PodHelper {
         long gracePeriodSeconds = getGracePeriodSeconds(info, clusterName);
         if (isServerShutdown(getServerStateFromInfo(info, serverName))) {
           gracePeriodSeconds = 0;
-        } else if (isServerStateUnknown(getServerStateFromInfo(info, serverName))) {
-          // Server status is unknown, add a 10 second fudge factor here to account for the fact that WLST takes
-          // ~6 seconds to start.
-          gracePeriodSeconds = DEFAULT_ADDITIONAL_DELETE_TIME;
         }
         return doNext(
             deletePod(name, info.getNamespace(), getPodDomainUid(oldPod), gracePeriodSeconds, getNext()),
@@ -755,10 +750,6 @@ public class PodHelper {
     @Nonnull
     private Boolean isServerShutdown(String serverState) {
       return Optional.ofNullable(serverState).map(SHUTDOWN_STATE::equals).orElse(false);
-    }
-
-    private Boolean isServerStateUnknown(String serverState) {
-      return Optional.ofNullable(serverState).map(UNKNOWN_STATE::equals).orElse(false);
     }
 
     @Nullable

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -14,8 +14,6 @@ import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 
-import static oracle.kubernetes.operator.steps.ShutdownManagedServerStep.createWaitForServerShutdownWithHttpStep;
-
 public class ServerDownStep extends Step {
   private final String serverName;
   private final boolean isPreserveServices;
@@ -53,7 +51,6 @@ public class ServerDownStep extends Step {
   @Nonnull
   private Step createShutdownManagedServerStep(V1Pod oldPod, Step next) {
     return ShutdownManagedServerStep
-        .createShutdownManagedServerStep(createWaitForServerShutdownWithHttpStep(
-            (PodHelper.deletePodStep(serverName, next)), serverName), serverName, oldPod);
+        .createShutdownManagedServerStep(PodHelper.deletePodStep(serverName, next), serverName, oldPod);
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ServerDownStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -338,7 +338,7 @@ public class ShutdownManagedServerStep extends Step {
       LOGGER.fine(MessageKeys.SERVER_SHUTDOWN_REST_SUCCESS, serverName);
       removeShutdownRequestRetryCount(packet);
       PodAwaiterStepFactory pw = packet.getSpi(PodAwaiterStepFactory.class);
-      return doNext(pw.waitForUnready(serverName, getDomainPresenceInfo(packet).getDomain(), getNext()), packet);
+      return doNext(pw.waitForServerShutdown(serverName, getDomainPresenceInfo(packet).getDomain(), getNext()), packet);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -40,6 +40,7 @@ import oracle.kubernetes.operator.wlsconfig.WlsServerConfig;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 
 import static oracle.kubernetes.operator.KubernetesConstants.WLS_CONTAINER_NAME;
@@ -309,6 +310,7 @@ public class ShutdownManagedServerStep extends Step {
       ShutdownManagedServerResponseStep shutdownManagedServerResponseStep =
           new ShutdownManagedServerResponseStep(PodHelper.getPodServerName(pod), getNext());
       HttpAsyncRequestStep requestStep = processing.createRequestStep(shutdownManagedServerResponseStep);
+      packet.put("HTTP_SHUTDOWN_START_TIME", SystemClock.now());
       return doNext(requestStep, packet);
     }
 
@@ -333,7 +335,7 @@ public class ShutdownManagedServerStep extends Step {
       LOGGER.fine(MessageKeys.SERVER_SHUTDOWN_REST_SUCCESS, serverName);
       removeShutdownRequestRetryCount(packet);
       PodAwaiterStepFactory pw = packet.getSpi(PodAwaiterStepFactory.class);
-      return doNext(pw.waitForUnready(getDomainPresenceInfo(packet).getServerPod(serverName), getNext()), packet);
+      return doNext(pw.waitForUnready(serverName, getDomainPresenceInfo(packet).getDomain(), getNext()), packet);
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -4,6 +4,7 @@
 package oracle.kubernetes.operator;
 
 import java.io.File;
+import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -12,9 +13,11 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.VersionInfo;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.KubernetesVersion;
+import oracle.kubernetes.operator.helpers.PodHelper;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.FiberGate;
 import oracle.kubernetes.operator.work.FiberTestSupport;
+import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
@@ -23,6 +26,7 @@ import static com.meterware.simplestub.Stub.createStrictStub;
 import static oracle.kubernetes.operator.JobWatcher.getFailedReason;
 import static oracle.kubernetes.operator.JobWatcher.isFailed;
 import static oracle.kubernetes.operator.ProcessingConstants.DELEGATE_COMPONENT_NAME;
+import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 
 /**
  * A test stub for processing domains in unit tests.
@@ -73,7 +77,7 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
 
   @Override
   public PodAwaiterStepFactory getPodAwaiterStepFactory(String namespace) {
-    return new PassthroughPodAwaiterStepFactory();
+    return new PassThroughWithServerShutdownAwaiterStepFactory();
   }
 
   @Override
@@ -134,8 +138,35 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
     }
 
     @Override
-    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
+    public Step waitForServerShutdown(String serverName, DomainResource domain, Step next) {
       return next;
+    }
+  }
+
+  private class PassThroughWithServerShutdownAwaiterStepFactory extends PassthroughPodAwaiterStepFactory {
+    @Override
+    public Step waitForServerShutdown(String serverName, DomainResource domain, Step next) {
+      if (Optional.ofNullable(PodHelper.getServerState(domain, serverName))
+          .map(s -> s.equals(SHUTDOWN_STATE)).orElse(false)) {
+        return next;
+      } else {
+        return new DelayStep(next, 1);
+      }
+    }
+  }
+
+  private static class DelayStep extends Step {
+    private final int delay;
+    private final Step next;
+
+    DelayStep(Step next, int delay) {
+      this.delay = delay;
+      this.next = next;
+    }
+
+    @Override
+    public NextAction apply(Packet packet) {
+      return doDelay(next, packet, delay, TimeUnit.SECONDS);
     }
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -131,6 +131,11 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
     public Step waitForDelete(V1Pod pod, Step next) {
       return next;
     }
+
+    @Override
+    public Step waitForUnready(V1Pod pod, Step next) {
+      return next;
+    }
   }
 
   private class TestJobAwaiterStepFactory implements JobAwaiterStepFactory {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorDelegateStub.java
@@ -17,6 +17,7 @@ import oracle.kubernetes.operator.work.FiberGate;
 import oracle.kubernetes.operator.work.FiberTestSupport;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
+import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
 import static oracle.kubernetes.operator.JobWatcher.getFailedReason;
@@ -133,7 +134,7 @@ public abstract class DomainProcessorDelegateStub implements DomainProcessorDele
     }
 
     @Override
-    public Step waitForUnready(V1Pod pod, Step next) {
+    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
       return next;
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -3,8 +3,6 @@
 
 package oracle.kubernetes.operator;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -133,7 +131,6 @@ import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTIO
 import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR_JOB;
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
-import static oracle.kubernetes.operator.WebLogicConstants.SUSPENDING_STATE;
 import static oracle.kubernetes.operator.helpers.AffinityHelper.getDefaultAntiAffinity;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.CLUSTER_CHANGED;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.CLUSTER_CREATED;
@@ -589,53 +586,13 @@ class DomainProcessorTest {
     processor.createMakeRightOperation(newInfo).execute();
 
     domainConfigurator.withDefaultServerStartPolicy(ServerStartPolicy.NEVER);
-    DomainStatus status = newInfo.getDomain().getStatus();
-    defineServerShutdownWithHttpOkResponse();
-    setAdminServerStatus(status, SUSPENDING_STATE);
-    setManagedServerState(status, SUSPENDING_STATE);
 
     processor.createMakeRightOperation(newInfo).withExplicitRecheck().execute();
     DomainResource updatedDomain = testSupport.getResourceWithName(DOMAIN, UID);
 
-    assertThat(getRunningPods().size(), equalTo(4));
-    setAdminServerStatus(status, SHUTDOWN_STATE);
-    setManagedServerState(status, SHUTDOWN_STATE);
-    testSupport.setTime(100, TimeUnit.SECONDS);
+    makePodsUnready();
     assertThat(getRunningPods().size(), equalTo(1));
     assertThat(getResourceVersion(updatedDomain), not(getResourceVersion(domain)));
-  }
-
-  private void defineServerShutdownWithHttpOkResponse() {
-    httpSupport.defineResponse(createShutdownRequest(ADMIN_NAME, 7001),
-        createStub(HttpResponseStub.class, HTTP_OK, OK_RESPONSE));
-    IntStream.range(1, 3).forEach(idx -> httpSupport.defineResponse(
-        createShutdownRequest("cluster-managed-server" + idx, 8001),
-        createStub(HttpResponseStub.class, HTTP_OK, OK_RESPONSE)));
-  }
-
-  private HttpRequest createShutdownRequest(String serverName, int portNumber) {
-    String url = "http://test-domain-" + serverName + ".namespace:" + portNumber;
-    return HttpRequest.newBuilder()
-        .uri(URI.create(url + "/management/weblogic/latest/serverRuntime/shutdown"))
-        .POST(HttpRequest.BodyPublishers.noBody())
-        .build();
-  }
-
-  private void setManagedServerState(DomainStatus status, String suspendingState) {
-    IntStream.range(1, 3).forEach(idx -> getManagedServerStatus(status, idx).setState(suspendingState));
-  }
-
-  private void setAdminServerStatus(DomainStatus status, String state) {
-    status.getServers().stream().filter(s -> matchingServerName(s, ADMIN_NAME)).forEach(s -> s.setState(state));
-  }
-
-  private ServerStatus getManagedServerStatus(DomainStatus status, int idx) {
-    return status.getServers().stream()
-        .filter(s -> matchingServerName(s, getManagedServerName(idx))).findAny().orElse(null);
-  }
-
-  private boolean matchingServerName(ServerStatus serverStatus, String serverName) {
-    return serverStatus.getServerName().equals(serverName);
   }
 
   @Test
@@ -696,6 +653,18 @@ class DomainProcessorTest {
   private V1PodStatus createReadyStatus() {
     return new V1PodStatus().phase("Running")
           .addConditionsItem(new V1PodCondition().type("Ready").status("True"));
+  }
+
+  private void makePodsUnready() {
+    testSupport.<V1Pod>getResources(POD).stream()
+        .filter(this::isWlsServer)
+        .forEach(pod -> pod.setStatus(createReadyStatus()));
+  }
+
+  private V1PodStatus createUnreadyStatus() {
+    return new V1PodStatus().phase("Running")
+        .addConditionsItem(new V1PodCondition().type("Ready").status("False"))
+        .addConditionsItem(new V1PodCondition().type("ContainersReady").status("False"));
   }
 
   private V1Secret createCredentialsSecret() {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -134,6 +134,7 @@ import static oracle.kubernetes.operator.ProcessingConstants.DOMAIN_INTROSPECTOR
 import static oracle.kubernetes.operator.WebLogicConstants.RUNNING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.SUSPENDING_STATE;
+import static oracle.kubernetes.operator.WebLogicConstants.UNKNOWN_STATE;
 import static oracle.kubernetes.operator.helpers.AffinityHelper.getDefaultAntiAffinity;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.CLUSTER_CHANGED;
 import static oracle.kubernetes.operator.helpers.EventHelper.EventItem.CLUSTER_CREATED;
@@ -734,6 +735,23 @@ class DomainProcessorTest {
     processor.createMakeRightOperation(newInfo).withExplicitRecheck().execute();
 
     assertThat((int) getServerServices().count(), equalTo(MIN_REPLICAS + NUM_ADMIN_SERVERS));
+    assertThat(getRunningPods().size(), equalTo(MIN_REPLICAS + NUM_ADMIN_SERVERS + NUM_JOB_PODS));
+  }
+
+  @Test
+  void whenDomainScaledDownAndServerStateUnknown_removeExcessPods() {
+    newInfo.updateLastKnownServerStatus("cluster-managed-server3", UNKNOWN_STATE);
+    newInfo.updateLastKnownServerStatus("cluster-managed-server4", UNKNOWN_STATE);
+    newInfo.updateLastKnownServerStatus("cluster-managed-server5", UNKNOWN_STATE);
+
+    defineServerResources(ADMIN_NAME);
+    Arrays.stream(MANAGED_SERVER_NAMES).forEach(this::defineServerResources);
+
+    domainConfigurator.configureCluster(newInfo, CLUSTER).withReplicas(MIN_REPLICAS);
+    newInfo.getReferencedClusters().forEach(testSupport::defineResources);
+
+    processor.createMakeRightOperation(newInfo).withExplicitRecheck().execute();
+
     assertThat(getRunningPods().size(), equalTo(MIN_REPLICAS + NUM_ADMIN_SERVERS + NUM_JOB_PODS));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -2844,7 +2844,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     }
 
     @Override
-    public Step waitForUnready(V1Pod pod, Step next) {
+    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
       return next;
     }
   }
@@ -2872,7 +2872,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     }
 
     @Override
-    public Step waitForUnready(V1Pod pod, Step next) {
+    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
       return next;
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -2844,7 +2844,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     }
 
     @Override
-    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
+    public Step waitForServerShutdown(String serverName, DomainResource domain, Step next) {
       return next;
     }
   }
@@ -2872,7 +2872,7 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     }
 
     @Override
-    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
+    public Step waitForServerShutdown(String serverName, DomainResource domain, Step next) {
       return next;
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -2842,6 +2842,11 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     public Step waitForDelete(V1Pod pod, Step next) {
       return next;
     }
+
+    @Override
+    public Step waitForUnready(V1Pod pod, Step next) {
+      return next;
+    }
   }
 
   public static class DelayedPodAwaiterStepFactory implements PodAwaiterStepFactory {
@@ -2864,6 +2869,11 @@ public abstract class PodHelperTestBase extends DomainValidationTestBase {
     @Override
     public Step waitForDelete(V1Pod pod, Step next) {
       return new DelayStep(next, delaySeconds);
+    }
+
+    @Override
+    public Step waitForUnready(V1Pod pod, Step next) {
+      return next;
     }
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
@@ -137,7 +137,7 @@ class DomainUpPlanTest {
     }
 
     @Override
-    public Step waitForUnready(V1Pod pod, Step next) {
+    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
       return null;
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
@@ -135,6 +135,11 @@ class DomainUpPlanTest {
     public Step waitForDelete(V1Pod pod, Step next) {
       return null;
     }
+
+    @Override
+    public Step waitForUnready(V1Pod pod, Step next) {
+      return null;
+    }
   }
 
   @SuppressWarnings("unused")

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
@@ -137,7 +137,7 @@ class DomainUpPlanTest {
     }
 
     @Override
-    public Step waitForUnready(String serverName, DomainResource domain, Step next) {
+    public Step waitForServerShutdown(String serverName, DomainResource domain, Step next) {
       return null;
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/makeright/DomainUpPlanTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.makeright;

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -48,6 +48,7 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
 import oracle.kubernetes.weblogic.domain.model.ServerStatus;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
+import org.hamcrest.junit.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -283,7 +284,7 @@ class ShutdownManagedServerStepTest {
   }
 
   @Test
-  void whenInvokeShutdown_standaloneServer_AndDomainNotFound_verifyFailure() {
+  void whenInvokeShutdown_standaloneServer_DomainNotFound_verifyFailureAndRunNextStep() {
     selectServer(MANAGED_SERVER1, standaloneServerService);
 
     defineResponse(404, "http://test-domain-managed-server1.namespace:7001");
@@ -291,6 +292,7 @@ class ShutdownManagedServerStepTest {
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
 
+    MatcherAssert.assertThat(terminalStep.wasRun(), is(true));
     assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_FAILURE));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static com.meterware.simplestub.Stub.createStub;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_FAILURE;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_RETRY;
 import static oracle.kubernetes.common.logging.MessageKeys.SERVER_SHUTDOWN_REST_SUCCESS;
@@ -275,6 +276,18 @@ class ShutdownManagedServerStepTest {
     selectServer(MANAGED_SERVER1, standaloneServerService);
 
     defineResponse(404, "http://test-domain-managed-server1.namespace:7001");
+
+    testSupport.runSteps(shutdownStandaloneManagedServer);
+
+    assertThat(logRecords, containsInfo(SERVER_SHUTDOWN_REST_FAILURE));
+  }
+
+  @Test
+  void whenInvokeShutdown_standaloneServer_AndDomainNotFound_verifyFailure() {
+    selectServer(MANAGED_SERVER1, standaloneServerService);
+
+    defineResponse(404, "http://test-domain-managed-server1.namespace:7001");
+    testSupport.failOnResource(KubernetesTestSupport.DOMAIN, UID, NS, HTTP_NOT_FOUND);
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
 

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;


### PR DESCRIPTION
Owls 105422 - Changes to periodically read the domain resource to get latest server state while waiting for the server state to transition to SHUTDOWN. It also has changes to read the latest domain resource when the REST call to shut down the server fails.

Integration test runs - 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15171/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15169/