### PR TITLE
OWLS-104942: managed server fail to join the cluster after patching the domain with new restartVersion

### DIFF
--- a/documentation/4.0/content/release-notes.md
+++ b/documentation/4.0/content/release-notes.md
@@ -449,6 +449,6 @@ Updated several dependencies, including the Oracle Linux base for the container 
 
 ### Known issues
 
-| Issue | Description |
-| --- | --- |
-| None currently |  |
+| Issue                                                                                    | Description |
+|------------------------------------------------------------------------------------------| --- |
+| Deadlock on WebLogic Managed Coherence Server startup with Oracle Coherence 12.2.1.3.20. | Intermittently, a deadlock may occur during deployment of the `CoherenceModule` which prevents a WebLogic Managed Coherence Server from reaching `RUNNING` state.  This issue has been resolved in Oracle Coherence versions 12.2.1.4.0 and above. |

--- a/documentation/4.0/content/release-notes.md
+++ b/documentation/4.0/content/release-notes.md
@@ -449,6 +449,6 @@ Updated several dependencies, including the Oracle Linux base for the container 
 
 ### Known issues
 
-| Issue                                                                                    | Description |
-|------------------------------------------------------------------------------------------| --- |
+| Issue | Description |
+|---| --- |
 | Deadlock on WebLogic Managed Coherence Server startup with Oracle Coherence 12.2.1.3.20. | Intermittently, a deadlock may occur during deployment of the `CoherenceModule` which prevents a WebLogic Managed Coherence Server from reaching `RUNNING` state.  This issue has been resolved in Oracle Coherence versions 12.2.1.4.0 and above. |

--- a/documentation/4.0/content/release-notes.md
+++ b/documentation/4.0/content/release-notes.md
@@ -449,6 +449,6 @@ Updated several dependencies, including the Oracle Linux base for the container 
 
 ### Known issues
 
-| Issue | Description |
-| --- | --- |
-| Deadlock on WebLogic Managed Coherence Server startup with Oracle Coherence 12.2.1.3.20. | Intermittently, a deadlock may occur during deployment of the `CoherenceModule` which prevents a WebLogic Managed Coherence Server from reaching `RUNNING` state.  This issue has been resolved in Oracle Coherence versions 12.2.1.4.0 and above. |
+| Issue | Description                                                                                                                                                                                                                                         |
+| --- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Deadlock on WebLogic Managed Coherence Server startup with Oracle Coherence 12.2.1.3.20. | Intermittently, a deadlock may occur during deployment of the `CoherenceModule`, which prevents a WebLogic Managed Coherence Server from reaching `RUNNING` state.  This issue has been resolved in Oracle Coherence versions 12.2.1.4.0 and later. |

--- a/documentation/4.0/content/release-notes.md
+++ b/documentation/4.0/content/release-notes.md
@@ -449,6 +449,6 @@ Updated several dependencies, including the Oracle Linux base for the container 
 
 ### Known issues
 
-| Issue                                                                                    | Description                                                                                                                                                                                                                                        |
-|------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Issue | Description |
+| --- | --- |
 | Deadlock on WebLogic Managed Coherence Server startup with Oracle Coherence 12.2.1.3.20. | Intermittently, a deadlock may occur during deployment of the `CoherenceModule` which prevents a WebLogic Managed Coherence Server from reaching `RUNNING` state.  This issue has been resolved in Oracle Coherence versions 12.2.1.4.0 and above. |

--- a/documentation/4.0/content/release-notes.md
+++ b/documentation/4.0/content/release-notes.md
@@ -449,6 +449,6 @@ Updated several dependencies, including the Oracle Linux base for the container 
 
 ### Known issues
 
-| Issue | Description |
-|---| --- |
+| Issue                                                                                    | Description                                                                                                                                                                                                                                        |
+|------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Deadlock on WebLogic Managed Coherence Server startup with Oracle Coherence 12.2.1.3.20. | Intermittently, a deadlock may occur during deployment of the `CoherenceModule` which prevents a WebLogic Managed Coherence Server from reaching `RUNNING` state.  This issue has been resolved in Oracle Coherence versions 12.2.1.4.0 and above. |


### PR DESCRIPTION
Add description in known issues section of the release note about the intermittent deadlock when deploying `CoherenceModule` during server startup.