### PR TITLE
Add workaround to prevent WLS session growth on status requests

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -9,7 +9,6 @@ public interface ProcessingConstants {
   String MAIN_COMPONENT_NAME = "main";
   String DELEGATE_COMPONENT_NAME = "delegate";
   String DOMAIN_COMPONENT_NAME = "domain";
-  String FIBER_COMPONENT_NAME = "fiber";
   String PODWATCHER_COMPONENT_NAME = "podWatcher";
   String JOBWATCHER_COMPONENT_NAME = "jobWatcher";
 
@@ -66,4 +65,5 @@ public interface ProcessingConstants {
   String DOMAIN_INTROSPECTION_COMPLETE = "Domain introspection complete";
   String SKIP_STATUS_UPDATE = "skipStatusUpdate";
   String END_OF_PROCESSING = "lastStatusUpdate";
+  String AUTHORIZATION_SOURCE = "AuthorizationSource";
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/SecretHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -8,6 +8,7 @@ import java.util.Optional;
 import io.kubernetes.client.openapi.models.V1Secret;
 import oracle.kubernetes.common.logging.LoggingFilter;
 import oracle.kubernetes.common.logging.MessageKeys;
+import oracle.kubernetes.operator.ProcessingConstants;
 import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
@@ -30,7 +31,6 @@ public class SecretHelper {
   // has 2 fields (username and password)
   public static final String USERNAME_KEY = "username";
   public static final String PASSWORD_KEY = "password";
-  private static final String AUTHORIZATION_SOURCE = "AuthorizationSource";
   private static final LoggingFacade LOGGER = LoggingFactory.getLogger("Operator", "Operator");
 
   /**
@@ -48,7 +48,7 @@ public class SecretHelper {
    * @param packet the packet to read.
    */
   public static AuthorizationSource getAuthorizationSource(Packet packet) {
-    return (AuthorizationSource) packet.get(AUTHORIZATION_SOURCE);
+    return (AuthorizationSource) packet.get(ProcessingConstants.AUTHORIZATION_SOURCE);
   }
 
   private static class AuthorizationSourceStep extends Step {
@@ -78,7 +78,7 @@ public class SecretHelper {
     }
 
     private void insertAuthorizationSource(Packet packet, V1Secret secret) {
-      packet.put(AUTHORIZATION_SOURCE,
+      packet.put(ProcessingConstants.AUTHORIZATION_SOURCE,
           new SecretContext(packet.getSpi(DomainPresenceInfo.class),
               secret, packet.getValue(LoggingFilter.LOGGING_FILTER_PACKET_KEY))
               .createAuthorizationSource());

--- a/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/http/client/HttpResponseStep.java
@@ -1,10 +1,11 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.http.client;
 
 import java.net.http.HttpResponse;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import oracle.kubernetes.operator.helpers.AuthorizationSource;
 import oracle.kubernetes.operator.helpers.SecretHelper;
@@ -20,8 +21,14 @@ import static oracle.kubernetes.operator.KubernetesConstants.HTTP_UNAUTHORIZED;
 public abstract class HttpResponseStep extends Step {
   private static final String RESPONSE = "httpResponse";
 
+  private Consumer<HttpResponse<?>> callback;
+
   protected HttpResponseStep(Step next) {
     super(next);
+  }
+
+  public void setCallback(Consumer<HttpResponse<?>> callback) {
+    this.callback = callback;
   }
 
   @Override
@@ -42,6 +49,7 @@ public abstract class HttpResponseStep extends Step {
   }
 
   private NextAction doApply(Packet packet, HttpResponse<String> response) {
+    Optional.ofNullable(callback).ifPresent(c -> c.accept(response));
     return isSuccess(response) ? onSuccess(packet, response) : wrapOnFailure(packet, response);
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -136,7 +136,7 @@ public class ShutdownManagedServerStep extends Step {
       String clusterName = getClusterNameFromServiceLabel();
       List<V1EnvVar> envVarList = getV1EnvVars();
 
-      Shutdown shutdown = Optional.ofNullable(getDomainPresenceInfo(packet).getServer(serverName, clusterName))
+      Shutdown shutdown = Optional.ofNullable(getDomainPresenceInfo(getPacket()).getServer(serverName, clusterName))
           .map(EffectiveServerSpec::getShutdown).orElse(null);
 
       isGracefulShutdown = isGracefulShutdown(envVarList, shutdown);
@@ -146,7 +146,7 @@ public class ShutdownManagedServerStep extends Step {
     }
 
     private List<V1EnvVar> getV1EnvVars() {
-      return Optional.ofNullable(pod.getSpec())
+      return Optional.ofNullable(getPod().getSpec())
               .map(this::getEnvVars).orElse(Collections.emptyList());
     }
 
@@ -227,7 +227,7 @@ public class ShutdownManagedServerStep extends Step {
       if (listenPort == null) {
         // This can only happen if the running server pod does not exist in the WLS Domain.
         // This is a rare case where the server was deleted from the WLS Domain config.
-        listenPort = getListenPortFromPod(this.pod);
+        listenPort = getListenPortFromPod(this.getPod());
       }
 
       return listenPort;
@@ -273,7 +273,7 @@ public class ShutdownManagedServerStep extends Step {
     }
 
     private String getServerName() {
-      return this.pod.getMetadata().getLabels().get(LabelConstants.SERVERNAME_LABEL);
+      return this.getPod().getMetadata().getLabels().get(LabelConstants.SERVERNAME_LABEL);
     }
 
     private WlsDomainConfig getWlsDomainConfig() {

--- a/operator/src/test/java/oracle/kubernetes/operator/http/client/HttpAsyncTestSupportTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/client/HttpAsyncTestSupportTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.http.client;
@@ -14,6 +14,7 @@ import static com.meterware.simplestub.Stub.createStub;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -89,6 +90,18 @@ class HttpAsyncTestSupportTest {
       support.defineResponse(createPostRequest("http://that", "abcd"),
           createStub(HttpResponseStub.class, 200, "Wrong"));
     });
+  }
+
+  @Test
+  void whenResponseIncludesSetCookieHeader_addToStoredCookies() {
+    support.defineResponse(createPostRequest("http://this", "abc"),
+          createStub(HttpResponseStub.class, 200, "Got it")).creatingSession("JSESSION", "xyz");
+
+    assertThat(
+          getResponse(createPostRequest("http://this", "abc"))
+                .headers()
+                .firstValue("Set-Cookie").orElse(""),
+          startsWith("JSESSION=xyz;"));
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/operator/src/test/java/oracle/kubernetes/operator/http/client/HttpResponseStub.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/http/client/HttpResponseStub.java
@@ -1,14 +1,23 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.http.client;
 
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public abstract class HttpResponseStub implements HttpResponse<String> {
 
   private final int statusCode;
   private String body;
+  private HttpHeaders headers = HttpHeaders.of(Collections.emptyMap(), (a,b) -> true);
+  private HttpRequest request;
 
   HttpResponseStub(int statusCode) {
     this.statusCode = statusCode;
@@ -20,6 +29,11 @@ public abstract class HttpResponseStub implements HttpResponse<String> {
   }
 
   @Override
+  public HttpRequest request() {
+    return request;
+  }
+
+  @Override
   public int statusCode() {
     return statusCode;
   }
@@ -27,5 +41,28 @@ public abstract class HttpResponseStub implements HttpResponse<String> {
   @Override
   public String body() {
     return body;
+  }
+
+  @Override
+  public HttpHeaders headers() {
+    return headers;
+  }
+
+  public HttpResponseStub withRequest(HttpRequest request) {
+    this.request = request;
+    return this;
+  }
+
+  /**
+   * Adds the specified header to the response and returns the modified response.
+   * @param name the name of the header
+   * @param value the value of the header
+   */
+  @SuppressWarnings("SameParameterValue")
+  public HttpResponseStub withHeader(String name, String value) {
+    final Map<String, List<String>> headerMap = new HashMap<>(headers.map());
+    headerMap.computeIfAbsent(name, n -> new ArrayList<>()).add(value);
+    headers = HttpHeaders.of(headerMap, (a,b) -> true);
+    return this;
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/HttpRequestProcessingTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/HttpRequestProcessingTest.java
@@ -1,0 +1,145 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.steps;
+
+import java.net.http.HttpRequest;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.meterware.simplestub.Memento;
+import oracle.kubernetes.operator.helpers.AuthorizationSource;
+import oracle.kubernetes.operator.http.client.HttpAsyncTestSupport;
+import oracle.kubernetes.operator.http.client.HttpResponseStepImpl;
+import oracle.kubernetes.operator.http.client.HttpResponseStub;
+import oracle.kubernetes.operator.work.FiberTestSupport;
+import oracle.kubernetes.operator.work.Packet;
+import oracle.kubernetes.utils.SystemClock;
+import oracle.kubernetes.utils.SystemClockTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.meterware.simplestub.Stub.createStub;
+import static oracle.kubernetes.operator.ProcessingConstants.AUTHORIZATION_SOURCE;
+import static oracle.kubernetes.operator.steps.HttpRequestProcessing.createRequestStep;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+class HttpRequestProcessingTest {
+  private static final String HOST1_URL_STRING1 = "http://myHost:123/search/here";
+  private static final String HOST1_URL_STRING2 = "http://myHost:123/search/there";
+  private static final String HOST2_STRING = "http://notMyHost:123/";
+  private static final int SECONDS_PER_HOUR = 60 * 60;
+
+  private final Packet packet = new Packet();
+  private final HttpRequestProcessing processing = createStub(HttpRequestProcessing.class, packet, null, null);
+  private final HttpResponseStepImpl responseStep = new HttpResponseStepImpl(null);
+  private final FiberTestSupport testSupport = new FiberTestSupport();
+  private final HttpAsyncTestSupport httpSupport = new HttpAsyncTestSupport();
+  private final List<Memento> mementos = new ArrayList<>();
+  private OffsetDateTime expirationTime;
+
+  @BeforeEach
+  void setUp() throws NoSuchFieldException {
+    mementos.add(httpSupport.install());
+    mementos.add(SystemClockTestSupport.installClock());
+
+    HttpRequestProcessing.clearCookies();
+    packet.put(AUTHORIZATION_SOURCE, new AuthorizationSourceStub());
+    expirationTime = SystemClock.now().plusSeconds(SECONDS_PER_HOUR);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  void initiallyRequestsCreatedWithoutCookies() {
+    final HttpRequest request = processing.createRequestBuilder(HOST1_URL_STRING1).GET().build();
+
+    assertThat(request.headers().allValues("Cookie"), empty());
+  }
+
+  @Test
+  void afterSetCookieReceived_requestToSameUrlSendsMatchingCookie() {
+    cacheSessionCookie(HOST1_URL_STRING1, "1234");
+
+    assertThat(createGetRequest(HOST1_URL_STRING1).headers().allValues("Cookie"), contains("SESSION=1234"));
+  }
+
+  private void cacheSessionCookie(String urlString, String sessionId) {
+    defineResponseWithSessionCookie(urlString, sessionId);
+
+    testSupport.runSteps(createRequestStep(createGetRequest(urlString), responseStep));
+  }
+
+  private void defineResponseWithSessionCookie(String urlString, String sessionId) {
+    httpSupport.defineResponse(
+          createGetRequest(urlString),
+          createStub(HttpResponseStub.class, 200).withHeader("Set-Cookie", "SESSION=" + sessionId));
+  }
+
+  @Test
+  void afterSetCookieReceived_requestToDifferentUrlDoesNotIncludeCookie() {
+    cacheSessionCookie(HOST2_STRING, "1234");
+
+    assertThat(createGetRequest(HOST1_URL_STRING1).headers().allValues("Cookie"), empty());
+  }
+
+  @Test
+  void afterSetCookieReceived_requestToDifferentUrlOnSameHostAndPortSendsMatchingCookie() {
+    cacheSessionCookie(HOST1_URL_STRING1, "1234");
+
+    assertThat(createGetRequest(HOST1_URL_STRING2).headers().allValues("Cookie"), contains("SESSION=1234"));
+  }
+
+  @Test
+  void afterSetCookieReceived_requestToSameUrlUpdatesIt() {
+    cacheSessionCookie(HOST1_URL_STRING1, "1234");
+    httpSupport.clearResponses(HOST1_URL_STRING1);
+    cacheSessionCookie(HOST1_URL_STRING1, "4567");
+
+    assertThat(createGetRequest(HOST1_URL_STRING2).headers().allValues("Cookie"), contains("SESSION=4567"));
+  }
+
+  @Test
+  void afterOneHourWithNoAccess_clearCookie() {
+    cacheSessionCookie(HOST1_URL_STRING1, "1234");
+
+    SystemClockTestSupport.setCurrentTime(expirationTime);
+
+    assertThat(createGetRequest(HOST1_URL_STRING1).headers().allValues("Cookie"), empty());
+  }
+
+  @Test
+  void intermediateAccesses_delayExpiration() {
+    cacheSessionCookie(HOST1_URL_STRING1, "1234");
+    SystemClockTestSupport.increment(SECONDS_PER_HOUR / 2);
+    createGetRequest(HOST1_URL_STRING1);
+
+    SystemClockTestSupport.setCurrentTime(expirationTime);
+
+    assertThat(createGetRequest(HOST1_URL_STRING2).headers().allValues("Cookie"), contains("SESSION=1234"));
+  }
+
+  private HttpRequest createGetRequest(String url) {
+    return processing.createRequestBuilder(url).GET().build();
+  }
+
+  private static class AuthorizationSourceStub implements AuthorizationSource {
+    @Override
+    public byte[] getUserName() {
+      return new byte[0];
+    }
+
+    @Override
+    public byte[] getPassword() {
+      return new byte[0];
+    }
+  }
+
+}


### PR DESCRIPTION
When the operator runs, it obtains the current state of each server by invoking that server's REST API. The REST API creates a new session on each invocation unless it receives a Session cookie with a valid current session. This change handles the Set-Cookie header in the REST response, and sends a corresponding Session header back with each subsequent request, thus preventing the creation of additional sessions.