### PR TITLE
OWLS-105105 - [wko-nightly] domain status Failed condition does not exist after create a domain with non-exist Auxiliary Image

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/JobWatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ProcessingConstants.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -43,6 +43,8 @@ public interface ProcessingConstants {
 
   String DOMAIN_VALIDATION_ERRORS = "domainValidationErrors";
   String INTROSPECTOR_JOB_FAILURE_LOGGED = "introspectorJobFailureLogged";
+  String INTROSPECTOR_JOB_FAILURE_THROWABLE = "introspectorJobFailureThrowable";
+
   String WAIT_FOR_POD_READY = "waitForPodReady";
 
   /** Key to an object of type MakeRightDomainOperation. */

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -20,6 +20,7 @@ import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
+import static oracle.kubernetes.operator.ProcessingConstants.INTROSPECTOR_JOB_FAILURE_THROWABLE;
 import static oracle.kubernetes.operator.ProcessingConstants.MAKE_RIGHT_DOMAIN_OPERATION;
 import static oracle.kubernetes.operator.helpers.KubernetesUtils.getDomainUidLabel;
 
@@ -286,7 +287,7 @@ abstract class WaitForReadyStep<T> extends Step {
     private void handleResourceReady(AsyncFiber fiber, Packet packet, T resource) {
       updatePacket(packet, resource);
       if (shouldTerminateFiber(resource)) {
-        fiber.terminate(createTerminationException(resource), packet);
+        packet.put(INTROSPECTOR_JOB_FAILURE_THROWABLE, createTerminationException(resource));
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/WaitForReadyStep.java
@@ -286,7 +286,7 @@ abstract class WaitForReadyStep<T> extends Step {
       }
     }
 
-    private void handleResourceReady(AsyncFiber fiber, Packet packet, T resource) {
+    private void handleResourceReady(Packet packet, T resource) {
       updatePacket(packet, resource);
       if (shouldTerminateFiber(resource)) {
         packet.put(INTROSPECTOR_JOB_FAILURE_THROWABLE, createTerminationException(resource));
@@ -297,7 +297,7 @@ abstract class WaitForReadyStep<T> extends Step {
     void proceedFromWait(T resource) {
       removeCallback(getResourceName(), this);
       if (mayResumeFiber()) {
-        handleResourceReady(fiber, packet, resource);
+        handleResourceReady(packet, resource);
         fiber.resume(packet);
       }
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;


### PR DESCRIPTION
Fix intermittent failure in ItMiiAuxiliaryImage.testDomainStatusErrorPullingAI.

When introspector job failed, the Callback in WaitForJobReadyStep terminates the suspended fiber, and domain status is updated by a FailureStep created by DomainPlanCompletionCallback during fiber terminate processing. Occassionally, the WaitForJobReadyStep callback is invoked from the child fiber of the fiber being terminated, and FiberGate does not allow a fiber to be started for running the FailureStep.  This change removed the fiber terminate call and resume the suspended fiber so it can terminate itself with a doTerminate call.

jenkins: https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15216/
No failure in 50 runs of ItMiiAuxiliaryImage 
