### PR TITLE
upgrade deprecated github action checkout@v2 to use v3

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2.6.0
+        uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 32
           path: main
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v2.6.0
+        uses: actions/checkout@v3
         with:
           ref: gh-pages
           path: gh-pages


### PR DESCRIPTION
actions/checkout v2 is deprecated.  Upgrading to v3