### PR TITLE
Owls104307 fix intermittent issue in missing domain Available event 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -390,6 +390,8 @@ class ItKubernetesDomainEvents {
   void testK8SEventsMultiClusterEvents() {
     OffsetDateTime timestamp = now();
     createNewCluster();
+    OffsetDateTime timestamp2 = now();
+    logger.info("Scale the newly-added cluster");
     scaleClusterWithRestApi(domainUid, cluster2Name, 1,
             externalRestHttpsPort, opNamespace, opServiceAccount);
     logger.info("verify the Domain_Available event is generated");
@@ -403,13 +405,13 @@ class ItKubernetesDomainEvents {
             domainUid, DOMAIN_COMPLETED, "Normal", timestamp);
     logger.info("verify the ClusterCompleted event is generated");
     checkEvent(opNamespace, domainNamespace3,
-        domainUid, CLUSTER_COMPLETED, "Normal", timestamp);
+        domainUid, CLUSTER_COMPLETED, "Normal", timestamp2);
     logger.info("verify the only 1 Completed event for domain is generated");
     assertEquals(1, getOpGeneratedEventCount(domainNamespace3, domainUid,
             DOMAIN_COMPLETED, timestamp));
     logger.info("verify the only 1 ClusterCompleted event for domain is generated");
     assertEquals(1, getOpGeneratedEventCount(domainNamespace3, domainUid,
-        CLUSTER_COMPLETED, timestamp));
+        CLUSTER_COMPLETED, timestamp2));
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -810,16 +810,16 @@ public class DomainPresenceInfo extends ResourcePresenceInfo {
 
 
   /**
-   * Check if the cluster status has been initially populated.
+   * Check if all cluster status have been initially populated.
    *
-   * @return true if the domain does not have any cluster or the cluster statuses have been initially populated.
+   * @return true if the domain has cluster(s) and the cluster statuses have all been initially populated.
    */
   public boolean clusterStatusInitialized() {
-    return getDomain().getSpec().getClusters().isEmpty() || !notAllClusterStatusInitialized();
+    return !getDomain().getSpec().getClusters().isEmpty() && allClusterStatusInitialized();
   }
 
-  private boolean notAllClusterStatusInitialized() {
-    return getClusterStatuses().size() < getDomain().getSpec().getClusters().size();
+  private boolean allClusterStatusInitialized() {
+    return getClusterStatuses().size() == getDomain().getSpec().getClusters().size();
   }
 
   @NotNull

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -48,6 +48,7 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.utils.SystemClock;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.ClusterSpec;
+import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.DomainSpec;
 import oracle.kubernetes.weblogic.domain.model.DomainStatus;
@@ -55,6 +56,7 @@ import oracle.kubernetes.weblogic.domain.model.PrivateDomainApi;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import static oracle.kubernetes.operator.helpers.PodHelper.hasClusterNameOrNull;
 import static oracle.kubernetes.operator.helpers.PodHelper.isNotAdminServer;
@@ -813,12 +815,17 @@ public class DomainPresenceInfo extends ResourcePresenceInfo {
    * @return true if the domain does not have any cluster or the cluster statuses have been initially populated.
    */
   public boolean clusterStatusInitialized() {
-    return getDomain().getSpec().getClusters().isEmpty() || !isClusterStatusNotInitialized();
+    return getDomain().getSpec().getClusters().isEmpty() || !notAllClusterStatusInitialized();
   }
 
-  private boolean isClusterStatusNotInitialized() {
+  private boolean notAllClusterStatusInitialized() {
+    return getClusterStatuses().size() < getDomain().getSpec().getClusters().size();
+  }
+
+  @NotNull
+  private List<ClusterStatus> getClusterStatuses() {
     return Optional.ofNullable(getDomain().getStatus()).map(DomainStatus::getClusters)
-        .orElse(Collections.emptyList()).isEmpty();
+        .orElse(Collections.emptyList());
   }
 
   @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -1925,9 +1925,10 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   private void initializeClusterStatus() {
-    ClusterStatus status = new ClusterStatus().addCondition(
+    List<ClusterStatus> statusList = info.getDomain().getStatus().getClusters();
+    ClusterStatus status = statusList.isEmpty() ? new ClusterStatus().withClusterName("cluster1") : statusList.get(0);
+    status.addCondition(
         new ClusterCondition(ClusterConditionType.AVAILABLE).withStatus(FALSE));
-    info.getDomain().getStatus().addCluster(status);
     ClusterResource clusterResource = testSupport.getResourceWithName(KubernetesTestSupport.CLUSTER, "cluster1");
     clusterResource.setStatus(status);
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;


### PR DESCRIPTION
The fix includes:

- Adjust the skip status update logic to check if all, instead of partial, cluster statuses have been initialized.
- Fix broken unit test code that was revealed by the new product code change to make sure that the unit test code does not generate a number of cluster status objects in the domain than specified in the spec.clusters.
- Fix ItKubernetesDomainEvents#testK8SEventsMultiClusterEvents to correctly check the cluster events that are related only to the cluster scale call.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15316/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15358/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15359/