### PR TITLE
Fix intermittent operator rest call issue by changing test code to use a different domainUid

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -342,7 +342,8 @@ class ItKubernetesDomainEvents {
   void testK8SEventsFailedLifeCycle() {
     V1Patch patch;
     String patchStr;
-    DomainResource domain = createDomain(domainNamespace5, domainUid, pvName5, pvcName5, "Never",
+    String domainUid5 = domainUid + "5";
+    DomainResource domain = createDomain(domainNamespace5, domainUid5, pvName5, pvcName5, "Never",
         spec -> spec.failureRetryLimitMinutes(2L));
     assertNotNull(domain, " Can't create domain resource");
 
@@ -352,12 +353,12 @@ class ItKubernetesDomainEvents {
 
     logger.info("Checking if the admin server {0} is shutdown in namespace {1}",
         adminServerPodName, domainNamespace5);
-    checkPodDoesNotExist(adminServerPodName, domainUid, domainNamespace5);
+    checkPodDoesNotExist(adminServerPodName, domainUid5, domainNamespace5);
 
     for (int i = 1; i <= replicaCount; i++) {
       logger.info("Checking if the managed server {0} is shutdown in namespace {1}",
           managedServerPodNamePrefix + i, domainNamespace5);
-      checkPodDoesNotExist(managedServerPodNamePrefix + i, domainUid, domainNamespace5);
+      checkPodDoesNotExist(managedServerPodNamePrefix + i, domainUid5, domainNamespace5);
     }
 
     logger.info("Replace the domainHome to a nonexisting location to verify the following events"
@@ -368,15 +369,15 @@ class ItKubernetesDomainEvents {
     logger.info("PatchStr for domainHome: {0}", patchStr);
 
     patch = new V1Patch(patchStr);
-    assertTrue(patchDomainCustomResource(domainUid, domainNamespace5, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
+    assertTrue(patchDomainCustomResource(domainUid5, domainNamespace5, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
         "patchDomainCustomResource failed");
 
     logger.info("verify domain changed event is logged");
-    checkEvent(opNamespace, domainNamespace5, domainUid, DOMAIN_CHANGED, "Normal", timestamp);
+    checkEvent(opNamespace, domainNamespace5, domainUid5, DOMAIN_CHANGED, "Normal", timestamp);
     logger.info("verify domain failed event");
-    checkFailedEvent(opNamespace, domainNamespace5, domainUid, ABORTED_ERROR, "Warning", timestamp);
+    checkFailedEvent(opNamespace, domainNamespace5, domainUid5, ABORTED_ERROR, "Warning", timestamp);
 
-    shutdownDomain(domainUid, domainNamespace5);
+    shutdownDomain(domainUid5, domainNamespace5);
   }
 
   /**


### PR DESCRIPTION
The Operator Rest API does not handle cluster scaling when there are multiple same-named domains in different namespaces.

Changing the integration test code to workaround an intermittent test issue caused by two test domains using the same domainUid in different namespaces. Without this change, the ItKubernetesDomainEvents#testK8SEventsMultiClusterEvents may fail intermittently because of missing ClusterCompleted event.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15425/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15426/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15427/