### PR TITLE
OWLS-105640: [wko-nightly] ServerStartPolicyUtils.scalingClusters failed for both ItServerStartPolicyConfigCluster and ItServerStartPolicyDynamicCluster 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyConfigCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyConfigCluster.java
@@ -389,24 +389,25 @@ class ItServerStartPolicyConfigCluster {
 
     // use clusterStatus.sh to make sure the server-to-be-test doesn't exist
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    5    1      1       1
-    String regex = ".*" + DYNAMIC_CLUSTER + "(\\s+)0(\\s+)5(\\s+)1(\\s+)1(\\s+)1";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    5    1      1       1
+    String regex =
+        ".*" + DYNAMIC_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)5(\\s+)1(\\s+)1(\\s+)1";
     scalingClusters(domainUid, domainNamespace, DYNAMIC_CLUSTER, dynamicServerPodName,
         replicaCount, regex, false, samplePath);
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    2    1      1       1
-    regex = ".*" + CONFIG_CLUSTER + "(\\s+)0(\\s+)2(\\s+)1(\\s+)1(\\s+)1";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    2    1      1       1
+    regex = ".*" + CONFIG_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)2(\\s+)1(\\s+)1(\\s+)1";
     scalingClusters(domainUid, domainNamespace, CONFIG_CLUSTER, configServerPodName,
         replicaCount, regex, false, samplePath);
 
     // use scaleCluster.sh to scale a dynamic cluster and
     // use clusterStatus.sh to verify scaling results
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    2    2       2      2
-    regex = ".*" + CONFIG_CLUSTER + "(\\s+)0(\\s+)2(\\s+)2(\\s+)2(\\s+)2";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    2    2       2      2
+    regex = ".*" + CONFIG_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)2(\\s+)2(\\s+)2(\\s+)2";
     scalingClusters(domainUid, domainNamespace, CONFIG_CLUSTER,
         configServerPodName, newReplicaCount, regex, true, samplePath);
 
@@ -418,9 +419,9 @@ class ItServerStartPolicyConfigCluster {
 
     // use clusterStatus.sh to restore test env
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    2    1      1       1
-    regex = ".*" + CONFIG_CLUSTER + "(\\s+)0(\\s+)2(\\s+)1(\\s+)1(\\s+)1";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    2    1      1       1
+    regex = ".*" + CONFIG_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)2(\\s+)1(\\s+)1(\\s+)1";
     scalingClusters(domainUid, domainNamespace, CONFIG_CLUSTER, configServerPodName,
         replicaCount, regex, false, samplePath);
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyConfigCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyConfigCluster.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyDynamicCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyDynamicCluster.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyDynamicCluster.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItServerStartPolicyDynamicCluster.java
@@ -527,24 +527,25 @@ class ItServerStartPolicyDynamicCluster {
 
     // use clusterStatus.sh to make sure the server-to-be-test doesn't exist
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    5    1     1      1
-    String regex = ".*" + DYNAMIC_CLUSTER + "(\\s+)0(\\s+)5(\\s+)1(\\s+)1(\\s+)1";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    5    1     1      1
+    String regex =
+        ".*" + DYNAMIC_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)5(\\s+)1(\\s+)1(\\s+)1";
     scalingClusters(domainUid, domainNamespace, DYNAMIC_CLUSTER,
         dynamicServerPodName, replicaCount, regex, false, samplePath);
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    2    1     1      1
-    regex = ".*" + CONFIG_CLUSTER + "(\\s+)0(\\s+)2(\\s+)1(\\s+)1(\\s+)1";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    2    1     1      1
+    regex = ".*" + CONFIG_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)2(\\s+)1(\\s+)1(\\s+)1";
     scalingClusters(domainUid, domainNamespace, configuredClusterResourceName, configServerPodName,
         replicaCount, regex, false, samplePath);
 
     // use scaleCluster.sh to scale a dynamic cluster and
     // use clusterStatus.sh to verify scaling results
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    5    2       2      2
-    regex = ".*" + DYNAMIC_CLUSTER + "(\\s+)0(\\s+)5(\\s+)2(\\s+)2(\\s+)2";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    5    2       2      2
+    regex = ".*" + DYNAMIC_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)5(\\s+)2(\\s+)2(\\s+)2";
     scalingClusters(domainUid, domainNamespace, DYNAMIC_CLUSTER,
         dynamicServerPodName, newReplicaCount, regex, true, samplePath);
 
@@ -556,9 +557,9 @@ class ItServerStartPolicyDynamicCluster {
 
     // use clusterStatus.sh to restore test env
     // String regex matches below
-    // cluster        min  max  goal  current  ready
-    // clusterName     0    5    1     1      1
-    regex = ".*" + DYNAMIC_CLUSTER + "(\\s+)0(\\s+)5(\\s+)1(\\s+)1(\\s+)1";
+    // cluster        status      available  min  max  goal  current  ready
+    // clusterName    Completed   True       0    5    1     1      1
+    regex = ".*" + DYNAMIC_CLUSTER + "(\\s+)Completed(\\s+)True(\\s+)0(\\s+)5(\\s+)1(\\s+)1(\\s+)1";
     scalingClusters(domainUid, domainNamespace,DYNAMIC_CLUSTER, dynamicServerPodName,
         replicaCount, regex, false, samplePath);
   }


### PR DESCRIPTION
The result format of the clusterStatus.sh script was recently changed in [PR 3811](https://github.com/oracle/weblogic-kubernetes-operator/pull/3811):

// use clusterStatus.sh to make sure the server-to-be-test doesn't exist
// String regex matches below
// cluster        status      available  min  max  goal  current  ready
// clusterName    Completed   True       0    5    1      1       1


The integration test scripts use a regex to verify results and needed to be updated.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15448/