### PR TITLE
Owls 105463 - Generate domain DELETED event when domain has deletion timestamp or not found during make-right

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/PodWatcher.java
@@ -41,6 +41,7 @@ import static oracle.kubernetes.common.logging.MessageKeys.EXECUTE_MAKE_RIGHT_DO
 import static oracle.kubernetes.common.logging.MessageKeys.LOG_WAITING_COUNT;
 import static oracle.kubernetes.operator.ProcessingConstants.SERVER_NAME;
 import static oracle.kubernetes.operator.WebLogicConstants.SHUTDOWN_STATE;
+import static oracle.kubernetes.operator.WebLogicConstants.UNKNOWN_STATE;
 
 /**
  * Watches for changes to pods.
@@ -453,7 +454,7 @@ public class PodWatcher extends Watcher<V1Pod> implements WatchListener<V1Pod>, 
 
       private boolean isServerShutdown(DomainPresenceInfo info) {
         return Optional.ofNullable(info).map(i -> i.getLastKnownServerStatus(serverName))
-            .map(s -> s.getStatus().equals(SHUTDOWN_STATE)).orElse(false);
+            .map(s -> SHUTDOWN_STATE.equals(s.getStatus()) || UNKNOWN_STATE.equals(s.getStatus())).orElse(false);
       }
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -264,10 +264,10 @@ public class MakeRightDomainOperationImpl extends MakeRightOperationImpl<DomainP
     if (Optional.ofNullable(eventData).map(e -> e.getItem() != DOMAIN_DELETED).orElse(true)) {
       eventStep = EventHelper.createEventStep(new EventHelper.EventData(DOMAIN_DELETED));
     }
-    return Step.chain(eventStep, new DeleteDomainStep(), new DownHeadStep(), new UnregisterStep());
+    return Step.chain(eventStep, new DeleteDomainStep(), new UnregisterStatusUpdaterStep(), new UnregisterDPIStep());
   }
 
-  private class DownHeadStep extends Step {
+  private class UnregisterStatusUpdaterStep extends Step {
 
     @Override
     public NextAction apply(Packet packet) {
@@ -384,7 +384,7 @@ public class MakeRightDomainOperationImpl extends MakeRightOperationImpl<DomainP
     }
   }
 
-  private class UnregisterStep extends Step {
+  private class UnregisterDPIStep extends Step {
 
     @Override
     public NextAction apply(Packet packet) {

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -27,7 +27,6 @@ import oracle.kubernetes.operator.calls.CallResponse;
 import oracle.kubernetes.operator.helpers.CallBuilder;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.PodHelper;
-import oracle.kubernetes.operator.helpers.ResponseStep;
 import oracle.kubernetes.operator.helpers.SecretHelper;
 import oracle.kubernetes.operator.http.client.HttpAsyncRequestStep;
 import oracle.kubernetes.operator.http.client.HttpResponseStep;
@@ -46,7 +45,6 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.Shutdown;
 
-import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
 import static oracle.kubernetes.operator.KubernetesConstants.WLS_CONTAINER_NAME;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.WebLogicConstants.ADMIN_STATE;
@@ -398,18 +396,11 @@ public class ShutdownManagedServerStep extends Step {
     }
   }
 
-  static class DomainUpdateStep extends ResponseStep<DomainResource> {
+  static class DomainUpdateStep extends DefaultResponseStep<DomainResource> {
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<DomainResource> callResponse) {
       packet.getSpi(DomainPresenceInfo.class).setDomain(callResponse.getResult());
       return doNext(packet);
-    }
-
-    @Override
-    public NextAction onFailure(Packet packet, CallResponse<DomainResource> callResponse) {
-      return callResponse.getStatusCode() == HTTP_NOT_FOUND
-          ? doNext(packet)
-          : super.onFailure(packet, callResponse);
     }
   }
 }

--- a/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/PodWatcherTest.java
@@ -479,7 +479,8 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
     final DomainResource domain = DomainProcessorTestSetup.createTestDomain();
     final AtomicBoolean stopping = new AtomicBoolean(false);
     final PodWatcher watcher = createWatcher(stopping);
-    testSupport.addDomainPresenceInfo(new DomainPresenceInfo(domain));
+    DomainPresenceInfo info = new DomainPresenceInfo(domain);
+    testSupport.addDomainPresenceInfo(info);
 
     try {
       testSupport.failOnResource(KubernetesTestSupport.DOMAIN, NAME, NS, HTTP_NOT_FOUND);
@@ -487,6 +488,8 @@ class PodWatcherTest extends WatcherTestBase implements WatchListener<V1Pod> {
     } finally {
       stopping.set(true);
     }
+    info.updateLastKnownServerStatus(NAME, SHUTDOWN_STATE);
+    testSupport.setTime(10, TimeUnit.SECONDS);
 
     assertThat(terminalStep.wasRun(), is(true));
     assertThat(domain, not(hasCondition(FAILED).withReason(KUBERNETES)));


### PR DESCRIPTION
Owls 105463 - Fix for ItKubernetesDomainEvents.testK8SEventsDelete test to generate DOMAIN_DELETED event when domain resource has deletion timestamp or not found during make-right. The integration test deletes the domain and cluster resource at the same time. The make-right is started by the cluster delete watch notification but the domain delete watch event is not received. This change generates the DELETED event (if its not being already generated) and sets `isDeleting` flag in DPI to `true` when creating the domain down plan due to deletion timestamp or domain not found during make-right.
In addition, it has changes to stop scheduled status updaters after the domain is deleted and changes to detect the server SHUTDOWN to resume the fiber when the server state is either UNKNOWN or SHUTDOWN.
Integration test runs - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15648
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15649 
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15650/