### PR TITLE
OWLS-105608 Fix a race in waitForDomain sample script

### DIFF
--- a/kubernetes/samples/scripts/domain-lifecycle/waitForDomain.sh
+++ b/kubernetes/samples/scripts/domain-lifecycle/waitForDomain.sh
@@ -305,8 +305,8 @@ getDomainInfo() {
   getDomainAIImages domain_info_goal_aiimages_current
   getDomainValue    domain_info_api_version            ".apiVersion"
   getDomainValue    domain_info_condition_failed_str   ".status.conditions[?(@.type==\"Failed\")]" # has full failure messages, if any
-  getDomainValue    domain_info_condition_completed    ".status.conditions[?(@.type==\"Completed\")].status" # "True" when complete
   getDomainValue    domain_info_observed_generation    ".status.observedGeneration"
+  getDomainValue    domain_info_condition_completed    ".status.conditions[?(@.type==\"Completed\")].status" # "True" when complete
 
   domain_info_clusters=$( echo "$domain_info_clusters" | sed 's/"name"//g' | tr -d '[]{}:' | sortlist | sed 's/,/ /') # convert to sorted space separated list
 


### PR DESCRIPTION
The root cause of the intermittent issue in ItMiiSampleWlsAux.testAIWlsUpdate1UseCase reported in OWLS-105608 is a race condition in sample script waitForDomain.sh, which is used by the test case to determine if the operator has done processing the changes to the domain resources.

The waitForDomain.sh script checks domain and cluster status periodically until the domain/clusters status matches what is expected (Success), or the expected statuses are not detected after a pre-defined period of time (Failure).  The expected conditions are domain Completed=true, the domain status' observedGeneration matches the domain's spec.generation, and each cluster's observedGeneration match its spec.generation.  

The problem is that the waitForDomain.sh script gets the values in the domain status one by one, each is a separate kubectl call to the apiServer, and furthermore, it gets the domain status's completed condition before it gets the observedGeneration. When the operator updates the domain status, to set the completed to false and update the observedGeneration, in the window between the waitForDomain.sh gets the completed condition and then gets the observedGeneration value, the completed condition may be true but stale. When this race window is hit, the waitForDomain.sh will return success prematurely (even before the introspector job is even completed). 

There are a couple of ways to fix this problem. Having discussed the potential fixes with Tom, we decided to go with a simple but yet sufficient fix, which changes the script to get the observedGeneration before getting the completed condition. 

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15929
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/15960 (still running)