### PR TITLE
Decorate Fluentd ConfigMap with domainUID

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/FluentdHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/FluentdHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -21,7 +21,7 @@ import oracle.kubernetes.operator.LogHomeLayoutType;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 import oracle.kubernetes.weblogic.domain.model.FluentdSpecification;
 
-import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_NAME;
+import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_NAME_SUFFIX;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_VOLUME;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIG_DATA_NAME;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONTAINER_NAME;
@@ -185,7 +185,7 @@ public class FluentdHelper {
     data.put(FLUENTD_CONFIG_DATA_NAME, fluentdConfBuilder.toString());
 
     V1ObjectMeta meta = new V1ObjectMeta()
-        .name(FLUENTD_CONFIGMAP_NAME)
+        .name(domainUid + FLUENTD_CONFIGMAP_NAME_SUFFIX)
         .labels(labels)
         .namespace(namespace);
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/JobStepContext.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -558,9 +558,11 @@ public class JobStepContext extends BasePodStepContext {
   protected List<V1Volume> getFluentdVolumes() {
     List<V1Volume> volumes = new ArrayList<>();
     Optional.ofNullable(getDomain())
-            .map(DomainResource::getFluentdSpecification)
-            .ifPresent(c -> volumes.add(new V1Volume().name(FLUENTD_CONFIGMAP_VOLUME)
-                    .configMap(new V1ConfigMapVolumeSource().name(FLUENTD_CONFIGMAP_NAME).defaultMode(420))));
+        .map(DomainResource::getFluentdSpecification)
+        .ifPresent(c -> volumes.add(new V1Volume().name(FLUENTD_CONFIGMAP_VOLUME)
+            .configMap(new V1ConfigMapVolumeSource()
+                .name(getDomainUid() + FLUENTD_CONFIGMAP_NAME_SUFFIX)
+                .defaultMode(420))));
     return volumes;
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextConstants.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/StepContextConstants.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -12,7 +12,8 @@ public interface StepContextConstants {
   String INTROSPECTOR_VOLUME = "weblogic-domain-introspect-cm-volume";
   String RUNTIME_ENCRYPTION_SECRET_VOLUME = "weblogic-domain-runtime-encryption-volume";
   String FLUENTD_CONFIGMAP_VOLUME = "weblogic-fluentd-configmap-volume";
-  String FLUENTD_CONFIGMAP_NAME = "weblogic-fluentd-configmap";
+  String OLD_FLUENTD_CONFIGMAP_NAME = "weblogic-fluentd-configmap";
+  String FLUENTD_CONFIGMAP_NAME_SUFFIX = "-" + OLD_FLUENTD_CONFIGMAP_NAME;
   String FLUENTD_CONTAINER_NAME = "fluentd";
   String FLUENTD_CONFIG_DATA_NAME = "fluentd.conf";
   String SECRETS_MOUNT_PATH = "/weblogic-operator/secrets";

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -148,7 +148,7 @@ import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.SECRET;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.SERVICE;
 import static oracle.kubernetes.operator.helpers.SecretHelper.PASSWORD_KEY;
 import static oracle.kubernetes.operator.helpers.SecretHelper.USERNAME_KEY;
-import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_NAME;
+import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_NAME_SUFFIX;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIG_DATA_NAME;
 import static oracle.kubernetes.operator.http.client.HttpAsyncTestSupport.OK_RESPONSE;
 import static oracle.kubernetes.operator.http.client.HttpAsyncTestSupport.createExpectedRequest;
@@ -1387,7 +1387,7 @@ class DomainProcessorTest {
 
     processor.createMakeRightOperation(newInfo).execute();
 
-    V1ConfigMap fluentdConfigMap = testSupport.getResourceWithName(CONFIG_MAP, FLUENTD_CONFIGMAP_NAME);
+    V1ConfigMap fluentdConfigMap = testSupport.getResourceWithName(CONFIG_MAP, UID + FLUENTD_CONFIGMAP_NAME_SUFFIX);
 
     assertThat(Optional.ofNullable(fluentdConfigMap)
             .map(V1ConfigMap::getData)
@@ -1405,7 +1405,7 @@ class DomainProcessorTest {
 
     processor.createMakeRightOperation(newInfo).execute();
 
-    V1ConfigMap fluentdConfigMap = testSupport.getResourceWithName(CONFIG_MAP, FLUENTD_CONFIGMAP_NAME);
+    V1ConfigMap fluentdConfigMap = testSupport.getResourceWithName(CONFIG_MAP, UID + FLUENTD_CONFIGMAP_NAME_SUFFIX);
 
     assertThat(Optional.ofNullable(fluentdConfigMap)
             .map(V1ConfigMap::getData)

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -97,7 +97,7 @@ import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createPodSecu
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createSecretKeyRefEnvVar;
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createSecurityContext;
 import static oracle.kubernetes.operator.helpers.PodHelperTestBase.createToleration;
-import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_NAME;
+import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIGMAP_NAME_SUFFIX;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONFIG_DATA_NAME;
 import static oracle.kubernetes.operator.helpers.StepContextConstants.FLUENTD_CONTAINER_NAME;
 import static oracle.kubernetes.operator.tuning.TuningParameters.INTROSPECTOR_JOB_ACTIVE_DEADLINE_SECONDS;
@@ -458,7 +458,7 @@ class JobHelperTest extends DomainValidationTestBase {
     Map<String, String> data = new HashMap<>();
     data.put(FLUENTD_CONFIG_DATA_NAME, "<fakedata/>");
     V1ObjectMeta metaData = new V1ObjectMeta()
-          .name(FLUENTD_CONFIGMAP_NAME)
+          .name(UID + FLUENTD_CONFIGMAP_NAME_SUFFIX)
           .namespace(domainPresenceInfo.getNamespace());
     V1ConfigMap configMap = new V1ConfigMap()
           .metadata(metaData)


### PR DESCRIPTION
Resolves issue #3865 by decorating the Fluentd ConfigMap with the domain UID. Presently, the operator is not decorating these ConfigMap names and if two domains in the same namespace are both configured to use the Fluentd sidecar then the ConfigMaps clash.

Used our standard pattern to not have unexpected rolls on upgrade.

The clean-up logic will delete both the old and new ConfigMaps.