### PR TITLE
[wko-nightly] Fix the failure from ItMiiClusterResource/testSharedClusterResource to delete shared-cluster

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ClusterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ClusterUtils.java
@@ -121,7 +121,7 @@ public class ClusterUtils {
     testUntil(
         withLongRetryPolicy,
         clusterDoesNotExist(clusterName, CLUSTER_VERSION, namespace),
-        getLogger(), "cluster {0} to be created in namespace {1}",
+        getLogger(), "Waiting to delete cluster custom resource {0} in namespace {1}",
         clusterName,
         namespace);
   }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ClusterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/ClusterUtils.java
@@ -119,9 +119,9 @@ public class ClusterUtils {
     Cluster.deleteClusterCustomResource(clusterName, namespace);
 
     testUntil(
+        withLongRetryPolicy,
         clusterDoesNotExist(clusterName, CLUSTER_VERSION, namespace),
-        getLogger(),
-        "cluster {0} to be created in namespace {1}",
+        getLogger(), "cluster {0} to be created in namespace {1}",
         clusterName,
         namespace);
   }


### PR DESCRIPTION
the Nightly Failure https://build.weblogick8s.org:8443/job/wko-kind-nightly-parallel/1212/testReport/oracle.weblogic.kubernetes/ItMiiClusterResource/testSharedClusterResource/

error:
message: 'Domain domain7 failed due to ''Domain validation error'': Cannot reference
cluster resource ''shared-cluster'' because it is used by ''domain8''. Update
the domain resource to correct the validation error.'
reason: Failed

we do verify domain/cluster deleted using withStandardRetryPolicy. I can't see any other issue causing the failure of deleting the cluster. We can try to increate the waiting time from withStandardRetryPolicy to withLongRetryPolicy
to make sure we have enough time in case the env is picky

Jenkins:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16001/