### PR TITLE
Update pod and security context for all generated pods and containers

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/BasePodStepContext.java
@@ -141,6 +141,7 @@ public abstract class BasePodStepContext extends StepContextBase {
             .command(Collections.singletonList(AUXILIARY_IMAGE_INIT_CONTAINER_WRAPPER_SCRIPT))
             .env(createEnv(auxiliaryImage, getName(index)))
             .resources(createResources())
+            .securityContext(PodSecurityHelper.getDefaultContainerSecurityContext())
             .volumeMounts(Arrays.asList(
                     new V1VolumeMount().name(AUXILIARY_IMAGE_INTERNAL_VOLUME_NAME)
                             .mountPath(AUXILIARY_IMAGE_TARGET_PATH),

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodSecurityHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodSecurityHelper.java
@@ -1,0 +1,44 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.kubernetes.operator.helpers;
+
+import java.util.Optional;
+
+import io.kubernetes.client.openapi.models.V1Capabilities;
+import io.kubernetes.client.openapi.models.V1PodSecurityContext;
+import io.kubernetes.client.openapi.models.V1SeccompProfile;
+import io.kubernetes.client.openapi.models.V1SecurityContext;
+import oracle.kubernetes.operator.tuning.TuningParameters;
+
+public class PodSecurityHelper {
+
+  /**
+   * Default pod security context conforming to restricted.
+   * @return Default pod security context
+   */
+  public static V1PodSecurityContext getDefaultPodSecurityContext() {
+    return new V1PodSecurityContext().seccompProfile(
+        new V1SeccompProfile().type("RuntimeDefault"));
+  }
+
+  /**
+   * Default container security context conforming to restricted.
+   * @return Default container security context.
+   */
+  public static V1SecurityContext getDefaultContainerSecurityContext() {
+    V1SecurityContext context = new V1SecurityContext()
+        .runAsNonRoot(true)
+        .privileged(false).allowPrivilegeEscalation(false)
+        .capabilities(new V1Capabilities().addDropItem("ALL"));
+
+    Optional.ofNullable(TuningParameters.getInstance()).ifPresent(instance -> {
+      if (!"OpenShift".equalsIgnoreCase(instance.getKubernetesPlatform())) {
+        context.runAsUser(1000L).runAsGroup(1000L);
+      }
+    });
+    return context;
+  }
+
+
+}

--- a/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
+++ b/operator/src/main/java/oracle/kubernetes/weblogic/domain/model/BaseConfiguration.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.weblogic.domain.model;
@@ -29,6 +29,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import static oracle.kubernetes.operator.helpers.AffinityHelper.getDefaultAntiAffinity;
+import static oracle.kubernetes.operator.helpers.PodSecurityHelper.getDefaultContainerSecurityContext;
+import static oracle.kubernetes.operator.helpers.PodSecurityHelper.getDefaultPodSecurityContext;
 
 /**
  * Configuration values shared by multiple levels: domain, admin server, managed server, and
@@ -254,7 +256,7 @@ public abstract class BaseConfiguration {
   }
 
   V1PodSecurityContext getPodSecurityContext() {
-    return serverPod.getPodSecurityContext();
+    return Optional.ofNullable(serverPod.getPodSecurityContext()).orElse(getDefaultPodSecurityContext());
   }
 
   void setPodSecurityContext(V1PodSecurityContext podSecurityContext) {
@@ -262,7 +264,7 @@ public abstract class BaseConfiguration {
   }
 
   V1SecurityContext getContainerSecurityContext() {
-    return serverPod.getContainerSecurityContext();
+    return Optional.ofNullable(serverPod.getContainerSecurityContext()).orElse(getDefaultContainerSecurityContext());
   }
 
   void setContainerSecurityContext(V1SecurityContext containerSecurityContext) {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/Matchers.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;
@@ -176,6 +176,7 @@ public class Matchers {
                 .mountPath(AUXILIARY_IMAGE_TARGET_PATH),
                     new V1VolumeMount().name(SCRIPTS_VOLUME).mountPath(SCRIPTS_MOUNTS_PATH)))
         .resources(resources)
+        .securityContext(PodSecurityHelper.getDefaultContainerSecurityContext())
         .env(PodHelperTestBase.getAuxiliaryImageEnvVariables(image, sourceWDTInstallHome, sourceModelHome, name));
   }
 


### PR DESCRIPTION
All generated pods and containers will now have security context that meets the V8o and restricted requirements. This includes pods and containers for WebLogic Server instances, pods and containers for the introspector job, auxiliary image containers, and the container for the monitoring exporter.