### PR TITLE
Owls 106174 - improve handling of cluster resource Added/Modified/Deleted watch notifications

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -35,6 +35,7 @@ import oracle.weblogic.kubernetes.annotations.IntegrationTest;
 import oracle.weblogic.kubernetes.annotations.Namespaces;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.DomainUtils;
+import oracle.weblogic.kubernetes.utils.K8sEvents;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -399,6 +400,12 @@ class ItKubernetesDomainEvents {
     checkEvent(opNamespace, domainNamespace3, domainUid,
             DOMAIN_AVAILABLE, "Normal", timestamp);
     logger.info("verify the Cluster_Available event is generated");
+    checkEvent(opNamespace, domainNamespace3, domainUid,
+        CLUSTER_CHANGED, "Normal", timestamp);
+    assertEquals(1, getOpGeneratedEventCount(domainNamespace3, domainUid,
+        CLUSTER_CHANGED, timestamp2));
+    assertEquals(1, K8sEvents.getOpGeneratedEventCountForResource(domainNamespace3, domainUid, cluster2Name,
+        CLUSTER_CHANGED, timestamp));
     checkEvent(opNamespace, domainNamespace3, domainUid,
         CLUSTER_AVAILABLE, "Normal", timestamp);
     logger.info("verify the Completed event is generated");

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/K8sEvents.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;

--- a/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
@@ -36,6 +36,7 @@ import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
 import static oracle.kubernetes.operator.KubernetesConstants.CLUSTER;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
+import static oracle.kubernetes.operator.helpers.EventHelper.createClusterResourceEventData;
 
 /**
  * Updates for status of Cluster resources.
@@ -255,14 +256,14 @@ public class ClusterResourceStatusUpdater {
 
     private EventData toTrueClusterResourceEvent(ClusterCondition condition) {
       return Optional.ofNullable(condition.getType().getAddedEvent())
-          .map(eventItem -> new ClusterResourceEventData(eventItem, resource))
+          .map(eventItem -> createClusterResourceEventData(eventItem, resource, domain.getDomainUid()))
           .map(this::initializeClusterResourceEventData)
           .orElse(null);
     }
 
     private EventData toFalseClusterResourceEvent(ClusterCondition removedCondition) {
       return Optional.ofNullable(removedCondition.getType().getRemovedEvent())
-          .map(eventItem -> new ClusterResourceEventData(eventItem, resource))
+          .map(eventItem -> createClusterResourceEventData(eventItem, resource, domain.getDomainUid()))
           .map(this::initializeClusterResourceEventData)
           .orElse(null);
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -40,6 +40,18 @@ public interface DomainProcessor {
    *
    * @param clusterEvent the event that needs to be generated
    * @param cluster the cluster resource that the event is associated with
+   * @param domainUid the UID of the domain that the cluster is referenced by
+   * @return Make-right operation
+   */
+  MakeRightClusterOperation createMakeRightOperationForClusterEvent(
+      EventItem clusterEvent, ClusterResource cluster, String domainUid);
+
+  /**
+   * Ensures that a cluster event is generated for a cluster resource no matter whether it is referenced by a domain
+   * or not.
+   *
+   * @param clusterEvent the event that needs to be generated
+   * @param cluster the cluster resource that the event is associated with
    * @return Make-right operation
    */
   MakeRightClusterOperation createMakeRightOperationForClusterEvent(

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -814,6 +814,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         createMakeRightOperationForClusterEvent(EventItem.CLUSTER_CHANGED, cluster, info.getDomainUid()).execute();
         createMakeRightOperation(info)
             .interrupt()
+            .withExplicitRecheck()
             .execute();
       });
     }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -978,11 +978,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     }
 
     @Override
-    protected void cacheResourcePresenceInfo(ResourcePresenceInfo presenceInfo) {
-      //No-op.
-    }
-
-    @Override
     public CompletionCallback createCompletionCallback() {
       return new DomainPlanCompletionCallback();
     }
@@ -1059,7 +1054,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
       return interval.getSeconds();
 
     }
-
   }
 
   private static class ClusterPlan extends Plan<MakeRightClusterOperation> {
@@ -1069,22 +1063,11 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     }
 
     @Override
-    protected void cacheResourcePresenceInfo(ResourcePresenceInfo presenceInfo) {
-      if (operation.getEventData().getItem() == EventHelper.EventItem.CLUSTER_DELETED) {
-        Optional.ofNullable(clusters.get(presenceInfo.getNamespace()))
-            .ifPresent(m -> m.remove(presenceInfo.getResourceName()));
-      } else {
-        clusters.computeIfAbsent(presenceInfo.getNamespace(), c -> new ConcurrentHashMap<>())
-            .put(presenceInfo.getResourceName(), (ClusterPresenceInfo) presenceInfo);
-      }
-    }
-
-    @Override
     public CompletionCallback createCompletionCallback() {
       return new ClusterPlanCompletionCallback();
     }
 
-    class ClusterPlanCompletionCallback implements CompletionCallback {
+    static class ClusterPlanCompletionCallback implements CompletionCallback {
 
       @Override
       public void onCompletion(Packet packet) {
@@ -1117,10 +1100,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
       this.firstStep = operation.createSteps();
       this.packet = operation.createPacket();
       this.gate = getMakeRightFiberGate(delegate, this.presenceInfo.getNamespace());
-      cacheResourcePresenceInfo(presenceInfo);
     }
-
-    protected abstract void cacheResourcePresenceInfo(ResourcePresenceInfo presenceInfo);
 
     private FiberGate getMakeRightFiberGate(DomainProcessorDelegate delegate, String ns) {
       return makeRightFiberGates.computeIfAbsent(ns, k -> delegate.createFiberGate());

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -406,8 +406,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   private boolean shouldContinue(MakeRightClusterOperation operation, ClusterPresenceInfo liveInfo) {
     final ClusterPresenceInfo cachedInfo = getExistingClusterPresenceInfo(liveInfo);
     if (hasDeletedClusterEventData(operation)) {
-      boolean found = findClusterPresenceInfo(liveInfo.getNamespace(), liveInfo.getResourceName());
-      return found;
+      return findClusterPresenceInfo(liveInfo.getNamespace(), liveInfo.getResourceName());
     } else if (isNewCluster(cachedInfo)) {
       return true;
     } else if (liveInfo.isFromOutOfDateEvent(operation, cachedInfo)) {
@@ -426,11 +425,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
 
   private boolean isNewCluster(ClusterPresenceInfo cachedInfo) {
     return Optional.ofNullable(cachedInfo).map(ClusterPresenceInfo::getCluster).orElse(null) == null;
-  }
-
-  private boolean isDeletingNonExistCluster(MakeRightClusterOperation operation, ClusterPresenceInfo cachedInfo) {
-    return hasDeletedClusterEventData(operation)
-        && !findClusterPresenceInfo(cachedInfo.getNamespace(), cachedInfo.getResourceName());
   }
 
   private boolean findClusterPresenceInfo(String namespace, String clusterName) {
@@ -976,7 +970,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
 
   }
 
-  private class DomainPlan extends Plan<MakeRightDomainOperation> {
+  private static class DomainPlan extends Plan<MakeRightDomainOperation> {
 
     public DomainPlan(MakeRightDomainOperation operation, DomainProcessorDelegate delegate) {
       super(operation, delegate);
@@ -1067,7 +1061,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
 
   }
 
-  private class ClusterPlan extends Plan<MakeRightClusterOperation> {
+  private static class ClusterPlan extends Plan<MakeRightClusterOperation> {
 
     public ClusterPlan(MakeRightClusterOperation operation, DomainProcessorDelegate delegate) {
       super(operation, delegate);
@@ -1107,7 +1101,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     }
   }
 
-  private abstract class Plan<T extends MakeRightOperation> {
+  private abstract static class Plan<T extends MakeRightOperation> {
 
     final T operation;
     protected final ResourcePresenceInfo presenceInfo;

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -1075,7 +1075,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
             .ifPresent(m -> m.remove(presenceInfo.getResourceName()));
       } else {
         clusters.computeIfAbsent(presenceInfo.getNamespace(), c -> new ConcurrentHashMap<>())
-            .computeIfAbsent(presenceInfo.getResourceName(), k -> (ClusterPresenceInfo) presenceInfo);
+            .put(presenceInfo.getResourceName(), (ClusterPresenceInfo) presenceInfo);
       }
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -235,7 +235,7 @@ class DomainResourcesValidation {
   }
 
   private void deActivateCluster(DomainProcessor dp, ClusterPresenceInfo info) {
-    dp.createMakeRightOperationForClusterEvent(EventHelper.EventItem.CLUSTER_DELETED, info.getResource()).execute();
+    dp.createMakeRightOperationForClusterEvent(EventHelper.EventItem.CLUSTER_DELETED, info.getCluster()).execute();
   }
 
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -52,11 +52,6 @@ public interface MakeRightDomainOperation extends MakeRightOperation<DomainPrese
    */
   MakeRightDomainOperation interrupt();
 
-  /**
-   * Returns true if this operation was started by an event.
-   */
-  boolean wasStartedFromEvent();
-
   boolean isDeleting();
 
   boolean isExplicitRecheck();

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightDomainOperation.java
@@ -39,7 +39,7 @@ public interface MakeRightDomainOperation extends MakeRightOperation<DomainPrese
 
   /**
    * Specifies that the current MakeRightOperation may skip updating the DomainStatus if the
-   * DomainPresenceInfo.ServerStartupInfo value has not yet been constructed..
+   * DomainPresenceInfo.ServerStartupInfo value has not yet been constructed.
    */
   default MakeRightDomainOperation skipUpdateDomainStatusIfNeeded() {
     return this;

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightExecutor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightExecutor.java
@@ -3,6 +3,7 @@
 
 package oracle.kubernetes.operator;
 
+import oracle.kubernetes.operator.helpers.ClusterPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.work.Step;
 
@@ -63,4 +64,16 @@ public interface MakeRightExecutor {
    * @param info the presence info which encapsulates the domain
    */
   void unregisterDomainPresenceInfo(DomainPresenceInfo info);
+
+  /**
+   * Adds the specified presence info to a cache.
+   * @param info the presence info which encapsulates the domain
+   */
+  void registerClusterPresenceInfo(ClusterPresenceInfo info);
+
+  /**
+   * Removes the specified presence info from the cache.
+   * @param info the presence info which encapsulates the domain
+   */
+  void unregisterClusterPresenceInfo(ClusterPresenceInfo info);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightExecutor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightExecutor.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightOperation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightOperation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightOperation.java
@@ -25,4 +25,6 @@ public interface MakeRightOperation<T extends ResourcePresenceInfo> extends Pack
   boolean isWillInterrupt();
 
   T getPresenceInfo();
+
+  boolean wasStartedFromEvent();
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ServerStatusReader.java
@@ -108,7 +108,6 @@ public class ServerStatusReader {
     /**
      * Creates asynchronous step to read WebLogic server state from a particular pod.
      *
-     * @param info the domain presence
      * @param pod The pod
      * @param serverName Server name
      * @param timeoutSeconds Timeout in seconds

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ClusterPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ClusterPresenceInfo.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ClusterPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ClusterPresenceInfo.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.helpers;
 import java.util.Optional;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import oracle.kubernetes.operator.MakeRightClusterOperation;
 import oracle.kubernetes.operator.work.Component;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
@@ -16,7 +17,7 @@ import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 public class ClusterPresenceInfo extends ResourcePresenceInfo {
 
   private static final String COMPONENT_KEY = "cpi";
-  private final ClusterResource cluster;
+  private ClusterResource cluster;
 
   /**
    * Create presence for a cluster resource.
@@ -33,12 +34,41 @@ public class ClusterPresenceInfo extends ResourcePresenceInfo {
     return Optional.of(cluster).map(ClusterResource::getMetadata).map(V1ObjectMeta::getName).orElse(null);
   }
 
-  public ClusterResource getResource() {
+  public ClusterResource getCluster() {
     return cluster;
+  }
+
+  public void setCluster(ClusterResource cluster) {
+    this.cluster = cluster;
   }
 
   @Override
   public void addToPacket(Packet packet) {
     packet.getComponents().put(COMPONENT_KEY, Component.createFor(this));
   }
+
+  /**
+   * Returns true if the cluster make-right operation was triggered by a domain event and the reported domain
+   * is older than the value already cached. That indicates that the event is old and should be ignored.
+   * @param operation the make-right operation.
+   * @param cachedInfo the cached domain presence info.
+   */
+  public boolean isFromOutOfDateEvent(MakeRightClusterOperation operation, ClusterPresenceInfo cachedInfo) {
+    return operation.wasStartedFromEvent() && !isNewerThan(cachedInfo);
+  }
+
+  private boolean isNewerThan(ClusterPresenceInfo cachedInfo) {
+    return getCluster() == null
+        || !KubernetesUtils.isFirstNewer(cachedInfo.getCluster().getMetadata(), getCluster().getMetadata());
+  }
+
+  /**
+   * Returns true if the cluster in this presence info has a later generation
+   * than the passed-in cached info.
+   * @param cachedInfo another presence info against which to compare this one.
+   */
+  public boolean isClusterGenerationChanged(ClusterPresenceInfo cachedInfo) {
+    return getGeneration(getCluster()).compareTo(getGeneration(cachedInfo.getCluster())) > 0;
+  }
+
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/DomainPresenceInfo.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1LocalObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -134,10 +133,6 @@ public class DomainPresenceInfo extends ResourcePresenceInfo {
    */
   public boolean isDomainGenerationChanged(DomainPresenceInfo cachedInfo) {
     return getGeneration(getDomain()).compareTo(getGeneration(cachedInfo.getDomain())) > 0;
-  }
-
-  private Long getGeneration(KubernetesObject resource) {
-    return Optional.ofNullable(resource).map(KubernetesObject::getMetadata).map(V1ObjectMeta::getGeneration).orElse(0L);
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -1076,7 +1076,7 @@ public class EventHelper {
           .orElse("");
     }
 
-    private String getResourceNameFromInfo() {
+    String getResourceNameFromInfo() {
       return Optional.ofNullable(info).map(DomainPresenceInfo::getDomainUid).orElse("");
     }
   }
@@ -1278,13 +1278,20 @@ public class EventHelper {
     }
   }
 
+  public static ClusterResourceEventData createClusterResourceEventData(
+      EventItem clusterEvent, ClusterResource cluster, String domainUid) {
+    return new ClusterResourceEventData(clusterEvent, cluster, domainUid);
+  }
+
   public static class ClusterResourceEventData extends EventData {
 
     private final ClusterResource resource;
+    private String domainUid;
 
-    public ClusterResourceEventData(EventItem eventItem, ClusterResource resource) {
+    private ClusterResourceEventData(EventItem eventItem, ClusterResource resource, String domainUid) {
       super(eventItem);
       this.resource = resource;
+      this.domainUid = domainUid;
     }
 
     @Override
@@ -1309,6 +1316,11 @@ public class EventHelper {
           .map(ClusterResource::getMetadata)
           .map(V1ObjectMeta::getUid)
           .orElse("");
+    }
+
+    @Override
+    public String getResourceNameFromInfo() {
+      return Optional.ofNullable(domainUid).orElse("");
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResourcePresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResourcePresenceInfo.java
@@ -3,6 +3,11 @@
 
 package oracle.kubernetes.operator.helpers;
 
+
+import java.util.Optional;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import oracle.kubernetes.operator.work.PacketComponent;
 
 /**
@@ -31,6 +36,10 @@ public abstract class ResourcePresenceInfo implements PacketComponent {
   }
 
   public abstract String getResourceName();
+
+  Long getGeneration(KubernetesObject resource) {
+    return Optional.ofNullable(resource).map(KubernetesObject::getMetadata).map(V1ObjectMeta::getGeneration).orElse(0L);
+  }
 
   @Override
   public String toString() {

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResourcePresenceInfo.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResourcePresenceInfo.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightClusterOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightClusterOperationImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.makeright;

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightClusterOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightClusterOperationImpl.java
@@ -23,8 +23,6 @@ import oracle.kubernetes.operator.work.Step;
 public class MakeRightClusterOperationImpl extends MakeRightOperationImpl<ClusterPresenceInfo>
     implements MakeRightClusterOperation {
 
-  private ClusterResourceEventData eventData;
-
   /**
    * Create the operation.
    *

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -67,7 +67,6 @@ public class MakeRightDomainOperationImpl extends MakeRightOperationImpl<DomainP
   private boolean explicitRecheck;
   private boolean deleting;
   private boolean inspectionRun;
-  private EventHelper.EventData eventData;
 
   /**
    * Create the operation.
@@ -135,11 +134,6 @@ public class MakeRightDomainOperationImpl extends MakeRightOperationImpl<DomainP
   public MakeRightDomainOperation interrupt() {
     willInterrupt = true;
     return this;
-  }
-
-  @Override
-  public boolean wasStartedFromEvent() {
-    return eventData != null;
   }
 
   @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightOperationImpl.java
@@ -6,6 +6,7 @@ package oracle.kubernetes.operator.makeright;
 import oracle.kubernetes.operator.DomainProcessorDelegate;
 import oracle.kubernetes.operator.MakeRightExecutor;
 import oracle.kubernetes.operator.MakeRightOperation;
+import oracle.kubernetes.operator.helpers.EventHelper.EventData;
 import oracle.kubernetes.operator.helpers.ResourcePresenceInfo;
 
 /**
@@ -15,6 +16,7 @@ import oracle.kubernetes.operator.helpers.ResourcePresenceInfo;
 public abstract class MakeRightOperationImpl<T extends ResourcePresenceInfo> implements MakeRightOperation<T> {
   protected T liveInfo;
   protected boolean willInterrupt;
+  protected EventData eventData;
 
   protected final MakeRightExecutor executor;
   protected final DomainProcessorDelegate delegate;
@@ -33,5 +35,9 @@ public abstract class MakeRightOperationImpl<T extends ResourcePresenceInfo> imp
 
   public boolean isWillInterrupt() {
     return willInterrupt;
+  }
+
+  public boolean wasStartedFromEvent() {
+    return eventData != null;
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightOperationImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.makeright;

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -450,13 +450,19 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
     }
 
     @Override
-    public MakeRightClusterOperation createMakeRightOperationForClusterEvent(EventHelper.EventItem item,
-                                                                            ClusterResource cluster) {
+    public MakeRightClusterOperation createMakeRightOperationForClusterEvent(
+        EventHelper.EventItem item, ClusterResource cluster, String domainUid) {
       ClusterPresenceInfo info = new ClusterPresenceInfo(NS, cluster);
       final MakeRightClusterOperationStub stub =
           createStrictStub(MakeRightClusterOperationStub.class, info, item, clusters.get(NS));
       clusterOperationStubs.add(stub);
       return stub;
+    }
+
+    @Override
+    public MakeRightClusterOperation createMakeRightOperationForClusterEvent(EventHelper.EventItem item,
+                                                                             ClusterResource cluster) {
+      return createMakeRightOperationForClusterEvent(item, cluster, null);
     }
 
     abstract static class MakeRightDomainOperationStub implements MakeRightDomainOperation {
@@ -529,7 +535,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
       if (eventItem == EventHelper.EventItem.CLUSTER_DELETED) {
         clusterResourceInfos.remove(info.getResourceName());
       } else {
-        clusterResourceInfos.computeIfAbsent(info.getResourceName(), k -> (ClusterPresenceInfo) info);
+        clusterResourceInfos.computeIfAbsent(info.getResourceName(), k -> info);
       }
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/EventHelperTest.java
@@ -886,7 +886,11 @@ class EventHelperTest {
 
   @Test
   void whenMakeRightCalled_withClusterDeletedEventData_clusterDeletedEventCreated() {
+    ClusterPresenceInfo info = new ClusterPresenceInfo(NS, cluster1);
+    processor.registerClusterPresenceInfo(info);
+
     processor.dispatchClusterWatch(new Watch.Response<>("DELETED", cluster1));
+    processor.unregisterClusterPresenceInfo(info);
 
     assertThat("Found CLUSTER_DELETED event",
         containsEvent(getEvents(testSupport), CLUSTER_DELETED_EVENT), is(true));
@@ -894,7 +898,11 @@ class EventHelperTest {
 
   @Test
   void whenMakeRightCalled_withClusterDeletedEventData_clusterDeletedEventCreatedWithExpectedMessage() {
+    ClusterPresenceInfo info = new ClusterPresenceInfo(NS, cluster1);
+    processor.registerClusterPresenceInfo(info);
+
     processor.dispatchClusterWatch(new Watch.Response<>("DELETED", cluster1));
+    processor.unregisterClusterPresenceInfo(info);
 
     assertThat("Found CLUSTER_DELETED event with expected message",
         containsEventWithMessage(getEvents(testSupport),
@@ -904,7 +912,11 @@ class EventHelperTest {
 
   @Test
   void whenMakeRightCalled_withClusterDeletedEventData_clusterDeletedEventCreatedWithExpectedNamespace() {
+    ClusterPresenceInfo info = new ClusterPresenceInfo(NS, cluster1);
+    processor.registerClusterPresenceInfo(info);
+
     processor.dispatchClusterWatch(new Watch.Response<>("DELETED", cluster1));
+    processor.unregisterClusterPresenceInfo(info);
 
     assertThat("Found CLUSTER_DELETED event with expected namespace",
         containsEventWithNamespace(getEvents(testSupport),


### PR DESCRIPTION
- Add shouldContinue check to MakeRightClusterOperation.
- Add the DomainUID label to the Created/Changed/Deleted events if the cluster is referenced by a domain.
- Code cleanup

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16100/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16107/

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16102/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16116/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16121/