### PR TITLE
Owls106230 fix NPEs caused by null domain object in the DomainPresenceInfo

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -133,9 +133,7 @@ public interface DomainProcessor {
     return new ConcurrentHashMap<>();
   }
 
-  default Map<String, FiberGate> getMakeRightFiberGateMap() {
-    return new ConcurrentHashMap<>();
-  }
+  Map<String, FiberGate> getMakeRightFiberGateMap();
 
   DomainPresenceInfo getExistingDomainPresenceInfo(String namespace, String domainUid);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -18,6 +18,7 @@ import io.kubernetes.client.util.Watch.Response;
 import oracle.kubernetes.operator.helpers.ClusterPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.EventHelper.EventItem;
+import oracle.kubernetes.operator.work.FiberGate;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
@@ -132,7 +133,9 @@ public interface DomainProcessor {
     return new ConcurrentHashMap<>();
   }
 
-  boolean isNotBeingProcessed(String namespace, String domainUid);
+  default Map<String, FiberGate> getMakeRightFiberGateMap() {
+    return new ConcurrentHashMap<>();
+  }
 
   DomainPresenceInfo getExistingDomainPresenceInfo(String namespace, String domainUid);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -4,9 +4,7 @@
 package oracle.kubernetes.operator;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -108,20 +106,18 @@ public interface DomainProcessor {
   }
 
   /**
-   * Finds stranded cached domain presence infos that are not identified by the key set.
-   * @param namespace namespace
-   * @param domainUids domain UID key set
-   * @return stream of cached domain presence infos.
+   * Get the map of domain presence infos for a given namespace.
+   * @return Map of cached domain presence infos.
    */
-  default Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
-    return Stream.empty();
+  default Map<String,DomainPresenceInfo> getDomainPresenceInfoMapInNamespace(String namespace) {
+    return new ConcurrentHashMap<>();
   }
 
   /**
    * Get the map of domain presence infos.
    * @return Map of cached domain presence infos.
    */
-  default Map<String, Map<String,DomainPresenceInfo>>  getDomainPresenceInfoMap() {
+  default Map<String, Map<String,DomainPresenceInfo>> getDomainPresenceInfoMap() {
     return new ConcurrentHashMap<>();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -4,7 +4,9 @@
 package oracle.kubernetes.operator;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -106,18 +108,20 @@ public interface DomainProcessor {
   }
 
   /**
-   * Get the map of domain presence infos for a given namespace.
-   * @return Map of cached domain presence infos.
+   * Finds stranded cached domain presence infos that are not identified by the key set.
+   * @param namespace namespace
+   * @param domainUids domain UID key set
+   * @return stream of cached domain presence infos.
    */
-  default Map<String,DomainPresenceInfo> getDomainPresenceInfoMapInNamespace(String namespace) {
-    return new ConcurrentHashMap<>();
+  default Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
+    return Stream.empty();
   }
 
   /**
    * Get the map of domain presence infos.
    * @return Map of cached domain presence infos.
    */
-  default Map<String, Map<String,DomainPresenceInfo>> getDomainPresenceInfoMap() {
+  default Map<String, Map<String,DomainPresenceInfo>>  getDomainPresenceInfoMap() {
     return new ConcurrentHashMap<>();
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -131,4 +131,6 @@ public interface DomainProcessor {
   default Map<String, Map<String, ClusterPresenceInfo>>  getClusterPresenceInfoMap() {
     return new ConcurrentHashMap<>();
   }
+
+  boolean isNotBeingProcessed(String namespace, String domainUid);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessor.java
@@ -133,4 +133,6 @@ public interface DomainProcessor {
   }
 
   boolean isNotBeingProcessed(String namespace, String domainUid);
+
+  DomainPresenceInfo getExistingDomainPresenceInfo(String namespace, String domainUid);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -11,11 +11,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.CoreV1Event;
@@ -82,6 +84,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   private static final String ADDED = "ADDED";
   private static final String MODIFIED = "MODIFIED";
   private static final String DELETED = "DELETED";
+  private static final String ERROR = "ERROR";
 
   @SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
   private static String debugPrefix = null;  // Debugging: set this to a non-null value to dump the make-right steps
@@ -147,13 +150,8 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   }
 
   @Override
-  public Map<String, Map<String,DomainPresenceInfo>> getDomainPresenceInfoMap() {
+  public Map<String, Map<String,DomainPresenceInfo>>  getDomainPresenceInfoMap() {
     return domains;
-  }
-
-  @Override
-  public Map<String,DomainPresenceInfo> getDomainPresenceInfoMapInNamespace(String namespace) {
-    return domains.get(namespace);
   }
 
   @Override
@@ -530,6 +528,12 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     }
   }
 
+  @Override
+  public Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
+    return Optional.ofNullable(domains.get(namespace)).orElse(Collections.emptyMap())
+        .entrySet().stream().filter(e -> !domainUids.contains(e.getKey())).map(Map.Entry::getValue);
+  }
+
   private String getDomainUid(Fiber fiber) {
     return Optional.ofNullable(fiber)
           .map(Fiber::getPacket)
@@ -584,6 +588,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         }
         break;
 
+      case ERROR:
       default:
     }
   }
@@ -716,6 +721,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
                     c.getMetadata().getNamespace(), productVersion));
           break;
 
+        case ERROR:
         default:
       }
     }
@@ -741,6 +747,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
       case DELETED:
         onDeleteEvent(ref.getKind(), ref.getName(), e);
         break;
+      case ERROR:
       default:
     }
   }
@@ -762,6 +769,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         handleDeletedCluster(item.object);
         break;
 
+      case ERROR:
       default:
     }
   }
@@ -862,6 +870,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         handleDeletedDomain(item.object);
         break;
 
+      case ERROR:
       default:
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -11,13 +11,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.openapi.models.CoreV1Event;
@@ -84,7 +82,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   private static final String ADDED = "ADDED";
   private static final String MODIFIED = "MODIFIED";
   private static final String DELETED = "DELETED";
-  private static final String ERROR = "ERROR";
 
   @SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
   private static String debugPrefix = null;  // Debugging: set this to a non-null value to dump the make-right steps
@@ -150,8 +147,13 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   }
 
   @Override
-  public Map<String, Map<String,DomainPresenceInfo>>  getDomainPresenceInfoMap() {
+  public Map<String, Map<String,DomainPresenceInfo>> getDomainPresenceInfoMap() {
     return domains;
+  }
+
+  @Override
+  public Map<String,DomainPresenceInfo> getDomainPresenceInfoMapInNamespace(String namespace) {
+    return domains.get(namespace);
   }
 
   @Override
@@ -528,12 +530,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     }
   }
 
-  @Override
-  public Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
-    return Optional.ofNullable(domains.get(namespace)).orElse(Collections.emptyMap())
-        .entrySet().stream().filter(e -> !domainUids.contains(e.getKey())).map(Map.Entry::getValue);
-  }
-
   private String getDomainUid(Fiber fiber) {
     return Optional.ofNullable(fiber)
           .map(Fiber::getPacket)
@@ -588,7 +584,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         }
         break;
 
-      case ERROR:
       default:
     }
   }
@@ -721,7 +716,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
                     c.getMetadata().getNamespace(), productVersion));
           break;
 
-        case ERROR:
         default:
       }
     }
@@ -747,7 +741,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
       case DELETED:
         onDeleteEvent(ref.getKind(), ref.getName(), e);
         break;
-      case ERROR:
       default:
     }
   }
@@ -769,7 +762,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         handleDeletedCluster(item.object);
         break;
 
-      case ERROR:
       default:
     }
   }
@@ -870,7 +862,6 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
         handleDeletedDomain(item.object);
         break;
 
-      case ERROR:
       default:
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -141,11 +141,11 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     return getExistingDomainPresenceInfo(newPresence.getNamespace(), newPresence.getDomainUid());
   }
 
-  private ClusterPresenceInfo getExistingClusterPresenceInfo(String ns, String clusterName) {
+  private static ClusterPresenceInfo getExistingClusterPresenceInfo(String ns, String clusterName) {
     return clusters.computeIfAbsent(ns, k -> new ConcurrentHashMap<>()).get(clusterName);
   }
 
-  private ClusterPresenceInfo getExistingClusterPresenceInfo(ClusterPresenceInfo newPresence) {
+  private static ClusterPresenceInfo getExistingClusterPresenceInfo(ClusterPresenceInfo newPresence) {
     return getExistingClusterPresenceInfo(newPresence.getNamespace(), newPresence.getResourceName());
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -411,7 +411,11 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   }
 
   private boolean hasDeletedClusterEventData(MakeRightClusterOperation operation) {
-    return operation.getEventData() != null && operation.getEventData().getItem().name().equals("CLUSTER_DELETED");
+    return EventItem.CLUSTER_DELETED == getEventItem(operation);
+  }
+
+  private EventItem getEventItem(MakeRightClusterOperation operation) {
+    return Optional.ofNullable(operation.getEventData()).map(EventData::getItem).orElse(null);
   }
 
   private void logStartingDomain(DomainPresenceInfo presenceInfo) {
@@ -729,24 +733,22 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
    */
   public void dispatchEventWatch(Watch.Response<CoreV1Event> item) {
     CoreV1Event e = item.object;
-    if (e != null) {
-      V1ObjectReference ref = e.getInvolvedObject();
+    V1ObjectReference ref = e.getInvolvedObject();
 
-      if (ref == null || ref.getName() == null || ref.getKind() == null) {
-        return;
-      }
+    if (ref == null || ref.getName() == null || ref.getKind() == null) {
+      return;
+    }
 
-      switch (item.type) {
-        case ADDED:
-        case MODIFIED:
-          onCreateModifyEvent(ref.getKind(), ref.getName(), e);
-          break;
-        case DELETED:
-          onDeleteEvent(ref.getKind(), ref.getName(), e);
-          break;
-        case ERROR:
-        default:
-      }
+    switch (item.type) {
+      case ADDED:
+      case MODIFIED:
+        onCreateModifyEvent(ref.getKind(), ref.getName(), e);
+        break;
+      case DELETED:
+        onDeleteEvent(ref.getKind(), ref.getName(), e);
+        break;
+      case ERROR:
+      default:
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -712,7 +712,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
    */
   public void dispatchConfigMapWatch(Watch.Response<V1ConfigMap> item) {
     V1ConfigMap c = item.object;
-    if (c != null && c.getMetadata() != null) {
+    if (c.getMetadata() != null) {
       switch (item.type) {
         case MODIFIED:
         case DELETED:

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -106,7 +106,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   private static Map<String, Map<String, ScheduledFuture<?>>> statusUpdaters = new ConcurrentHashMap<>();
 
   // List of clusters in a namespace.
-  private static Map<String, Map<String, ClusterPresenceInfo>> clusters = new ConcurrentHashMap<>();
+  private static final Map<String, Map<String, ClusterPresenceInfo>> clusters = new ConcurrentHashMap<>();
 
   private final DomainProcessorDelegate delegate;
   private final SemanticVersion productVersion;

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -477,6 +477,10 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   @Override
   public void unregisterDomainPresenceInfo(DomainPresenceInfo info) {
     unregisterPresenceInfo(info.getNamespace(), info.getDomainUid());
+  }
+
+  @Override
+  public void unregisterDomainEventK8SObjects(DomainPresenceInfo info) {
     unregisterEventK8SObject(info.getNamespace(), info.getDomainUid());
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -251,18 +251,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   }
 
   private static void onCreateModifyEvent(CoreV1Event event) {
-    V1ObjectReference ref = event.getInvolvedObject();
-
-    if (ref == null || ref.getName() == null) {
-      return;
-    }
-
-    String kind = ref.getKind();
-    if (kind == null) {
-      return;
-    }
-
-    switch (kind) {
+    switch (event.getInvolvedObject().getKind()) {
       case EventConstants.EVENT_KIND_POD:
         processPodEvent(event);
         break;
@@ -279,12 +268,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   }
 
   private static void processPodEvent(CoreV1Event event) {
-    V1ObjectReference ref = event.getInvolvedObject();
-
-    if (ref == null || ref.getName() == null) {
-      return;
-    }
-    if (ref.getName().equals(NamespaceHelper.getOperatorPodName())) {
+    if (event.getInvolvedObject().getName().equals(NamespaceHelper.getOperatorPodName())) {
       updateEventK8SObjects(event);
     } else {
       processServerEvent(event);
@@ -327,16 +311,7 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   private void onDeleteEvent(CoreV1Event event) {
     V1ObjectReference ref = event.getInvolvedObject();
 
-    if (ref == null || ref.getName() == null) {
-      return;
-    }
-
-    String kind = ref.getKind();
-    if (kind == null) {
-      return;
-    }
-
-    switch (kind) {
+    switch (ref.getKind()) {
       case EventConstants.EVENT_KIND_DOMAIN:
       case EventConstants.EVENT_KIND_NAMESPACE:
         deleteEventK8SObjects(event);
@@ -757,6 +732,17 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   public void dispatchEventWatch(Watch.Response<CoreV1Event> item) {
     CoreV1Event e = item.object;
     if (e != null) {
+      V1ObjectReference ref = e.getInvolvedObject();
+
+      if (ref == null || ref.getName() == null) {
+        return;
+      }
+
+      String kind = ref.getKind();
+      if (kind == null) {
+        return;
+      }
+
       switch (item.type) {
         case ADDED:
         case MODIFIED:

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -158,6 +158,11 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
     return clusters;
   }
 
+  @Override
+  public boolean isNotBeingProcessed(String namespace, String domainUid) {
+    return makeRightFiberGates.get(namespace).getCurrentFibers().get(domainUid) == null;
+  }
+
   private static List<DomainPresenceInfo> getExistingDomainPresenceInfoForCluster(String ns, String cluster) {
     List<DomainPresenceInfo> referencingDomains = new ArrayList<>();
     Optional.ofNullable(domains.get(ns)).ifPresent(d -> d.values().stream()

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -243,7 +243,7 @@ class DomainResourcesValidation {
     info.setPopulated(true);
     MakeRightDomainOperation makeRight = dp.createMakeRightOperation(info).withExplicitRecheck();
     if (info.getDomain().getStatus() == null) {
-      makeRight = makeRight.withEventData(new EventData(DOMAIN_CREATED)).interrupt();
+      makeRight.withEventData(new EventData(DOMAIN_CREATED)).interrupt();
     }
     makeRight.execute();
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -139,10 +139,13 @@ class DomainResourcesValidation {
   private void addPod(V1Pod pod) {
     String domainUid = PodHelper.getPodDomainUid(pod);
     String serverName = PodHelper.getPodServerName(pod);
-    DomainPresenceInfo info = getExistingDomainPresenceInfo(domainUid);
-    if (domainUid != null && serverName != null && info != null) {
-      info.setServerPodFromEvent(serverName, pod);
+    if (domainUid != null && serverName != null) {
+      setServerPodFromEvent(getExistingDomainPresenceInfo(domainUid), serverName, pod);
     }
+  }
+
+  private void setServerPodFromEvent(DomainPresenceInfo info, String serverName, V1Pod pod) {
+    Optional.ofNullable(info).ifPresent(i -> i.setServerPodFromEvent(serverName, pod));
   }
 
   private DomainPresenceInfo getOrComputeDomainPresenceInfo(String domainUid) {
@@ -167,9 +170,8 @@ class DomainResourcesValidation {
 
   private void addService(V1Service service) {
     String domainUid = ServiceHelper.getServiceDomainUid(service);
-    DomainPresenceInfo info = getExistingDomainPresenceInfo(domainUid);
-    if (domainUid != null && info != null) {
-      ServiceHelper.addToPresence(info, service);
+    if (domainUid != null) {
+      ServiceHelper.addToPresence(getExistingDomainPresenceInfo(domainUid), service);
     }
   }
 
@@ -179,9 +181,8 @@ class DomainResourcesValidation {
 
   private void addPodDisruptionBudget(V1PodDisruptionBudget pdb) {
     String domainUid = PodDisruptionBudgetHelper.getDomainUid(pdb);
-    DomainPresenceInfo info = getExistingDomainPresenceInfo(domainUid);
-    if (domainUid != null && info != null) {
-      PodDisruptionBudgetHelper.addToPresence(info, pdb);
+    if (domainUid != null) {
+      PodDisruptionBudgetHelper.addToPresence(getExistingDomainPresenceInfo(domainUid), pdb);
     }
   }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -5,9 +5,11 @@ package oracle.kubernetes.operator;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -221,7 +223,13 @@ class DomainResourcesValidation {
   private Stream<DomainPresenceInfo> getStrandedDomainPresenceInfos(DomainProcessor dp) {
     return Stream.concat(
         getDomainPresenceInfoMap().values().stream().filter(this::isStranded),
-        dp.findStrandedDomainPresenceInfos(namespace, getDomainPresenceInfoMap().keySet()));
+        findStrandedDomainPresenceInfos(dp, namespace, getDomainPresenceInfoMap().keySet()));
+  }
+
+  private Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(
+      DomainProcessor dp, String namespace, Set<String> domainUids) {
+    return Optional.ofNullable(dp.getDomainPresenceInfoMapInNamespace(namespace)).orElse(Collections.emptyMap())
+        .entrySet().stream().filter(e -> !domainUids.contains(e.getKey())).map(Map.Entry::getValue);
   }
 
   private boolean isStranded(DomainPresenceInfo dpi) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -5,11 +5,9 @@ package oracle.kubernetes.operator;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -223,13 +221,7 @@ class DomainResourcesValidation {
   private Stream<DomainPresenceInfo> getStrandedDomainPresenceInfos(DomainProcessor dp) {
     return Stream.concat(
         getDomainPresenceInfoMap().values().stream().filter(this::isStranded),
-        findStrandedDomainPresenceInfos(dp, namespace, getDomainPresenceInfoMap().keySet()));
-  }
-
-  private Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(
-      DomainProcessor dp, String namespace, Set<String> domainUids) {
-    return Optional.ofNullable(dp.getDomainPresenceInfoMapInNamespace(namespace)).orElse(Collections.emptyMap())
-        .entrySet().stream().filter(e -> !domainUids.contains(e.getKey())).map(Map.Entry::getValue);
+        dp.findStrandedDomainPresenceInfos(namespace, getDomainPresenceInfoMap().keySet()));
   }
 
   private boolean isStranded(DomainPresenceInfo dpi) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -87,7 +87,7 @@ class DomainResourcesValidation {
       @Override
       public void completeProcessing(Packet packet) {
         DomainProcessor dp = Optional.ofNullable(packet.getSpi(DomainProcessor.class)).orElse(processor);
-        getStrandedDomainPresenceInfos(dp).forEach(info -> removeStrandedDomainPresenceInfo(dp, info));
+        //getStrandedDomainPresenceInfos(dp).forEach(info -> removeStrandedDomainPresenceInfo(dp, info));
         Optional.ofNullable(activeClusterResources).ifPresent(c -> getActiveDomainPresenceInfos()
             .forEach(info -> adjustClusterResources(c, info)));
         executeMakeRightForDeletedClusters(dp);
@@ -189,7 +189,12 @@ class DomainResourcesValidation {
 
     getDomainPresenceInfoMap().values().stream()
         .filter(dpi -> !domainNamesFromList.contains(dpi.getDomainUid())).collect(Collectors.toList())
-        .forEach(i -> getDomainPresenceInfo(i.getDomainUid()).setDomain(null));
+        .forEach(i -> recordStrandedDomain(i));
+  }
+
+  private void recordStrandedDomain(DomainPresenceInfo i) {
+    getDomainPresenceInfo(i.getDomainUid()).setDomain(null);
+    removeStrandedDomainPresenceInfo(processor, i);
   }
 
   private void addDomain(DomainResource domain) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -196,9 +196,13 @@ class DomainResourcesValidation {
 
     getDomainPresenceInfoMap().values().stream()
         .filter(dpi -> !domainNamesFromList.contains(dpi.getDomainUid()))
-        .filter(dpi -> processor.isNotBeingProcessed(dpi.getNamespace(), dpi.getDomainUid()))
+        .filter(dpi -> isNotBeingProcessed(dpi.getNamespace(), dpi.getDomainUid()))
         .collect(Collectors.toList())
         .forEach(i -> i.setDomain(null));
+  }
+
+  private boolean isNotBeingProcessed(String namespace, String domainUid) {
+    return processor.getMakeRightFiberGateMap().get(namespace).getCurrentFibers().get(domainUid) == null;
   }
 
   private void addDomain(DomainResource domain) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -193,8 +193,10 @@ class DomainResourcesValidation {
   }
 
   private void recordStrandedDomain(DomainPresenceInfo i) {
-    getDomainPresenceInfo(i.getDomainUid()).setDomain(null);
-    removeStrandedDomainPresenceInfo(processor, i);
+    if (processor.isNotBeingProcessed(i.getNamespace(), i.getDomainUid())) {
+      getDomainPresenceInfo(i.getDomainUid()).setDomain(null);
+      removeStrandedDomainPresenceInfo(processor, i);
+    }
   }
 
   private void addDomain(DomainResource domain) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -621,10 +621,6 @@ public class DomainStatusUpdater {
     @Override
     DomainStatusUpdaterContext createContext(Packet packet) {
       return new StatusUpdateContext(packet, this);
-    }
-
-    @Override
-    void modifyStatus(DomainStatus domainStatus) { // no-op; modification happens in the context itself.
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -628,8 +628,7 @@ public class DomainStatusUpdater {
       if (isDomainNotPresent(packet)) {
         return doNext(packet);
       }
-      packet.put(ProcessingConstants.SKIP_STATUS_UPDATE,
-          Boolean.valueOf(shouldSkipDomainStatusUpdate(packet)));
+      packet.put(ProcessingConstants.SKIP_STATUS_UPDATE, shouldSkipDomainStatusUpdate(packet));
       if (endOfProcessing) {
         packet.put(ProcessingConstants.END_OF_PROCESSING, Boolean.TRUE);
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -534,7 +534,7 @@ public class DomainStatusUpdater {
       if (!isStatusUnchanged()) {
         result.add(createDomainStatusReplaceStep());
       } else {
-        if (endOfProcessing && isMakeRight) {
+        if (endOfProcessing) {
           Optional.ofNullable(createDomainStatusObservedGenerationReplaceStep()).ifPresent(result::add);
         }
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -482,9 +482,8 @@ public class DomainStatusUpdater {
 
     private Step createDomainStatusReplaceStep() {
       LOGGER.fine(MessageKeys.DOMAIN_STATUS, getDomainUid(), getNewStatus());
-      if (LOGGER.isFinerEnabled()) {
-        LOGGER.finer("status change: " + createPatchString());
-      }
+      LOGGER.finer("status change: " + createPatchString());
+
       DomainResource oldDomain = getDomain();
       DomainStatus status = getNewStatus();
       if (isMakeRight) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -395,7 +395,9 @@ public class DomainStatusUpdater {
   static class DomainUpdateStep extends ResponseStep<DomainResource> {
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<DomainResource> callResponse) {
-      packet.getSpi(DomainPresenceInfo.class).setDomain(callResponse.getResult());
+      if (callResponse.getResult() != null) {
+        packet.getSpi(DomainPresenceInfo.class).setDomain(callResponse.getResult());
+      }
       return doNext(packet);
     }
 

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -629,6 +629,9 @@ public class DomainStatusUpdater {
 
     @Override
     public NextAction apply(Packet packet) {
+      if (isDomainNotPresent(packet)) {
+        return doNext(packet);
+      }
       packet.put(ProcessingConstants.SKIP_STATUS_UPDATE,
           Boolean.valueOf(shouldSkipDomainStatusUpdate(packet)));
       if (endOfProcessing) {
@@ -642,6 +645,11 @@ public class DomainStatusUpdater {
       return info.getServerStartupInfo() == null
           && info.clusterStatusInitialized()
           && !endOfProcessing;
+    }
+
+    private boolean isDomainNotPresent(Packet packet) {
+      DomainPresenceInfo info = packet.getSpi(DomainPresenceInfo.class);
+      return info == null || info.getDomain() == null;
     }
 
     static class StatusUpdateContext extends DomainStatusUpdaterContext {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -534,7 +534,7 @@ public class DomainStatusUpdater {
       if (!isStatusUnchanged()) {
         result.add(createDomainStatusReplaceStep());
       } else {
-        if (endOfProcessing) {
+        if (endOfProcessing && isMakeRight) {
           Optional.ofNullable(createDomainStatusObservedGenerationReplaceStep()).ifPresent(result::add);
         }
       }

--- a/operator/src/main/java/oracle/kubernetes/operator/MakeRightExecutor.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/MakeRightExecutor.java
@@ -76,4 +76,6 @@ public interface MakeRightExecutor {
    * @param info the presence info which encapsulates the domain
    */
   void unregisterClusterPresenceInfo(ClusterPresenceInfo info);
+
+  void unregisterDomainEventK8SObjects(DomainPresenceInfo info);
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/EventHelper.java
@@ -1286,7 +1286,7 @@ public class EventHelper {
   public static class ClusterResourceEventData extends EventData {
 
     private final ClusterResource resource;
-    private String domainUid;
+    private final String domainUid;
 
     private ClusterResourceEventData(EventItem eventItem, ClusterResource resource, String domainUid) {
       super(eventItem);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodDisruptionBudgetHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodDisruptionBudgetHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodDisruptionBudgetHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodDisruptionBudgetHelper.java
@@ -347,7 +347,7 @@ public class PodDisruptionBudgetHelper {
   }
 
   public static void addToPresence(DomainPresenceInfo presenceInfo, V1PodDisruptionBudget pdb) {
-    presenceInfo.setPodDisruptionBudget(getClusterName(pdb), pdb);
+    Optional.ofNullable(presenceInfo).ifPresent(i -> i.setPodDisruptionBudget(getClusterName(pdb), pdb));
   }
 
   /**

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ServiceHelper.java
@@ -101,7 +101,7 @@ public class ServiceHelper {
   }
 
   public static void addToPresence(DomainPresenceInfo info, V1Service service) {
-    OperatorServiceType.getType(service).addToPresence(info, service);
+    Optional.ofNullable(info).ifPresent(i -> OperatorServiceType.getType(service).addToPresence(i, service));
   }
 
   public static void updatePresenceFromEvent(DomainPresenceInfo info, V1Service service) {

--- a/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/makeright/MakeRightDomainOperationImpl.java
@@ -369,8 +369,12 @@ public class MakeRightDomainOperationImpl extends MakeRightOperationImpl<DomainP
     }
 
     private void updateCache(DomainPresenceInfo info, DomainResource domain) {
-      info.setDeleting(domain.getMetadata().getDeletionTimestamp() != null);
+      info.setDeleting(isBeingDeleted(domain));
       info.setDomain(domain);
+    }
+
+    private boolean isBeingDeleted(DomainResource domain) {
+      return domain == null || domain.getMetadata().getDeletionTimestamp() != null;
     }
 
     @Override

--- a/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStep.java
@@ -399,7 +399,9 @@ public class ShutdownManagedServerStep extends Step {
   static class DomainUpdateStep extends DefaultResponseStep<DomainResource> {
     @Override
     public NextAction onSuccess(Packet packet, CallResponse<DomainResource> callResponse) {
-      packet.getSpi(DomainPresenceInfo.class).setDomain(callResponse.getResult());
+      if (callResponse.getResult() != null) {
+        packet.getSpi(DomainPresenceInfo.class).setDomain(callResponse.getResult());
+      }
       return doNext(packet);
     }
   }

--- a/operator/src/main/java/oracle/kubernetes/operator/work/Fiber.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/work/Fiber.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.work;
@@ -92,6 +92,11 @@ public final class Fiber implements Runnable, ComponentRegistry, AsyncFiber, Bre
   private Collection<Fiber> children = null;
   // Will only be populated if log level is at least FINE
   private List<BreadCrumbFactory> breadCrumbs = null;
+
+  // for unit test only
+  public Fiber() {
+    this(null);
+  }
 
   Fiber(Engine engine) {
     this(engine, null);

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -7,11 +7,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -374,6 +372,19 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
+  void whenK8sHasOneDomainWithMissingInfoAndDomainUidLabel_dontRecordAdminServerService() {
+    addDomainResource(UID1, NS);
+    V1Service service = createServerService(UID1, NS, "admin");
+    testSupport.defineResources(service);
+    service.getMetadata().getLabels().remove(DOMAINUID_LABEL);
+
+    testSupport.addComponent("DP", DomainProcessor.class, dp);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
+
+    assertThat(getDomainPresenceInfo(dp, UID1).getServerService("admin"), equalTo(null));
+  }
+
+  @Test
   void whenK8sHasOneDomainWithPod_recordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
@@ -412,7 +423,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodButPodNoServerName_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodButMissingServerName_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
@@ -440,13 +451,40 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndNoServerNameLabel_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
     pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
     pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
     dp.domains.computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, info);
+
+    testSupport.addComponent("DP", DomainProcessor.class, dp);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
+
+    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
+  }
+
+  @Test
+  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
+    addDomainResource(UID1, NS);
+    V1Pod pod = createPodResource(UID1, NS, "admin");
+    testSupport.defineResources(pod);
+    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
+    pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
+
+    testSupport.addComponent("DP", DomainProcessor.class, dp);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
+
+    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
+  }
+
+  @Test
+  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabel_dontRecordPodPresence() {
+    addDomainResource(UID1, NS);
+    V1Pod pod = createPodResource(UID1, NS, "admin");
+    testSupport.defineResources(pod);
+    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
 
     testSupport.addComponent("DP", DomainProcessor.class, dp);
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
@@ -557,11 +595,6 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
             .orElse(false);
     }
 
-    @Override
-    public Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
-      return dpis.entrySet().stream().filter(e -> !domainUids.contains(e.getKey())).map(Map.Entry::getValue);
-    }
-
     private MakeRightDomainOperationStub getMakeRightOperations(String uid) {
       return operationStubs.stream().filter(s -> uid.equals(s.getUid())).findFirst().orElse(null);
     }
@@ -569,6 +602,11 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
     @Override
     public Map<String, Map<String,DomainPresenceInfo>> getDomainPresenceInfoMap() {
       return domains;
+    }
+
+    @Override
+    public Map<String, DomainPresenceInfo> getDomainPresenceInfoMapInNamespace(String namespace) {
+      return dpis;
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
@@ -372,19 +374,6 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithMissingInfoAndDomainUidLabel_dontRecordAdminServerService() {
-    addDomainResource(UID1, NS);
-    V1Service service = createServerService(UID1, NS, "admin");
-    testSupport.defineResources(service);
-    service.getMetadata().getLabels().remove(DOMAINUID_LABEL);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerService("admin"), equalTo(null));
-  }
-
-  @Test
   void whenK8sHasOneDomainWithPod_recordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
@@ -423,7 +412,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodButMissingServerName_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodButPodNoServerName_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
@@ -451,40 +440,13 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndNoServerNameLabel_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
     pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
     pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
     dp.domains.computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, info);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
-  }
-
-  @Test
-  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
-    addDomainResource(UID1, NS);
-    V1Pod pod = createPodResource(UID1, NS, "admin");
-    testSupport.defineResources(pod);
-    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
-    pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
-  }
-
-  @Test
-  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabel_dontRecordPodPresence() {
-    addDomainResource(UID1, NS);
-    V1Pod pod = createPodResource(UID1, NS, "admin");
-    testSupport.defineResources(pod);
-    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
 
     testSupport.addComponent("DP", DomainProcessor.class, dp);
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
@@ -595,6 +557,11 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
             .orElse(false);
     }
 
+    @Override
+    public Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
+      return dpis.entrySet().stream().filter(e -> !domainUids.contains(e.getKey())).map(Map.Entry::getValue);
+    }
+
     private MakeRightDomainOperationStub getMakeRightOperations(String uid) {
       return operationStubs.stream().filter(s -> uid.equals(s.getUid())).findFirst().orElse(null);
     }
@@ -602,11 +569,6 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
     @Override
     public Map<String, Map<String,DomainPresenceInfo>> getDomainPresenceInfoMap() {
       return domains;
-    }
-
-    @Override
-    public Map<String, DomainPresenceInfo> getDomainPresenceInfoMapInNamespace(String namespace) {
-      return dpis;
     }
 
     @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -374,6 +374,19 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
+  void whenK8sHasOneDomainWithMissingInfoAndDomainUidLabel_dontRecordAdminServerService() {
+    addDomainResource(UID1, NS);
+    V1Service service = createServerService(UID1, NS, "admin");
+    testSupport.defineResources(service);
+    service.getMetadata().getLabels().remove(DOMAINUID_LABEL);
+
+    testSupport.addComponent("DP", DomainProcessor.class, dp);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
+
+    assertThat(getDomainPresenceInfo(dp, UID1).getServerService("admin"), equalTo(null));
+  }
+
+  @Test
   void whenK8sHasOneDomainWithPod_recordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
@@ -412,7 +425,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodButPodNoServerName_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodButMissingServerName_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
@@ -440,13 +453,40 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndNoServerNameLabel_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
     pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
     pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
     dp.domains.computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, info);
+
+    testSupport.addComponent("DP", DomainProcessor.class, dp);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
+
+    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
+  }
+
+  @Test
+  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
+    addDomainResource(UID1, NS);
+    V1Pod pod = createPodResource(UID1, NS, "admin");
+    testSupport.defineResources(pod);
+    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
+    pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
+
+    testSupport.addComponent("DP", DomainProcessor.class, dp);
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
+
+    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
+  }
+
+  @Test
+  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabel_dontRecordPodPresence() {
+    addDomainResource(UID1, NS);
+    V1Pod pod = createPodResource(UID1, NS, "admin");
+    testSupport.defineResources(pod);
+    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
 
     testSupport.addComponent("DP", DomainProcessor.class, dp);
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -27,6 +27,7 @@ import oracle.kubernetes.operator.builders.StubWatchFactory;
 import oracle.kubernetes.operator.helpers.ClusterPresenceInfo;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.EventHelper;
+import oracle.kubernetes.operator.helpers.EventHelper.EventData;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.helpers.LegalNames;
 import oracle.kubernetes.operator.helpers.OperatorServiceType;
@@ -426,7 +427,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
     private final List<MakeRightClusterOperationStub> clusterOperationStubs = new ArrayList<>();
     Map<String, Map<String, DomainPresenceInfo>> domains = new ConcurrentHashMap<>();
     Map<String, Map<String, ClusterPresenceInfo>> clusters = new ConcurrentHashMap<>();
-    private Map<String, Boolean> beingProcessed = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> beingProcessed = new ConcurrentHashMap<>();
 
     Map<String, DomainPresenceInfo> getDomainPresenceInfos() {
       return dpis;
@@ -509,7 +510,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
       private final Map<String, DomainPresenceInfo> dpis;
       private boolean explicitRecheck;
       private boolean deleting;
-      private EventHelper.EventData eventData;
+      private EventData eventData;
 
       MakeRightDomainOperationStub(DomainPresenceInfo info, Map<String, DomainPresenceInfo> dpis) {
         this.info = info;
@@ -541,9 +542,14 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
       }
 
       @Override
-      public MakeRightDomainOperation withEventData(EventHelper.EventData eventData) {
+      public MakeRightDomainOperation withEventData(EventData eventData) {
         this.eventData = eventData;
         return this;
+      }
+
+      @Override
+      public boolean wasStartedFromEvent() {
+        return eventData != null;
       }
 
       @Override
@@ -574,7 +580,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
       if (eventItem == EventHelper.EventItem.CLUSTER_DELETED) {
         clusterResourceInfos.remove(info.getResourceName());
       } else {
-        clusterResourceInfos.computeIfAbsent(info.getResourceName(), k -> info);
+        clusterResourceInfos.put(info.getResourceName(), info);
       }
     }
   }

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -374,19 +374,6 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithMissingInfoAndDomainUidLabel_dontRecordAdminServerService() {
-    addDomainResource(UID1, NS);
-    V1Service service = createServerService(UID1, NS, "admin");
-    testSupport.defineResources(service);
-    service.getMetadata().getLabels().remove(DOMAINUID_LABEL);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerService("admin"), equalTo(null));
-  }
-
-  @Test
   void whenK8sHasOneDomainWithPod_recordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
@@ -425,68 +412,12 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenK8sHasOneDomainWithPodButMissingServerName_dontRecordPodPresence() {
+  void whenK8sHasOneDomainWithPodButMissingServerNameLabel_dontRecordPodPresence() {
     addDomainResource(UID1, NS);
     V1Pod pod = createPodResource(UID1, NS, "admin");
     testSupport.defineResources(pod);
     pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
     dp.domains.computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, info);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
-  }
-
-  @Test
-  void whenK8sHasOneDomainWithPodNoDomainUidLabel_dontRecordPodPresence() {
-    addDomainResource(UID1, NS);
-    V1Pod pod = createPodResource(UID1, NS, "admin");
-    testSupport.defineResources(pod);
-    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
-    dp.domains.computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, info);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
-  }
-
-  @Test
-  void whenK8sHasOneDomainWithPodNoDomainUidLabelAndNoServerNameLabel_dontRecordPodPresence() {
-    addDomainResource(UID1, NS);
-    V1Pod pod = createPodResource(UID1, NS, "admin");
-    testSupport.defineResources(pod);
-    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
-    pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
-    dp.domains.computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, info);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
-  }
-
-  @Test
-  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabelAndServerNameLabel_dontRecordPodPresence() {
-    addDomainResource(UID1, NS);
-    V1Pod pod = createPodResource(UID1, NS, "admin");
-    testSupport.defineResources(pod);
-    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
-    pod.getMetadata().getLabels().remove(SERVERNAME_LABEL);
-
-    testSupport.addComponent("DP", DomainProcessor.class, dp);
-    testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));
-
-    assertThat(getDomainPresenceInfo(dp, UID1).getServerPod("admin"), equalTo(null));
-  }
-
-  @Test
-  void whenK8sHasOneDomainWithPodMissingInfoNoDomainUidLabel_dontRecordPodPresence() {
-    addDomainResource(UID1, NS);
-    V1Pod pod = createPodResource(UID1, NS, "admin");
-    testSupport.defineResources(pod);
-    pod.getMetadata().getLabels().remove(DOMAINUID_LABEL);
 
     testSupport.addComponent("DP", DomainProcessor.class, dp);
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, dp));

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -1851,6 +1851,19 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
+  void whenUpdateDomainStatusFail503ErrorSuccessOnRetry_observedGenerationUpdated() {
+    testSupport.getPacket().put(MAKE_RIGHT_DOMAIN_OPERATION, createDummyMakeRightOperation());
+
+    info.getDomain().getMetadata().setGeneration(2L);
+    testSupport.failOnReplaceStatus(DOMAIN_STATUS, info.getDomainUid(), info.getNamespace(), HTTP_UNAVAILABLE);
+    retryStrategy.setNumRetriesLeft(1);
+    testSupport.addRetryStrategy(retryStrategy);
+    updateDomainStatusInEndOfProcessing();
+
+    assertThat(getRecordedDomain().getStatus().getObservedGeneration(), equalTo(2L));
+  }
+
+  @Test
   void whenUpdateDomainStatusWith404Error_observedGenerationNotUpdated() {
     testSupport.getPacket().put(MAKE_RIGHT_DOMAIN_OPERATION, createDummyMakeRightOperation());
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -317,6 +317,19 @@ abstract class DomainStatusUpdateTestBase {
   }
 
   @Test
+  void statusStepWhenInfoHasNullDomain_dontUpdatesDomainStatus() {
+    defineScenario()
+        .withCluster("clusterA", "server1")
+        .build();
+    domain.setStatus(null);
+    info.setDomain(null);
+
+    updateDomainStatus();
+
+    assertThat(getRecordedDomain().getStatus(), equalTo(null));
+  }
+
+  @Test
   void whenServerIntentionallyNotStarted_reportItsStateAsShutdown() {    
     defineScenario().withServers("server1").notStarting("server1").build();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainStatusUpdateTestBase.java
@@ -33,6 +33,7 @@ import io.kubernetes.client.openapi.models.V1PodStatus;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
 import oracle.kubernetes.operator.helpers.EventHelper;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
+import oracle.kubernetes.operator.helpers.RetryStrategyStub;
 import oracle.kubernetes.operator.logging.LoggingFacade;
 import oracle.kubernetes.operator.logging.LoggingFactory;
 import oracle.kubernetes.operator.tuning.TuningParameters;
@@ -65,6 +66,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.meterware.simplestub.Stub.createStrictStub;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static oracle.kubernetes.common.logging.MessageKeys.CLUSTER_NOT_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.NON_CLUSTERED_SERVERS_NOT_READY;
 import static oracle.kubernetes.common.logging.MessageKeys.NO_APPLICATION_SERVERS_READY;
@@ -93,6 +97,8 @@ import static oracle.kubernetes.operator.WebLogicConstants.SHUTTING_DOWN_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.STANDBY_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.STARTING_STATE;
 import static oracle.kubernetes.operator.WebLogicConstants.UNKNOWN_STATE;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN;
+import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.DOMAIN_STATUS;
 import static oracle.kubernetes.operator.helpers.KubernetesTestSupport.EVENT;
 import static oracle.kubernetes.weblogic.domain.model.DomainCondition.FALSE;
 import static oracle.kubernetes.weblogic.domain.model.DomainCondition.TRUE;
@@ -124,6 +130,7 @@ abstract class DomainStatusUpdateTestBase {
   private final DomainResource domain = DomainProcessorTestSetup.createTestDomain();
   private final DomainPresenceInfo info = new DomainPresenceInfo(domain);
   private List<String> liveServers;
+  private final RetryStrategyStub retryStrategy = createStrictStub(RetryStrategyStub.class);
 
   @BeforeEach
   void setUp() throws NoSuchFieldException {
@@ -1816,6 +1823,44 @@ abstract class DomainStatusUpdateTestBase {
     updateDomainStatusInEndOfProcessing();
 
     assertThat(getRecordedDomain().getStatus().getObservedGeneration(), equalTo(2L));
+  }
+
+  @Test
+  void whenUpdateDomainStatusWithEmptyResult_observedGenerationUpdated() {
+    testSupport.getPacket().put(MAKE_RIGHT_DOMAIN_OPERATION, createDummyMakeRightOperation());
+
+    info.getDomain().getMetadata().setGeneration(2L);
+    testSupport.returnEmptyResult(DOMAIN, info.getDomainUid(), info.getNamespace());
+    updateDomainStatusInEndOfProcessing();
+
+    assertThat(getRecordedDomain().getStatus().getObservedGeneration(), equalTo(2L));
+  }
+
+  @Test
+  void whenUpdateDomainStatusWithEmptyResultOnRetry_observedGenerationUpdated() {
+    testSupport.getPacket().put(MAKE_RIGHT_DOMAIN_OPERATION, createDummyMakeRightOperation());
+
+    info.getDomain().getMetadata().setGeneration(2L);
+    testSupport.failOnReplaceStatus(DOMAIN_STATUS, info.getDomainUid(), info.getNamespace(), HTTP_UNAVAILABLE);
+    testSupport.returnEmptyResultOnRead(DOMAIN, info.getDomainUid(), info.getNamespace());
+    retryStrategy.setNumRetriesLeft(1);
+    testSupport.addRetryStrategy(retryStrategy);
+    updateDomainStatusInEndOfProcessing();
+
+    assertThat(getRecordedDomain().getStatus().getObservedGeneration(), equalTo(2L));
+  }
+
+  @Test
+  void whenUpdateDomainStatusWith404Error_observedGenerationNotUpdated() {
+    testSupport.getPacket().put(MAKE_RIGHT_DOMAIN_OPERATION, createDummyMakeRightOperation());
+
+    info.getDomain().getMetadata().setGeneration(2L);
+    testSupport.failOnReplaceStatus(DOMAIN_STATUS, info.getDomainUid(), info.getNamespace(), HTTP_NOT_FOUND);
+    retryStrategy.setNumRetriesLeft(1);
+    testSupport.addRetryStrategy(retryStrategy);
+    updateDomainStatusInEndOfProcessing();
+
+    assertThat(getRecordedDomain().getStatus().getObservedGeneration(), not(equalTo(2L)));
   }
 
   @Nullable

--- a/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import java.util.stream.Stream;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -237,6 +239,11 @@ class StuckPodTest {
       public MakeRightDomainOperation createMakeRightOperation(DomainPresenceInfo info) {
         Optional.ofNullable(info).map(DomainPresenceInfo::getDomain).ifPresent(delegateStub.invocations::add);
         return createStrictStub(MakeRightDomainOperationStub.class);
+      }
+
+      @Override
+      public Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
+        return Stream.empty();
       }
 
       @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator;
@@ -8,11 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import java.util.stream.Stream;
 
 import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -239,11 +237,6 @@ class StuckPodTest {
       public MakeRightDomainOperation createMakeRightOperation(DomainPresenceInfo info) {
         Optional.ofNullable(info).map(DomainPresenceInfo::getDomain).ifPresent(delegateStub.invocations::add);
         return createStrictStub(MakeRightDomainOperationStub.class);
-      }
-
-      @Override
-      public Stream<DomainPresenceInfo> findStrandedDomainPresenceInfos(String namespace, Set<String> domainUids) {
-        return Stream.empty();
       }
 
       @Override

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/JobHelperTest.java
@@ -1037,7 +1037,7 @@ class JobHelperTest extends DomainValidationTestBase {
                 "echo managed server && sleep 120"))
         .configureIntrospector()
             .withRequestRequirement("cpu", "512m")
-             .withLimitRequirement("memory", "1Gi");    ;
+             .withLimitRequirement("memory", "1Gi");
 
     V1JobSpec jobSpec = createJobSpec();
 

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodPresenceTest.java
@@ -404,6 +404,44 @@ class PodPresenceTest {
   }
 
   @Test
+  void onDeleteEventWithInfoNotDeletingInfoHasMissingDomain_ignoreIt() {
+    V1Pod service = createServerPod();
+    info.setServerPod(SERVER, service);
+    info.setDeleting(false);
+    info.setDomain(null);
+    Watch.Response<V1Pod> event = WatchEvent.createDeletedEvent(service).toWatchResponse();
+
+    processor.dispatchPodWatch(event);
+
+    assertThat(info.getServerPod(SERVER), nullValue());
+  }
+
+  @Test
+  void onDeleteEventWithInfoDeleting_ignoreIt() {
+    V1Pod service = createServerPod();
+    info.setServerPod(SERVER, service);
+    info.setDeleting(true);
+    Watch.Response<V1Pod> event = WatchEvent.createDeletedEvent(service).toWatchResponse();
+
+    processor.dispatchPodWatch(event);
+
+    assertThat(info.getServerPod(SERVER), nullValue());
+  }
+
+  @Test
+  void onDeleteEventWithInfoDeletingInfoHasMissingDomain_ignoreIt() {
+    V1Pod service = createServerPod();
+    info.setServerPod(SERVER, service);
+    info.setDeleting(true);
+    info.setDomain(null);
+    Watch.Response<V1Pod> event = WatchEvent.createDeletedEvent(service).toWatchResponse();
+
+    processor.dispatchPodWatch(event);
+
+    assertThat(info.getServerPod(SERVER), nullValue());
+  }
+
+  @Test
   void onDeleteEventWithOlderServerPod_keepCurrentValue() {
     V1Pod oldPod = createServerPod();
     V1Pod currentPod = createServerPod();

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
@@ -144,9 +144,9 @@ class ServicePresenceTest {
 
   @Test
   void onAddEventWithNoRecordedClusterServiceMissingInfo_dontAddIt() {
-    domains.get(NS).remove(UID);
     V1Service newService = createClusterService();
     Watch.Response<V1Service> event = WatchEvent.createAddedEvent(newService).toWatchResponse();
+    domains.get(NS).remove(UID);
 
     processor.dispatchServiceWatch(event);
 
@@ -277,6 +277,17 @@ class ServicePresenceTest {
     processor.dispatchServiceWatch(event);
 
     assertThat(info.getClusterService(CLUSTER), nullValue());
+  }
+
+  @Test
+  void onDeleteEventWithNoRecordedClusterServiceInfoMissingDomainObject_dontAddIt() {
+    V1Service newService = createClusterService();
+    Watch.Response<V1Service> event = WatchEvent.createDeletedEvent(newService).toWatchResponse();
+    domains.get(NS).get(UID).setDomain(null);
+
+    processor.dispatchServiceWatch(event);
+
+    assertThat(info.getClusterService(CLUSTER), equalTo(null));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/ServicePresenceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
+import static oracle.kubernetes.operator.DomainProcessorTestSetup.UID;
 import static oracle.kubernetes.operator.LabelConstants.CLUSTERNAME_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.CREATEDBYOPERATOR_LABEL;
 import static oracle.kubernetes.operator.LabelConstants.DOMAINUID_LABEL;
@@ -66,7 +67,9 @@ class ServicePresenceTest {
     mementos.add(StaticStubSupport.install(DomainProcessorImpl.class, "domains", domains));
     mementos.add(UnitTestHash.install());
 
-    domains.put(NS, ImmutableMap.of(UID, info));
+    HashMap<String, DomainPresenceInfo> infoMap = new HashMap<>();
+    infoMap.put(UID, info);
+    domains.put(NS, infoMap);
     disableMakeRightDomainProcessing();
     DomainResource domain = new DomainResource().withMetadata(new V1ObjectMeta().name(UID));
     DomainConfiguratorFactory.forDomain(domain)
@@ -137,6 +140,39 @@ class ServicePresenceTest {
     processor.dispatchServiceWatch(event);
 
     assertThat(info.getClusterService(CLUSTER), sameInstance(newService));
+  }
+
+  @Test
+  void onAddEventWithNoRecordedClusterServiceMissingInfo_dontAddIt() {
+    domains.get(NS).remove(UID);
+    V1Service newService = createClusterService();
+    Watch.Response<V1Service> event = WatchEvent.createAddedEvent(newService).toWatchResponse();
+
+    processor.dispatchServiceWatch(event);
+
+    assertThat(info.getClusterService(CLUSTER), equalTo(null));
+  }
+
+  @Test
+  void onAddEventWithNoRecordedClusterServiceMissingDomainUidLabel_dontAddIt() {
+    V1Service newService = createClusterService();
+    newService.getMetadata().getLabels().remove(DOMAINUID_LABEL);
+    Watch.Response<V1Service> event = WatchEvent.createAddedEvent(newService).toWatchResponse();
+
+    processor.dispatchServiceWatch(event);
+
+    assertThat(info.getClusterService(CLUSTER), equalTo(null));
+  }
+
+  @Test
+  void onAddEventWithNoRecordedClusterServiceMissingNamespace_dontAddIt() {
+    V1Service newService = createClusterService();
+    newService.getMetadata().setNamespace(null);
+    Watch.Response<V1Service> event = WatchEvent.createAddedEvent(newService).toWatchResponse();
+
+    processor.dispatchServiceWatch(event);
+
+    assertThat(info.getClusterService(CLUSTER), equalTo(null));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/introspection/IntrospectionStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/introspection/IntrospectionStatusTest.java
@@ -132,6 +132,14 @@ class IntrospectionStatusTest {
   }
 
   @Test
+  void whenNewIntrospectorJobPodWhenInfoIsMissingFromMapAndJobNameLabelMissing_dontUpdateDomainStatus() {
+    presenceInfoMap.get(NS).remove(UID);
+    IntrospectorJobPodBuilder.createPodAddedEvent().withNullStatus().dispatchWithMissingJobLabel(processor);
+
+    assertThat(getDomain(), hasStatus().withEmptyReasonAndMessage());
+  }
+
+  @Test
   void whenPodReady_dontLogFailureMessage() {
     consoleHandlerMemento.collectLogMessages(logRecords, INTROSPECTOR_POD_FAILED);
 

--- a/operator/src/test/java/oracle/kubernetes/operator/introspection/IntrospectionStatusTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/introspection/IntrospectionStatusTest.java
@@ -125,6 +125,14 @@ class IntrospectionStatusTest {
   }
 
   @Test
+  void whenNewIntrospectorJobPodWhenInfoMissingDomainObject_dontUpdateDomainStatus() {
+    presenceInfoMap.get(NS).get(UID).setDomain(null);
+    IntrospectorJobPodBuilder.createPodAddedEvent().withNullStatus().dispatch(processor);
+
+    assertThat(getDomain(), hasStatus().withEmptyReasonAndMessage());
+  }
+
+  @Test
   void whenNewIntrospectorJobPodJobNameLabelMissing_dontUpdateDomainStatus() {
     IntrospectorJobPodBuilder.createPodAddedEvent().withNullStatus().dispatchWithMissingJobLabel(processor);
 

--- a/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
+++ b/operator/src/test/java/oracle/kubernetes/weblogic/domain/model/DomainValidationTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class DomainValidationTest extends DomainValidationTestBase {
+public class DomainValidationTest extends DomainValidationTestBase {
 
   private static final String ENV_NAME1 = "MY_ENV";
   private static final String RAW_VALUE_1 = "123";


### PR DESCRIPTION
This contains fixes to a couple of problems in the operator code that may cause an in-flight make right operation to hit NPEs because the domain object in the DomainPresenceInfo (DPI) is null.

- Some K8S async calls (such as replace domain status or read a domain) may succeed with a null domain object in the response when the domain resource has been deleted. The operator uses the domain object in the response to update the corresponding DPI, which may be null out the domain object when the response contains a null result. The fix  is to only update the DPI when the domain object in the response is not null.

- In a periodical domain recheck, the operator reads all domains in each namespace, and then refreshes its "domains" map and detects all stranded domains. It first nulls out the corresponding DPI's domain object to indicate the domain is stranded, and then issues a make right operation to process the domain. Potentially, the domain object in the DPI that an inflight make right operation is using to process the domain can be nulled out underneath. The fix skips handling an stranded domain when there is fiber still works on the domain, a subsequent recheck may handle the stranded domain when it is not worked by a fiber. The fix also removes the corresponding DPI from the map before processing the deletion of the domain.

- The operator uses getDomainPresenceInfo() to not only fetch an existing DPI, but also populate the entry in the map if the entry does not exist. A number of place where this method is called do not expect the domain object is null. The fix is to split the method into two: getOrComputeDomainPresenceInfo(), which keeps the current behavior, and getExistingDomainPresenceInfo(), which returns what is in the map currently (can be null). The caller of the method is changed to use one of the two new methods accordingly.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16217/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16227/, https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16230/

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16276/
