### PR TITLE
Fix to list the init containers generated from 3.x/v8 aux image configuration at the top before other init containers.

### DIFF
--- a/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
+++ b/common/src/main/java/oracle/kubernetes/common/utils/SchemaConversionUtils.java
@@ -589,14 +589,14 @@ public class SchemaConversionUtils {
   private void addInitContainersVolumeAndMountsToServerPod(Map<String, Object> serverPod, List<Object> auxiliaryImages,
                                                                          List<Object> auxiliaryImageVolumes) {
     addEmptyDirVolume(serverPod, auxiliaryImageVolumes);
-    List<Object> initContainers = Optional.ofNullable((List<Object>) serverPod.get(INIT_CONTAINERS))
-        .orElse(new ArrayList<>());
+    List<Object> initContainers =  new ArrayList<>();
     for (Object auxiliaryImage : auxiliaryImages) {
       initContainers.add(
           createInitContainerForAuxiliaryImage((Map<String, Object>) auxiliaryImage, containerIndex.get(),
               auxiliaryImageVolumes));
       containerIndex.addAndGet(1);
     }
+    initContainers.addAll(Optional.ofNullable((List<Object>) serverPod.get(INIT_CONTAINERS)).orElse(new ArrayList<>()));
     serverPod.put(INIT_CONTAINERS, initContainers);
     auxiliaryImages.forEach(ai -> addVolumeMount(serverPod, (Map<String, Object>)ai, auxiliaryImageVolumes));
     addAuxiliaryImageEnv(auxiliaryImages, serverPod, auxiliaryImageVolumes);


### PR DESCRIPTION
In some cases, init containers listed in the `serverPod` configuration for the WL server pod can depend on the init container(s) generated from `3.x/v8` aux image(s) configuration. This change is to put the init containers generated from 3.x/v8 aux image configuration at the top before listing other init containers in the `serverPod` spec.