### PR TITLE
remove ItDedicatedMode.java from olcne profile 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDedicatedMode.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItDedicatedMode.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -64,7 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Tag("oke-sequential")
 @Tag("okd-wls-mrg")
 @IntegrationTest
-@Tag("olcne")
 class ItDedicatedMode {
   // namespace constants
   private static String opNamespace = null;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRecoveryDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRecoveryDomainInPV.java
@@ -132,7 +132,7 @@ class ItRecoveryDomainInPV  {
    * Make sure all 100 persistent messages are recovered form managed server(2)
    */
   @Test
-  @DisplayName("verifies persistent WebLogic data survives the server pod")
+  @DisplayName("verifies persistent WebLogic data survives the server pod scaling")
   void testRecoveryDomainHomeInPv() {
 
     final String managedServerNameBase = "managed-";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRecoveryDomainInPV.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItRecoveryDomainInPV.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -132,7 +132,7 @@ class ItRecoveryDomainInPV  {
    * Make sure all 100 persistent messages are recovered form managed server(2)
    */
   @Test
-  @DisplayName("verifies persistent WebLogic data survies the server pod")
+  @DisplayName("verifies persistent WebLogic data survives the server pod")
   void testRecoveryDomainHomeInPv() {
 
     final String managedServerNameBase = "managed-";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItValidateWebhookReplicas.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItValidateWebhookReplicas.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -101,8 +101,8 @@ class ItValidateWebhookReplicas {
   private static String opNamespace = null;
   private static String domainNamespace = null;
   private static String domainNamespace2 = null;
-  private static String domainUid = "domain1";
-  private static String domainUid2 = "domain2";
+  private static String domainUid = "valwebrepdomain1";
+  private static String domainUid2 = "valwebrepdomain2";
 
   private static String adminServerPodName = String.format("%s-%s", domainUid, ADMIN_SERVER_NAME_BASE);
   private static String managedServerPrefix = String.format("%s-%s", domainUid, MANAGED_SERVER_NAME_BASE);
@@ -695,7 +695,7 @@ class ItValidateWebhookReplicas {
 
     // check only managed server1 pod exists, all other managed server pods are deleted
     String managedServerPrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
-    for (int i = DEFAULT_MAX_CLUSTER_SIZE + 1; i > 1; i--) {
+    for (int i = DEFAULT_MAX_CLUSTER_SIZE; i > 1; i--) {
       checkPodDeleted(managedServerPrefix + i, domainUid, domainNamespace);
     }
     checkPodReadyAndServiceExists(managedServerPrefix + "1", domainUid, domainNamespace);

--- a/kubernetes/samples/scripts/common/utility.sh
+++ b/kubernetes/samples/scripts/common/utility.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 #
@@ -855,7 +855,7 @@ checkPodDelete() {
 checkPodState() {
 
  status="NotReady"
- max=60
+ max=120
  count=1
 
  pod=$1
@@ -880,7 +880,7 @@ checkPodState() {
   count=`expr $count + 1`
  done
  if [ $count -gt $max ] ; then
-   echo "[ERROR] Unable to start the Pod [$pod] after 300s "; 
+   echo "[ERROR] Unable to start the Pod [$pod] after 600s ";
    exit 1
  fi 
 


### PR DESCRIPTION
remove ItDedicatedMode.java from olcne profile since it will delete the domain crd in the test and can only run in sequential mode. It causes other tests fail when running in parallel mode. 

Jenkins result:
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16238/