### PR TITLE
Release/3.4 Avoid docker pull for logstash,kibana,fluentd images

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -368,7 +368,7 @@ class ItElasticLoggingFluentd {
     final String volumeName = "weblogic-domain-storage-volume";
     final String logHomeRootPath = "/scratch";
     // create the domain CR
-
+    logger.info("Choosen FLUENTD_IMAGE {0}", FLUENTD_IMAGE);
     FluentdSpecification fluentdSpecification = new FluentdSpecification();
     fluentdSpecification.setImage(FLUENTD_IMAGE);
     fluentdSpecification.setWatchIntrospectorLogs(true);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -117,7 +117,7 @@ public interface TestConstants {
   public static final String DB_IMAGE_TAG = getNonEmptySystemProperty("wko.it.db.image.tag", DB_IMAGE_TAG_DEFAULT);
 
   // WebLogic Base Image with Japanease Locale
-  public static final String LOCALE_IMAGE_NAME = "phx.ocir.io/weblogick8s/test-images/weblogic";
+  public static final String LOCALE_IMAGE_NAME = TEST_IMAGES_REPO + "/weblogick8s/test-images/weblogic";
   public static final String LOCALE_IMAGE_TAG = "12.2.1.4-jp";
 
   // For kind, replace repo name in image name with KIND_REPO, otherwise use the actual image name
@@ -197,7 +197,7 @@ public interface TestConstants {
   public static final String ELASTICSEARCH_NAME = "elasticsearch";
   public static final String ELK_STACK_VERSION = "7.8.1";
   public static final String FLUENTD_IMAGE_VERSION =
-      getNonEmptySystemProperty("wko.it.fluentd.image.version", "v1.14.5-debian-elasticsearch7-1.1");
+      getNonEmptySystemProperty("wko.it.fluentd.image.version", "v1.14.5");
   public static final String ELASTICSEARCH_IMAGE = ELASTICSEARCH_NAME + ":" + ELK_STACK_VERSION;
   public static final String ELASTICSEARCH_HOST = "elasticsearch.default.svc.cluster.local";
   public static final int DEFAULT_LISTEN_PORT = 7100;
@@ -211,12 +211,17 @@ public interface TestConstants {
   public static final String WEBLOGIC_INDEX_KEY = "wls";
   public static final String KIBANA_INDEX_KEY = "kibana";
   public static final String KIBANA_NAME = "kibana";
-  public static final String KIBANA_IMAGE = KIBANA_NAME + ":" + ELK_STACK_VERSION;
+  public static final String KIBANA_IMAGE_NAME = TEST_IMAGES_REPO + "/weblogick8s/test-images/docker/kibana";
+  public static final String KIBANA_IMAGE = KIBANA_IMAGE_NAME + ":" + ELK_STACK_VERSION;
   public static final String KIBANA_TYPE = "NodePort";
   public static final int KIBANA_PORT = 5601;
   public static final String LOGSTASH_NAME = "logstash";
-  public static final String LOGSTASH_IMAGE = LOGSTASH_NAME + ":" + ELK_STACK_VERSION;
-  public static final String FLUENTD_IMAGE = "fluent/fluentd-kubernetes-daemonset:" + FLUENTD_IMAGE_VERSION;
+  public static final String LOGSTASH_IMAGE_NAME = TEST_IMAGES_REPO + "/weblogick8s/test-images/docker/logstash";
+  public static final String LOGSTASH_IMAGE = LOGSTASH_IMAGE_NAME + ":" + ELK_STACK_VERSION;
+  
+  public static final String FLUENTD_IMAGE = TEST_IMAGES_REPO
+            + "/weblogick8s/test-images/docker/fluentd-kubernetes-daemonset:"
+            + FLUENTD_IMAGE_VERSION;
   public static final String JAVA_LOGGING_LEVEL_VALUE = "INFO";
 
   public static final String WLS_LOGGING_EXPORTER_YAML_FILE_NAME = "WebLogicLoggingExporter.yaml";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;
@@ -119,6 +119,7 @@ public class LoggingExporterUtils {
         .kibanaContainerPort(KIBANA_PORT);
 
     // install Kibana
+    logger.info("Choosen KIBANA_IMAGE {0}", KIBANA_IMAGE);
     assertThat(installKibana(kibanaParams))
         .as("Kibana installation succeeds")
         .withFailMessage("Kibana installation is failed")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/OperatorUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;
@@ -590,6 +590,7 @@ public class OperatorUtils {
       if (!createLogStashConfigMap) {
         opParams.createLogStashConfigMap(createLogStashConfigMap);
       }
+      logger.info("Choosen LOGSTASH_IMAGE {0}", LOGSTASH_IMAGE);
       opParams.elkIntegrationEnabled(elkIntegrationEnabled);
       opParams.elasticSearchHost(elasticSearchHost);
       opParams.elasticSearchPort(ELASTICSEARCH_HTTP_PORT);


### PR DESCRIPTION
Added above images to OCIR and updated the Test Constant file

phx.ocir.io/weblogick8s/test-images/docker/logstash
phx.ocir.io/weblogick8s/test-images/docker/fluentd-kubernetes-daemonset
phx.ocir.io/weblogick8s/test-images/docker/kibana

Note: This is backport for PR https://github.com/oracle/weblogic-kubernetes-operator/pull/3941

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16245