### PR TITLE
Main: Modify install-istio.sh to remove docker.io dependency

### DIFF
--- a/integration-tests/src/test/resources/bash-scripts/images.properties
+++ b/integration-tests/src/test/resources/bash-scripts/images.properties
@@ -61,12 +61,6 @@ database/enterprise:12.2.0.1-slim;weblogick8s/test-images/database/enterprise:12
 # Oracle DB Operator Image
 database/operator:0.2.0;weblogick8s/test-images/database/operator:0.2.0
 
-# Manually Update the Target Reposiotory for the following image(s)
-#busybox:1.34.1;weblogick8s/test-images/docker/busybox:1.34.1
-#elasticsearch:7.8.1;weblogick8s/test-images/docker/elasticsearch:7.8.1
-#k8s.gcr.io/ingress-nginx/controller:v1.2.0;weblogick8s/test-images/ingress-nginx/controller:v1.2.0
-
-
 # WebLogic CPU Release 14.1.1.0
 middleware/weblogic_cpu:14.1.1.0-generic-jdk11-ol7;weblogick8s/test-images/weblogic:14.1.1.0-generic-jdk11-ol7-cpu
 middleware/weblogic_cpu:14.1.1.0-generic-jdk11-ol8;weblogick8s/test-images/weblogic:14.1.1.0-generic-jdk11-ol8-cpu
@@ -98,3 +92,11 @@ middleware/fmw-infrastructure_cpu:12.2.1.4-jdk8-ol8;weblogick8s/test-images/fmw-
 # FMW CPU Release 12.2.1.3
 middleware/fmw-infrastructure_cpu:12.2.1.3-jdk8-ol7;weblogick8s/test-images/fmw-infrastructure:12.2.1.3-jdk8-ol7-cpu
 middleware/fmw-infrastructure_cpu:12.2.1.3-jdk8-ol8;weblogick8s/test-images/fmw-infrastructure:12.2.1.3-jdk8-ol8-cpu
+
+# Manually Update the Target Repository for the following image(s)
+#busybox:1.34.1;weblogick8s/test-images/docker/busybox:1.34.1
+#docker.elastic.co/elasticsearch/elasticsearch:7.8.1;weblogick8s/test-images/docker/elasticsearch:7.8.1
+#docker.elastic.co/elasticsearch/kibana:7.8.1;weblogick8s/test-images/docker/kibana:7.8.1
+#docker.elastic.co/elasticsearch/logstach:7.8.1;weblogick8s/test-images/docker/logstach:7.8.1
+#ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.14.5-20230131231729-f85741b;weblogick8s/test-images/fluentd-kubernetes-daemonset:v1.14.5
+#k8s.gcr.io/ingress-nginx/controller:v1.2.0;weblogick8s/test-images/ingress-nginx/controller:v1.2.0

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -1,16 +1,15 @@
 #!/bin/bash -x
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 # Description:
 #
 #  This script install a given version of istio using Helm v3.x
-#  Default istio version is 1.11.1
+#  Default istio version is 1.13.2
 #  https://istio.io/docs/setup/install/istioctl/
 #  https://istio.io/latest/docs/setup/install/standalone-operator/
 #  https://github.com/istio/istio/releases
 #  https://github.com/istio/istio/tags
-
 
 # Usage:
 #
@@ -39,9 +38,12 @@ ${KUBERNETES_CLI} create namespace istio-system
 
 ( ${KUBERNETES_CLI} create secret generic docker-istio-secret --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=$HOME/.docker/config.json -n istio-system )
 
+ # set custom docker registry to gcr.io/istio-release to avoid 
+ # docker.io/istio dependency.
+ echo "Modifying docker registry to gcr.io/istio-release instead of docker.io"
 ( cd ${istiodir}
   bin/istioctl x precheck
-  bin/istioctl install --set profile=demo --set values.global.imagePullSecrets[0]=docker-istio-secret --set meshConfig.enablePrometheusMerge=false -y
+  bin/istioctl install --set meshConfig.enablePrometheusMerge=false --set values.global.imagePullSecrets[0]=docker-istio-secret --set hub=gcr.io/istio-release --set profile=demo -y
   bin/istioctl verify-install
   bin/istioctl version
 )

--- a/integration-tests/src/test/resources/bash-scripts/install-istio.sh
+++ b/integration-tests/src/test/resources/bash-scripts/install-istio.sh
@@ -40,7 +40,7 @@ ${KUBERNETES_CLI} create namespace istio-system
 
  # set custom docker registry to gcr.io/istio-release to avoid 
  # docker.io/istio dependency.
- echo "Modifying docker registry to gcr.io/istio-release instead of docker.io"
+ echo "Set the image registry to gcr.io/istio-release during istio installation"
 ( cd ${istiodir}
   bin/istioctl x precheck
   bin/istioctl install --set meshConfig.enablePrometheusMerge=false --set values.global.imagePullSecrets[0]=docker-istio-secret --set hub=gcr.io/istio-release --set profile=demo -y


### PR DESCRIPTION
Set custom docker registry to gcr.io/istio-release to avoid  docker.io/istio dependency during istio installation.

Jenkin run
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16249
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16255