### PR TITLE
Port fix adminservername problem

### DIFF
--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -10,14 +10,18 @@
 def filter_model(model):
 	if model and 'topology' in model:
             topology = model['topology']
-            if model['topology']['AdminServerName'] != None:
+            if 'AdminServerName' in model['topology']:
                 admin_server = topology['AdminServerName']
-                model['topology'] = {}
-                model['topology']['AdminServerName'] = admin_server
-                model['topology']['Server'] = {}
-                model['topology']['Server'][admin_server] = topology['Server'][admin_server]   
             else:
-                model['topology'] = {}
+                # weblogic default
+                admin_server = 'AdminServer'
+            model['topology'] = {}
+            model['topology']['AdminServerName'] = admin_server
+            model['topology']['Server'] = {}
+            if admin_server in topology['Server']:
+                model['topology']['Server'][admin_server] = topology['Server'][admin_server]
+            else:
+                model['topology']['Server'][admin_server] = {}
 
             if 'Name' in topology:
                 model['topology']['Name'] = topology['Name']

--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -179,8 +179,17 @@ def filter_model(model):
         customizeNodeManagerCreds(topology)
         customizeDomainLogPath(topology)
 
-        if 'Server' in topology:
-          customizeServers(model)
+        if 'AdminServerName' in topology:
+          admin_server = topology['AdminServerName']
+        else:
+          # weblogic default
+          admin_server = 'AdminServer'
+          topology['AdminServerName'] = admin_server
+
+        if admin_server not in topology['Server']:
+          topology['Server'][admin_server] = {}
+
+        customizeServers(model)
 
         if 'ServerTemplate' in topology:
           customizeServerTemplates(model)
@@ -462,12 +471,8 @@ def addAdminChannelPortForwardNetworkAccessPoints(server):
   admin_channel_port_forwarding_enabled = env.getEnvOrDef("ADMIN_CHANNEL_PORT_FORWARDING_ENABLED", "true")
   if (admin_channel_port_forwarding_enabled == 'false'):
     return
-
-  admin_server_port = server['ListenPort']
   # Set the default if it is not provided to avoid nap default to 0 which fails validation.
-
-  if admin_server_port is None:
-    admin_server_port = 7001
+  admin_server_port = _get_default_listen_port(server)
 
   model = env.getModel()
 
@@ -645,4 +650,8 @@ def getSecretManager():
 def istioVersionRequiresLocalHostBindings():
   return False
 
-
+def _get_default_listen_port(server):
+  if 'ListenPort' not in server:
+    return 7001
+  else:
+    return server['ListenPort']

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 import ast

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -332,6 +332,27 @@ class WdtUpdateFilterCase(unittest.TestCase):
     model = self.getModel()
     self.assertFalse(model_wdt_mii_filter.istioVersionRequiresLocalHostBindings())
 
+  def test_adminserver_name_missing(self):
+    try:
+      model = self.getModel()
+      topology = model['topology']
+      del topology['AdminServerName']
+      model_wdt_mii_filter.filter_model(model)
+      self.assertEqual('AdminServer', topology['AdminServerName'],
+                       "Expected AdminServerName set to AdminServer after filter")
+      admin_server_exists = 'AdminServer' in topology['Server']
+      self.assertTrue(admin_server_exists, "Expected AdminServer added if AdminServerName is not set")
+
+      topology['AdminServerName'] = 'MyAdminServer'
+      model_wdt_mii_filter.filter_model(model)
+      self.assertEqual('MyAdminServer', topology['AdminServerName'],
+                       "Expected AdminServerName set to MyAdminServer after filter")
+      admin_server_exists = 'MyAdminServer' in topology['Server']
+      self.assertTrue(admin_server_exists, "Expected MyAdminServer added if AdminServerName is not set")
+
+    except ImportError as ie:
+      self.assertTrue(ie is not None)
+
 class MockOfflineWlstEnv(model_wdt_mii_filter.OfflineWlstEnv):
 
   WLS_CRED_USERNAME = 'weblogic'


### PR DESCRIPTION
This PR fixes the case where AdminServerName is specified or missing in the WDT model's topology section, but either not matching any server in the Server sections causing unexpected behavior as typical WDT/WLS expectation.