### PR TITLE
Fix adminservername problem

### DIFF
--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------

--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -10,21 +10,24 @@
 def filter_model(model):
 	if model and 'topology' in model:
             topology = model['topology']
-            if model['topology']['AdminServerName'] != None:
+            if 'AdminServerName' in model['topology']:
                 admin_server = topology['AdminServerName']
-                model['topology'] = {}
-                model['topology']['AdminServerName'] = admin_server
-                model['topology']['Server'] = {}
-                model['topology']['Server'][admin_server] = topology['Server'][admin_server]   
             else:
-                model['topology'] = {}
+                # weblogic default
+                admin_server = 'AdminServer'
+            model['topology'] = {}
+            model['topology']['AdminServerName'] = admin_server
+            model['topology']['Server'] = {}
+            if admin_server in topology['Server']:
+                model['topology']['Server'][admin_server] = topology['Server'][admin_server]
+            else:
+                model['topology']['Server'][admin_server] = {}
 
             if 'Name' in topology:
                 model['topology']['Name'] = topology['Name']
 
             if 'Security' in topology:
                 model['topology']['Security'] = topology['Security']
-
 
 	if model and 'appDeployments' in model:
             model['appDeployments'] = {}

--- a/operator/src/main/resources/scripts/model_wdt_mii_filter.py
+++ b/operator/src/main/resources/scripts/model_wdt_mii_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------
@@ -53,6 +53,8 @@ tmp_callerframerecord = inspect.stack()[0]    # 0 represents this line # 1 repre
 tmp_info = inspect.getframeinfo(tmp_callerframerecord[0])
 tmp_scriptdir=os.path.dirname(tmp_info[0])
 sys.path.append(tmp_scriptdir)
+
+import utils
 
 env = None
 ISTIO_NAP_NAMES = ['tcp-cbt', 'tcp-ldap', 'tcp-iiop', 'tcp-snmp', 'http-default', 'tcp-default', 'https-secure', 'tls-ldaps', 'tls-default', 'tls-cbts', 'tls-iiops', 'https-admin']
@@ -196,9 +198,9 @@ def filter_model(model):
           customizeServerTemplates(model)
   except:
     exc_type, exc_obj, exc_tb = sys.exc_info()
-    ex_strings = traceback.format_exception(exc_type, exc_obj, exc_tb)
-    print(ex_strings)
-    raise Exception("WDT MII failed execution")
+    ee_string = traceback.format_exception(exc_type, exc_obj, exc_tb)
+    utils.trace('SEVERE', 'Error in applying MII filter:\n ' + str(ee_string))
+    raise
 
 
 def initOfflineWlstEnv(model):

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 import ast

--- a/operator/src/test/python/test_wdt_mii_filter.py
+++ b/operator/src/test/python/test_wdt_mii_filter.py
@@ -464,6 +464,26 @@ class WdtUpdateFilterCase(unittest.TestCase):
     except ImportError as ie:
       self.assertTrue(ie is not None)
 
+  def test_adminserver_name_missing(self):
+    try:
+      model = self.getModel()
+      topology = model['topology']
+      del topology['AdminServerName']
+      model_wdt_mii_filter.filter_model(model)
+      self.assertEqual('AdminServer', topology['AdminServerName'],
+                       "Expected AdminServerName set to AdminServer after filter")
+      admin_server_exists = 'AdminServer' in topology['Server']
+      self.assertTrue(admin_server_exists, "Expected AdminServer added if AdminServerName is not set")
+
+      topology['AdminServerName'] = 'MyAdminServer'
+      model_wdt_mii_filter.filter_model(model)
+      self.assertEqual('MyAdminServer', topology['AdminServerName'],
+                       "Expected AdminServerName set to MyAdminServer after filter")
+      admin_server_exists = 'MyAdminServer' in topology['Server']
+      self.assertTrue(admin_server_exists, "Expected MyAdminServer added if AdminServerName is not set")
+
+    except ImportError as ie:
+      self.assertTrue(ie is not None)
 
 
 


### PR DESCRIPTION
This PR fixes the case where AdminServerName is specified or missing in the WDT model's topology section, but either not matching any server in the Server sections causing unexpected behavior as typical WDT/WLS expectation.