### PR TITLE
OWLS-106472 - Improve error handling when Server template is not set for dynamic cluster.

### DIFF
--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -256,11 +256,11 @@ class OfflineWlstEnv(object):
       # or
       # /Cluster/<clusterName>/DynamicServers/NO_NAME_0/
       childObjs = ls(returnMap='true', returnType='c')
+
       if not childObjs.isEmpty():
+        # Cluster is a dynamic cluster if a DynamicServer MBean is found
         cd(childObjs[0])
-        if get('ServerTemplate') is not None:
-          # Cluster is a dynamic cluster if a ServerTemplate MBean is found
-          ret = cmo
+        ret = cmo
     except:
       trace("Ignoring cd() exception for cluster '" + cluster.getName() + "' in getDynamicServerOrNone() and returning None.")
     return ret;
@@ -547,7 +547,7 @@ class TopologyGenerator(Generator):
             self.addError("The WebLogic dynamic cluster " + self.name(cluster) + " is referenced the server template " + self.name(server_template) + " and the server template " + self.name(template) + ".")
             return
     if server_template is None:
-      self.addError("The WebLogic dynamic cluster " + self.name(cluster) + "' is not referenced by any server template.")
+      self.addError("The WebLogic dynamic cluster " + self.name(cluster) + " is not referenced by any server template.")
 
   def validateServerTemplateNapListenPortIsSet(self, server_or_template):
     naps = server_or_template.getNetworkAccessPoints()

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -256,7 +256,6 @@ class OfflineWlstEnv(object):
       # or
       # /Cluster/<clusterName>/DynamicServers/NO_NAME_0/
       childObjs = ls(returnMap='true', returnType='c')
-
       if not childObjs.isEmpty():
         # Cluster is a dynamic cluster if a DynamicServer MBean is found
         cd(childObjs[0])

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -257,9 +257,10 @@ class OfflineWlstEnv(object):
       # /Cluster/<clusterName>/DynamicServers/NO_NAME_0/
       childObjs = ls(returnMap='true', returnType='c')
       if not childObjs.isEmpty():
-        # Cluster is a dynamic cluster if a DynamicServer MBean is found
         cd(childObjs[0])
-        ret = cmo
+        if get('ServerTemplate') is not None or int(get('DynamicClusterSize')) > 0:
+          # Cluster is a dynamic cluster if a ServerTemplate MBean is found or DynamicClusterSize is greater than 0.
+          ret = cmo
     except:
       trace("Ignoring cd() exception for cluster '" + cluster.getName() + "' in getDynamicServerOrNone() and returning None.")
     return ret;

--- a/operator/src/main/resources/scripts/introspectDomain.py
+++ b/operator/src/main/resources/scripts/introspectDomain.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------


### PR DESCRIPTION
OWLS-106472 - Currently if there's no ServerTemplate configured in the dynamic server configuration, the server is considered to be part of a configured cluster. This change modifies the check for dynamic cluster to either look for presence of a ServerTemplate or `DynamicClusterSize` greater than 0. If the dynamic cluster is not referenced by a ServerTemplate, the subsequent validation in `validateDynamicClusterReferencedByOneServerTemplate` function will catch this and provide correct error message.
Integration test run - https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16305/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16306/