### PR TITLE
Remove docker dependency for traefik installation 

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -53,6 +53,8 @@ import static oracle.weblogic.kubernetes.TestConstants.SKIP_BUILD_IMAGES_IF_EXIS
 import static oracle.weblogic.kubernetes.TestConstants.TEST_IMAGES_REPO;
 import static oracle.weblogic.kubernetes.TestConstants.TEST_IMAGES_REPO_SECRET_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.TEST_NGINX_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.TRAEFIK_INGRESS_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.TRAEFIK_INGRESS_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TAG_DEFAULT;
 import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_IMAGE_TO_USE_IN_SPEC;
@@ -424,8 +426,17 @@ class ItWlsSamples {
   void testTraefikIngressController() {
     Path testSamplePath = get(WORK_DIR, "wls-sample-testing", "traefik");
     setupSample(testSamplePath);
+    Map<String, String> templateMap  = new HashMap<>();
+    templateMap.put("TRAEFIK_INGRESS_IMAGE_NAME", TRAEFIK_INGRESS_IMAGE_NAME);
+    templateMap.put("TRAEFIK_INGRESS_IMAGE_TAG", TRAEFIK_INGRESS_IMAGE_TAG);
+    Path srcPropFile = Paths.get(RESOURCE_DIR, "traefik.template.properties");
+    Path targetPropFile = assertDoesNotThrow(
+        () -> generateFileFromTemplate(srcPropFile.toString(), "traefik.properties", templateMap));
+    logger.info("Generated traefik.properties file at {0}", targetPropFile);
+
     Path scriptBase = get(testSamplePath.toString(), "charts/util");
-    setupLoadBalancer(scriptBase, "traefik", " -c -n " + traefikNamespace);
+    setupLoadBalancer(scriptBase, "traefik", " -c -n " + traefikNamespace 
+         + " -p " + targetPropFile.toString());
     setupLoadBalancer(scriptBase, "traefik", " -d -n " + traefikNamespace);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWlsSamples.java
@@ -428,7 +428,6 @@ class ItWlsSamples {
     setupSample(testSamplePath);
     Map<String, String> templateMap  = new HashMap<>();
     templateMap.put("TRAEFIK_INGRESS_IMAGE_NAME", TRAEFIK_INGRESS_IMAGE_NAME);
-    templateMap.put("TRAEFIK_INGRESS_IMAGE_TAG", TRAEFIK_INGRESS_IMAGE_TAG);
     Path srcPropFile = Paths.get(RESOURCE_DIR, "traefik.template.properties");
     Path targetPropFile = assertDoesNotThrow(
         () -> generateFileFromTemplate(srcPropFile.toString(), "traefik.properties", templateMap));
@@ -436,7 +435,8 @@ class ItWlsSamples {
 
     Path scriptBase = get(testSamplePath.toString(), "charts/util");
     setupLoadBalancer(scriptBase, "traefik", " -c -n " + traefikNamespace 
-         + " -p " + targetPropFile.toString());
+         + " -p " + targetPropFile.toString() 
+         + " -v " + TRAEFIK_INGRESS_IMAGE_TAG);
     setupLoadBalancer(scriptBase, "traefik", " -d -n " + traefikNamespace);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -172,17 +172,19 @@ public interface TestConstants {
   public static final String NGINX_REPO_NAME = "ingress-nginx";
   public static final String NGINX_CHART_NAME = "ingress-nginx";
   public static final String NGINX_CHART_VERSION = "4.0.17";
-  public static final String NGINX_INGRESS_IMAGE_TAG = "v1.2.0";
   public static final String NGINX_INGRESS_IMAGE_DIGEST = 
       "sha256:314435f9465a7b2973e3aa4f2edad7465cc7bcdc8304be5d146d70e4da136e51";  
   public static final String TEST_NGINX_IMAGE_NAME = "weblogick8s/test-images/ingress-nginx/controller";
-  public static final String GCR_NGINX_IMAGE_NAME = "k8s.gcr.io/ingress-nginx/controller";
+  public static final String NGINX_INGRESS_IMAGE_TAG = "v1.2.0";
 
   // Traefik constants
   public static final String TRAEFIK_REPO_URL = "https://helm.traefik.io/traefik";
-  public static final String TRAEFIK_REPO_NAME = "traefik";
   public static final String TRAEFIK_RELEASE_NAME = "traefik-release" + BUILD_ID;
+  public static final String TRAEFIK_REPO_NAME = "traefik";
   public static final String TRAEFIK_CHART_NAME = "traefik";
+  public static final String TRAEFIK_INGRESS_IMAGE_NAME = TEST_IMAGES_REPO 
+           + "/weblogick8s/test-images/traefik-ingress/traefik";
+  public static final String TRAEFIK_INGRESS_IMAGE_TAG = "v2.9.6";
 
   // Voyager constants
   public static final String APPSCODE_REPO_URL = "https://charts.appscode.com/stable/";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/TraefikParams.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/TraefikParams.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.actions.impl;
@@ -9,6 +9,9 @@ import java.util.Objects;
 
 import oracle.weblogic.kubernetes.actions.impl.primitive.HelmParams;
 
+import static oracle.weblogic.kubernetes.TestConstants.TRAEFIK_INGRESS_IMAGE_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.TRAEFIK_INGRESS_IMAGE_TAG;
+
 // All parameters needed to install Traefik Operator
 public class TraefikParams {
 
@@ -16,9 +19,13 @@ public class TraefikParams {
   private int nodePortsHttp;
   private int nodePortsHttps;
   private HelmParams helmParams;
+  private String traefikImage = TRAEFIK_INGRESS_IMAGE_NAME;
+  private String traefikImageTag = TRAEFIK_INGRESS_IMAGE_TAG;
 
   private static final String NODEPORTS_HTTP = "ports.web.nodePort";
   private static final String NODEPORTS_HTTPS = "ports.websecure.nodePort";
+  private static final String TRAEFIK_IMAGE = "image.repository";
+  private static final String TRAEFIK_IMAGE_TAG = "image.tag";
 
   public TraefikParams nodePortsHttp(int nodePortsHttp) {
     this.nodePortsHttp = nodePortsHttp;
@@ -39,6 +46,16 @@ public class TraefikParams {
     return helmParams;
   }
 
+  public TraefikParams traefikImage(String traefikImage) {
+    this.traefikImage = traefikImage;
+    return this;
+  }
+
+  public TraefikParams traefikImageTag(String traefikImageTag) {
+    this.traefikImageTag = traefikImageTag;
+    return this;
+  }
+
   /**
    * Loads Helm values into a value map.
    *
@@ -53,6 +70,9 @@ public class TraefikParams {
     if (nodePortsHttps > 0) {
       values.put(NODEPORTS_HTTPS, nodePortsHttps);
     }
+
+    values.put(TRAEFIK_IMAGE, traefikImage);
+    values.put(TRAEFIK_IMAGE_TAG, traefikImageTag);
 
     values.values().removeIf(Objects::isNull);
     return values;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoadBalancerUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;
@@ -40,7 +40,6 @@ import static oracle.weblogic.kubernetes.TestConstants.APACHE_SAMPLE_CHART_DIR;
 import static oracle.weblogic.kubernetes.TestConstants.APPSCODE_REPO_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.APPSCODE_REPO_URL;
 import static oracle.weblogic.kubernetes.TestConstants.BASE_IMAGES_REPO_SECRET_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.GCR_NGINX_IMAGE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
 import static oracle.weblogic.kubernetes.TestConstants.K8S_NODEPORT_HOST;
 import static oracle.weblogic.kubernetes.TestConstants.NGINX_CHART_NAME;
@@ -62,8 +61,6 @@ import static oracle.weblogic.kubernetes.actions.TestActions.createService;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPersistentVolume;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPersistentVolumeClaim;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
-import static oracle.weblogic.kubernetes.actions.TestActions.imagePull;
-import static oracle.weblogic.kubernetes.actions.TestActions.imageTag;
 import static oracle.weblogic.kubernetes.actions.TestActions.installApache;
 import static oracle.weblogic.kubernetes.actions.TestActions.installNginx;
 import static oracle.weblogic.kubernetes.actions.TestActions.installTraefik;
@@ -843,16 +840,6 @@ public class LoadBalancerUtils {
         ingressName, domainUid, domainNamespace);
 
     return ingressHostList;
-  }
-
-  private static Callable<Boolean> pullImageFromOcirAndTag(String localImage) {
-    return (() -> {
-      String nginxImage = GCR_NGINX_IMAGE_NAME + ":" + "v0.35.0";
-      LoggingFacade logger = getLogger();
-      logger.info("pulling image {0} from BASE_IMAGES_REPO, tag it as image {1} ",
-          localImage, nginxImage);
-      return imagePull(localImage) && imageTag(localImage, nginxImage);
-    });
   }
 
   /**

--- a/integration-tests/src/test/resources/bash-scripts/images.properties
+++ b/integration-tests/src/test/resources/bash-scripts/images.properties
@@ -100,3 +100,4 @@ middleware/fmw-infrastructure_cpu:12.2.1.3-jdk8-ol8;weblogick8s/test-images/fmw-
 #docker.elastic.co/elasticsearch/logstach:7.8.1;weblogick8s/test-images/docker/logstach:7.8.1
 #ghcr.io/verrazzano/fluentd-kubernetes-daemonset:v1.14.5-20230131231729-f85741b;weblogick8s/test-images/fluentd-kubernetes-daemonset:v1.14.5
 #k8s.gcr.io/ingress-nginx/controller:v1.2.0;weblogick8s/test-images/ingress-nginx/controller:v1.2.0
+#public.ecr.aws/docker/library/traefik:v2.9.6;weblogick8s/test-images/traefik-ingress/traefik:v2.9.6

--- a/integration-tests/src/test/resources/traefik.template.properties
+++ b/integration-tests/src/test/resources/traefik.template.properties
@@ -1,1 +1,1 @@
---set image.repository=TRAEFIK_INGRESS_IMAGE_NAME --set image.tag=TRAEFIK_INGRESS_IMAGE_TAG
+--set image.repository=TRAEFIK_INGRESS_IMAGE_NAME

--- a/integration-tests/src/test/resources/traefik.template.properties
+++ b/integration-tests/src/test/resources/traefik.template.properties
@@ -1,0 +1,1 @@
+--set image.repository=TRAEFIK_INGRESS_IMAGE_NAME --set image.tag=TRAEFIK_INGRESS_IMAGE_TAG


### PR DESCRIPTION
Added traefik ingress image to  
       phx.ocir.io/weblogick8s/test-images/traefik-ingress/traefik:v2.9.6

Jenkin Run

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16294
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16295
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16297

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16304  (full run) 



