### PR TITLE
Change the network address assignment after the cluster creation

### DIFF
--- a/vztest.sh
+++ b/vztest.sh
@@ -234,7 +234,7 @@ function wait_for_installs() {
 	echo "It took $elapsed_time minutes to complete verrazzano installation"
 	done=0
       else
-        elapsed_time=$((elapsedtime + 3))
+        elapsed_time=$((elapsed_time + 3))
         echo "verrazzano installtion is not complete"
       fi
       $KA get all -A

--- a/vztest.sh
+++ b/vztest.sh
@@ -223,7 +223,25 @@ EOF
 
 function wait_for_installs() {
   if [ "$ADMIN_CLUSTER" != "false" ] ; then
-    $KA wait --timeout=60m --for=condition=InstallComplete verrazzano/admin
+    done=1
+    elapsed_time=0
+    while [ $done -ne 0 ] && [ $elapsed_time -lt $VZ_INSTALL_TIMEOUT ]
+    do	    
+      install_status=$($KA wait --timeout=3m --for=condition=InstallComplete verrazzano/admin)
+      echo $install_status
+      if echo "$install_status" | grep -q 'condition met'; then
+        echo "verrazzano installation complete"
+	echo "It took $elapsed_time minutes to complete verrazzano installation"
+	done=0
+      else
+        timeout=$((elapsedtime + 3))
+        echo "verrazzano installtion is not complete"
+      fi
+      $KA get all -A
+    done      
+    if[ "$?" != "0" ] ; then
+      $KA get all -A
+    fi
   fi
   if [ "$MANAGED_CLUSTER" != "false" ] ; then
     $K1 wait --timeout=60m --for=condition=InstallComplete verrazzano/managed1

--- a/vztest.sh
+++ b/vztest.sh
@@ -447,6 +447,8 @@ MANAGED1_ADDR_RANGE="${SUBNET%.*}.210-${SUBNET%.*}.229"
 if [ "$ADMIN_CLUSTER" != "false" ] ; then
 echo
   create_cluster admin
+  SUBNET=$(${WLSIMG_BUILDER:-docker} inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r | sed 's|/.*||g')
+  ADMIN_ADDR_RANGE="${SUBNET%.*}.230-${SUBNET%.*}.250"
   install_metallb $ADMIN_ADDR_RANGE "$KA"
   install_verrazzano_admin
 fi

--- a/vztest.sh
+++ b/vztest.sh
@@ -435,14 +435,14 @@ if [ "$REGISTER_ONLY" != "true" ]; then
 delete_cluster admin
 delete_cluster managed1
 
-${WLSIMG_BUILDER:-docker} ps
-${WLSIMG_BUILDER:-docker} images
-${WLSIMG_BUILDER:-docker} network ls
-${WLSIMG_BUILDER:-docker} volume ls
-${WLSIMG_BUILDER:-docker} inspect kind | jq
-SUBNET=$(${WLSIMG_BUILDER:-docker} inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r | sed 's|/.*||g')
-ADMIN_ADDR_RANGE="${SUBNET%.*}.230-${SUBNET%.*}.250"
-MANAGED1_ADDR_RANGE="${SUBNET%.*}.210-${SUBNET%.*}.229"
+#${WLSIMG_BUILDER:-docker} ps
+#${WLSIMG_BUILDER:-docker} images
+#${WLSIMG_BUILDER:-docker} network ls
+#${WLSIMG_BUILDER:-docker} volume ls
+#${WLSIMG_BUILDER:-docker} inspect kind | jq
+#SUBNET=$(${WLSIMG_BUILDER:-docker} inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r | sed 's|/.*||g')
+#ADMIN_ADDR_RANGE="${SUBNET%.*}.230-${SUBNET%.*}.250"
+#MANAGED1_ADDR_RANGE="${SUBNET%.*}.210-${SUBNET%.*}.229"
 
 if [ "$ADMIN_CLUSTER" != "false" ] ; then
 echo
@@ -455,6 +455,8 @@ fi
 if [ "$MANAGED_CLUSTER" != "false" ] ; then
 echo
   create_cluster managed1
+  SUBNET=$(${WLSIMG_BUILDER:-docker} inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r | sed 's|/.*||g')
+  MANAGED1_ADDR_RANGE="${SUBNET%.*}.210-${SUBNET%.*}.229"
   install_metallb $MANAGED1_ADDR_RANGE "$K1"
   install_verrazzano_managed
 fi

--- a/vztest.sh
+++ b/vztest.sh
@@ -238,6 +238,7 @@ function wait_for_installs() {
         echo "verrazzano installtion is not complete"
       fi
       $KA get all -A
+      $KA get events -A --sort-by=.lastTimestamp
     done      
   fi
   if [ "$MANAGED_CLUSTER" != "false" ] ; then

--- a/vztest.sh
+++ b/vztest.sh
@@ -234,7 +234,7 @@ function wait_for_installs() {
 	echo "It took $elapsed_time minutes to complete verrazzano installation"
 	done=0
       else
-        timeout=$((elapsedtime + 3))
+        elapsed_time=$((elapsedtime + 3))
         echo "verrazzano installtion is not complete"
       fi
       $KA get all -A

--- a/vztest.sh
+++ b/vztest.sh
@@ -239,9 +239,6 @@ function wait_for_installs() {
       fi
       $KA get all -A
     done      
-    if[ "$?" != "0" ] ; then
-      $KA get all -A
-    fi
   fi
   if [ "$MANAGED_CLUSTER" != "false" ] ; then
     $K1 wait --timeout=60m --for=condition=InstallComplete verrazzano/managed1

--- a/vztest.sh
+++ b/vztest.sh
@@ -435,15 +435,6 @@ if [ "$REGISTER_ONLY" != "true" ]; then
 delete_cluster admin
 delete_cluster managed1
 
-#${WLSIMG_BUILDER:-docker} ps
-#${WLSIMG_BUILDER:-docker} images
-#${WLSIMG_BUILDER:-docker} network ls
-#${WLSIMG_BUILDER:-docker} volume ls
-#${WLSIMG_BUILDER:-docker} inspect kind | jq
-#SUBNET=$(${WLSIMG_BUILDER:-docker} inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r | sed 's|/.*||g')
-#ADMIN_ADDR_RANGE="${SUBNET%.*}.230-${SUBNET%.*}.250"
-#MANAGED1_ADDR_RANGE="${SUBNET%.*}.210-${SUBNET%.*}.229"
-
 if [ "$ADMIN_CLUSTER" != "false" ] ; then
 echo
   create_cluster admin

--- a/vztest.sh
+++ b/vztest.sh
@@ -435,6 +435,11 @@ if [ "$REGISTER_ONLY" != "true" ]; then
 delete_cluster admin
 delete_cluster managed1
 
+${WLSIMG_BUILDER:-docker} ps
+${WLSIMG_BUILDER:-docker} images
+${WLSIMG_BUILDER:-docker} network ls
+${WLSIMG_BUILDER:-docker} volume ls
+${WLSIMG_BUILDER:-docker} inspect kind | jq
 SUBNET=$(${WLSIMG_BUILDER:-docker} inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r | sed 's|/.*||g')
 ADMIN_ADDR_RANGE="${SUBNET%.*}.230-${SUBNET%.*}.250"
 MANAGED1_ADDR_RANGE="${SUBNET%.*}.210-${SUBNET%.*}.229"


### PR DESCRIPTION
When there are no kind clusters running in the machine the 
`docker inspect kind | jq '.[0].IPAM.Config[0].Subnet'`  was returning null since no containers were running.
This caused the metal lb installation to fail and affecting vz installation.

To fix this issue moving the docker inspect to assign the subnet address after the kind cluster is created.

https://build.weblogick8s.org:8443/job/v8o-kind-nightly/44/
https://build.weblogick8s.org:8443/job/v8o-kind-nightly/43/
https://build.weblogick8s.org:8443/job/v8o-kind-nightly/42/
https://build.weblogick8s.org:8443/job/v8o-kind-nightly/41/
https://build.weblogick8s.org:8443/job/v8o-kind-nightly/40/
