### PR TITLE
OWLS-106777 - Fix for string index out of bounds exception in PodStepContext

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/PodStepContext.java
@@ -346,7 +346,7 @@ public abstract class PodStepContext extends BasePodStepContext {
   @NotNull
   private String getPortNamePrefix(String name) {
     // Use first 12 characters of port name as prefix due to 15 character port name limit
-    return name.substring(0, 12);
+    return name.length() > 12 ? name.substring(0, 12) : name;
   }
 
   Integer getListenPort() {

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/helpers/PodHelperTestBase.java
@@ -416,6 +416,17 @@ public abstract class PodHelperTestBase extends DomainValidationBaseTest {
   }
 
   @Test
+  void whenOneNapNameExceedsMaxPortNameLengthAndOtherNapWithShortName_podContainerCreatedWithCorrectPortNames() {
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint("shortname", "admin", 8001, 8001));
+    getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME + "1", "admin", 8001, 8001));
+
+    assertThat(
+        getContainerPorts(),
+        hasItems(createContainerPort(TRUNCATED_PORT_NAME_PREFIX + "-01"),
+            createContainerPort("shortname")));
+  }
+
+  @Test
   void whenPodCreatedWithMultipleNapsSomeWithNamesExceedingMaxPortNameLength_podContainerCreatedWithMixedPortNames() {
     getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint(LONG_CHANNEL_NAME, "admin", 8001, 8001));
     getServerTopology().addNetworkAccessPoint(new NetworkAccessPoint("My_Channel_Name", "admin", 8001, 8001));


### PR DESCRIPTION
OWLS-106777 - Fix for string index out of bounds exception in PodStepContext