### PR TITLE
Fix indentation for webhook

### DIFF
--- a/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
+++ b/kubernetes/charts/weblogic-operator/templates/_operator-dep.tpl
@@ -263,11 +263,11 @@ spec:
               type: RuntimeDefault
           {{- with .nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: "weblogic-operator-webhook"


### PR DESCRIPTION
The indentation of `nodeSelector` and `affinity` elements were wrong because the webhook content is offset more than for the operator's deployment.