### PR TITLE
OWLS-107005 correct Failed condition handling at the async request processing layer

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
@@ -59,15 +59,6 @@ public class ClusterResourceStatusUpdater {
     return new ClusterResourceStatusUpdaterStep(next);
   }
 
-  private static Step createUpdateClusterResourceStatusSteps(Packet packet,
-      Collection<ClusterResource> clusterResources) {
-    List<StepAndPacket> result = clusterResources.stream()
-        .filter(res -> createContext(packet, res).isClusterResourceStatusChanged())
-        .map(res -> new StepAndPacket(createContext(packet, res).createReplaceClusterResourceStatusStep(), packet))
-        .collect(Collectors.toList());
-    return result.isEmpty() ? null : new RunInParallelStep(result);
-  }
-
   private static ReplaceClusterStatusContext createContext(Packet packet, ClusterResource resource) {
     return new ReplaceClusterStatusContext(packet, resource);
   }
@@ -91,6 +82,15 @@ public class ClusterResourceStatusUpdater {
           .map(domain -> createUpdateClusterResourceStatusSteps(packet, info.getClusterResources()))
           .orElse(null);
       return doNext(chainStep(step, getNext()), packet);
+    }
+    
+    private static Step createUpdateClusterResourceStatusSteps(Packet packet,
+                                                               Collection<ClusterResource> clusterResources) {
+      List<StepAndPacket> result = clusterResources.stream()
+          .filter(res -> createContext(packet, res).isClusterResourceStatusChanged())
+          .map(res -> new StepAndPacket(createContext(packet, res).createReplaceClusterResourceStatusStep(), packet))
+          .collect(Collectors.toList());
+      return result.isEmpty() ? null : new RunInParallelStep(result);
     }
 
     private static Step chainStep(Step one, Step two) {

--- a/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
@@ -28,7 +28,6 @@ import oracle.kubernetes.operator.steps.DefaultResponseStep;
 import oracle.kubernetes.operator.work.NextAction;
 import oracle.kubernetes.operator.work.Packet;
 import oracle.kubernetes.operator.work.Step;
-import oracle.kubernetes.operator.work.Step.StepAndPacket;
 import oracle.kubernetes.weblogic.domain.model.ClusterCondition;
 import oracle.kubernetes.weblogic.domain.model.ClusterResource;
 import oracle.kubernetes.weblogic.domain.model.ClusterStatus;
@@ -83,7 +82,7 @@ public class ClusterResourceStatusUpdater {
           .orElse(null);
       return doNext(chainStep(step, getNext()), packet);
     }
-    
+
     private static Step createUpdateClusterResourceStatusSteps(Packet packet,
                                                                Collection<ClusterResource> clusterResources) {
       List<StepAndPacket> result = clusterResources.stream()

--- a/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/ClusterResourceStatusUpdater.java
@@ -317,7 +317,7 @@ public class ClusterResourceStatusUpdater {
       // Get the ClusterResource, that was refreshed, from DomainPresenceInfo.
       DomainPresenceInfo info = DomainPresenceInfo.fromPacket(packet).orElseThrow();
       ClusterResource res = info.getClusterResource(clusterName);
-      return doNext(new ReplaceClusterStatusContext(packet, res).createReplaceClusterResourceStatusStep(), packet);
+      return doNext(createContext(packet, res).createReplaceClusterResourceStatusStep(), packet);
     }
   }
 }

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainStatusUpdater.java
@@ -765,7 +765,11 @@ public class DomainStatusUpdater {
         public Conditions(DomainStatus status) {
           this.status = status != null ? status : new DomainStatus();
           this.clusterChecks = createClusterChecks();
-          conditionList.add(new DomainCondition(COMPLETED).withStatus(isProcessingCompleted()));
+          boolean isCompleted = isProcessingCompleted();
+          conditionList.add(new DomainCondition(COMPLETED).withStatus(isCompleted));
+          if (isCompleted && this.status.hasConditionWithType(FAILED)) {
+            this.status.removeConditionsWithType(FAILED);
+          }
           conditionList.add(createAvailableCondition());
           if (allIntendedServersReady()) {
             this.status.removeConditionsWithType(ROLLING);

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -26,6 +26,7 @@ import oracle.kubernetes.operator.work.Step;
 import oracle.kubernetes.weblogic.domain.model.DomainCondition;
 import oracle.kubernetes.weblogic.domain.model.DomainResource;
 
+import static oracle.kubernetes.operator.KubernetesConstants.HTTP_CONFLICT;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_FORBIDDEN;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_NOT_FOUND;
 import static oracle.kubernetes.operator.KubernetesConstants.HTTP_UNAUTHORIZED;
@@ -177,7 +178,9 @@ public abstract class ResponseStep<T> extends Step {
   }
 
   private NextAction logNoRetry(Packet packet, CallResponse<T> callResponse) {
-    if ((callResponse != null) && (callResponse.getStatusCode() != HTTP_NOT_FOUND)) {
+    if ((callResponse != null)
+        && (callResponse.getStatusCode() != HTTP_NOT_FOUND)
+        && (callResponse.getStatusCode() != HTTP_CONFLICT)) {
       addDomainFailureStatus(packet, callResponse.getRequestParams(), callResponse.getE());
       if (LOGGER.isWarningEnabled()) {
         LOGGER.warning(

--- a/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/helpers/ResponseStep.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.helpers;

--- a/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/calls/AsyncRequestStepTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.calls;
@@ -194,6 +194,14 @@ class AsyncRequestStepTest {
         containsString(OP_NAME), containsString(RESOURCE_TYPE),
         containsString(RESOURCE_NAME), containsString(NS), containsString(EXPLANATION)
     ));
+  }
+
+  @Test
+  void afterFailedCallback409_failedStatusConditionNotSet() {
+    testSupport.addDomainPresenceInfo(info);
+    sendFailedCallback(HttpURLConnection.HTTP_CONFLICT);
+
+    assertThat(domain.getStatus().hasConditionWithType(FAILED), is(false));
   }
 
   @Test


### PR DESCRIPTION
The problem reported in OWLS-107005 is that an async call failure is left in domain status after the condition is recovered, and even after the domain processing is successfully completed.

The fix includes:

- Don't add Failed condition at the low async request processing layer when the error code is 409 (conflict) because the operator will retry the request after refresh the resource.
- When the domain status Completed condition becomes true, clear Failed conditions.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16635/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16638/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16640/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16647/