### PR TITLE
Fix adminserver name 34

### DIFF
--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -19,7 +19,7 @@ def filter_model(model):
                 else:
                     # weblogic default
                     if 'Server' in topology and 'adminserver' in topology['Server']:
-                        raise ValueError('Your model does not have AdminServerName set in the topology section but have a server named "adminserver", this is not supported.  Please set the AdminServerName attribute in the topology section in the model to the actual administration server name')
+                        raise ValueError('Your model does not have AdminServerName set in the topology section but have a server named "adminserver" in topology/Server section, this is not supported.  Please set the AdminServerName attribute in the topology section to the actual administration server name')
                     admin_server = 'AdminServer'
                 model['topology'] = {}
                 model['topology']['AdminServerName'] = admin_server

--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -18,7 +18,7 @@ def filter_model(model):
                     admin_server = topology['AdminServerName']
                 else:
                     # weblogic default
-                    if 'adminserver' in model['topology']['Server']:
+                    if 'Server' in topology and 'adminserver' in topology['Server']:
                         raise ValueError('Your model does not have AdminServerName set in the topology section but have a server named "adminserver", this is not supported.  Please set the AdminServerName attribute in the topology section in the model to the actual administration server name')
                     admin_server = 'AdminServer'
                 model['topology'] = {}

--- a/operator/src/main/resources/scripts/model-wdt-create-filter.py
+++ b/operator/src/main/resources/scripts/model-wdt-create-filter.py
@@ -18,6 +18,8 @@ def filter_model(model):
                     admin_server = topology['AdminServerName']
                 else:
                     # weblogic default
+                    if 'adminserver' in model['topology']['Server']:
+                        raise ValueError('Your model does not have AdminServerName set in the topology section but have a server named "adminserver", this is not supported.  Please set the AdminServerName attribute in the topology section in the model to the actual administration server name')
                     admin_server = 'AdminServer'
                 model['topology'] = {}
                 model['topology']['AdminServerName'] = admin_server


### PR DESCRIPTION
This is a fix to the cover the edge case when the user did not specify AdminServerName and there is a server named adminserver - the filter wlll then have two server with same lowercased listen address and WebLogic does not allow that.