### PR TITLE
Remove WebLogic Logging Exporter integration test from WKO main

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -342,6 +342,7 @@ class ItElasticLogging {
    * Use Elasticsearch Search APIs to query WebLogic log info pushed to Elasticsearch repository
    * by WebLogic Logging Exporter. Verify that log occurrence for WebLogic servers are not empty.
    */
+  @Disabled("Disabled the test because WLS logging exporter is not longer used")
   @Test
   @DisplayName("Use Elasticsearch Search APIs to query WebLogic log info in WLS server pod and verify")
   @DisabledIfEnvironmentVariable(named = "OKD", matches = "true")

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -34,6 +34,7 @@ import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_IMAGE;
+import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_TYPE;
@@ -229,6 +230,10 @@ class ItElasticLogging {
     // Verify that ELK Stack is ready to use
     testVarMap = new HashMap<String, String>();
     testVarMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, LOGSTASH_INDEX_KEY);
+    Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, KIBANA_INDEX_KEY);
+
+    // merge testVarMap and kibanaMap
+    testVarMap.putAll(kibanaMap);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes;
@@ -105,8 +105,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ItElasticLogging {
 
   // constants for creating domain image using model in image
-  private static final String WLS_LOGGING_MODEL_FILE = "model.wlslogging.yaml";
-  private static final String WLS_LOGGING_IMAGE_NAME = "wls-logging-image";
+  private static final String WLS_ELK_LOGGING_MODEL_FILE = "model.wlslogging.yaml";
+  private static final String WLS_ELK_LOGGING_IMAGE_NAME = "wls-logging-image";
 
   // constants for testing WebLogic Logging Exporter
   private static final String wlsLoggingExporterYamlFileLoc = RESOURCE_DIR + "/loggingexporter";
@@ -389,17 +389,17 @@ class ItElasticLogging {
     // create image with model files
     if (!OKD) {
       logger.info("Create image with model file and verify");
-      miiImage = createMiiImageAndVerify(WLS_LOGGING_IMAGE_NAME, WLS_LOGGING_MODEL_FILE,MII_BASIC_APP_NAME);
+      miiImage = createMiiImageAndVerify(WLS_ELK_LOGGING_IMAGE_NAME, WLS_ELK_LOGGING_MODEL_FILE,MII_BASIC_APP_NAME);
     } else {
       List<String> appList = new ArrayList<>();
       appList.add(MII_BASIC_APP_NAME);
 
       // build the model file list
-      final List<String> modelList = Collections.singletonList(MODEL_DIR + "/" + WLS_LOGGING_MODEL_FILE);
+      final List<String> modelList = Collections.singletonList(MODEL_DIR + "/" + WLS_ELK_LOGGING_MODEL_FILE);
 
       // create image with model files
       logger.info("Create image with model file and verify");
-      miiImage = createMiiImageAndVerify(WLS_LOGGING_IMAGE_NAME, modelList, appList);
+      miiImage = createMiiImageAndVerify(WLS_ELK_LOGGING_IMAGE_NAME, modelList, appList);
     }
 
     // repo login and push image to registry if necessary

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -28,15 +28,15 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+//import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
+//import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTPS_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_IMAGE;
-import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
+//import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_TYPE;
@@ -47,14 +47,14 @@ import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.SKIP_CLEANUP;
-import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_INDEX_KEY;
-import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.DOWNLOAD_DIR;
+//import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_INDEX_KEY;
+//import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
+//import static oracle.weblogic.kubernetes.actions.ActionConstants.DOWNLOAD_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.SNAKE_DOWNLOADED_FILENAME;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.WLE_DOWNLOAD_FILENAME_DEFAULT;
+//import static oracle.weblogic.kubernetes.actions.ActionConstants.SNAKE_DOWNLOADED_FILENAME;
+//import static oracle.weblogic.kubernetes.actions.ActionConstants.WLE_DOWNLOAD_FILENAME_DEFAULT;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
@@ -75,7 +75,7 @@ import static oracle.weblogic.kubernetes.utils.ImageUtils.createTestRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.imageRepoLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyElasticsearch;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyKibana;
-import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyWlsLoggingExporter;
+//import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyWlsLoggingExporter;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyElasticsearch;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyKibana;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.verifyLoggingExporterReady;
@@ -97,17 +97,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *    test createLogStashConfigMap = false.
  * 3. Verify that ELK Stack is ready to use by checking the index status of
  *    Kibana and Logstash created in the Operator pod successfully.
- * 4. Install WebLogic Logging Exporter in all WebLogic server pods by
- *    adding WebLogic Logging Exporter binary to the image builder process
- *    so that it will be available in the domain image via
- *    --additionalBuildCommands and --additionalBuildFiles.
- * 5. Create and start the WebLogic domain.
- * 6. Verify that
+ * 4. Create and start the WebLogic domain.
+ * 5. Verify that
  *    1) Elasticsearch collects data from WebLogic logs and
- *       stores them in its repository correctly.
- *    2) Using WebLogic Logging Exporter, WebLogic server Logs can be integrated to
- *       ELK Stack in the same pod that the domain is running on.
- *    3) Users can update logstash configuration by updating the configmap
+ *       stores them in its repository correctly..
+ *    2) Users can update logstash configuration by updating the configmap
  *       weblogic-operator-logstash-cm instead of rebuilding operator image
  */
 @DisplayName("Test to use Elasticsearch API to query WebLogic logs")
@@ -226,11 +220,6 @@ class ItElasticLogging {
         "operator to be running in namespace {0}",
         opNamespace);
 
-    // install WebLogic Logging Exporter if in non-OKD env
-    if (!OKD) {
-      installAndVerifyWlsLoggingExporter(managedServerFilter, wlsLoggingExporterYamlFileLoc, elasticSearchNs);
-    }
-
     // create and verify WebLogic domain image using model in image with model files
     String imageName = createAndVerifyDomainImage();
 
@@ -249,10 +238,10 @@ class ItElasticLogging {
     // Verify that ELK Stack is ready to use
     testVarMap = new HashMap<String, String>();
     testVarMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, LOGSTASH_INDEX_KEY);
-    Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, KIBANA_INDEX_KEY);
+    //Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, KIBANA_INDEX_KEY);
 
     // merge testVarMap and kibanaMap
-    testVarMap.putAll(kibanaMap);
+    //testVarMap.putAll(kibanaMap);
   }
 
   /**
@@ -339,47 +328,6 @@ class ItElasticLogging {
   }
 
   /**
-   * Use Elasticsearch Search APIs to query WebLogic log info pushed to Elasticsearch repository
-   * by WebLogic Logging Exporter. Verify that log occurrence for WebLogic servers are not empty.
-   */
-  @Disabled("Disabled the test because WLS logging exporter is not longer used")
-  @Test
-  @DisplayName("Use Elasticsearch Search APIs to query WebLogic log info in WLS server pod and verify")
-  @DisabledIfEnvironmentVariable(named = "OKD", matches = "true")
-  void testWlsLoggingExporter() throws Exception {
-    Map<String, String> wlsMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, WEBLOGIC_INDEX_KEY);
-    // merge testVarMap and wlsMap
-    testVarMap.putAll(wlsMap);
-
-    // Verify that occurrence of log level = Notice are not empty
-    String regex = ".*took\":(\\d+),.*hits\":\\{(.+)\\}";
-    String queryCriteria = "/_search?q=level:Notice";
-    verifyCountsHitsInSearchResults(queryCriteria, regex, WEBLOGIC_INDEX_KEY, false);
-
-    // Verify that occurrence of loggerName = WebLogicServer are not empty
-    queryCriteria = "/_search?q=loggerName:WebLogicServer";
-    verifyCountsHitsInSearchResults(queryCriteria, regex, WEBLOGIC_INDEX_KEY, false);
-
-    // Verify that occurrence of _type:doc are not empty
-    queryCriteria = "/_search?q=_type:doc";
-    verifyCountsHitsInSearchResults(queryCriteria, regex, WEBLOGIC_INDEX_KEY, false);
-
-    // Verify that serverName:managed-server1 is filtered out
-    // by checking the count of logs from serverName:managed-server1 is zero and no failures
-    regex = "(?m).*\\s*.*count\"\\s*:\\s*(\\d+),.*failed\"\\s*:\\s*(\\d+)";
-    StringBuffer queryCriteriaBuff = new StringBuffer("/doc/_count?pretty")
-        .append(" -H 'Content-Type: application/json'")
-        .append(" -d'{\"query\":{\"query_string\":{\"query\":\"")
-        .append(managedServerFilter)
-        .append("\",\"fields\":[\"serverName\"],\"default_operator\": \"AND\"}}}'");
-
-    queryCriteria = queryCriteriaBuff.toString();
-    verifyCountsHitsInSearchResults(queryCriteria, regex, WEBLOGIC_INDEX_KEY, true, "notExist");
-
-    logger.info("Query WebLogic log info succeeded");
-  }
-
-  /**
    * Test when variable createLogStashConfigMap sets to true, a configMap named weblogic-operator-logstash-cm
    * is created and users can update logstash configuration by updating the configmap
    * instead of rebuilding operator image.
@@ -448,6 +396,7 @@ class ItElasticLogging {
 
     // create image with model files
     if (!OKD) {
+      /*
       String additionalBuildCommands = WORK_DIR + "/" + COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
       StringBuffer additionalBuildFilesVarargsBuff = new StringBuffer()
           .append(WORK_DIR)
@@ -460,11 +409,11 @@ class ItElasticLogging {
           .append(",")
           .append(DOWNLOAD_DIR)
           .append("/")
-          .append(SNAKE_DOWNLOADED_FILENAME);
+          .append(SNAKE_DOWNLOADED_FILENAME);*/
 
       logger.info("Create image with model file and verify");
-      miiImage = createMiiImageAndVerify(WLS_LOGGING_IMAGE_NAME, WLS_LOGGING_MODEL_FILE,
-          MII_BASIC_APP_NAME, additionalBuildCommands, additionalBuildFilesVarargsBuff.toString());
+      miiImage = createMiiImageAndVerify(WLS_LOGGING_IMAGE_NAME, WLS_LOGGING_MODEL_FILE,MII_BASIC_APP_NAME);
+      //MII_BASIC_APP_NAME, additionalBuildCommands, additionalBuildFilesVarargsBuff.toString());
     } else {
       List<String> appList = new ArrayList<>();
       appList.add(MII_BASIC_APP_NAME);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -28,15 +28,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-//import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTPS_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_IMAGE;
-//import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_TYPE;
@@ -47,14 +44,9 @@ import static oracle.weblogic.kubernetes.TestConstants.OKD;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_CHART_DIR;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.SKIP_CLEANUP;
-//import static oracle.weblogic.kubernetes.TestConstants.WEBLOGIC_INDEX_KEY;
-//import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
-//import static oracle.weblogic.kubernetes.actions.ActionConstants.DOWNLOAD_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.ITTESTS_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.MODEL_DIR;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.RESOURCE_DIR;
-//import static oracle.weblogic.kubernetes.actions.ActionConstants.SNAKE_DOWNLOADED_FILENAME;
-//import static oracle.weblogic.kubernetes.actions.ActionConstants.WLE_DOWNLOAD_FILENAME_DEFAULT;
 import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
@@ -75,7 +67,6 @@ import static oracle.weblogic.kubernetes.utils.ImageUtils.createTestRepoSecret;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.imageRepoLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyElasticsearch;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyKibana;
-//import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.installAndVerifyWlsLoggingExporter;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyElasticsearch;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.uninstallAndVerifyKibana;
 import static oracle.weblogic.kubernetes.utils.LoggingExporterUtils.verifyLoggingExporterReady;
@@ -238,10 +229,6 @@ class ItElasticLogging {
     // Verify that ELK Stack is ready to use
     testVarMap = new HashMap<String, String>();
     testVarMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, LOGSTASH_INDEX_KEY);
-    //Map<String, String> kibanaMap = verifyLoggingExporterReady(opNamespace, elasticSearchNs, null, KIBANA_INDEX_KEY);
-
-    // merge testVarMap and kibanaMap
-    //testVarMap.putAll(kibanaMap);
   }
 
   /**
@@ -396,24 +383,8 @@ class ItElasticLogging {
 
     // create image with model files
     if (!OKD) {
-      /*
-      String additionalBuildCommands = WORK_DIR + "/" + COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
-      StringBuffer additionalBuildFilesVarargsBuff = new StringBuffer()
-          .append(WORK_DIR)
-          .append("/")
-          .append(WLS_LOGGING_EXPORTER_YAML_FILE_NAME)
-          .append(",")
-          .append(DOWNLOAD_DIR)
-          .append("/")
-          .append(WLE_DOWNLOAD_FILENAME_DEFAULT)
-          .append(",")
-          .append(DOWNLOAD_DIR)
-          .append("/")
-          .append(SNAKE_DOWNLOADED_FILENAME);*/
-
       logger.info("Create image with model file and verify");
       miiImage = createMiiImageAndVerify(WLS_LOGGING_IMAGE_NAME, WLS_LOGGING_MODEL_FILE,MII_BASIC_APP_NAME);
-      //MII_BASIC_APP_NAME, additionalBuildCommands, additionalBuildFilesVarargsBuff.toString());
     } else {
       List<String> appList = new ArrayList<>();
       appList.add(MII_BASIC_APP_NAME);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLogging.java
@@ -92,7 +92,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 4. Create and start the WebLogic domain.
  * 5. Verify that
  *    1) Elasticsearch collects data from WebLogic logs and
- *       stores them in its repository correctly..
+ *       stores them in its repository correctly.
  *    2) Users can update logstash configuration by updating the configmap
  *       weblogic-operator-logstash-cm instead of rebuilding operator image
  */

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItElasticLoggingFluentd.java
@@ -117,8 +117,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ItElasticLoggingFluentd {
 
   // constants for creating domain image using model in image
-  private static final String WLS_LOGGING_MODEL_FILE = WORK_DIR + "/" + "new.model.wlslogging.yaml";
-  private static final String WLS_LOGGING_IMAGE_NAME = "wls-logging-image";
+  private static final String WLS_ELK_LOGGING_MODEL_FILE = WORK_DIR + "/" + "new.model.wlslogging.yaml";
+  private static final String WLS_ELK_LOGGING_IMAGE_NAME = "wls-logging-image";
   private static final String FLUENTD_CONFIGMAP_YAML = "fluentd.configmap.elk.yaml";
 
   // constants for Domain
@@ -315,7 +315,7 @@ class ItElasticLoggingFluentd {
     // create image with model files
     logger.info("Create image with model file and verify");
     String miiImage =
-        createMiiImageAndVerify(WLS_LOGGING_IMAGE_NAME, WLS_LOGGING_MODEL_FILE, MII_BASIC_APP_NAME);
+        createMiiImageAndVerify(WLS_ELK_LOGGING_IMAGE_NAME, WLS_ELK_LOGGING_MODEL_FILE, MII_BASIC_APP_NAME);
 
     // repo login and push image to registry if necessary
     imageRepoLoginAndPushImageToRegistry(miiImage);
@@ -493,12 +493,12 @@ class ItElasticLoggingFluentd {
   private static void modifyModelConfigfile() {
     final String sourceConfigFile = MODEL_DIR + "/model.wlslogging.yaml";
 
-    assertDoesNotThrow(() -> copy(Paths.get(sourceConfigFile), Paths.get(WLS_LOGGING_MODEL_FILE)),
+    assertDoesNotThrow(() -> copy(Paths.get(sourceConfigFile), Paths.get(WLS_ELK_LOGGING_MODEL_FILE)),
         "copy model.wlslogging.yaml failed");
 
     String[] deleteLineKeys
         = new String[]{"resources", "StartupClass", "LoggingExporterStartupClass", "ClassName", "Target"};
-    try (RandomAccessFile file = new RandomAccessFile(WLS_LOGGING_MODEL_FILE, "rw")) {
+    try (RandomAccessFile file = new RandomAccessFile(WLS_ELK_LOGGING_MODEL_FILE, "rw")) {
       String lineToKeep = "";
       String allLines = "";
       boolean fountit = false;
@@ -515,7 +515,7 @@ class ItElasticLoggingFluentd {
         allLines += lineToKeep + "\n";
       }
 
-      try (BufferedWriter writer = new BufferedWriter(new FileWriter(WLS_LOGGING_MODEL_FILE))) {
+      try (BufferedWriter writer = new BufferedWriter(new FileWriter(WLS_ELK_LOGGING_MODEL_FILE))) {
         writer.write(allLines);
       } catch (Exception ex) {
         ex.printStackTrace();

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -238,9 +238,6 @@ public interface TestConstants {
             + FLUENTD_IMAGE_VERSION;
   public static final String JAVA_LOGGING_LEVEL_VALUE = "INFO";
 
-  //public static final String WLS_LOGGING_EXPORTER_YAML_FILE_NAME = "WebLogicLoggingExporter.yaml";
-  //public static final String COPY_WLS_LOGGING_EXPORTER_FILE_NAME = "copy-logging-files-cmds.txt";
-
   // MII image constants
   public static final String MII_BASIC_WDT_MODEL_FILE = "model-singleclusterdomain-sampleapp-wls.yaml";
   public static final String MII_BASIC_IMAGE_NAME = DOMAIN_IMAGES_REPO + "mii-basic-image";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -238,8 +238,8 @@ public interface TestConstants {
             + FLUENTD_IMAGE_VERSION;
   public static final String JAVA_LOGGING_LEVEL_VALUE = "INFO";
 
-  public static final String WLS_LOGGING_EXPORTER_YAML_FILE_NAME = "WebLogicLoggingExporter.yaml";
-  public static final String COPY_WLS_LOGGING_EXPORTER_FILE_NAME = "copy-logging-files-cmds.txt";
+  //public static final String WLS_LOGGING_EXPORTER_YAML_FILE_NAME = "WebLogicLoggingExporter.yaml";
+  //public static final String COPY_WLS_LOGGING_EXPORTER_FILE_NAME = "copy-logging-files-cmds.txt";
 
   // MII image constants
   public static final String MII_BASIC_WDT_MODEL_FILE = "model-singleclusterdomain-sampleapp-wls.yaml";

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -1821,22 +1821,6 @@ public class TestActions {
     return LoggingExporter.verifyLoggingExporterReady(opNamespace, esNamespace, labelSelector, index);
   }
 
-  // --------------------------- WebLogic Logging Exporter---------------------------------
-  /**
-   * Install WebLogic Logging Exporter.
-   *
-   * @param filter the value of weblogicLoggingExporterFilters to be added to WebLogic Logging Exporter YAML file
-   * @param wlsLoggingExporterYamlFileLoc the directory where WebLogic Logging Exporter YAML file stores
-   * @param namespace logging exporter publish host namespace
-   * @return true if WebLogic Logging Exporter is successfully installed, false otherwise.
-   */
-  public static boolean installWlsLoggingExporter(String filter,
-                                                  String wlsLoggingExporterYamlFileLoc, String namespace) {
-    //return LoggingExporter.installWlsLoggingExporter(filter,
-    //wlsLoggingExporterYamlFileLoc, namespace);
-    return true;
-  }
-
   /**
    * Patch the domain resource with a new restartVersion.
    *

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/TestActions.java
@@ -1832,8 +1832,9 @@ public class TestActions {
    */
   public static boolean installWlsLoggingExporter(String filter,
                                                   String wlsLoggingExporterYamlFileLoc, String namespace) {
-    return LoggingExporter.installWlsLoggingExporter(filter,
-        wlsLoggingExporterYamlFileLoc, namespace);
+    //return LoggingExporter.installWlsLoggingExporter(filter,
+    //wlsLoggingExporterYamlFileLoc, namespace);
+    return true;
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -33,13 +33,10 @@ import oracle.weblogic.kubernetes.utils.ExecResult;
 
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_TAG;
-//import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
-//import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
-//import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Installer.defaultInstallSnakeParams;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -3,10 +3,6 @@
 
 package oracle.weblogic.kubernetes.actions.impl;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -34,17 +30,16 @@ import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
 import oracle.weblogic.kubernetes.assertions.impl.Deployment;
 import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import oracle.weblogic.kubernetes.utils.ExecResult;
-import oracle.weblogic.kubernetes.utils.FileUtils;
 
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_IMAGE;
 import static oracle.weblogic.kubernetes.TestConstants.BUSYBOX_TAG;
-import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
+//import static oracle.weblogic.kubernetes.TestConstants.COPY_WLS_LOGGING_EXPORTER_FILE_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.ELASTICSEARCH_HTTP_PORT;
 import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
 import static oracle.weblogic.kubernetes.TestConstants.KIBANA_INDEX_KEY;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
-import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
-import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
+//import static oracle.weblogic.kubernetes.TestConstants.WLS_LOGGING_EXPORTER_YAML_FILE_NAME;
+//import static oracle.weblogic.kubernetes.actions.ActionConstants.WORK_DIR;
 import static oracle.weblogic.kubernetes.actions.TestActions.execCommand;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Installer.defaultInstallSnakeParams;
@@ -333,47 +328,6 @@ public class LoggingExporter {
         .download();
   }
 
-  /**
-   * Install WebLogic Logging Exporter.
-   *
-   * @param filter the value of weblogicLoggingExporterFilters to be added to WebLogic Logging Exporter YAML file
-   * @param wlsLoggingExporterYamlFileLoc the directory where WebLogic Logging Exporter YAML file stores
-   * @param namespace logging exporter publish host namespace
-   * @return true if WebLogic Logging Exporter is successfully installed, false otherwise.
-   */
-  public static boolean installWlsLoggingExporter(String filter,
-                                                  String wlsLoggingExporterYamlFileLoc, String namespace) {
-    // Copy WebLogic Logging Exporter files to WORK_DIR
-    String[] loggingExporterFiles =
-        {WLS_LOGGING_EXPORTER_YAML_FILE_NAME, COPY_WLS_LOGGING_EXPORTER_FILE_NAME};
-
-    for (String loggingFile : loggingExporterFiles) {
-      Path srcPath = Paths.get(wlsLoggingExporterYamlFileLoc, loggingFile);
-      Path destPath = Paths.get(WORK_DIR, loggingFile);
-      assertDoesNotThrow(() -> FileUtils.copy(srcPath, destPath),
-          String.format("Failed to copy %s to %s", srcPath, destPath));
-      assertDoesNotThrow(() -> FileUtils.replaceStringInFile(destPath.toString(), "default", namespace),
-          String.format("Failed to replace namespace default to %s", namespace));
-      logger.info("Copied {0} to {1}}", srcPath, destPath);
-    }
-
-    // Add filter to weblogicLoggingExporterFilters in WebLogic Logging Exporter YAML file
-    assertDoesNotThrow(() -> addFilterToElkFile(filter),
-        "Failed to add WebLogic Logging Exporter filter");
-
-    // Download WebLogic Logging Exporter jar file
-    if (!downloadWle()) {
-      return false;
-    }
-
-    // Download the YAML parser, SnakeYAML
-    if (!downloadSnake()) {
-      return false;
-    }
-
-    return true;
-  }
-
   private static V1Deployment createElasticsearchDeploymentCr(LoggingExporterParams params) {
 
     String elasticsearchName = params.getElasticsearchName();
@@ -563,6 +517,7 @@ public class LoggingExporter {
     return statusLine.stdout();
   }
 
+  /*
   private static void addFilterToElkFile(String filter) throws Exception {
     String filterStr = new StringBuffer()
         .append(System.lineSeparator())
@@ -576,5 +531,5 @@ public class LoggingExporter {
 
     Files.write(Paths.get(WORK_DIR, WLS_LOGGING_EXPORTER_YAML_FILE_NAME),
         filterStr.getBytes(), StandardOpenOption.APPEND);
-  }
+  }*/
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.actions.impl;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/LoggingExporter.java
@@ -516,20 +516,4 @@ public class LoggingExporter {
 
     return statusLine.stdout();
   }
-
-  /*
-  private static void addFilterToElkFile(String filter) throws Exception {
-    String filterStr = new StringBuffer()
-        .append(System.lineSeparator())
-        .append("weblogicLoggingExporterFilters:")
-        .append(System.lineSeparator())
-        .append("- FilterExpression: NOT(SERVER = '")
-        .append(filter)
-        .append("')")
-        .toString();
-    logger.info("Command to add filter {0}", filterStr);
-
-    Files.write(Paths.get(WORK_DIR, WLS_LOGGING_EXPORTER_YAML_FILE_NAME),
-        filterStr.getBytes(), StandardOpenOption.APPEND);
-  }*/
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
@@ -136,27 +136,6 @@ public class LoggingExporterUtils {
   }
 
   /**
-   * Install WebLogic Logging Exporter.
-   *
-   * @param filter the value of weblogicLoggingExporterFilters to be added to WebLogic Logging Exporter YAML file
-   * @param wlsLoggingExporterYamlFileLoc the directory where WebLogic Logging Exporter YAML file stores
-   * @param namespace logging exporter publish host namespace
-   * @return true if WebLogic Logging Exporter is successfully installed, false otherwise.
-   */
-  public static boolean installAndVerifyWlsLoggingExporter(String filter,
-                                                           String wlsLoggingExporterYamlFileLoc, String namespace) {
-    /*
-    // Install WebLogic Logging Exporter
-    assertThat(TestActions.installWlsLoggingExporter(filter,
-        wlsLoggingExporterYamlFileLoc, namespace))
-        .as("WebLogic Logging Exporter installation succeeds")
-        .withFailMessage("WebLogic Logging Exporter installation failed")
-        .isTrue();*/
-
-    return true;
-  }
-
-  /**
    * Verify that the logging exporter is ready to use in Operator pod or WebLogic server pod.
    *
    * @param opNamespace namespace of Operator pod (for ELK Stack) or

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingExporterUtils.java
@@ -145,12 +145,13 @@ public class LoggingExporterUtils {
    */
   public static boolean installAndVerifyWlsLoggingExporter(String filter,
                                                            String wlsLoggingExporterYamlFileLoc, String namespace) {
+    /*
     // Install WebLogic Logging Exporter
     assertThat(TestActions.installWlsLoggingExporter(filter,
         wlsLoggingExporterYamlFileLoc, namespace))
         .as("WebLogic Logging Exporter installation succeeds")
         .withFailMessage("WebLogic Logging Exporter installation failed")
-        .isTrue();
+        .isTrue();*/
 
     return true;
   }

--- a/integration-tests/src/test/resources/wdt-models/model.wlslogging.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model.wlslogging.yaml
@@ -24,8 +24,3 @@ topology:
         "cluster-1-template":
             Cluster: "cluster-1"
             ListenPort : 8001
-resources:
-    StartupClass:
-        LoggingExporterStartupClass:
-            ClassName: weblogic.logging.exporter.Startup
-            Target: 'cluster-1'

--- a/integration-tests/src/test/resources/wdt-models/model.wlslogging.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model.wlslogging.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 domainInfo:


### PR DESCRIPTION
Removed our WebLogic Logging Exporter test from the main line as per Monica suggestion.

Jenkins Jobs

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16590
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16592
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16658
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16659

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16703
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16704

with latest changes:

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16728