### PR TITLE
Infra changes to collect logs from verrazzano installation

### DIFF
--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/ApplicationList.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/ApplicationList.java
@@ -1,0 +1,141 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.verrazzano.weblogic;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@ApiModel(description = "ApplicationList is a list of ApplicationConfiguration.")
+public class ApplicationList implements KubernetesListObject {
+
+  @ApiModelProperty("The API version for the Domain.")
+  private String apiVersion;
+
+  @ApiModelProperty("The type of resource. Must be 'DomainList'.")
+  private String kind;
+
+  @ApiModelProperty(
+      "Standard list metadata. "
+          + "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds.")
+  private V1ListMeta metadata;
+
+  @ApiModelProperty(
+      "List of domains. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md. Required.")
+  private List<ApplicationConfiguration> items = new ArrayList<ApplicationConfiguration>();
+
+  public ApplicationList apiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return this;
+  }
+
+  public String apiVersion() {
+    return apiVersion;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public ApplicationList kind(String kind) {
+    this.kind = kind;
+    return this;
+  }
+
+  public String kind() {
+    return kind;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public ApplicationList metadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public V1ListMeta metadata() {
+    return metadata;
+  }
+
+  public V1ListMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public ApplicationList items(List<ApplicationConfiguration> items) {
+    this.items = items;
+    return this;
+  }
+
+  public List<ApplicationConfiguration> items() {
+    return items;
+  }
+
+  public List<ApplicationConfiguration> getItems() {
+    return items;
+  }
+
+  public void setItems(List<ApplicationConfiguration> items) {
+    this.items = items;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("apiVersion", apiVersion)
+        .append("kind", kind)
+        .append("metadata", metadata)
+        .append("items", items)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .append(apiVersion)
+        .append(kind)
+        .append(metadata)
+        .append(items)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    ApplicationList rhs = (ApplicationList) other;
+    return new EqualsBuilder()
+        .append(apiVersion, rhs.apiVersion)
+        .append(kind, rhs.kind)
+        .append(metadata, rhs.metadata)
+        .append(items, rhs.items)
+        .isEquals();
+  }
+}

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/ApplicationList.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/ApplicationList.java
@@ -21,7 +21,7 @@ public class ApplicationList implements KubernetesListObject {
   @ApiModelProperty("The API version for the Domain.")
   private String apiVersion;
 
-  @ApiModelProperty("The type of resource. Must be 'DomainList'.")
+  @ApiModelProperty("The type of resource. Must be 'ComponentList'.")
   private String kind;
 
   @ApiModelProperty(

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/ApplicationList.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/ApplicationList.java
@@ -1,8 +1,7 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.verrazzano.weblogic;
-
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,10 +17,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @ApiModel(description = "ApplicationList is a list of ApplicationConfiguration.")
 public class ApplicationList implements KubernetesListObject {
 
-  @ApiModelProperty("The API version for the Domain.")
+  @ApiModelProperty("The API version for the ApplicationConfiguration.")
   private String apiVersion;
 
-  @ApiModelProperty("The type of resource. Must be 'ComponentList'.")
+  @ApiModelProperty("The type of resource. Must be 'ApplicationConfiguration'.")
   private String kind;
 
   @ApiModelProperty(

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/ComponentList.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/ComponentList.java
@@ -15,13 +15,13 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-@ApiModel(description = "ApplicationList is a list of ApplicationConfiguration.")
+@ApiModel(description = "ComponentList is a list of Components.")
 public class ComponentList implements KubernetesListObject {
 
   @ApiModelProperty("The API version for the Domain.")
   private String apiVersion;
 
-  @ApiModelProperty("The type of resource. Must be 'DomainList'.")
+  @ApiModelProperty("The type of resource. Must be 'ComponentList'.")
   private String kind;
 
   @ApiModelProperty(
@@ -31,7 +31,7 @@ public class ComponentList implements KubernetesListObject {
 
   @ApiModelProperty(
       "List of domains. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md. Required.")
-  private List<ApplicationConfiguration> items = new ArrayList<ApplicationConfiguration>();
+  private List<Component> items = new ArrayList<Component>();
 
   public ComponentList apiVersion(String apiVersion) {
     this.apiVersion = apiVersion;
@@ -84,20 +84,20 @@ public class ComponentList implements KubernetesListObject {
     this.metadata = metadata;
   }
 
-  public ComponentList items(List<ApplicationConfiguration> items) {
+  public ComponentList items(List<Component> items) {
     this.items = items;
     return this;
   }
 
-  public List<ApplicationConfiguration> items() {
+  public List<Component> items() {
     return items;
   }
 
-  public List<ApplicationConfiguration> getItems() {
+  public List<Component> getItems() {
     return items;
   }
 
-  public void setItems(List<ApplicationConfiguration> items) {
+  public void setItems(List<Component> items) {
     this.items = items;
   }
 

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/ComponentList.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/ComponentList.java
@@ -1,0 +1,141 @@
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.verrazzano.weblogic;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@ApiModel(description = "ApplicationList is a list of ApplicationConfiguration.")
+public class ComponentList implements KubernetesListObject {
+
+  @ApiModelProperty("The API version for the Domain.")
+  private String apiVersion;
+
+  @ApiModelProperty("The type of resource. Must be 'DomainList'.")
+  private String kind;
+
+  @ApiModelProperty(
+      "Standard list metadata. "
+          + "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds.")
+  private V1ListMeta metadata;
+
+  @ApiModelProperty(
+      "List of domains. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md. Required.")
+  private List<ApplicationConfiguration> items = new ArrayList<ApplicationConfiguration>();
+
+  public ComponentList apiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return this;
+  }
+
+  public String apiVersion() {
+    return apiVersion;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public ComponentList kind(String kind) {
+    this.kind = kind;
+    return this;
+  }
+
+  public String kind() {
+    return kind;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public ComponentList metadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public V1ListMeta metadata() {
+    return metadata;
+  }
+
+  public V1ListMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public ComponentList items(List<ApplicationConfiguration> items) {
+    this.items = items;
+    return this;
+  }
+
+  public List<ApplicationConfiguration> items() {
+    return items;
+  }
+
+  public List<ApplicationConfiguration> getItems() {
+    return items;
+  }
+
+  public void setItems(List<ApplicationConfiguration> items) {
+    this.items = items;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("apiVersion", apiVersion)
+        .append("kind", kind)
+        .append("metadata", metadata)
+        .append("items", items)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .append(apiVersion)
+        .append(kind)
+        .append(metadata)
+        .append(items)
+        .toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    ComponentList rhs = (ComponentList) other;
+    return new EqualsBuilder()
+        .append(apiVersion, rhs.apiVersion)
+        .append(kind, rhs.kind)
+        .append(metadata, rhs.metadata)
+        .append(items, rhs.items)
+        .isEquals();
+  }
+}

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/ComponentList.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/ComponentList.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.verrazzano.weblogic;
@@ -18,10 +18,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @ApiModel(description = "ComponentList is a list of Components.")
 public class ComponentList implements KubernetesListObject {
 
-  @ApiModelProperty("The API version for the Domain.")
+  @ApiModelProperty("The API version for the Component.")
   private String apiVersion;
 
-  @ApiModelProperty("The type of resource. Must be 'ComponentList'.")
+  @ApiModelProperty("The type of resource. Must be 'Component'.")
   private String kind;
 
   @ApiModelProperty(

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/kubernetes/ItVzMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/kubernetes/ItVzMiiDomain.java
@@ -189,7 +189,7 @@ class ItVzMiiDomain {
     String address = getLoadbalancerAddress();
 
     // verify WebLogic console page is accessible through istio/loadbalancer
-    String message = "Oracle WebLogic Server Administration Console";
+    String message = "Oracle WebLogic Server Administration Console1";
     String consoleUrl = "https://" + host + "/console/login/LoginForm.jsp --resolve " + host + ":443:" + address;
     assertTrue(verifyVzApplicationAccess(consoleUrl, message), "Failed to get WebLogic administration console");
 

--- a/integration-tests/src/test/java/oracle/verrazzano/weblogic/kubernetes/ItVzMiiDomain.java
+++ b/integration-tests/src/test/java/oracle/verrazzano/weblogic/kubernetes/ItVzMiiDomain.java
@@ -189,7 +189,7 @@ class ItVzMiiDomain {
     String address = getLoadbalancerAddress();
 
     // verify WebLogic console page is accessible through istio/loadbalancer
-    String message = "Oracle WebLogic Server Administration Console1";
+    String message = "Oracle WebLogic Server Administration Console";
     String consoleUrl = "https://" + host + "/console/login/LoginForm.jsp --resolve " + host + ":443:" + address;
     assertTrue(verifyVzApplicationAccess(consoleUrl, message), "Failed to get WebLogic administration console");
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -6,6 +6,7 @@ package oracle.weblogic.kubernetes;
 import java.net.InetAddress;
 import java.util.Optional;
 
+import static oracle.weblogic.kubernetes.actions.TestActions.listNamespaces;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getDateAndTimeStamp;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getEnvironmentProperty;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.getKindRepoValue;
@@ -405,4 +406,12 @@ public interface TestConstants {
   // metrics server constants
   public static final String METRICS_SERVER_YAML =
       "https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.8.2/components.yaml";
+  
+  // verrazzano related constants
+  public static final String VZ_SYSTEM_NS = "ingress-nginx";
+  public static final String VZ_INGRESS_NS = "verrazzano-system";
+  public static final String VZ_ISTIO_NS = "istio-system";
+  public static final boolean VZ_ENV = assertDoesNotThrow(() -> listNamespaces().stream()
+        .anyMatch(ns -> ns.equals(VZ_SYSTEM_NS)));
+  
 }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/TestConstants.java
@@ -408,8 +408,8 @@ public interface TestConstants {
       "https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.8.2/components.yaml";
   
   // verrazzano related constants
-  public static final String VZ_SYSTEM_NS = "ingress-nginx";
-  public static final String VZ_INGRESS_NS = "verrazzano-system";
+  public static final String VZ_INGRESS_NS = "ingress-nginx";
+  public static final String VZ_SYSTEM_NS = "verrazzano-system";
   public static final String VZ_ISTIO_NS = "istio-system";
   public static final boolean VZ_ENV = assertDoesNotThrow(() -> listNamespaces().stream()
         .anyMatch(ns -> ns.equals(VZ_SYSTEM_NS)));

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -3492,7 +3492,7 @@ public class Kubernetes {
    * @return V1CustomResourceDefinitionList list of crds
    * @throws ApiException when list fails.
    */
-  public static Object listCrds() throws ApiException {
+  public static String listCrds() throws ApiException {
     Object crds;
     try {
       crds = vzCustomObjectsApi
@@ -3513,9 +3513,7 @@ public class Kubernetes {
       getLogger().severe(ex.getMessage());
       throw ex;
     }
-    getLogger().info("Dumping in listCrds method");
-    getLogger().info(crds.toString());
-    return crds;
+    return crds.toString();
   }
   
   //------------------------

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -136,7 +136,6 @@ public class Kubernetes {
   private static CoreV1Api coreV1Api = null;
   private static PolicyV1Api policyV1Api = null;
   private static CustomObjectsApi customObjectsApi = null;
-  private static CustomObjectsApi vzCustomObjectsApi = null;
   private static RbacAuthorizationV1Api rbacAuthApi = null;
   private static AdmissionregistrationV1Api admissionregistrationApi = null;
   private static DeleteOptions deleteOptions = null;
@@ -171,7 +170,6 @@ public class Kubernetes {
       coreV1Api = new CoreV1Api();
       policyV1Api = new PolicyV1Api();
       customObjectsApi = new CustomObjectsApi();
-      vzCustomObjectsApi = new CustomObjectsApi();
       rbacAuthApi = new RbacAuthorizationV1Api();
       admissionregistrationApi = new AdmissionregistrationV1Api();
       initializeGenericKubernetesApiClients();
@@ -1354,7 +1352,7 @@ public class Kubernetes {
 
     Object response;
     try {
-      response = vzCustomObjectsApi.createNamespacedCustomObject(COMPONENT_GROUP, // custom resource's group name
+      response = customObjectsApi.createNamespacedCustomObject(COMPONENT_GROUP, // custom resource's group name
           componentVersion, //custom resource's version
           namespace, // custom resource's namespace
           COMPONENT_PLURAL, // custom resource's plural name
@@ -1415,7 +1413,7 @@ public class Kubernetes {
     JsonElement json = convertToJson(application);
     Object response;    
     try {
-      response = vzCustomObjectsApi.createNamespacedCustomObject(APPLICATION_GROUP, // custom resource's group name
+      response = customObjectsApi.createNamespacedCustomObject(APPLICATION_GROUP, // custom resource's group name
           applicationVersion, //custom resource's version
           namespace, // custom resource's namespace
           APPLICATION_PLURAL, // custom resource's plural name
@@ -3493,7 +3491,7 @@ public class Kubernetes {
   public static String listCrds() throws ApiException {
     Object crds;
     try {
-      crds = vzCustomObjectsApi
+      crds = customObjectsApi
           .listClusterCustomObject("apiextensions.k8s.io",
               "v1",
               "customresourcedefinitions",

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -45,6 +45,7 @@ import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionList;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentList;
 import io.kubernetes.client.openapi.models.V1Ingress;
@@ -3486,6 +3487,29 @@ public class Kubernetes {
     return ingress;
   }
 
+  /**
+   * Get a list of custom resource definitions deployed in the cluster.
+   *
+   * @return V1CustomResourceDefinitionList list of crds
+   * @throws ApiException when list fails.
+   */
+  public static V1CustomResourceDefinitionList listCrds() throws ApiException {
+    V1CustomResourceDefinitionList crds = (V1CustomResourceDefinitionList) vzCustomObjectsApi
+        .listClusterCustomObject("apiextensions.k8s.io",
+            "v1",
+            "customresourcedefinitions",
+            null,
+            false,
+            null,
+            null,
+            null,
+            0,
+            null,
+            null,
+            0,
+            false);
+    return crds;
+  }
   //------------------------
 
   private static String readExecCmdData(InputStream is) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -3494,7 +3494,7 @@ public class Kubernetes {
    * @throws ApiException when list fails.
    */
   public static V1CustomResourceDefinitionList listCrds() throws ApiException {
-    V1CustomResourceDefinitionList crds = (V1CustomResourceDefinitionList) vzCustomObjectsApi
+    Object listClusterCustomObject = vzCustomObjectsApi
         .listClusterCustomObject("apiextensions.k8s.io",
             "v1",
             "customresourcedefinitions",
@@ -3508,7 +3508,9 @@ public class Kubernetes {
             null,
             0,
             false);
-    return crds;
+    getLogger().info("Dumping all crds");
+    getLogger().info(Yaml.dump(listClusterCustomObject));
+    return null;
   }
   //------------------------
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -3513,6 +3513,8 @@ public class Kubernetes {
       getLogger().severe(ex.getMessage());
       throw ex;
     }
+    getLogger().info("Dumping in listCrds method");
+    getLogger().info(crds.toString());
     return crds;
   }
   

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.actions.impl.primitive;
@@ -126,10 +126,10 @@ public class Kubernetes {
   private static final int GRACE_PERIOD = 0;
   private static final String COMPONENT_VERSION = "v1alpha2";
   private static final String COMPONENT_GROUP = "core.oam.dev";
-  public static final String COMPONENT_PLURAL = "components";
+  private static final String COMPONENT_PLURAL = "components";
   private static final String APPLICATION_VERSION = "v1alpha2";
   private static final String APPLICATION_GROUP = "core.oam.dev";
-  public static final String APPLICATION_PLURAL = "applicationconfigurations";   
+  private static final String APPLICATION_PLURAL = "applicationconfigurations";   
 
   // Core Kubernetes API clients
   private static ApiClient apiClient = null;
@@ -183,7 +183,7 @@ public class Kubernetes {
   /**
    * Create static instances of GenericKubernetesApi clients.
    */
-  private static void initializeGenericKubernetesApiClients() {    
+  private static void initializeGenericKubernetesApiClients() {
     // Invocation parameters aren't changing so create them as statics
     configMapClient =
         new GenericKubernetesApi<>(
@@ -1372,15 +1372,14 @@ public class Kubernetes {
   }
 
   /**
-   * List Component Custom Resources for a given namespace.
+   * List Component Custom Resources from a given namespace.
    *
-   * @param namespace name of namespace
+   * @param namespace namespace name
    * @return List of Component Custom Resources
    * @throws io.kubernetes.client.openapi.ApiException when list fails
    */
   public static ComponentList listComponents(String namespace)
       throws ApiException {
-
     KubernetesApiResponse<ComponentList> response = null;
     try {
       response = vzComCrdClient.list(namespace);
@@ -1434,15 +1433,14 @@ public class Kubernetes {
   }
   
   /**
-   * List ApplicationConfiguration Custom Resources for a given namespace.
+   * List ApplicationConfiguration Custom Resources from a given namespace.
    *
-   * @param namespace name of namespace
+   * @param namespace namespace name
    * @return List of ApplicationConfiguration Custom Resources
    * @throws io.kubernetes.client.openapi.ApiException when list fails
    */
   public static ApplicationList listApplications(String namespace)
       throws ApiException {
-
     KubernetesApiResponse<ApplicationList> response = null;
     try {
       response = vzAppCrdClient.list(namespace);
@@ -3487,9 +3485,9 @@ public class Kubernetes {
   }
 
   /**
-   * Get a list of custom resource definitions deployed in the cluster.
+   * Get a list of custom resource definitions deployed in the Kubernetes cluster.
    *
-   * @return V1CustomResourceDefinitionList list of crds
+   * @return String list of crds as String of V1CustomResourceDefinitionList
    * @throws ApiException when list fails.
    */
   public static String listCrds() throws ApiException {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/actions/impl/primitive/Kubernetes.java
@@ -45,7 +45,6 @@ import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
-import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionList;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentList;
 import io.kubernetes.client.openapi.models.V1Ingress;
@@ -3493,25 +3492,30 @@ public class Kubernetes {
    * @return V1CustomResourceDefinitionList list of crds
    * @throws ApiException when list fails.
    */
-  public static V1CustomResourceDefinitionList listCrds() throws ApiException {
-    Object listClusterCustomObject = vzCustomObjectsApi
-        .listClusterCustomObject("apiextensions.k8s.io",
-            "v1",
-            "customresourcedefinitions",
-            null,
-            false,
-            null,
-            null,
-            null,
-            0,
-            null,
-            null,
-            0,
-            false);
-    getLogger().info("Dumping all crds");
-    getLogger().info(Yaml.dump(listClusterCustomObject));
-    return null;
+  public static Object listCrds() throws ApiException {
+    Object crds;
+    try {
+      crds = vzCustomObjectsApi
+          .listClusterCustomObject("apiextensions.k8s.io",
+              "v1",
+              "customresourcedefinitions",
+              null,
+              false,
+              null,
+              null,
+              null,
+              0,
+              null,
+              null,
+              0,
+              false);
+    } catch (Exception ex) {
+      getLogger().severe(ex.getMessage());
+      throw ex;
+    }
+    return crds;
   }
+  
   //------------------------
 
   private static String readExecCmdData(InputStream is) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/extensions/IntegrationTestWatcher.java
@@ -36,6 +36,10 @@ import org.junit.jupiter.api.extension.TestWatcher;
 import static oracle.weblogic.kubernetes.TestConstants.COLLECT_LOGS_ON_SUCCESS;
 import static oracle.weblogic.kubernetes.TestConstants.SKIP_CLEANUP;
 import static oracle.weblogic.kubernetes.TestConstants.SLEEP_SECONDS_AFTER_FAILURE;
+import static oracle.weblogic.kubernetes.TestConstants.VZ_ENV;
+import static oracle.weblogic.kubernetes.TestConstants.VZ_INGRESS_NS;
+import static oracle.weblogic.kubernetes.TestConstants.VZ_ISTIO_NS;
+import static oracle.weblogic.kubernetes.TestConstants.VZ_SYSTEM_NS;
 import static oracle.weblogic.kubernetes.actions.TestActions.createUniqueNamespace;
 import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -366,6 +370,13 @@ public class IntegrationTestWatcher implements
 
     // collect the logs in ns-webhook namespace
     LoggingUtil.collectLogs("ns-webhook", resultDir.toString());
+    
+    // collect logs for verrzzano environment    
+    if (VZ_ENV) {
+      LoggingUtil.collectLogs(VZ_SYSTEM_NS, resultDir.toString());
+      LoggingUtil.collectLogs(VZ_ISTIO_NS, resultDir.toString());
+      LoggingUtil.collectLogs(VZ_INGRESS_NS, resultDir.toString());
+    }
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -30,7 +30,6 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
-import io.kubernetes.client.util.Yaml;
 import io.kubernetes.client.util.exception.CopyNotSupportedException;
 import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
@@ -39,8 +38,8 @@ import oracle.weblogic.kubernetes.logging.LoggingFacade;
 import static io.kubernetes.client.util.Yaml.dump;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
+import static oracle.weblogic.kubernetes.TestConstants.VZ_ENV;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
-import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listCrds;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
@@ -286,30 +285,19 @@ public class LoggingUtil {
       logger.warning(ex.getMessage());
     }
 
-    // get verrazzano applications
-    String crds = null;
-    try {
-      crds = listCrds();
-      logger.info(Yaml.dump(crds));
-    } catch (Exception ex) {
-      logger.warning(ex.getMessage());
-      logger.warning("Listing crds failed, not collecting any data for applications");
-    }
-
-    if (crds.toLowerCase().contains("applicationconfigurations.core.oam.dev")) {
+    // get verrazzano applications and components
+    if (VZ_ENV) {
       try {
         writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.applications.log");
       } catch (Exception ex) {
         logger.warning("Listing applications failed, not collecting any data for applications");
       }
-      // get verrazzano components
       try {
         writeToFile(Kubernetes.listComponents(namespace), resultDir, namespace + ".list.components.log");
       } catch (Exception ex) {
         logger.warning("Listing components failed, not collecting any data for components");
       }
     }
-
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -24,8 +23,6 @@ import java.util.concurrent.TimeoutException;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Container;
-import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
-import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
@@ -43,8 +40,6 @@ import static io.kubernetes.client.util.Yaml.dump;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
-import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.APPLICATION_PLURAL;
-import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.COMPONENT_PLURAL;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listCrds;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
@@ -292,31 +287,23 @@ public class LoggingUtil {
     }
 
     // get verrazzano applications
-    V1CustomResourceDefinitionList crds = null;
+    String crds = null;
     try {
-      crds = listCrds();
+      crds = (String)listCrds();
       logger.info(Yaml.dump(crds));
     } catch (ApiException ex) {
       logger.warning("Listing crds failed, not collecting any data for applications");
     }
 
-    if (crds != null) {
+    if (crds.toLowerCase().contains("applicationconfiguration")) {
       try {
-        Optional<V1CustomResourceDefinition> application = crds.getItems().stream()
-            .findAny().filter(res -> res.getMetadata().getName().equals(APPLICATION_PLURAL));
-        if (application.isPresent()) {
-          writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.applications.log");
-        }
+        writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.applications.log");
       } catch (Exception ex) {
         logger.warning("Listing applications failed, not collecting any data for applications");
       }
       // get verrazzano components
       try {
-        Optional<V1CustomResourceDefinition> component = crds.getItems().stream()
-            .findAny().filter(res -> res.getMetadata().getName().equals(COMPONENT_PLURAL));
-        if (component.isPresent()) {
-          writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.component.log");
-        }
+        writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.component.log");
       } catch (Exception ex) {
         logger.warning("Listing components failed, not collecting any data for components");
       }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -34,6 +34,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.util.Yaml;
 import io.kubernetes.client.util.exception.CopyNotSupportedException;
 import oracle.weblogic.kubernetes.TestConstants;
 import oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes;
@@ -295,6 +296,7 @@ public class LoggingUtil {
     V1APIResourceList apiResources = null;
     try {
       apiResources = coreV1Api.getAPIResources();
+      logger.info(Yaml.dump(apiResources));
       Optional<V1APIResource> application = apiResources.getResources().stream()
           .findAny().filter(res -> res.getName().equals(APPLICATION_PLURAL));
       if (application.isPresent()) {

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -289,14 +289,14 @@ public class LoggingUtil {
     // get verrazzano applications
     String crds = null;
     try {
-      crds = (String)listCrds();
+      crds = listCrds();
       logger.info(Yaml.dump(crds));
     } catch (Exception ex) {
       logger.warning(ex.getMessage());
       logger.warning("Listing crds failed, not collecting any data for applications");
     }
 
-    if (crds.toLowerCase().contains("applicationconfiguration")) {
+    if (crds.toLowerCase().contains("applicationconfigurations.core.oam.dev")) {
       try {
         writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.applications.log");
       } catch (Exception ex) {
@@ -304,7 +304,7 @@ public class LoggingUtil {
       }
       // get verrazzano components
       try {
-        writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.component.log");
+        writeToFile(Kubernetes.listComponents(namespace), resultDir, namespace + ".list.components.log");
       } catch (Exception ex) {
         logger.warning("Listing components failed, not collecting any data for components");
       }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -291,7 +291,8 @@ public class LoggingUtil {
     try {
       crds = (String)listCrds();
       logger.info(Yaml.dump(crds));
-    } catch (ApiException ex) {
+    } catch (Exception ex) {
+      logger.warning(ex.getMessage());
       logger.warning("Listing crds failed, not collecting any data for applications");
     }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/LoggingUtil.java
@@ -23,10 +23,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1APIResource;
-import io.kubernetes.client.openapi.models.V1APIResourceList;
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
@@ -46,6 +45,7 @@ import static oracle.weblogic.kubernetes.TestConstants.IMAGE_PULL_POLICY;
 import static oracle.weblogic.kubernetes.actions.TestActions.getPodLog;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.APPLICATION_PLURAL;
 import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.COMPONENT_PLURAL;
+import static oracle.weblogic.kubernetes.actions.impl.primitive.Kubernetes.listCrds;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podDoesNotExist;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.podReady;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
@@ -292,29 +292,35 @@ public class LoggingUtil {
     }
 
     // get verrazzano applications
-    CoreV1Api coreV1Api = new CoreV1Api();
-    V1APIResourceList apiResources = null;
+    V1CustomResourceDefinitionList crds = null;
     try {
-      apiResources = coreV1Api.getAPIResources();
-      logger.info(Yaml.dump(apiResources));
-      Optional<V1APIResource> application = apiResources.getResources().stream()
-          .findAny().filter(res -> res.getName().equals(APPLICATION_PLURAL));
-      if (application.isPresent()) {
-        writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.applications.log");
-      }
-    } catch (Exception ex) {
-      logger.warning("Listing applications failed, not collecting any data for applications");
+      crds = listCrds();
+      logger.info(Yaml.dump(crds));
+    } catch (ApiException ex) {
+      logger.warning("Listing crds failed, not collecting any data for applications");
     }
-    // get verrazzano components
-    try {
-      Optional<V1APIResource> component = apiResources.getResources().stream()
-          .findAny().filter(res -> res.getName().equals(COMPONENT_PLURAL));
-      if (component.isPresent()) {
-        writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.component.log");
+
+    if (crds != null) {
+      try {
+        Optional<V1CustomResourceDefinition> application = crds.getItems().stream()
+            .findAny().filter(res -> res.getMetadata().getName().equals(APPLICATION_PLURAL));
+        if (application.isPresent()) {
+          writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.applications.log");
+        }
+      } catch (Exception ex) {
+        logger.warning("Listing applications failed, not collecting any data for applications");
       }
-    } catch (Exception ex) {
-      logger.warning("Listing components failed, not collecting any data for components");
-    }   
+      // get verrazzano components
+      try {
+        Optional<V1CustomResourceDefinition> component = crds.getItems().stream()
+            .findAny().filter(res -> res.getMetadata().getName().equals(COMPONENT_PLURAL));
+        if (component.isPresent()) {
+          writeToFile(Kubernetes.listApplications(namespace), resultDir, namespace + ".list.component.log");
+        }
+      } catch (Exception ex) {
+        logger.warning("Listing components failed, not collecting any data for components");
+      }
+    }
 
   }
 


### PR DESCRIPTION
The changes from this PR collects the logs for all artifacts in the verrazano-system, ingress-nginx, istio-system namespaces and also the ApplicationConfiguration, Component artifacts from the domain namespace.

The new artifacts are listed in this simulated fail run
https://build.weblogick8s.org:8443/job/v8o-kind-nightly/76/artifact/logdir/jenkins-v8o-kind-nightly-76/wl_k8s_test_results/diagnostics/ItVzMiiDomain/testCreateVzMiiDomain/

The normal Jenkins results with the changes
https://build.weblogick8s.org:8443/job/v8o-kind-nightly/77