### PR TITLE
owls-106707 adjust domain Created and Changed events in recheck

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainProcessorImpl.java
@@ -375,17 +375,11 @@ public class DomainProcessorImpl implements DomainProcessor, MakeRightExecutor {
   private boolean shouldContinue(MakeRightDomainOperation operation, DomainPresenceInfo liveInfo) {
     final DomainPresenceInfo cachedInfo = getExistingDomainPresenceInfo(liveInfo);
     if (isNewDomain(cachedInfo)) {
-      if (!operation.hasEventData()) {
-        operation.withEventData(new EventData(DOMAIN_CREATED));
-      }
       return true;
     } else if (liveInfo.isFromOutOfDateEvent(operation, cachedInfo)
         || liveInfo.isDomainProcessingHalted(cachedInfo)) {
       return false;
     } else if (operation.isExplicitRecheck() || liveInfo.isDomainGenerationChanged(cachedInfo)) {
-      if (!operation.hasEventData() && liveInfo.isDomainGenerationChanged(cachedInfo)) {
-        operation.withEventData(new EventData(DOMAIN_CHANGED));
-      }
       return true;
     } else {
       cachedInfo.setDomain(liveInfo.getDomain());

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -273,13 +273,13 @@ class DomainResourcesValidation {
     EventItem eventItem = getEventItem(info);
     MakeRightDomainOperation makeRight = dp.createMakeRightOperation(info).withExplicitRecheck();
     if (eventItem != null) {
-      makeRight.withEventData(new EventData(getEventItem(info))).interrupt();
+      makeRight.withEventData(new EventData(eventItem)).interrupt();
     }
     makeRight.execute();
   }
 
   private EventItem getEventItem(DomainPresenceInfo info) {
-    if (newDomainNames.contains(info.getDomainUid())) {
+    if (newDomainNames.contains(info.getDomainUid()) || info.getDomain().getStatus() == null) {
       return DOMAIN_CREATED;
     }
     if (modifiedDomainNames.contains(info.getDomainUid())) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -270,13 +270,21 @@ class DomainResourcesValidation {
 
   private void activateDomain(DomainProcessor dp, DomainPresenceInfo info) {
     info.setPopulated(true);
-    MakeRightDomainOperation makeRight = dp.createMakeRightOperation(info).withExplicitRecheck();
+    dp.createMakeRightOperation(info)
+        .withEventData(new EventData(getEventItem(info)))
+        .withExplicitRecheck()
+        .interrupt()
+        .execute();
+  }
+
+  private EventItem getEventItem(DomainPresenceInfo info) {
     if (newDomainNames.contains(info.getDomainUid())) {
-      makeRight.withEventData(new EventData(DOMAIN_CREATED)).interrupt();
-    } else if (modifiedDomainNames.contains(info.getDomainUid())) {
-      makeRight.withEventData(new EventData(DOMAIN_CHANGED)).interrupt();
+      return DOMAIN_CREATED;
     }
-    makeRight.execute();
+    if (modifiedDomainNames.contains(info.getDomainUid())) {
+      return DOMAIN_CHANGED;
+    }
+    return null;
   }
 
   private boolean generationChanged(DomainPresenceInfo cachedInfo, DomainResource domain) {

--- a/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/DomainResourcesValidation.java
@@ -270,11 +270,12 @@ class DomainResourcesValidation {
 
   private void activateDomain(DomainProcessor dp, DomainPresenceInfo info) {
     info.setPopulated(true);
-    dp.createMakeRightOperation(info)
-        .withEventData(new EventData(getEventItem(info)))
-        .withExplicitRecheck()
-        .interrupt()
-        .execute();
+    EventItem eventItem = getEventItem(info);
+    MakeRightDomainOperation makeRight = dp.createMakeRightOperation(info).withExplicitRecheck();
+    if (eventItem != null) {
+      makeRight.withEventData(new EventData(getEventItem(info))).interrupt();
+    }
+    makeRight.execute();
   }
 
   private EventItem getEventItem(DomainPresenceInfo info) {

--- a/operator/src/main/java/oracle/kubernetes/operator/Namespaces.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/Namespaces.java
@@ -347,7 +347,7 @@ public class Namespaces {
     }
 
     private boolean isNotManaged(String ns) {
-      return !allDomainNamespaces.contains(ns) || domainNamespaces.isStopping(ns).get();
+      return isNoLongerActiveDomainNamespace(ns) || domainNamespaces.isStopping(ns).get();
     }
 
     private boolean isNoLongerActiveDomainNamespace(String ns) {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainPresenceTest.java
@@ -356,6 +356,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
 
   @Test
   void whenNewDomainAdded_generateDomainCreatedEvent() {
+    processor.getDomainPresenceInfoMap().clear();
     addDomainResource(UID1, NS);
 
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, processor));
@@ -364,7 +365,7 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
   }
 
   @Test
-  void whenNewDomainChanged_generateDomainChangedEvent() {
+  void whenDomainChanged_generateDomainChangedEvent() {
     DomainResource domain1 = createDomain(UID1, NS);
     domain1.getMetadata().setGeneration(1234L);
     processor.getDomainPresenceInfoMap()
@@ -376,6 +377,20 @@ class DomainPresenceTest extends ThreadFactoryTestBase {
     testSupport.runSteps(domainNamespaces.readExistingResources(NS, processor));
 
     assertThat(testSupport, hasEvent(DOMAIN_CHANGED.getReason()));
+  }
+
+
+  @Test
+  void whenDomainStatusBecameNull_generateDomainCreatedEvent() {
+    DomainResource domain1 = createDomain(UID1, NS);
+    processor.getDomainPresenceInfoMap()
+        .computeIfAbsent(NS, k -> new ConcurrentHashMap<>()).put(UID1, new DomainPresenceInfo(domain1));
+    domain1.setStatus(null);
+    testSupport.defineResources(domain1);
+
+    testSupport.runSteps(domainNamespaces.readExistingResources(NS, processor));
+
+    assertThat(testSupport, hasEvent(DOMAIN_CREATED.getReason()));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -305,14 +305,6 @@ class DomainProcessorTest {
   }
 
   @Test
-  void whenDomainAdded_runMakeRightAndGenerateDomainCreatedEvent() {
-    processor.createMakeRightOperation(newInfo).execute();
-
-    assertThat(logRecords, not(containsFine(NOT_STARTING_DOMAINUID_THREAD)));
-    assertThat(testSupport, hasEvent(DOMAIN_CREATED.getReason()));
-  }
-
-  @Test
   void whenDomainAddedWithChangedEventData_runMakeRightButDontGenerateDomainCreatedEvent() {
     processor.createMakeRightOperation(newInfo).withEventData(new EventData(DOMAIN_CHANGED)).execute();
 
@@ -412,15 +404,6 @@ class DomainProcessorTest {
     processor.createMakeRightOperation(newInfo).execute();
 
     assertThat(logRecords, not(containsFine(NOT_STARTING_DOMAINUID_THREAD)));
-  }
-
-  @Test
-  void whenDomainChangedSpec_generateDomainChangedEvent() {
-    processor.registerDomainPresenceInfo(originalInfo);
-
-    processor.createMakeRightOperation(newInfo).execute();
-
-    assertThat(testSupport, hasEvent(DOMAIN_CHANGED.getReason()));
   }
 
   @Test

--- a/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/StuckPodTest.java
@@ -16,6 +16,7 @@ import com.meterware.simplestub.Memento;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import oracle.kubernetes.operator.helpers.DomainPresenceInfo;
+import oracle.kubernetes.operator.helpers.EventHelper;
 import oracle.kubernetes.operator.helpers.KubernetesTestSupport;
 import oracle.kubernetes.operator.tuning.TuningParametersStub;
 import oracle.kubernetes.operator.work.Component;
@@ -249,6 +250,16 @@ class StuckPodTest {
 
       @Override
       public MakeRightDomainOperation withExplicitRecheck() {
+        return this;
+      }
+
+      @Override
+      public MakeRightDomainOperation withEventData(EventHelper.EventData eventData) {
+        return this;
+      }
+
+      @Override
+      public MakeRightDomainOperation interrupt() {
         return this;
       }
 


### PR DESCRIPTION
This is an improvement of generating domain created/changed event in the recheck code path in case that the domain watch events are missing.

Original solution in PR#3998 is to determine if and which event needs to be added to the make right operation in shouldContinue logic. It turned out that it is easier to correctly determine that in the DomainResourcesValidation code when the operator handles the results of listing resources from the K8S API server.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16706/
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16707/

