### PR TITLE
Delete the cluster at correct index to prevent intermittent test failures

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -378,10 +378,9 @@ class ItKubernetesDomainEvents {
     logger.info("verify domain failed event");
     checkFailedEvent(opNamespace, domainNamespace5, domainUid5, ABORTED_ERROR, "Warning", timestamp);
 
-    listObjects();
     shutdownDomain(domainUid5, domainNamespace5);
     listObjects();
-    deleteDomainResource(domainUid5, domainNamespace5);
+    deleteDomainResource(domainNamespace5, domainUid5);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -1009,7 +1009,7 @@ class ItKubernetesDomainEvents {
         .getClusters().stream().filter(o -> o.getName().equals(clusterName)).findAny();
     int clusterIndex = -1;
     if (cluster.isPresent()) {
-      clusterIndex = domainCustomResource.getSpec().getClusters().indexOf(cluster);
+      clusterIndex = domainCustomResource.getSpec().getClusters().indexOf(cluster.get());
       logger.info("Cluster index is {0}", clusterIndex);
     } else {
       logger.info("Cluster {0} not found in domain resource {1} in namespace {2}", clusterName, domainUid, namespace);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -476,7 +476,6 @@ class ItKubernetesDomainEvents {
     createDomain(domainNamespace4, domainUid, pvName4, pvcName4);
     scaleDomainAndVerifyCompletedEvent(1, ScaleAction.scaleDown, true, domainNamespace4);
     scaleDomainAndVerifyCompletedEvent(2, ScaleAction.scaleUp, true, domainNamespace4);
-    shutdownDomain(domainUid, domainNamespace4);
     deleteDomainResource(domainNamespace4, domainUid);
   }
 

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -368,7 +368,6 @@ class ItKubernetesDomainEvents {
     checkFailedEvent(opNamespace, domainNamespace5, domainUid5, ABORTED_ERROR, "Warning", timestamp);
 
     shutdownDomain(domainUid5, domainNamespace5);
-    deleteDomainResource(domainNamespace5, domainUid5);
   }
 
   /**
@@ -680,7 +679,6 @@ class ItKubernetesDomainEvents {
     checkEvent(opNamespace, domainNamespace2, domainUid, DOMAIN_DELETED, "Normal", timestamp);
     //verify cluster deleted event
     checkEvent(opNamespace, domainNamespace2, null, CLUSTER_DELETED, "Normal", timestamp);
-    deleteDomainResource(domainNamespace2, domainUid);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -81,6 +81,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ConfigMapUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.deleteDomainResource;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.verifyDomainStatusConditionTypeDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createBaseRepoSecret;
@@ -379,7 +380,7 @@ class ItKubernetesDomainEvents {
 
     shutdownDomain(domainUid5, domainNamespace5);
     listObjects();
-    //deleteDomainResource(domainNamespace5, domainUid5);
+    deleteDomainResource(domainNamespace5, domainUid5);
   }
 
   /**
@@ -489,6 +490,7 @@ class ItKubernetesDomainEvents {
     scaleDomainAndVerifyCompletedEvent(1, ScaleAction.scaleDown, true, domainNamespace4);
     scaleDomainAndVerifyCompletedEvent(2, ScaleAction.scaleUp, true, domainNamespace4);
     shutdownDomain(domainUid, domainNamespace4);
+    deleteDomainResource(domainNamespace4, domainUid);
   }
 
   /**
@@ -690,6 +692,7 @@ class ItKubernetesDomainEvents {
     checkEvent(opNamespace, domainNamespace2, domainUid, DOMAIN_DELETED, "Normal", timestamp);
     //verify cluster deleted event
     checkEvent(opNamespace, domainNamespace2, null, CLUSTER_DELETED, "Normal", timestamp);
+    deleteDomainResource(domainNamespace2, domainUid);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -79,6 +79,7 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ConfigMapUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.deleteDomainResource;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.verifyDomainStatusConditionTypeDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createBaseRepoSecret;
 import static oracle.weblogic.kubernetes.utils.JobUtils.createDomainJob;
@@ -375,6 +376,7 @@ class ItKubernetesDomainEvents {
     checkFailedEvent(opNamespace, domainNamespace5, domainUid5, ABORTED_ERROR, "Warning", timestamp);
 
     shutdownDomain(domainUid5, domainNamespace5);
+    deleteDomainResource(domainUid5, domainNamespace5);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -81,7 +81,6 @@ import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
 import static oracle.weblogic.kubernetes.utils.CommonTestUtils.withLongRetryPolicy;
 import static oracle.weblogic.kubernetes.utils.ConfigMapUtils.createConfigMapForDomainCreation;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainAndVerify;
-import static oracle.weblogic.kubernetes.utils.DomainUtils.deleteDomainResource;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.verifyDomainStatusConditionTypeDoesNotExist;
 import static oracle.weblogic.kubernetes.utils.ExecCommand.exec;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createBaseRepoSecret;
@@ -380,7 +379,7 @@ class ItKubernetesDomainEvents {
 
     shutdownDomain(domainUid5, domainNamespace5);
     listObjects();
-    deleteDomainResource(domainNamespace5, domainUid5);
+    //deleteDomainResource(domainNamespace5, domainUid5);
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItKubernetesDomainEvents.java
@@ -26,6 +26,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.util.Yaml;
 import oracle.weblogic.domain.AdminServer;
 import oracle.weblogic.domain.AdminService;
 import oracle.weblogic.domain.Channel;
@@ -1001,12 +1002,15 @@ class ItKubernetesDomainEvents {
   
   private static void removeClusterInDomainResource(String clusterName, String domainUid, String namespace)
       throws ApiException {
+    logger.info("Removing the cluster {0} from domain resource {1}", clusterName, domainUid);
     DomainResource domainCustomResource = getDomainCustomResource(domainUid, namespace);
+    logger.info(Yaml.dump(domainCustomResource));
     Optional<V1LocalObjectReference> cluster = domainCustomResource.getSpec()
         .getClusters().stream().filter(o -> o.getName().equals(clusterName)).findAny();
     int clusterIndex = -1;
     if (cluster.isPresent()) {
       clusterIndex = domainCustomResource.getSpec().getClusters().indexOf(cluster);
+      logger.info("Cluster index is {0}", clusterIndex);
     } else {
       logger.info("Cluster {0} not found in domain resource {1} in namespace {2}", clusterName, domainUid, namespace);
     }

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -39,7 +39,6 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
-import io.kubernetes.client.util.Yaml;
 import oracle.weblogic.domain.AdminServer;
 import oracle.weblogic.domain.AdminService;
 import oracle.weblogic.domain.AuxiliaryImage;
@@ -423,7 +422,6 @@ public class DomainUtils {
     LoggingFacade logger = getLogger();
     logger.info("Removing the cluster {0} from domain resource {1}", clusterName, domainUid);
     DomainResource domainCustomResource = getDomainCustomResource(domainUid, namespace);
-    logger.info(Yaml.dump(domainCustomResource));
     Optional<V1LocalObjectReference> cluster = domainCustomResource.getSpec()
         .getClusters().stream().filter(o -> o.getName().equals(clusterName)).findAny();
     int clusterIndex = -1;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -16,11 +16,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -37,6 +39,7 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.util.Yaml;
 import oracle.weblogic.domain.AdminServer;
 import oracle.weblogic.domain.AdminService;
 import oracle.weblogic.domain.AuxiliaryImage;
@@ -407,6 +410,46 @@ public class DomainUtils {
         domainNS);
   }
 
+  /**
+   * Remove cluster reference from domain resource.
+   *
+   * @param clusterName name of the cluster to be removed from domain resource
+   * @param domainUid name of the domain resource
+   * @param namespace namespace in which domain resource exists
+   * @throws ApiException throws when cluster interaction fails
+   */
+  public static void removeClusterInDomainResource(String clusterName, String domainUid, String namespace)
+      throws ApiException {
+    LoggingFacade logger = getLogger();
+    logger.info("Removing the cluster {0} from domain resource {1}", clusterName, domainUid);
+    DomainResource domainCustomResource = getDomainCustomResource(domainUid, namespace);
+    logger.info(Yaml.dump(domainCustomResource));
+    Optional<V1LocalObjectReference> cluster = domainCustomResource.getSpec()
+        .getClusters().stream().filter(o -> o.getName().equals(clusterName)).findAny();
+    int clusterIndex = -1;
+    if (cluster.isPresent()) {
+      clusterIndex = domainCustomResource.getSpec().getClusters().indexOf(cluster.get());
+      logger.info("Cluster index is {0}", clusterIndex);
+    } else {
+      logger.warning("Cluster {0} not found in domain resource {1} in namespace {2}", 
+          clusterName, domainUid, namespace);
+    }
+    if (clusterIndex != -1) {
+      String patchStr = "[{\"op\": \"remove\",\"path\": \"/spec/clusters/" + clusterIndex + "\"}]";
+      logger.info("Updating domain configuration using patch string: {0}\n", patchStr);
+      V1Patch patch = new V1Patch(patchStr);
+      assertTrue(patchDomainCustomResource(domainUid, namespace, patch, V1Patch.PATCH_FORMAT_JSON_PATCH),
+          "Failed to patch domain");
+      Callable<Boolean> clusterNotFound = () -> !getDomainCustomResource(domainUid, namespace).getSpec()
+          .getClusters().stream().anyMatch(c -> c.getName().equals(clusterName));
+      testUntil(clusterNotFound, logger, "cluster {0} to be removed from domain resource in namespace {1}",
+          clusterName, namespace);
+    } else {
+      logger.warning("Cluster {0} not found in domain resource {1} in namespace {2}", 
+          clusterName, domainUid, namespace);
+    }
+  }
+  
   /**
    * Patch a domain with auxiliary image and verify pods are rolling restarted.
    * @param oldImageName old auxiliary image name


### PR DESCRIPTION
The test was deleting a different cluster than intended and it was causing intermittent failures. The changes in this PR adds a new utility method to delete cluster by determining the correct index and then patching to remove it from the domain resource.

https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/16782/