### PR TITLE
Backport to release/3.4: Add Functional Regression tests for OWLS-106473, OWLS-106637

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWDTModelNoServer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWDTModelNoServer.java
@@ -3,7 +3,6 @@
 
 package oracle.weblogic.kubernetes;
 
-import java.util.Collections;
 import java.util.List;
 
 import oracle.weblogic.kubernetes.annotations.IntegrationTest;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
 import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
 import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
-import static oracle.weblogic.kubernetes.actions.TestActions.deleteClusterCustomResource;
 import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
 import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
 import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPod;
@@ -34,7 +32,7 @@ import static oracle.weblogic.kubernetes.utils.DomainUtils.deleteDomainResource;
 import static oracle.weblogic.kubernetes.utils.DomainUtils.shutdownDomainAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createMiiImageAndVerify;
 import static oracle.weblogic.kubernetes.utils.ImageUtils.createTestRepoSecret;
-import static oracle.weblogic.kubernetes.utils.ImageUtils.imageRepoLoginAndPushImageToRegistry;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.dockerLoginAndPushImageToRegistry;
 import static oracle.weblogic.kubernetes.utils.LoggingUtil.checkPodLogContainsString;
 import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
 import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
@@ -141,7 +139,6 @@ class ItWDTModelNoServer {
     // delete domain and cluster
     shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
     deleteDomainResource(domainNamespace, domainUid);
-    deleteClusterCustomResource(clusterName, domainNamespace);
   }
 
   /**
@@ -186,7 +183,6 @@ class ItWDTModelNoServer {
     // delete domain and cluster
     shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
     deleteDomainResource(domainNamespace, domainUid);
-    deleteClusterCustomResource(clusterName, domainNamespace);
   }
 
   /**
@@ -227,7 +223,6 @@ class ItWDTModelNoServer {
     // delete domain and cluster
     shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
     deleteDomainResource(domainNamespace, domainUid);
-    deleteClusterCustomResource(clusterName, domainNamespace);
   }
 
   /**
@@ -270,7 +265,6 @@ class ItWDTModelNoServer {
     // delete domain and cluster
     shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
     deleteDomainResource(domainNamespace, domainUid);
-    deleteClusterCustomResource(clusterName, domainNamespace);
   }
 
   /**
@@ -317,7 +311,6 @@ class ItWDTModelNoServer {
     // delete domain and cluster
     shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
     deleteDomainResource(domainNamespace, domainUid);
-    deleteClusterCustomResource(clusterName, domainNamespace);
   }
 
   /**
@@ -337,7 +330,7 @@ class ItWDTModelNoServer {
         domainUid,
         imageName,
         replicaCount,
-        Collections.singletonList(clusterName),
+        clusterName,
         false,
         null);
 
@@ -349,7 +342,6 @@ class ItWDTModelNoServer {
     checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
 
     // delete the domain and cluster
-    deleteClusterCustomResource(clusterName, domainNamespace);
     deleteDomainResource(domainNamespace, domainUid);
   }
 
@@ -376,8 +368,7 @@ class ItWDTModelNoServer {
     String operatorPodName = assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
     checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
 
-    // delete the domain and cluster
-    deleteClusterCustomResource(clusterName, domainNamespace);
+    // delete the domain
     deleteDomainResource(domainNamespace, domainUid);
   }
 
@@ -405,7 +396,6 @@ class ItWDTModelNoServer {
     checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
 
     // delete the domain and cluster
-    deleteClusterCustomResource(clusterName, domainNamespace);
     deleteDomainResource(domainNamespace, domainUid);
   }
 
@@ -478,7 +468,7 @@ class ItWDTModelNoServer {
         createMiiImageAndVerify(MII_IMAGE_NAME, wdtModelFileForMiiDomain, MII_BASIC_APP_NAME);
 
     // repo login and push image to registry if necessary
-    imageRepoLoginAndPushImageToRegistry(miiImage);
+    dockerLoginAndPushImageToRegistry(miiImage);
 
     // create registry secret to pull the image from registry
     // this secret is used only for non-kind cluster

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWDTModelNoServer.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItWDTModelNoServer.java
@@ -1,0 +1,500 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package oracle.weblogic.kubernetes;
+
+import java.util.Collections;
+import java.util.List;
+
+import oracle.weblogic.kubernetes.annotations.IntegrationTest;
+import oracle.weblogic.kubernetes.annotations.Namespaces;
+import oracle.weblogic.kubernetes.logging.LoggingFacade;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static oracle.weblogic.kubernetes.TestConstants.MANAGED_SERVER_NAME_BASE;
+import static oracle.weblogic.kubernetes.TestConstants.MII_BASIC_APP_NAME;
+import static oracle.weblogic.kubernetes.TestConstants.OPERATOR_RELEASE_NAME;
+import static oracle.weblogic.kubernetes.actions.TestActions.deleteClusterCustomResource;
+import static oracle.weblogic.kubernetes.actions.TestActions.getOperatorPodName;
+import static oracle.weblogic.kubernetes.actions.TestActions.getServiceNodePort;
+import static oracle.weblogic.kubernetes.assertions.TestAssertions.appAccessibleInPod;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomain;
+import static oracle.weblogic.kubernetes.utils.CommonMiiTestUtils.createMiiDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkPodReadyAndServiceExists;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkServiceDoesNotExist;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.checkSystemResourceDomainConfig;
+import static oracle.weblogic.kubernetes.utils.CommonTestUtils.testUntil;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainInImageUsingWdt;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.createDomainOnPvUsingWdt;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.deleteDomainResource;
+import static oracle.weblogic.kubernetes.utils.DomainUtils.shutdownDomainAndVerify;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.createMiiImageAndVerify;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.createTestRepoSecret;
+import static oracle.weblogic.kubernetes.utils.ImageUtils.imageRepoLoginAndPushImageToRegistry;
+import static oracle.weblogic.kubernetes.utils.LoggingUtil.checkPodLogContainsString;
+import static oracle.weblogic.kubernetes.utils.OKDUtils.createRouteForOKD;
+import static oracle.weblogic.kubernetes.utils.OperatorUtils.installAndVerifyOperator;
+import static oracle.weblogic.kubernetes.utils.PodUtils.checkPodDoesNotExist;
+import static oracle.weblogic.kubernetes.utils.PodUtils.getExternalServicePodName;
+import static oracle.weblogic.kubernetes.utils.ThreadSafeLogger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test creating MII domain with different AdminServerName and Server settings in WDT model file.
+ * The test contains the following usecases:
+ * 1) AdminServerName is not specified and no Server section in the model file.
+ * 2) AdminServerName is not specified and no 'AdminServer' specified in Server section.
+ *    There is a server 'myadmin' specified in the Server instead.
+ * 3) AdminServerName is not specified and 'AdminServer' is specified in the Server section.
+ * 4) AdminServerName is not specified and 'adminserver' (all lower case) is specified in the Server section.
+ * 5) AdminServerName is specified and the named server is not set in the Server section.
+ * 6) Configured cluster defined but no managed server associated with it in the Server section.
+ * 7) Empty topology (no AdminServerName, Server and Cluster section)
+ */
+@DisplayName("Test creating MII domain with different AdminServerName and Server settings in WDT model file")
+@IntegrationTest
+@Tag("kind-parallel")
+class ItWDTModelNoServer {
+
+  // domain constants
+  private static final String domainUid = "wdtmodelnoserver";
+  private static final String MII_IMAGE_NAME = "wdtmodelnoserver-mii";
+  private static final int replicaCount = 2;
+  private static final String internalPort = "8001";
+  private static final String appPath = "sample-war/index.jsp";
+  private static final String adminServerPodName = domainUid + "-adminserver";
+  private static final String managedServerPrefix = domainUid + "-" + MANAGED_SERVER_NAME_BASE;
+  private static final String clusterName = "cluster-1";
+
+  private static String domainNamespace = null;
+  private static String opNamespace = null;
+  private static LoggingFacade logger = null;
+  private static String imageName = null;
+
+  /**
+   * Get namespaces for operator and WebLogic domain.
+   *
+   * @param namespaces list of namespaces created by the IntegrationTestWatcher by the
+   *                   JUnit engine parameter resolution mechanism
+   */
+  @BeforeAll
+  public static void initAll(@Namespaces(2) List<String> namespaces) {
+
+    logger = getLogger();
+
+    // get a unique operator namespace
+    logger.info("Getting a unique namespace for operator");
+    assertNotNull(namespaces.get(0), "Namespace list is null");
+    opNamespace = namespaces.get(0);
+
+    // get a unique domain namespace
+    logger.info("Getting a unique namespace for WebLogic domain");
+    assertNotNull(namespaces.get(1), "Namespace list is null");
+    domainNamespace = namespaces.get(1);
+
+    // install and verify operator
+    installAndVerifyOperator(opNamespace, domainNamespace);
+  }
+
+  /**
+   * Test in the WDT model file there is no AdminServerName and no Server section defined.
+   * Verify AdminServer Pod "domainUid-adminserver" is running and the defined WebLogic cluster is up and running.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is no AdminServerName and no Server section defined")
+  void testWdtModelNoAdminServerNameNoServer() {
+
+    String wdtModelFile = "model-noadminservername-noserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    // Verify the domain is created. The admin server pod "domainUid-adminserver" is up and running.
+    // Also verify the cluster is up and running.
+    createMiiDomainAndVerify(domainNamespace, domainUid,
+        imageName, adminServerPodName, managedServerPrefix, replicaCount);
+
+    // check the admin server name is 'AdminServer'
+    checkAdminServerName(adminServerPodName, "AdminServer");
+
+    //check and wait for the application to be accessible in all server pods
+    for (int j = 1; j <= replicaCount; j++) {
+      String managedServerPodName = managedServerPrefix + j;
+      String expectedStr = "Hello World, you have reached server " + MANAGED_SERVER_NAME_BASE + j;
+
+      logger.info("Checking that application is running on managed server pod {0}  in namespace {1} with "
+          + "expectedString {3}", managedServerPodName, domainNamespace, expectedStr);
+      checkAppIsRunning(
+          domainNamespace,
+          managedServerPodName,
+          expectedStr);
+    }
+
+    logger.info("Domain {0} is fully started in namespace {1} - servers are running and application is available",
+        domainUid, domainNamespace);
+
+    // delete domain and cluster
+    shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
+    deleteDomainResource(domainNamespace, domainUid);
+    deleteClusterCustomResource(clusterName, domainNamespace);
+  }
+
+  /**
+   * Test in the WDT model file AdminServerName is not specified and in Server section there is a server 'myadmin' set.
+   * Verify that AdminServerName is set to 'AdminServer' and the admin server pod with name domainuid-adminserver
+   * is created. A managed server pod domainuid-myadmin is also created.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is no AdminServerName and in Server section myadmin defined")
+  void testWdtModelNoAdminServerNameWithMyAdminInServer() {
+
+    String wdtModelFile = "model-noadminservername-hasmyadminserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    // Verify the domain is created and the admin server pod "domainUid-adminserver" is up and running.
+    // Also verify the defined cluster is up and running.
+    createMiiDomainAndVerify(domainNamespace, domainUid,
+        imageName, adminServerPodName, managedServerPrefix, replicaCount);
+
+    // check the admin server name is 'AdminServer'
+    checkAdminServerName(adminServerPodName, "AdminServer");
+
+    // check there is also a pod with name domainUid-myadmin running
+    checkPodReadyAndServiceExists(domainUid + "-myadmin", domainUid, domainNamespace);
+
+    //check and wait for the application to be accessible in all server pods
+    for (int j = 1; j <= replicaCount; j++) {
+      String managedServerPodName = managedServerPrefix + j;
+      String expectedStr = "Hello World, you have reached server " + MANAGED_SERVER_NAME_BASE + j;
+
+      logger.info("Checking that application is running on managed server pod {0}  in namespace {1} with "
+          + "expectedString {3}", managedServerPodName, domainNamespace, expectedStr);
+      checkAppIsRunning(
+          domainNamespace,
+          managedServerPodName,
+          expectedStr);
+    }
+
+    logger.info("Domain {0} is fully started in namespace {1} - servers are running and application is available",
+        domainUid, domainNamespace);
+
+    // delete domain and cluster
+    shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
+    deleteDomainResource(domainNamespace, domainUid);
+    deleteClusterCustomResource(clusterName, domainNamespace);
+  }
+
+  /**
+   * Test in the WDT model file there is no AdminServerName and in Server section the server 'AdminServer' defined.
+   * Verify that AdminServerName is set to 'AdminServer' and the admin server pod is created.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is no AdminServerName and in Server section AdminServer defined")
+  void testWdtModelNoAdminServerNameWithAdminServerInServer() {
+
+    String wdtModelFile = "model-noadminservername-hasadminserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    // Verify the domain is created and the admin server pod "domainUid-adminserver" is up and running.
+    // Also verify the defined cluster is up and running.
+    createMiiDomainAndVerify(domainNamespace, domainUid,
+        imageName, adminServerPodName, managedServerPrefix, replicaCount);
+
+    // check the admin server name is 'AdminServer'
+    checkAdminServerName(adminServerPodName, "AdminServer");
+
+    //check and wait for the application to be accessible in all server pods
+    for (int j = 1; j <= replicaCount; j++) {
+      String managedServerPodName = managedServerPrefix + j;
+      String expectedStr = "Hello World, you have reached server " + MANAGED_SERVER_NAME_BASE + j;
+
+      logger.info("Checking that application is running on managed server pod {0}  in namespace {1} with "
+          + "expectedString {3}", managedServerPodName, domainNamespace, expectedStr);
+      checkAppIsRunning(
+          domainNamespace,
+          managedServerPodName,
+          expectedStr);
+    }
+
+    logger.info("Domain {0} is fully started in namespace {1} - servers are running and application is available",
+        domainUid, domainNamespace);
+
+    // delete domain and cluster
+    shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
+    deleteDomainResource(domainNamespace, domainUid);
+    deleteClusterCustomResource(clusterName, domainNamespace);
+  }
+
+  /**
+   * Test in the WDT model file there is no AdminServerName and in Server 'adminserver' (all lower case) defined.
+   * Note that the server name 'adminserver' is all lower case.
+   * Disabled due to bug.
+   */
+  @Disabled
+  @Test
+  @DisplayName("Test in the WDT model file there is no AdminServerName and in Server section 'adminserver' defined")
+  void testWdtModelNoAdminServerNameWithAdminServerLowercaseInServer() {
+
+    String wdtModelFile = "model-noadminservername-hasadminserverlowercase.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    // Verify the domain is created and the admin server pod "domainUid-adminserver" is up and running.
+    // Also verify the defined cluster is up and running.
+    createMiiDomainAndVerify(domainNamespace, domainUid,
+        imageName, adminServerPodName, managedServerPrefix, replicaCount);
+
+    // check the admin server name is 'AdminServer'
+    checkAdminServerName(adminServerPodName, "AdminServer");
+
+    //check and wait for the application to be accessible in all server pods
+    for (int j = 1; j <= replicaCount; j++) {
+      String managedServerPodName = managedServerPrefix + j;
+      String expectedStr = "Hello World, you have reached server " + MANAGED_SERVER_NAME_BASE + j;
+
+      logger.info("Checking that application is running on managed server pod {0}  in namespace {1} with "
+          + "expectedString {3}", managedServerPodName, domainNamespace, expectedStr);
+      checkAppIsRunning(
+          domainNamespace,
+          managedServerPodName,
+          expectedStr);
+    }
+
+    logger.info("Domain {0} is fully started in namespace {1} - servers are running and application is available",
+        domainUid, domainNamespace);
+
+    // delete domain and cluster
+    shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
+    deleteDomainResource(domainNamespace, domainUid);
+    deleteClusterCustomResource(clusterName, domainNamespace);
+  }
+
+  /**
+   * Test in the WDT model file there is AdminServerName set and the named server is not in Server section.
+   * In the model file, the AdminServerName is set to 'new-admin-server'. In the Server section, there is no
+   * 'new-admin-server' set. There is a server 'admin-server' set instead.
+   * Verify WDT will create the named server 'new-admin-server' as in the AdminServerName.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is AdminServerName set and the named server is not in Server section")
+  void testWdtModelAdminServerNameSetNamedServerNotInServer() {
+
+    String wdtModelFile = "model-hasadminservername-namedservernotinserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+    String namedAdminServerPodName = domainUid + "-new-admin-server";
+
+    // Verify the domain is created and the admin server pod "domainUid-new-admin-server" is up and running.
+    // Also verify the defined cluster is up and running.
+    createMiiDomainAndVerify(domainNamespace, domainUid, imageName, namedAdminServerPodName,
+        managedServerPrefix, replicaCount);
+
+    // check the admin server name is 'new-admin-server'
+    checkAdminServerName(namedAdminServerPodName, "new-admin-server");
+
+    // check that there is another pod domainUid-admin-server running in 7001 since it is defined in Server section
+    checkPodReadyAndServiceExists(domainUid + "-admin-server", domainUid, domainNamespace);
+
+    //check and wait for the application to be accessible in all server pods
+    for (int j = 1; j <= replicaCount; j++) {
+      String managedServerPodName = managedServerPrefix + j;
+      String expectedStr = "Hello World, you have reached server " + MANAGED_SERVER_NAME_BASE + j;
+
+      logger.info("Checking that application is running on managed server pod {0}  in namespace {1} with "
+          + "expectedString {3}", managedServerPodName, domainNamespace, expectedStr);
+      checkAppIsRunning(
+          domainNamespace,
+          managedServerPodName,
+          expectedStr);
+    }
+
+    logger.info("Domain {0} is fully started in namespace {1} - servers are running and application is available",
+        domainUid, domainNamespace);
+
+    // delete domain and cluster
+    shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
+    deleteDomainResource(domainNamespace, domainUid);
+    deleteClusterCustomResource(clusterName, domainNamespace);
+  }
+
+  /**
+   * Test in the WDT model file a configured cluster is defined but no managed server associated with it in Server.
+   * Create a model-in-image type domain using this model file.
+   * Verify the operator will generate validation error in the log.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is configured cluster set but no managed servers in Server section")
+  void testWdtModelConfiguredClusterNoManagedServersInServerMII() {
+
+    String wdtModelFile = "model-configuredcluster-noserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    createMiiDomain(
+        domainNamespace,
+        domainUid,
+        imageName,
+        replicaCount,
+        Collections.singletonList(clusterName),
+        false,
+        null);
+
+    // verify the error msg is logged in the operator log
+    String expectedErrorMsg = "The WebLogic configured cluster \\\""
+        + clusterName
+        + "\\\" is not referenced by any servers.  You must have managed servers defined that belong to this cluster";
+    String operatorPodName = assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
+    checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
+
+    // delete the domain and cluster
+    deleteClusterCustomResource(clusterName, domainNamespace);
+    deleteDomainResource(domainNamespace, domainUid);
+  }
+
+  /**
+   * Test in the WDT model file a configured cluster is defined but no managed server associated with it in Server.
+   * Create a domain-in-image type of domain using this WDT model file.
+   * Verify the operator will generate validation error in the log.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is configured cluster set but no managed servers in Server section")
+  void testWdtModelConfiguredClusterNoManagedServersInServerWithDII() {
+
+    String wdtModelFile = "model-configuredcluster-noserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    String wlSecretName = "weblogic-credentials";
+    createDomainInImageUsingWdt(domainUid, domainNamespace,
+        wdtModelFile, null, null, wlSecretName, clusterName, replicaCount);
+
+    // verify the error msg is logged in the operator log
+    String expectedErrorMsg = "The WebLogic configured cluster \\\""
+        + clusterName
+        + "\\\" is not referenced by any servers.  You must have managed servers defined that belong to this cluster";
+    String operatorPodName = assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
+    checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
+
+    // delete the domain and cluster
+    deleteClusterCustomResource(clusterName, domainNamespace);
+    deleteDomainResource(domainNamespace, domainUid);
+  }
+
+  /**
+   * Test in the WDT model file a configured cluster is defined but no managed server associated with it in Server.
+   * Create a domain-on-pv type of domain using this WDT model file.
+   * Verify the operator will generate validation error in the log.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is configured cluster set but no managed servers in Server section")
+  void testWdtModelConfiguredClusterNoManagedServersInServerWithDomainOnPV() {
+
+    String wdtModelFile = "model-configuredcluster-noserver.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    String wlSecretName = "weblogic-credentials";
+    createDomainOnPvUsingWdt(domainUid, domainNamespace, wlSecretName,
+        clusterName, replicaCount, ItWDTModelNoServer.class.getSimpleName(), wdtModelFile, false);
+
+    // verify the error msg is logged in the operator log
+    String expectedErrorMsg = "The WebLogic configured cluster \\\""
+        + clusterName
+        + "\\\" is not referenced by any servers.  You must have managed servers defined that belong to this cluster";
+    String operatorPodName = assertDoesNotThrow(() -> getOperatorPodName(OPERATOR_RELEASE_NAME, opNamespace));
+    checkPodLogContainsString(opNamespace, operatorPodName, expectedErrorMsg);
+
+    // delete the domain and cluster
+    deleteClusterCustomResource(clusterName, domainNamespace);
+    deleteDomainResource(domainNamespace, domainUid);
+  }
+
+  /**
+   * Test in the WDT model file there is no AdminServerName, no Server and no Cluster section defined.
+   * Verify AdminServer Pod "domainUid-adminserver" is running.
+   * Verify there are no cluster service or managed server pods/services existing.
+   */
+  @Test
+  @DisplayName("Test in the WDT model file there is no AdminServerName, no Server and no Cluster section defined")
+  void testWdtModelNoAdminServerNameNoServerNoCluster() {
+
+    String wdtModelFile = "model-emptytopology.yaml";
+    imageName = createAndVerifyDomainImage(wdtModelFile);
+
+    // Verify the domain is created. The admin server pod "domainUid-adminserver" is up and running.
+    createMiiDomain(
+        domainNamespace,
+        domainUid,
+        imageName,
+        replicaCount,
+        null,
+        false,
+        null);
+
+    // verify the admin server is started
+    checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+
+    // check cluster-1 service does not exist
+    checkServiceDoesNotExist(domainUid + "-cluster-" + clusterName, domainNamespace);
+    // check managed server pods and services do not exist
+    for (int i = 1; i <= replicaCount; i++) {
+      checkPodDoesNotExist(managedServerPrefix + i, domainUid, domainNamespace);
+      checkServiceDoesNotExist(managedServerPrefix + i, domainNamespace);
+    }
+
+    // check the admin server name is 'AdminServer'
+    checkAdminServerName(adminServerPodName, "AdminServer");
+
+    // delete domain
+    shutdownDomainAndVerify(domainNamespace, domainUid, replicaCount);
+    deleteDomainResource(domainNamespace, domainUid);
+  }
+
+  private static void checkAppIsRunning(
+      String namespace,
+      String podName,
+      String expectedStr
+  ) {
+
+    // check that the application is NOT running inside of a server pod
+    testUntil(
+        () -> appAccessibleInPod(
+          namespace,
+          podName,
+          internalPort,
+          appPath,
+          expectedStr),
+        logger,
+        "application {0} is running on pod {1} in namespace {2}",
+        appPath,
+        podName,
+        namespace);
+  }
+
+  private static String createAndVerifyDomainImage(String wdtModelFileForMiiDomain) {
+
+    logger.info("Create image with model file and verify");
+    String miiImage =
+        createMiiImageAndVerify(MII_IMAGE_NAME, wdtModelFileForMiiDomain, MII_BASIC_APP_NAME);
+
+    // repo login and push image to registry if necessary
+    imageRepoLoginAndPushImageToRegistry(miiImage);
+
+    // create registry secret to pull the image from registry
+    // this secret is used only for non-kind cluster
+    logger.info("Create registry secret in namespace {0}", domainNamespace);
+    createTestRepoSecret(domainNamespace);
+    return miiImage;
+  }
+
+  private void checkAdminServerName(String adminServerPodName, String expectedAdminServerName) {
+    String adminSvcExtHost = createRouteForOKD(getExternalServicePodName(adminServerPodName), domainNamespace);
+    int adminServiceNodePort
+        = getServiceNodePort(domainNamespace, getExternalServicePodName(adminServerPodName), "default");
+    assertNotEquals(-1, adminServiceNodePort, "admin server default node port is not valid");
+    assertTrue(checkSystemResourceDomainConfig(adminSvcExtHost, adminServiceNodePort,
+        "\"adminServerName\": \"" + expectedAdminServerName + "\""),
+        "Admin server name is not '" + expectedAdminServerName + "'");
+    logger.info("AdminServerName is {0}", expectedAdminServerName);
+  }
+}

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonMiiTestUtils.java
@@ -238,6 +238,77 @@ public class CommonMiiTestUtils {
   }
 
   /**
+   * Create a basic Kubernetes domain resource and verify the domain is created.
+   *
+   * @param domainNamespace Kubernetes namespace that the pod is running in
+   * @param domainUid identifier of the domain
+   * @param imageName name of the image including its tag
+   * @param replicaCount number of managed servers to start
+   * @param clusterName names of cluster
+   * @param setDataHome whether to set dataHome in the domain spec
+   * @param dataHome dataHome override in the domain spec
+   * @return DomainResource
+   */
+  public static Domain createMiiDomain(
+      String domainNamespace,
+      String domainUid,
+      String imageName,
+      int replicaCount,
+      String clusterName,
+      boolean setDataHome,
+      String dataHome) {
+
+    LoggingFacade logger = getLogger();
+    // this secret is used only for non-kind cluster
+    logger.info("Create the repo secret {0} to pull the image", TEST_IMAGES_REPO_SECRET_NAME);
+    assertDoesNotThrow(() -> createTestRepoSecret(domainNamespace),
+        String.format("createSecret failed for %s", TEST_IMAGES_REPO_SECRET_NAME));
+
+    // create secret for admin credentials
+    logger.info("Create secret for admin credentials");
+    String adminSecretName = "weblogic-credentials";
+    assertDoesNotThrow(() -> createSecretWithUsernamePassword(
+        adminSecretName,
+        domainNamespace,
+        ADMIN_USERNAME_DEFAULT,
+        ADMIN_PASSWORD_DEFAULT),
+        String.format("createSecret failed for %s", adminSecretName));
+
+    // create encryption secret
+    logger.info("Create encryption secret");
+    String encryptionSecretName = "encryptionsecret";
+    assertDoesNotThrow(() -> createSecretWithUsernamePassword(
+        encryptionSecretName,
+        domainNamespace,
+        "weblogicenc",
+        "weblogicenc"),
+        String.format("createSecret failed for %s", encryptionSecretName));
+
+    // create the domain custom resource
+    logger.info("Create domain resource {0} object in namespace {1} and verify that it is created",
+        domainUid, domainNamespace);
+    Domain domain = createDomainResource(domainUid,
+        domainNamespace,
+        imageName,
+        adminSecretName,
+        new String[]{TEST_IMAGES_REPO_SECRET_NAME},
+        encryptionSecretName,
+        replicaCount,
+        clusterName);
+
+    // set the dataHome in the domain spec
+    if (setDataHome) {
+      DomainSpec domainSpec = domain.getSpec();
+      domainSpec.dataHome(dataHome);
+      domain.spec(domainSpec);
+    }
+
+    createDomainAndVerify(domain, domainNamespace);
+
+    return domain;
+  }
+
+  /**
    * Create a domain object for a Kubernetes domain custom resource using the basic model-in-image
    * image.
    *
@@ -295,15 +366,18 @@ public class CommonMiiTestUtils {
                     .addChannelsItem(new oracle.weblogic.domain.Channel()
                         .channelName("default")
                         .nodePort(0))))
-            .addClustersItem(new oracle.weblogic.domain.Cluster()
-                .clusterName(clusterName)
-                .replicas(replicaCount)
-                .serverStartState("RUNNING"))
             .configuration(new oracle.weblogic.domain.Configuration()
                 .model(new oracle.weblogic.domain.Model()
                     .domainType("WLS")
                     .runtimeEncryptionSecret(encryptionSecretName))
                 .introspectorJobActiveDeadlineSeconds(300L)));
+
+    if (clusterName != null && !clusterName.isEmpty()) {
+      domain.spec().addClustersItem(new oracle.weblogic.domain.Cluster()
+          .clusterName(clusterName)
+          .replicas(replicaCount)
+          .serverStartState("RUNNING"));
+    }
     domain.spec().setImagePullSecrets(secrets);
 
     setPodAntiAffinity(domain);

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/CommonTestUtils.java
@@ -825,6 +825,32 @@ public class CommonTestUtils {
   }
 
   /**
+   * Check the system resource configuration using REST API.
+   * @param adminSvcExtHost Used only in OKD env - this is the route host created for AS external service
+   * @param nodePort admin node port
+   * @param expectedValue expected value returned in the REST call
+   * @return true if the REST API results matches expected status code
+   */
+  public static boolean checkSystemResourceDomainConfig(String adminSvcExtHost, int nodePort,
+                                                        String expectedValue) {
+    final LoggingFacade logger = getLogger();
+
+    String hostAndPort = (OKD) ? adminSvcExtHost : K8S_NODEPORT_HOST + ":" + nodePort;
+    logger.info("hostAndPort = {0} ", hostAndPort);
+
+    StringBuffer curlString = new StringBuffer("curl --user ");
+    curlString.append(ADMIN_USERNAME_DEFAULT + ":" + ADMIN_PASSWORD_DEFAULT)
+        .append(" http://" + hostAndPort)
+        .append("/management/weblogic/latest/domainConfig/");
+
+    logger.info("checkSystemResource: curl command {0}", new String(curlString));
+    return Command
+        .withParams(new CommandParams()
+            .command(curlString.toString()))
+        .executeAndVerify(expectedValue);
+  }
+
+  /**
    * Check the system resource runtime using REST API.
    * @param adminSvcExtHost Used only in OKD env - this is the route host created for AS external service
    * @param nodePort admin node port

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -166,25 +166,46 @@ public class DomainUtils {
   public static void createDomainAndVerify(String domainUid, Domain domain,
                                            String domainNamespace, String adminServerPodName,
                                            String managedServerPodNamePrefix, int replicaCount) {
+    createDomainAndVerify(domainUid, domain, domainNamespace, adminServerPodName, managedServerPodNamePrefix,
+        replicaCount, true);
+  }
+
+  /**
+   * Create a domain in the specified namespace, wait up to five minutes until the domain exists and
+   * verify the servers are running.
+   *
+   * @param domainUid domain
+   * @param domain the oracle.weblogic.domain.DomainResource object to create domain custom resource
+   * @param domainNamespace namespace in which the domain will be created
+   * @param adminServerPodName admin server pod name
+   * @param managedServerPodNamePrefix managed server pod prefix
+   * @param replicaCount replica count
+   * @param verifyServerPods whether to verify server pods of the domain
+   */
+  public static void createDomainAndVerify(String domainUid, DomainResource domain,
+                                           String domainNamespace, String adminServerPodName,
+                                           String managedServerPodNamePrefix, int replicaCount,
+                                           boolean verifyServerPods) {
     LoggingFacade logger = getLogger();
 
     // create domain and verify
     createDomainAndVerify(domain, domainNamespace);
 
-    // check that admin service/pod exists in the domain namespace
-    logger.info("Checking that admin service/pod {0} exists in namespace {1}",
-        adminServerPodName, domainNamespace);
-    checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
+    if (verifyServerPods) {
+      // check that admin service/pod exists in the domain namespace
+      logger.info("Checking that admin service/pod {0} exists in namespace {1}",
+          adminServerPodName, domainNamespace);
+      checkPodReadyAndServiceExists(adminServerPodName, domainUid, domainNamespace);
 
-    for (int i = 1; i <= replicaCount; i++) {
-      String managedServerPodName = managedServerPodNamePrefix + i;
+      for (int i = 1; i <= replicaCount; i++) {
+        String managedServerPodName = managedServerPodNamePrefix + i;
 
-      // check that ms service/pod exists in the domain namespace
-      logger.info("Checking that clustered ms service/pod {0} exists in namespace {1}",
-          managedServerPodName, domainNamespace);
-      checkPodReadyAndServiceExists(managedServerPodName, domainUid, domainNamespace);
+        // check that ms service/pod exists in the domain namespace
+        logger.info("Checking that clustered ms service/pod {0} exists in namespace {1}",
+            managedServerPodName, domainNamespace);
+        checkPodReadyAndServiceExists(managedServerPodName, domainUid, domainNamespace);
+      }
     }
-
   }
 
   /**
@@ -325,6 +346,109 @@ public class DomainUtils {
     createDomainAndVerify(domainUid, domain, domainNamespace, domainUid + "-" + ADMIN_SERVER_NAME_BASE,
         domainUid + "-" + MANAGED_SERVER_NAME_BASE, replicaCount);
 
+    return domain;
+  }
+
+  /**
+   * Create a domain in PV using WDT.
+   *
+   * @param domainUid uid of the domain
+   * @param domainNamespace namespace in which the domain will be created
+   * @param wlSecretName WLS secret name
+   * @param clusterName WLS domain cluster name
+   * @param replicaCount domain replica count
+   * @param testClassName the test class name calling this method
+   * @param wdtModelFile WDT model file to create the domain
+   * @param verifyServerPods whether to verify the server pods
+   * @return oracle.weblogic.domain.Domain objects
+   */
+  public static DomainResource createDomainOnPvUsingWdt(String domainUid,
+                                                        String domainNamespace,
+                                                        String wlSecretName,
+                                                        String clusterName,
+                                                        int replicaCount,
+                                                        String testClassName,
+                                                        String wdtModelFile,
+                                                        boolean verifyServerPods) {
+
+    int t3ChannelPort = getNextFreePort();
+
+    final String pvName = getUniqueName(domainUid + "-pv-"); // name of the persistent volume
+    final String pvcName = getUniqueName(domainUid + "-pvc-"); // name of the persistent volume claim
+
+    // create pull secrets for WebLogic image when running in non Kind Kubernetes cluster
+    // this secret is used only for non-kind cluster
+    createBaseRepoSecret(domainNamespace);
+
+    // create WebLogic domain credential secret
+    createSecretWithUsernamePassword(wlSecretName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
+
+    // create persistent volume and persistent volume claim for domain
+    // these resources should be labeled with domainUid for cleanup after testing
+
+    createPV(pvName, domainUid, testClassName);
+    createPVC(pvName, pvcName, domainUid, domainNamespace);
+
+    String labelSelector = String.format("weblogic.domainUid in (%s)", domainUid);
+    LoggingFacade logger = getLogger();
+    // check the persistent volume and persistent volume claim exist
+    testUntil(
+        assertDoesNotThrow(() -> pvExists(pvName, labelSelector),
+            String.format("pvExists failed with ApiException when checking pv %s", pvName)),
+        logger,
+        "persistent volume {0} exists",
+        pvName);
+
+    testUntil(
+        assertDoesNotThrow(() -> pvcExists(pvcName, domainNamespace),
+            String.format("pvcExists failed with ApiException when checking pvc %s in namespace %s",
+                pvcName, domainNamespace)),
+        logger,
+        "persistent volume claim {0} exists in namespace {1}",
+        pvcName,
+        domainNamespace);
+
+
+    // create a temporary WebLogic domain property file as a input for WDT model file
+    File domainPropertiesFile = assertDoesNotThrow(() -> createTempFile("domainonpv" + domainUid, "properties"),
+        "Failed to create domain properties file");
+
+    Properties p = new Properties();
+    p.setProperty("adminUsername", ADMIN_USERNAME_DEFAULT);
+    p.setProperty("adminPassword", ADMIN_PASSWORD_DEFAULT);
+    p.setProperty("domainName", domainUid);
+    p.setProperty("adminServerName", ADMIN_SERVER_NAME_BASE);
+    p.setProperty("productionModeEnabled", "true");
+    p.setProperty("clusterName", clusterName);
+    p.setProperty("configuredManagedServerCount", "4");
+    p.setProperty("managedServerNameBase", MANAGED_SERVER_NAME_BASE);
+    p.setProperty("t3ChannelPort", Integer.toString(t3ChannelPort));
+    p.setProperty("t3PublicAddress", K8S_NODEPORT_HOST);
+    p.setProperty("managedServerPort", "8001");
+    p.setProperty("adminServerSslPort", "7002");
+    assertDoesNotThrow(() ->
+            p.store(new FileOutputStream(domainPropertiesFile), "WDT properties file"),
+        "Failed to write domain properties file");
+
+    // shell script to download WDT and run the WDT createDomain script
+    Path wdtScript = get(RESOURCE_DIR, "bash-scripts", "setup_wdt.sh");
+
+    // create configmap and domain in persistent volume using WDT
+    runCreateDomainOnPVJobUsingWdt(wdtScript, get(RESOURCE_DIR, "wdt-models", wdtModelFile),
+        domainPropertiesFile.toPath(),
+        domainUid, pvName, pvcName, domainNamespace, testClassName);
+
+    DomainResource domain = createDomainResourceForDomainOnPV(domainUid, domainNamespace, wlSecretName, pvName, pvcName,
+        clusterName, replicaCount);
+
+    // Verify the domain custom resource is created.
+    // Also verify the admin server pod and managed server pods are up and running.
+    if (verifyServerPods) {
+      createDomainAndVerify(domainUid, domain, domainNamespace, domainUid + "-" + ADMIN_SERVER_NAME_BASE,
+          domainUid + "-" + MANAGED_SERVER_NAME_BASE, replicaCount);
+    } else {
+      createDomainAndVerify(domain, domainNamespace);
+    }
     return domain;
   }
 
@@ -640,6 +764,57 @@ public class DomainUtils {
 
     return createDomainInImageAndVerify(domainUid, domainNamespace, domainInImageWithWDTImage, wlSecretName,
         clusterName, replicaCount);
+  }
+
+  /**
+   * Create a WebLogic domain in image using WDT.
+   *
+   * @param domainUid domain uid
+   * @param domainNamespace namespace in which the domain to be created
+   * @param wdtModelFileForDomainInImage WDT model file used to create domain image
+   * @param appSrcDirList list of the app src in WDT model file
+   * @param propertyFiles list of property files
+   * @param wlSecretName wls admin secret name
+   * @param clusterName cluster name
+   * @param replicaCount replica count of the cluster
+   * @return oracle.weblogic.domain.DomainResource object
+   */
+  public static DomainResource createDomainInImageUsingWdt(String domainUid,
+                                                           String domainNamespace,
+                                                           String wdtModelFileForDomainInImage,
+                                                           List<String> appSrcDirList,
+                                                           List<String> propertyFiles,
+                                                           String wlSecretName,
+                                                           String clusterName,
+                                                           int replicaCount) {
+
+    // create secret for admin credentials
+    getLogger().info("Create secret for admin credentials");
+    createSecretWithUsernamePassword(wlSecretName, domainNamespace, ADMIN_USERNAME_DEFAULT, ADMIN_PASSWORD_DEFAULT);
+
+    // create image with model files
+    getLogger().info("Creating image with model file and verify");
+    String domainInImageWithWDTImage = createImageAndVerify("domaininimage-wdtimage",
+        Collections.singletonList(MODEL_DIR + "/" + wdtModelFileForDomainInImage), appSrcDirList,
+        propertyFiles,
+        WEBLOGIC_IMAGE_NAME, WEBLOGIC_IMAGE_TAG, WLS_DOMAIN_TYPE, false,
+        domainUid, false);
+
+    // repo login and push image to registry if necessary
+    imageRepoLoginAndPushImageToRegistry(domainInImageWithWDTImage);
+
+    // Create the repo secret to pull the image
+    // this secret is used only for non-kind cluster
+    createTestRepoSecret(domainNamespace);
+
+    // create the domain custom resource
+    DomainResource domain = createDomainResourceForDomainInImage(domainUid, domainNamespace, domainInImageWithWDTImage,
+        wlSecretName, clusterName, replicaCount);
+
+    // create domain and verify
+    createDomainAndVerify(domain, domainNamespace);
+
+    return domain;
   }
 
   /**

--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/utils/DomainUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.weblogic.kubernetes.utils;

--- a/integration-tests/src/test/resources/wdt-models/model-configuredcluster-noserver.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-configuredcluster-noserver.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: 'weblogic'
+    AdminPassword: 'welcome1'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'
+    AdminServerName: "admin-server"
+    Cluster:
+        "cluster-1":
+    Server:
+        "admin-server":
+            ListenPort: 7001

--- a/integration-tests/src/test/resources/wdt-models/model-emptytopology.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-emptytopology.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'

--- a/integration-tests/src/test/resources/wdt-models/model-hasadminservername-namedservernotinserver.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-hasadminservername-namedservernotinserver.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'
+    AdminServerName: "new-admin-server"
+    Cluster:
+        "cluster-1":
+            DynamicServers:
+                ServerTemplate:  "cluster-1-template"
+                ServerNamePrefix: "managed-server"
+                DynamicClusterSize: 5
+                MaxDynamicClusterSize: 5
+                CalculatedListenPorts: false
+    Server:
+        "admin-server":
+            ListenPort: 7001
+    ServerTemplate:
+        "cluster-1-template":
+            Cluster: "cluster-1"
+            ListenPort : 8001
+            WebServer:
+                WebServerLog:
+                    BufferSizeKb: 1
+
+appDeployments:
+    Application:
+        myear:
+            SourcePath: "wlsdeploy/applications/sample-app.ear"
+            ModuleType: ear
+            Target: 'cluster-1'

--- a/integration-tests/src/test/resources/wdt-models/model-noadminservername-hasadminserver.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-noadminservername-hasadminserver.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'
+    Cluster:
+        "cluster-1":
+            DynamicServers:
+                ServerTemplate:  "cluster-1-template"
+                ServerNamePrefix: "managed-server"
+                DynamicClusterSize: 5
+                MaxDynamicClusterSize: 5
+                CalculatedListenPorts: false
+    Server:
+        "AdminServer":
+            ListenPort: 7001
+    ServerTemplate:
+        "cluster-1-template":
+            Cluster: "cluster-1"
+            ListenPort : 8001
+            WebServer:
+                WebServerLog:
+                    BufferSizeKb: 1
+
+appDeployments:
+    Application:
+        myear:
+            SourcePath: "wlsdeploy/applications/sample-app.ear"
+            ModuleType: ear
+            Target: 'cluster-1'

--- a/integration-tests/src/test/resources/wdt-models/model-noadminservername-hasadminserverlowercase.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-noadminservername-hasadminserverlowercase.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'
+    Cluster:
+        "cluster-1":
+            DynamicServers:
+                ServerTemplate:  "cluster-1-template"
+                ServerNamePrefix: "managed-server"
+                DynamicClusterSize: 5
+                MaxDynamicClusterSize: 5
+                CalculatedListenPorts: false
+    Server:
+        "adminserver":
+            ListenPort: 7001
+    ServerTemplate:
+        "cluster-1-template":
+            Cluster: "cluster-1"
+            ListenPort : 8001
+            WebServer:
+                WebServerLog:
+                    BufferSizeKb: 1
+
+appDeployments:
+    Application:
+        myear:
+            SourcePath: "wlsdeploy/applications/sample-app.ear"
+            ModuleType: ear
+            Target: 'cluster-1'

--- a/integration-tests/src/test/resources/wdt-models/model-noadminservername-hasmyadminserver.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-noadminservername-hasmyadminserver.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'
+    Cluster:
+        "cluster-1":
+            DynamicServers:
+                ServerTemplate:  "cluster-1-template"
+                ServerNamePrefix: "managed-server"
+                DynamicClusterSize: 5
+                MaxDynamicClusterSize: 5
+                CalculatedListenPorts: false
+    Server:
+        "myadmin":
+            ListenPort: 7001
+    ServerTemplate:
+        "cluster-1-template":
+            Cluster: "cluster-1"
+            ListenPort : 8001
+            WebServer:
+                WebServerLog:
+                    BufferSizeKb: 1
+
+appDeployments:
+    Application:
+        myear:
+            SourcePath: "wlsdeploy/applications/sample-app.ear"
+            ModuleType: ear
+            Target: 'cluster-1'

--- a/integration-tests/src/test/resources/wdt-models/model-noadminservername-noserver.yaml
+++ b/integration-tests/src/test/resources/wdt-models/model-noadminservername-noserver.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+domainInfo:
+    AdminUserName: '@@SECRET:__weblogic-credentials__:username@@'
+    AdminPassword: '@@SECRET:__weblogic-credentials__:password@@'
+
+topology:
+    Name: "wls-domain1"
+    ProductionModeEnabled: 'true'
+    Cluster:
+        "cluster-1":
+            DynamicServers:
+                ServerTemplate:  "cluster-1-template"
+                ServerNamePrefix: "managed-server"
+                DynamicClusterSize: 5
+                MaxDynamicClusterSize: 5
+                CalculatedListenPorts: false
+    ServerTemplate:
+        "cluster-1-template":
+            Cluster: "cluster-1"
+            ListenPort : 8001
+            WebServer:
+                WebServerLog:
+                    BufferSizeKb: 1
+
+appDeployments:
+    Application:
+        myear:
+            SourcePath: "wlsdeploy/applications/sample-app.ear"
+            ModuleType: ear
+            Target: 'cluster-1'


### PR DESCRIPTION
Backport to release/3.4: Add Functional Regression tests for OWLS-106473, OWLS-106637

Jenkins result:
https://build.weblogick8s.org:8443/view/Kind%20(WKO)/job/weblogic-kubernetes-operator-kind-new/16791/ (running with release/3.4 branch got the same failures, see the below job link)
https://build.weblogick8s.org:8443/view/Kind%20(WKO)/job/weblogic-kubernetes-operator-kind-new/16796/