### PR TITLE
back ported fix from main for ItMiiCreateAuxImageWithImageTool.testNegativeCreateAuxImageUnsupportedPM failed due to options change in imagetool.sh

### DIFF
--- a/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCreateAuxImageWithImageTool.java
+++ b/integration-tests/src/test/java/oracle/weblogic/kubernetes/ItMiiCreateAuxImageWithImageTool.java
@@ -401,8 +401,7 @@ class ItMiiCreateAuxImageWithImageTool {
         .modelFiles(Collections.singletonList(MODEL_DIR + "/model.update.wm.yaml"));
 
     ExecResult result = createAuxImageUsingWITAndReturnResult(witParams);
-    String exepectedErrorMsg = "Invalid value for option '--packageManager': expected one of "
-        + "[OS_DEFAULT, NONE, YUM, DNF, MICRODNF, APTGET, APK, ZYPPER] (case-insensitive) but was 'pkm'";
+    String exepectedErrorMsg = "Invalid value for option '--packageManager':";
     assertTrue(result.exitValue() != 0 && result.stderr().contains(exepectedErrorMsg));
   }
 


### PR DESCRIPTION
https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind/12