### PR TITLE
Add .svc suffix to make URI's consistently valid

### DIFF
--- a/operator/src/main/java/oracle/kubernetes/operator/steps/HttpRequestProcessing.java
+++ b/operator/src/main/java/oracle/kubernetes/operator/steps/HttpRequestProcessing.java
@@ -131,7 +131,7 @@ abstract class HttpRequestProcessing {
 
   private String toServiceHost(@Nonnull V1ObjectMeta meta) {
     String ns = Optional.ofNullable(meta.getNamespace()).orElse("default");
-    return meta.getName() + "." + ns;
+    return meta.getName() + "." + ns + ".svc";
   }
 
   protected V1Pod getPod() {

--- a/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/DomainProcessorTest.java
@@ -646,7 +646,7 @@ class DomainProcessorTest {
   }
 
   private HttpRequest createShutdownRequest(String serverName, int portNumber) {
-    String url = "http://test-domain-" + serverName + ".namespace:" + portNumber;
+    String url = "http://test-domain-" + serverName + ".namespace.svc:" + portNumber;
     return HttpRequest.newBuilder()
         .uri(URI.create(url + "/management/weblogic/latest/serverRuntime/shutdown"))
         .POST(HttpRequest.BodyPublishers.noBody())
@@ -739,7 +739,7 @@ class DomainProcessorTest {
 
   @SuppressWarnings("HttpUrlsUsage")
   private void defineOKResponse(@Nonnull String serverName, int port) {
-    final String url = "http://" + UID + "-" + serverName + "." + NS + ":" + port;
+    final String url = "http://" + UID + "-" + serverName + "." + NS + ".svc:" + port;
     httpSupport.defineResponse(createExpectedRequest(url), createStub(HttpResponseStub.class, HTTP_OK, OK_RESPONSE));
   }
 

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/MonitoringExporterStepsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;
@@ -188,7 +188,7 @@ class MonitoringExporterStepsTest {
 
   @Nonnull
   private String getExporterHost(String serverName) {
-    return DOMAIN_NAME + "-" + serverName + "." + NS;
+    return DOMAIN_NAME + "-" + serverName + "." + NS + ".svc";
   }
 
   @Nonnull

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ReadHealthStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ReadHealthStepTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oracle.kubernetes.operator.steps;
@@ -137,7 +137,7 @@ class ReadHealthStepTest {
   @Test
   void whenReadAdminServerHealth_decrementRemainingServers() {
     selectServer(ADMIN_NAME);
-    defineResponse(200, OK_RESPONSE, "http://" + ADMIN_NAME + ".Test:3456");
+    defineResponse(200, OK_RESPONSE, "http://" + ADMIN_NAME + ".Test.svc:3456");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -155,7 +155,7 @@ class ReadHealthStepTest {
   void whenReadConfiguredManagedServerHealth_decrementRemainingServers() {
     V1Service service = selectServer(CONFIGURED_MANAGED_SERVER1);
     configureServiceWithClusterName(CONFIGURED_CLUSTER_NAME, service);
-    defineResponse(200, OK_RESPONSE, "http://" + CONFIGURED_MANAGED_SERVER1 + ".Test:7001");
+    defineResponse(200, OK_RESPONSE, "http://" + CONFIGURED_MANAGED_SERVER1 + ".Test.svc:7001");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -169,7 +169,7 @@ class ReadHealthStepTest {
   void whenReadDynamicManagedServerHealth_decrementRemainingServers() {
     V1Service service = selectServer(DYNAMIC_MANAGED_SERVER1);
     configureServiceWithClusterName(DYNAMIC_CLUSTER_NAME, service);
-    defineResponse(200, OK_RESPONSE, "http://" + DYNAMIC_MANAGED_SERVER1 + ".Test:7001");
+    defineResponse(200, OK_RESPONSE, "http://" + DYNAMIC_MANAGED_SERVER1 + ".Test.svc:7001");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -180,7 +180,7 @@ class ReadHealthStepTest {
   void whenServerRunning_verifyServerHealth() {
     selectServer(MANAGED_SERVER1);
 
-    defineResponse(200, OK_RESPONSE, "http://" + MANAGED_SERVER1 + ".Test:8001");
+    defineResponse(200, OK_RESPONSE, "http://" + MANAGED_SERVER1 + ".Test.svc:8001");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -199,7 +199,7 @@ class ReadHealthStepTest {
   @Test
   void whenAdminPodIPNull_verifyServerHealth() {
     selectServer(ADMIN_NAME);
-    defineResponse(200, OK_RESPONSE, "http://admin-server.Test:3456");
+    defineResponse(200, OK_RESPONSE, "http://admin-server.Test.svc:3456");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -209,7 +209,7 @@ class ReadHealthStepTest {
   @Test
   void whenAdminPodIPNull_requestSendWithCredentials() {
     selectServer(ADMIN_NAME);
-    defineResponse(200, OK_RESPONSE, "http://admin-server.Test:3456");
+    defineResponse(200, OK_RESPONSE, "http://admin-server.Test.svc:3456");
 
     testSupport.runSteps(readHealthStep);
 
@@ -232,7 +232,7 @@ class ReadHealthStepTest {
   void whenServerOverloaded_verifyServerHealth() {
     selectServer(MANAGED_SERVER1);
 
-    defineResponse(500, "", "http://" + MANAGED_SERVER1 + ".Test:8001");
+    defineResponse(500, "", "http://" + MANAGED_SERVER1 + ".Test.svc:8001");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -245,7 +245,7 @@ class ReadHealthStepTest {
   void whenUnableToReadHealth_verifyNotAvailable() {
     selectServer(MANAGED_SERVER1);
 
-    defineResponse(404, "", "http://" + MANAGED_SERVER1 + ".Test:8001");
+    defineResponse(404, "", "http://" + MANAGED_SERVER1 + ".Test.svc:8001");
 
     Packet packet = testSupport.runSteps(readHealthStep);
 
@@ -394,7 +394,7 @@ class ReadHealthStepTest {
   void whenNotAuthorizedToReadHealth_verifySecretCleared() {
     selectServer(MANAGED_SERVER1);
 
-    defineResponse(403, "", "http://" + MANAGED_SERVER1 + ".Test:8001");
+    defineResponse(403, "", "http://" + MANAGED_SERVER1 + ".Test.svc:8001");
 
     testSupport.runSteps(readHealthStep);
 
@@ -402,7 +402,7 @@ class ReadHealthStepTest {
   }
 
   private void defineExpectedURLInResponse(String protocol, int port) {
-    defineResponse(200, OK_RESPONSE, protocol + "://dyn-managed-server2.Test:" + port);
+    defineResponse(200, OK_RESPONSE, protocol + "://dyn-managed-server2.Test.svc:" + port);
   }
 
   private boolean readServerHealthSucceeded(Packet packet) {

--- a/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
+++ b/operator/src/test/java/oracle/kubernetes/operator/steps/ShutdownManagedServerStepTest.java
@@ -227,7 +227,7 @@ class ShutdownManagedServerStepTest {
   void whenAuthorizedToInvokeShutdown_verifySecretSet() {
     selectServer(CONFIGURED_MANAGED_SERVER1, configuredServerService);
 
-    defineResponse(200, "http://test-domain-conf-managed-server1.namespace:7001");
+    defineResponse(200, "http://test-domain-conf-managed-server1.namespace.svc:7001");
 
     // Validate not set before running steps
     assertThat(info.getWebLogicCredentialsSecret(), is(nullValue()));
@@ -243,7 +243,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_configuredClusterServer_verifySuccess() {
     selectServer(CONFIGURED_MANAGED_SERVER1, configuredServerService);
 
-    defineResponse(200, "http://test-domain-conf-managed-server1.namespace:7001");
+    defineResponse(200, "http://test-domain-conf-managed-server1.namespace.svc:7001");
 
     testSupport.runSteps(shutdownConfiguredManagedServer);
 
@@ -254,7 +254,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_configuredClusterServer_verifyFailure() {
     selectServer(CONFIGURED_MANAGED_SERVER1, configuredServerService);
 
-    defineResponse(404, "http://test-domain-conf-managed-server1.namespace:7001");
+    defineResponse(404, "http://test-domain-conf-managed-server1.namespace.svc:7001");
 
     testSupport.runSteps(shutdownConfiguredManagedServer);
 
@@ -265,7 +265,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_standaloneServer_verifySuccess() {
     selectServer(MANAGED_SERVER1, standaloneServerService);
 
-    defineResponse(200, "http://test-domain-managed-server1.namespace:8001");
+    defineResponse(200, "http://test-domain-managed-server1.namespace.svc:8001");
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
 
@@ -276,7 +276,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_standaloneServer_verifyFailure() {
     selectServer(MANAGED_SERVER1, standaloneServerService);
 
-    defineResponse(404, "http://test-domain-managed-server1.namespace:7001");
+    defineResponse(404, "http://test-domain-managed-server1.namespace.svc:7001");
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
 
@@ -287,7 +287,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_standaloneServer_DomainNotFound_verifyFailureAndRunNextStep() {
     selectServer(MANAGED_SERVER1, standaloneServerService);
 
-    defineResponse(404, "http://test-domain-managed-server1.namespace:7001");
+    defineResponse(404, "http://test-domain-managed-server1.namespace.svc:7001");
     testSupport.failOnResource(KubernetesTestSupport.DOMAIN, UID, NS, HTTP_NOT_FOUND);
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
@@ -300,7 +300,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_dynamicServer_verifySuccess() {
     selectServer(DYNAMIC_MANAGED_SERVER1, dynamicServerService);
 
-    defineResponse(200, "http://test-domain-dyn-managed-server1.namespace:7001");
+    defineResponse(200, "http://test-domain-dyn-managed-server1.namespace.svc:7001");
 
     testSupport.runSteps(shutdownDynamicManagedServer);
 
@@ -311,7 +311,7 @@ class ShutdownManagedServerStepTest {
   void whenInvokeShutdown_dynamicServer_verifyFailure() {
     selectServer(DYNAMIC_MANAGED_SERVER1, dynamicServerService);
 
-    defineResponse(404, "http://test-domain-dyn-managed-server1.namespace:8001");
+    defineResponse(404, "http://test-domain-dyn-managed-server1.namespace.svc:8001");
 
     testSupport.runSteps(shutdownDynamicManagedServer);
 
@@ -323,7 +323,7 @@ class ShutdownManagedServerStepTest {
     selectServer(MANAGED_SERVER1, standaloneServerService);
     setForcedShutdownType(MANAGED_SERVER1);
 
-    defineResponse(false, 200, "http://test-domain-managed-server1.namespace:8001");
+    defineResponse(false, 200, "http://test-domain-managed-server1.namespace.svc:8001");
 
     testSupport.runSteps(shutdownStandaloneManagedServer);
 


### PR DESCRIPTION
A customer selected a namespace name that started with a number. This is, perhaps surprisingly, legal, as per [Namespaces and DNS](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#namespaces-and-dns), which states that, As a result, all namespace names must be valid [RFC 1123 DNS labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)." and the definition of RFC-1123 labels requires that:

* contain at most 63 characters
* contain only lowercase alphanumeric characters or '-'
* start with an alphanumeric character
* end with an alphanumeric character

Sadly, if the final component of the hostname of a URL starts with a number than the URI is invalid. The customer saw many SEVERE messages in the log as the operator tried to contact WebLogic Server instances. This issue is resolved if we add ".svc" to the end of the hostname.
