### PR TITLE
Update OpenShift documentation and certifications

### DIFF
--- a/documentation/4.0/content/introduction/platforms/environments.md
+++ b/documentation/4.0/content/introduction/platforms/environments.md
@@ -168,12 +168,12 @@ OpenShift can be a cloud platform or can be deployed on premises.
 
 - Operator v3.4.6 is certified for use on:
   - OpenShift Container Platform 4.9.50 with Kubernetes 1.22, RedHat OpenShift Mesh 2.3, and Istio 1.14.
-  - OpenShift Container Platform 4.10.4 with Kubernetes 1.23, RedHat OpenShift Mesh 2.3, and Istio 1.14.
-  - OpenShift Container Platform 4.11.0 with Kubernetes 1.24, RedHat OpenShift Mesh 2.3, and Istio 1.14.
+  - OpenShift Container Platform 4.10.20 with Kubernetes 1.23, RedHat OpenShift Mesh 2.2.1, and Istio 1.14.
+  - OpenShift Container Platform 4.11.6 with Kubernetes 1.24, RedHat OpenShift Mesh 2.2.3, and Istio 1.12.9.
   - 
 - Operator v4.0.5 is certified for use on:
-  - OpenShift Container Platform 4.11.30 with Kubernetes 1.24, RedHat OpenShift Mesh 2.3, and Istio 1.14.
-  - OpenShift Container Platform 4.12.2 with Kubernetes 1.25, RedHat OpenShift Mesh 2.3, and Istio 1.14.
+  - OpenShift Container Platform 4.11.30 with Kubernetes 1.24, RedHat OpenShift Mesh 2.3.2, and Istio 1.14.5.
+  - OpenShift Container Platform 4.12.2 with Kubernetes 1.25, RedHat OpenShift Mesh 2.3.2, and Istio 1.14.5.
 
 To accommodate OpenShift security requirements:
 - For security requirements to run WebLogic Server in OpenShift, see the [OpenShift]({{<relref "/security/openshift.md">}}) documentation.

--- a/documentation/4.0/content/introduction/platforms/environments.md
+++ b/documentation/4.0/content/introduction/platforms/environments.md
@@ -166,10 +166,14 @@ See also the [Tanzu Kubernetes Grid sample]({{<relref "/samples/tanzu-kubernetes
 
 OpenShift can be a cloud platform or can be deployed on premises.
 
-- Operator 3.4.0+ is certified for use on OpenShift Container Platform 4.10.4+ with Kubernetes 1.23+.
-- Operator v3.4.4 is certified for use on:
+- Operator v3.4.6 is certified for use on:
   - OpenShift Container Platform 4.9.50 with Kubernetes 1.22, RedHat OpenShift Mesh 2.3, and Istio 1.14.
+  - OpenShift Container Platform 4.10.4 with Kubernetes 1.23, RedHat OpenShift Mesh 2.3, and Istio 1.14.
   - OpenShift Container Platform 4.11.0 with Kubernetes 1.24, RedHat OpenShift Mesh 2.3, and Istio 1.14.
+  - 
+- Operator v4.0.5 is certified for use on:
+  - OpenShift Container Platform 4.11.30 with Kubernetes 1.24, RedHat OpenShift Mesh 2.3, and Istio 1.14.
+  - OpenShift Container Platform 4.12.2 with Kubernetes 1.25, RedHat OpenShift Mesh 2.3, and Istio 1.14.
 
 To accommodate OpenShift security requirements:
 - For security requirements to run WebLogic Server in OpenShift, see the [OpenShift]({{<relref "/security/openshift.md">}}) documentation.

--- a/documentation/4.0/content/security/openshift.md
+++ b/documentation/4.0/content/security/openshift.md
@@ -5,6 +5,40 @@ weight: 7
 description: "OpenShift information for the operator."
 ---
 
+#### Set the Helm chart property `kubernetesPlatform` to `OpenShift`
+
+Beginning with operator version 3.3.2,
+set the operator `kubernetesPlatform` Helm chart property to `OpenShift`.
+This property accommodates OpenShift security requirements. Specifically, the operator's deployment and any pods created
+by the operator for WebLogic Server instances will not contain `runAsUser: 1000` in the configuration of the `securityContext`. This is to
+accommodate OpenShift's default `restricted` security context constraint.
+For more information, see [Operator Helm configuration values]({{<relref "/managing-operators/using-helm#operator-helm-configuration-values">}}).
+
+#### Use a dedicated namespace
+
+When the user that installs an individual instance of the operator
+does _not_ have the required privileges to create resources at the Kubernetes cluster level,
+they can use a `Dedicated` namespace selection strategy for the operator instance to limit
+it to managing domain resources in its local namespace only
+(see [Operator namespace management]({{< relref "/managing-operators/namespace-management#choose-a-domain-namespace-selection-strategy" >}})),
+and they may need to manually install the Domain Custom Resource (CRD)
+(see [Prepare for installation]({{< relref "/managing-operators/preparation.md" >}})).
+
+#### With WIT, set the `target` parameter to `OpenShift`
+
+When using the [WebLogic Image Tool](https://oracle.github.io/weblogic-image-tool/) (WIT),
+`create`, `rebase`, or `update` command, to create a
+[Domain in Image]({{< relref "/managing-domains/choosing-a-model/_index.md" >}}) domain home,
+[Model in Image]({{< relref "/managing-domains/choosing-a-model/_index.md" >}}) image,
+or [Model in Image]({{< relref "/managing-domains/choosing-a-model/_index.md" >}}) auxiliary image,
+you can specify the `--target` parameter for the target Kubernetes environment.
+Its value can be either `Default` or `OpenShift`.
+The `OpenShift` option changes the domain directory files such that the group permissions
+for those files will be the same as the user permissions (group writable, in most cases).
+If you do not supply the OS group and user setting with `--chown`,
+then the `Default` setting for this option is changed from `oracle:oracle` to `oracle:root`
+to be in line with the expectations of an OpenShift environment.
+
 #### Security requirements to run WebLogic in OpenShift
 
 WebLogic Kubernetes Operator images starting with version 3.1 and
@@ -49,6 +83,10 @@ Security Context Constraint, because it provides more permissions
 than are needed, and is therefore less secure.
 
 #### Create a custom Security Context Constraint
+
+For most use cases, customers should use OpenShift's default `restricted` security context constraint. If you do need to
+create and use a custom security context constraint, this section describes the settings necessary to be compatible with
+the operator and pods for WebLogic Server instances.
 
 To create a custom security context constraint, create a YAML file with the following
 content.  This example assumes that your OpenShift project is called `weblogic` and
@@ -113,34 +151,3 @@ For additional information about OpenShift requirements and the operator,
 see [OpenShift]({{<relref  "/introduction/platforms/environments#openshift">}}).
 {{% /notice %}}
 
-#### Use a dedicated namespace
-
-When the user that installs an individual instance of the operator
-does _not_ have the required privileges to create resources at the Kubernetes cluster level,
-they can use a `Dedicated` namespace selection strategy for the operator instance to limit
-it to managing domain resources in its local namespace only
-(see [Operator namespace management]({{< relref "/managing-operators/namespace-management#choose-a-domain-namespace-selection-strategy" >}})),
-and they may need to manually install the Domain Custom Resource (CRD)
-(see [Prepare for installation]({{< relref "/managing-operators/preparation.md" >}})).
-
-#### Set the Helm chart property `kubernetesPlatform` to `OpenShift`
-
-Beginning with operator version 3.3.2,
-set the operator `kubernetesPlatform` Helm chart property to `OpenShift`.
-This property accommodates OpenShift security requirements.
-For more information, see [Operator Helm configuration values]({{<relref "/managing-operators/using-helm#operator-helm-configuration-values">}}).
-
-#### With WIT, set the `target` parameter to `OpenShift`
-
-When using the [WebLogic Image Tool](https://oracle.github.io/weblogic-image-tool/) (WIT),
-`create`, `rebase`, or `update` command, to create a
-[Domain in Image]({{< relref "/managing-domains/choosing-a-model/_index.md" >}}) domain home,
-[Model in Image]({{< relref "/managing-domains/choosing-a-model/_index.md" >}}) image,
-or [Model in Image]({{< relref "/managing-domains/choosing-a-model/_index.md" >}}) auxiliary image,
-you can specify the `--target` parameter for the target Kubernetes environment.
-Its value can be either `Default` or `OpenShift`.
-The `OpenShift` option changes the domain directory files such that the group permissions
-for those files will be the same as the user permissions (group writable, in most cases).
-If you do not supply the OS group and user setting with `--chown`,
-then the `Default` setting for this option is changed from `oracle:oracle` to `oracle:root`
-to be in line with the expectations of an OpenShift environment.

--- a/documentation/4.0/content/security/openshift.md
+++ b/documentation/4.0/content/security/openshift.md
@@ -22,7 +22,7 @@ they can use a `Dedicated` namespace selection strategy for the operator instanc
 it to managing domain resources in its local namespace only
 (see [Operator namespace management]({{< relref "/managing-operators/namespace-management#choose-a-domain-namespace-selection-strategy" >}})),
 and they may need to manually install the Domain Custom Resource (CRD)
-(see [Prepare for installation]({{< relref "/managing-operators/preparation.md" >}})).
+(see [Prepare for installation]({{< relref "/managing-operators/preparation/#how-to-manually-install-the-domain-resource-custom-resource-definition-crd" >}})).
 
 #### With WIT, set the `target` parameter to `OpenShift`
 


### PR DESCRIPTION
Updated the certified versions.

Reordered the OpenShift page to highlight the requirement to use the Helm variable, `kubernetesPlatform`, and its effect and to deemphasize the now less common use case of needing to create a custom security context constraint.