### PR TITLE
OWLS-107875 check WebLogic version change in base image

### DIFF
--- a/operator/src/main/resources/scripts/createDomainOnPV.sh
+++ b/operator/src/main/resources/scripts/createDomainOnPV.sh
@@ -70,6 +70,19 @@ createDomainOnPVWLDomain() {
   # create domain again
   if  [ -f ${DOMAIN_HOME}/config/config.xml ]; then
     trace "Domain already exists: no operation needed"
+    if [ "${WDT_DOMAIN_TYPE}" == 'JRF' ]; then
+      local curl_wl_ver="`getWebLogicVersion`"
+      local curl_domain_ver="`getDomainVersion`"
+      local wl_major_ver="`getMajorVersion ${curl_wl_ver}`"
+      local domain_major_ver="`getMajorVersion ${curl_domain_ver}`"
+  
+      trace INFO "WebLogic najor version='$wl_major_ver'. Domain major version='${domain_major_ver}'."
+      if ! versionEQ "$wl_major_ver" "${domain_major_ver}" ; then
+        trace SEVERE "WebLogic version '${curl_wl_ver}' is newer than the initialized domain version '${curl_domain_ver}'. Once an initializeDomainOnPV domain is created, the major version of the WebLogic Server in the base image cannot be changed."
+        exitOrLoop
+      fi
+    fi
+
   else
     createDomainFromWDTModel
   fi

--- a/operator/src/main/resources/scripts/utils.sh
+++ b/operator/src/main/resources/scripts/utils.sh
@@ -505,6 +505,27 @@ getWebLogicVersion()
   echo ${wlver:-"9999.9999.9999.9999"}
 }
 
+# getDomainVersion
+#   parse wl domain version from config.xml
+getDomainVersion()
+{
+  local config_file=$DOMAIN_HOME/config/config.xml
+
+  [ ! -f $config_file ] && echo "9999.9999.9999.9999" && return
+
+  local domainver="`grep 'domain-version' $config_file \
+               | sed -ne '/domain-version/{s/.*<domain-version>\(.*\)<\/domain-version>.*/\1/p;q;}'`"
+
+  echo ${domainver:-"9999.9999.9999.9999"}
+}
+
+# getMajorVersion
+#   parse wl major version from a full version number
+getMajorVersion()
+{
+  local major_ver="`echo ${1} | sed  's/\([0-9]*\.[0-9]*\).*$/\1/'`"
+  echo ${major_ver}
+}
 
 # checkWebLogicVersion
 #   check if the WL version is supported by the Operator


### PR DESCRIPTION
When the introspector detects an existing JRF domain on PV, the introspector checks the major WebLogic version in the base image and makes sure that it is not upgraded/downgraded against the major version of the existing JRF domain.  