### PR TITLE
BugFix: Fix Wrong Function Syntax Error

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh
@@ -67,7 +67,7 @@ print_red() {
 
 steps=0
 total_steps=11
-print_step {
+print_step() {
     ((steps++))
     print_blue "Progress $steps/$total_steps.......... $1"
 }

--- a/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh
@@ -762,7 +762,7 @@ sleep $interval
 
 while [ $waiting_time -lt $max_wait_time ]; do
     status=$(${kubernetesCli} get pod/${domainUID}-admin-server -o=jsonpath='{.status.phase}')
-    ready=$(${kubernetesCli} get pod/${domainUID}-admin-server -o=jsonpath='{.ready.phase}')
+    ready=$(${kubernetesCli} get pod/${domainUID}-admin-server --no-headers | awk '{print $2}')
     if [ "$status" == "Running" ]; then
         if [ "$ready" == "1/1" ]; then
           echo "${domainUID}-admin-server is running. Exiting..."


### PR DESCRIPTION
## Context
The [commit](https://github.com/oracle/weblogic-kubernetes-operator/commit/430f3d0b32801db0232fd6444a47c5447a765b16) removed keyword `function`, but it should add `()` instead.
- <img width="1246" alt="image" src="https://github.com/oracle/weblogic-kubernetes-operator/assets/4465723/f5a623e6-9345-4ca1-8596-5e2d193e43d4">


