### PR TITLE
BugFix 'Microsoft.ContainerRegistry/registries' could not be found  in subscription

### DIFF
--- a/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh
+++ b/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh
@@ -191,6 +191,9 @@ parametersValidate() {
 initialize() {
 
   print_step "initializing"
+
+  az provider register -n Microsoft.ContainerRegistry
+
   source ./create-domain-on-aks-inputs.sh
   source ~/.bashrc
   
@@ -218,7 +221,7 @@ initialize() {
   echo "azureResourceGroupName=${azureResourceGroupName}"
   echo "image_build_base_dir=${image_build_base_dir}"
   echo "acr_account_name=${acr_account_name}"
-  
+
   
 }
 
@@ -818,11 +821,11 @@ cd ${scriptDir}
 # Do these steps to create Azure resources and a WebLogic Server domain.
 #
 
-# Setup the environment for running this script and perform initial validation checks
-initialize
-
 # Validate the host environment meets the prerequisites.
 envValidate
+
+# Setup the environment for running this script and perform initial validation checks
+initialize
 
 # Validate the parameters
 parametersValidate "$@"


### PR DESCRIPTION
## Context
Refer to the doc: [The resource with name 'name' and type 'Microsoft.ContainerRegistry/registries' could not be found in subscription](https://learn.microsoft.com/en-us/answers/questions/1188413/the-resource-with-name-name-and-type-microsoft-con)
I got the same error when running the [create-domain-on-aks.sh](https://github.com/backwind1233/weblogic-kubernetes-operator/blob/3f51c35bd891bc90f227c7a61fdb146f1773facb/kubernetes/samples/scripts/create-weblogic-domain-on-azure-kubernetes-service/create-domain-on-aks.sh).

## Goal
Fix bug: 'Microsoft.ContainerRegistry/registries' could not be found in subscription