### PR TITLE
Update aks use guide for autoscaling.

### DIFF
--- a/documentation/site/content/managing-domains/aks/_index.md
+++ b/documentation/site/content/managing-domains/aks/_index.md
@@ -53,17 +53,18 @@ Use the **Basics** blade to provide the basic configuration details for deployin
 
 | Field | Description |
 |-------|-------------|
-| Accept defaults for optional configuration? | If you want to retain the default values for the optional configuration, such as **Name prefix for Managed Server**, **WebLogic Domain Name** and others, set the toggle button to **Yes**, and click **Next: Configure AKS cluster**. If you want to specify different values for the optional configuration, set the toggle button to **No**, and enter the following details. |
+| Accept defaults for optional configuration? | If you want to retain the default values for the optional configuration, such as **Name prefix for Managed Server**, **WebLogic Domain Name** and others, set the toggle button to **Yes**, and click **Next** to configure AKS cluster. If you want to specify different values for the optional configuration, set the toggle button to **No**, and enter the following details. |
 | Name prefix for Managed Server | Enter a prefix for the Managed Server name. |
 | WebLogic Domain Name | Enter the name of the domain that will be created by the offer. |
+| WebLogic Domain UID | Enter the UID of the domain that will be created by the offer. |
 | Maximum dynamic cluster size | The maximum size of the dynamic WebLogic cluster created. |
 |Custom Java Options to start WebLogic Server | Java VM arguments passed to the invocation of WebLogic Server. For more information, see the [FAQ]({{< relref "/faq/resource-settings/_index.md" >}}). |
 
-When you are satisfied with your selections, select **Next : Configure AKS cluster**.
+When you are satisfied with your selections, select **Next** and open **AKS** blade.
 
-### Configure AKS cluster
+### AKS
 
-Use the **Configure AKS Cluster** blade to configure fundamental details of how Oracle WebLogic Server runs on AKS. To do this, enter the values for the fields listed in the following tables.
+Use the **AKS** blade to configure fundamental details of how Oracle WebLogic Server runs on AKS. To do this, enter the values for the fields listed in the following tables.
 
 #### Azure Kubernetes Service
 
@@ -72,11 +73,9 @@ In this section, you can configure some options about the AKS which will run Web
 | Field | Description |
 |-------|-------------|
 |Create a new AKS cluster| If set to **Yes**, the deployment will create a new AKS cluster resource in the specified resource group. If set to **No**, you have the opportunity to select an existing AKS cluster, into which the deployment is configured. Note: the offer assumes the existing AKS cluster has no WebLogic related deployments. |
-|Use latest supported AKS Kubernetes version| The currently supported version is **1.24.3**.  Oracle tracks the AKS release versions in [Supported Kubernetes versions in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions). After a new version emerges, Oracle qualifies WLS on AKS against that version and will update the offer to that version. Please see "WebLogic Kubernetes ToolKit Support Policy (Doc ID 2790123.1)" and "Support for Oracle Fusion Middleware on Azure and Oracle Linux (Doc ID 2914257.1)" in My Oracle Support for the Oracle support policy for WLS on Kubernetes, including AKS.|
-| Node count | The initial number of nodes in the AKS cluster. This value can be changed after deployment. For information, see [Scaling]({{< relref "/managing-domains/domain-lifecycle/scaling.md" >}}). |
+| Minimum node count | The minimum node count in the AKS cluster. This value can be changed after deployment. For information, see [AKS autoscaler](https://learn.microsoft.com/azure/aks/cluster-autoscaler). |
+| Maximum node count | The maximum node count in the AKS cluster. This value can be changed after deployment. For information, see [AKS autoscaler](https://learn.microsoft.com/azure/aks/cluster-autoscaler). |
 | Node size | The default VM size is 2x Standard DSv2, 2 vcpus, 7 GB memory. If you want to select a different VM size, select **Change Size**, select the size from the list (for example, A3) on the Select a VM size page, and select **Select**. For more information about sizing the virtual machine, see the [Azure documentation on Sizes](https://docs.microsoft.com/azure/cloud-services/cloud-services-sizes-specs).|
-|Enable Container insights| If selected, cause the deployment to create an Azure Monitoring workspace and connect it to the AKS cluster as the Azure Monitoring Agent. Azure Monitoring Agent is a tool that collects data and sends it to Azure Container Insights. Container insights gives you performance visibility by collecting memory and processor metrics from controllers, nodes, and containers that are available in Kubernetes through the Metrics API. Container logs are also collected. Metrics are written to the metrics store and log data is written to the logs store associated with your Log Analytics workspace. For more information, see [Azure Monitor Agent overview](/azure/azure-monitor/agents/agents-overview) and [Container insights overview](https://aka.ms/wls-aks-container-insights). |
-|Create Persistent Volume using Azure File share service|If selected, an Azure Storage Account and an Azure Files share will be provisioned. The file system type is NFS. The name of the Azure Files share is **weblogic**. The mount point is `/shared` as a persistent volume in the nodes of the AKS cluster. For more information, see [Oracle WebLogic Server persistent storage]({{< relref "/managing-domains/persistent-storage/_index.md" >}}) and [persistent volume with Azure Files share on AKS](https://docs.microsoft.com/azure/aks/azure-files-volume).|
 
 #### Image selection
 
@@ -84,34 +83,42 @@ In this section, you can configure the image that is deployed using the model-in
 
 | Field | Description |
 |-------|-------------|
-| Use a pre-existing WebLogic Server Docker image from Oracle Container Registry (OCR)? | If set to **Yes**, the subsequent options are constrained to allow only selecting from a set of pre-existing WebLogic Server Docker images stored in the Oracle Container Registry. If set to **No**, the user may refer to a pre-existing Azure Container Registry, and must specify the Docker tag of the WebLogic Server image within that registry that will be used to create the domain. The specified image is assumed to be compatible with the WebLogic Kubernetes Operator. This allows the use of custom images, such as images with a specific one-off patch or Oracle quarterly patches (PSUs). For more about WebLogic Server images, see [WebLogic images]({{< relref "/base-images/_index.md" >}}).|
 |Create a new Azure Container Registry to store application images?|If set to **Yes**, the offer will create a new Azure Container Registry (ACR) to hold the images for use in the deployment.  If set to **No**, you must specify an existing ACR. In this case, you must be sure the selected ACR has the admin account enabled. For details, please see [Admin account](https://docs.microsoft.com/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account). |
-| Select existing ACR instance | This option is shown only if **Use a pre-existing WebLogic Server Docker image from Oracle Container Registry?** is set to **No**. If visible, select an existing Acure Container Registry instance. |
-| Please provide the image path | This option is shown only if **Use a pre-existing WebLogic Server Docker image from Oracle Container Registry?** is set to **No**. If visible, the value must be a fully qualified Docker tag of an image within the specified ACR. |
+| Select ACR instance | This option is shown if **Create a new Azure Container Registry to store application images?** is set to **No**. If visible, select an existing Acure Container Registry instance. |
 | Username for Oracle Single Sign-On authentication | The Oracle Single Sign-on account user name for which the Terms and Restrictions for the selected WebLogic Server image have been accepted. |
 | Password for Oracle Single Sign-On authentication | The password for that account. |
 | Confirm password | Re-enter the value of the preceding field. | If 'Yes' is selected; the deployment process will pull from the CPU WebLogic Server image repository in the OCR. If 'No' is selected the deployment process will pull from the WebLogic Server image repository in OCR. |
-| Is the specified SSO account associated with an active Oracle support contract? | If set to **Yes**, you must accept the license agreement in the `middleware/weblogic_cpu` repository. If set to **No**, you must accept the license agreement in the `middleware/weblogic`. Steps to accept the license agreement: log in to the [Oracle Container Registry](https://container-registry.oracle.com/); navigate to the `middleware/weblogic_cpu` and `middleware/weblogic` repository; accept license agreement. See this [document](https://aka.ms/wls-aks-ocr-doc) for more information. |
-| Select WebLogic Server Docker tag | Select one of the supported images. |
+| Select the type of WebLogic Server Images. | If set to **Patched WebLogic Server Images**, you must accept the license agreement in the `middleware/weblogic_cpu` repository. If set to **General WebLogic Server Images**, you must accept the license agreement in the `middleware/weblogic`. Steps to accept the license agreement: log in to the [Oracle Container Registry](https://container-registry.oracle.com/); navigate to the `middleware/weblogic_cpu` and `middleware/weblogic` repository; accept license agreement. See this [document](https://aka.ms/wls-aks-ocr-doc) for more information. |
+| Select desired combination of WebLogic Server, JDK and Operating System or fully qualified Docker tag | Select one of the supported images. |
 
-#### Java EE Application
+#### Application
 
 In this section you can deploy a Java EE Application along with the WebLogic Server deployment.
 
 | Field | Description |
 |-------|-------------|
-| Deploy your application package? | If set to **Yes**, you must specify a Java EE WAR, EAR, or JAR file suitable for deployment with the selected version of WebLogic Server. If set to **No**, no application is deployed.|
+| Deploy an application? | If set to **Yes**, you must specify a Java EE WAR, EAR, or JAR file suitable for deployment with the selected version of WebLogic Server. If set to **No**, no application is deployed.|
 | Application package (.war,.ear,.jar) | With the **Browse** button, you can select a file from a pre-existing Azure Storage Account and Storage Container within that account.  To learn how to create a Storage Account and Container, see [Create a storage account](https://docs.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-portal) and [Create a Storage Container and upload application files](https://docs.microsoft.com/azure/storage/blobs/storage-quickstart-blobs-portal). |
-| Fail deployment if application does not become ACTIVE. | If selected, the deployment will wait for the deployed application to reach the **ACTIVE** state and fail the deployment if it does not. For more details, see the [Oracle documentation](https://aka.ms/wls-aks-deployment-state). |
 | Number of WebLogic Managed Server replicas | The initial value of the `replicas` field of the Domain. For information, see [Scaling]({{< relref "/managing-domains/domain-lifecycle/scaling.md" >}}). |
 
-When you are satisfied with your selections, select **Next : TLS/SSL configuration**.
+#### Advanced 
 
-### TLS/SSL configuration
+| Field | Description |
+|-------|-------------|
+| Show advanced configuration? | If you want to retain the default values for the optional configuration, such as **Enable Container insights**, **Create Persistent Volume using Azure File share service** and others, set the toggle button to **No**, and click **Next** to configure TLS/SSL. If you want to specify different values for the optional configuration, set the toggle button to **Yes**, and enter the following details. |
+|Enable Container insights| If selected, cause the deployment to create an Azure Monitoring workspace and connect it to the AKS cluster as the Azure Monitoring Agent. Azure Monitoring Agent is a tool that collects data and sends it to Azure Container Insights. Container insights gives you performance visibility by collecting memory and processor metrics from controllers, nodes, and containers that are available in Kubernetes through the Metrics API. Container logs are also collected. Metrics are written to the metrics store and log data is written to the logs store associated with your Log Analytics workspace. For more information, see [Azure Monitor Agent overview](/azure/azure-monitor/agents/agents-overview) and [Container insights overview](https://aka.ms/wls-aks-container-insights). |
+|Create Persistent Volume using Azure File share service|If selected, an Azure Storage Account and an Azure Files share will be provisioned. The file system type is NFS. The name of the Azure Files share is **weblogic**. The mount point is `/shared` as a persistent volume in the nodes of the AKS cluster. For more information, see [Oracle WebLogic Server persistent storage]({{< relref "/managing-domains/persistent-storage/_index.md" >}}) and [persistent volume with Azure Files share on AKS](https://docs.microsoft.com/azure/aks/azure-files-volume).|
+| Bring your own WebLogic Server Docker image from Azure Container Registry? | If check the checkbox, the subsequent options are constrained to allow only selecting from a set of pre-existing WebLogic Server Docker images stored in the Oracle Container Registry. |
+| Select existing ACR instance | This option is shown only if **Bring your own WebLogic Server Docker image from Azure Container Registry?** is checked. If visible, select an existing Acure Container Registry instance. |
+| Please provide the image path | This option is shown only if **Bring your own WebLogic Server Docker image from Azure Container Registry?** is checked. If visible, the value must be a fully qualified Docker tag of an image within the specified ACR. |
 
-With the **TLS/SSL configuration** blade, you can configure Oracle WebLogic Server Administration Console on a secure HTTPS port, with your own SSL certificate provided by a Certifying Authority (CA). See [Oracle WebLogic Server Keystores configuration](https://aka.ms/arm-oraclelinux-wls-ssl-configuration) for more information.
+When you are satisfied with your selections, select **Next** and open **TLS/SSL** blade.
 
-Select **Yes** or **No** for the option **Configure WebLogic Server Administration Console, Remote Console, and cluster to use HTTPS (Secure) ports, with your own TLS/SSL certificate.** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by selecting **Next : Networking**. If you select **Yes**, you can choose to provide the required configuration details by either uploading existing keystores or by using keystores stored in Azure Key Vault.
+### TLS/SSL
+
+With the **TLS/SSL** blade, you can configure Oracle WebLogic Server Administration Console on a secure HTTPS port, with your own SSL certificate provided by a Certifying Authority (CA). See [Oracle WebLogic Server Keystores configuration](https://aka.ms/arm-oraclelinux-wls-ssl-configuration) for more information.
+
+Select **Yes** or **No** for the option **Configure WebLogic Server Administration Console, Remote Console, and cluster to use HTTPS (Secure) ports, with your own TLS/SSL certificate.** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by selecting **Next**. If you select **Yes**, you can choose to provide the required configuration details by either uploading existing keystores or by using keystores stored in Azure Key Vault.
 
 If you want to upload existing keystores, select **Upload existing KeyStores** for the option **How would you like to provide required configuration**, and enter the values for the fields listed in the following table.
 
@@ -148,33 +155,21 @@ If you want to use keystores that are stored in Azure Key Vault, select **Use Ke
 | The name of the secret in the specified Key Vault whose value is the passphrase for the Trust KeyStore | Enter the name of the Azure Key Vault secret that holds the value of the the passphrase for the trust keystore. |
 | The Trust KeyStore type (JKS,PKCS12) | Select the type of custom trust keystore. The supported values are JKS and PKCS12. |
 
-When you are satisfied with your selections, select **Next : Networking**.
+When you are satisfied with your selections, select **Next** and open **Load balancing** blade.
 
-### Networking
+### Load balancing
 
-Use this blade to configure options for load balancing and ingress controller.
+Use this blade to configure load balancing. There are three options:
 
-#### Standard Load Balancer service
-
-Selecting **Yes** here will cause the offer to provision the Azure Load Balancer as a Kubernetes load balancer service. For more information on the Standard Load Balancer see [Use a public Standard Load Balancer in Azure Kubernetes Service (AKS)](https://aka.ms/wls-aks-standard-load-balancer).  You can still deploy an Azure Application Gateway even if you select **No** here.
-
-If you select **Yes**, you have the option of configuring the Load Balancer as an internal Load Balancer.  For more information on Azure internal load balancers see [Use an internal load balancer with Azure Kubernetes Service (AKS)](https://aka.ms/wls-aks-internal-load-balancer).
-
-If you select **Yes**, you must fill in the following table to map the services to load balancer ports.
-
-**Service name prefix** column:
-
-You can fill in any valid value in this column.
-
-**Target** and **Port** column:
-
-For the ports, the recommended values are the usual 7001 for the **admin-server** and 8001 for the **cluster-1**.
+* Application Gateway Ingress Controller.
+* Standard Load Balancer service.
+* No Load Balancer.
 
 #### Application Gateway Ingress Controller
 
 In this section, you can create an Azure Application Gateway instance as the ingress controller of your WebLogic Server. This Application Gateway is pre-configured for end-to-end-SSL with TLS termination at the gateway using the provided SSL certificate and load balances across your cluster.
 
-Select **Yes** or **No** for the option **Connect to Azure Application Gateway?** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by selecting **Next : DNS Configuration >**. If you select **Yes**, you must specify the details required for the Application Gateway integration by entering the values for the fields as described next.
+Select **Application Gateway Ingress Controller** for the option **Load Balancing Options** based on your preference. You must specify the details required for the Application Gateway integration by entering the values for the fields as described next.
 
 You can specify a virtual network for the application gateway. To do this, enter the values for the fields listed in the following tables.
 
@@ -184,13 +179,18 @@ You can specify a virtual network for the application gateway. To do this, enter
 |-------|-------------|
 | Virtual network | Select a virtual network in which to place the application gateway. Make sure your virtual network meets the requirements in [Application Gateway virtual network and dedicated subnet](https://docs.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#virtual-network-and-dedicated-subnet). |
 | Subnet | An application gateway is a dedicated deployment in your virtual network. Within your virtual network, a dedicated subnet is required for the application gateway. See [Application Gateway virtual network and dedicated subnet](https://docs.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#virtual-network-and-dedicated-subnet). |
-| Configure frontend IP with private IP address | If set to **Yes**, the Azure Marketplace offer will pick one of the available IP addresses from the application gateway subnet to be the private front-end IP address. For more information, see [Application Gateway front-end IP address configuration](https://docs.microsoft.com/en-us/azure/application-gateway/configuration-front-end-ip). |
 
 You must select one of the following three options, each described in turn.
 
+* Generate a self-signed front-end certificate: Generate a self-signed front-end certificate and apply it during deployment.
 * Upload a TLS/SSL certificate: Upload the pre-signed certificate now.
 * Identify an Azure Key Vault: The Key Vault must already contain the certificate and its password stored as secrets.
-* Generate a self-signed front-end certificate: Generate a self-signed front-end certificate and apply it during deployment.
+
+**Generate a self-signed frontend certificate**
+
+| Field | Description |
+|-------|-------------|
+| Trusted root certificate(.cer, .cert) | A trusted root certificate is required to allow back-end instances in the application gateway. The root certificate is a Base-64 encoded X.509(.CER) format root certificate. |
 
 **Upload a TLS/SSL certificate**
 
@@ -211,27 +211,37 @@ You must select one of the following three options, each described in turn.
 | The name of the secret in the specified Key Vault whose value is the password for the front-end TLS/SSL certificate | Enter the name of the Azure Key Vault secret that holds the value of the password for the application gateway front-end SSL certificate. |
 | The name of the secret in the specified Key Vault whose value is the trusted root certificate data | A trusted root certificate is required to allow back-end instances in the application gateway. Enter the name of the Azure Key Vault secret that holds the value of the application gateway trusted root certificate data. Follow [Store the TLS/SSL certificate in the Key Vault](#store-the-tlsssl-certificate-in-the-key-vault) to upload the certificate to Azure Key Vault. |
 
-**Generate a self-signed frontend certificate**
-
-| Field | Description |
-|-------|-------------|
-| Trusted root certificate(.cer, .cert) | A trusted root certificate is required to allow back-end instances in the application gateway. The root certificate is a Base-64 encoded X.509(.CER) format root certificate. |
-
 Regardless of how you provide the certificates, there are several other options when configuring the Application Gateway, as described next.
 
 | Field | Description |
 |-------|-------------|
-|Enable cookie based affinity | Select this box to enable cookie based affinity (sometimes called "sticky sessions"). For more information, see [Enable Cookie based affinity with an Application Gateway](https://docs.microsoft.com/azure/application-gateway/ingress-controller-cookie-affinity). |
+|Disable cookie based affinity | Select this box to disable cookie based affinity (sometimes called "sticky sessions"). For more information, see [Enable Cookie based affinity with an Application Gateway](https://docs.microsoft.com/azure/application-gateway/ingress-controller-cookie-affinity). |
 | Create ingress for Administration Console. | Select **Yes** to create an ingress for the Administration Console with the path `/console`. |
 | Create ingress for WebLogic Remote Console. | Select **Yes** to create an ingress for the Remote Console with the path `/remoteconsole`. |
 
-When you are satisfied with your selections, select **Next : DNS Configuration**.
+#### Standard Load Balancer service
 
-### DNS Configuration
+Selecting **Yes** here will cause the offer to provision the Azure Load Balancer as a Kubernetes load balancer service. For more information on the Standard Load Balancer see [Use a public Standard Load Balancer in Azure Kubernetes Service (AKS)](https://aka.ms/wls-aks-standard-load-balancer).  You can still deploy an Azure Application Gateway even if you select **No** here.
 
-With the **DNS Configuration** blade, you can provision the Oracle WebLogic Server Administration Console using a custom DNS name.
+If you select **Yes**, you have the option of configuring the Load Balancer as an internal Load Balancer.  For more information on Azure internal load balancers see [Use an internal load balancer with Azure Kubernetes Service (AKS)](https://aka.ms/wls-aks-internal-load-balancer).
 
-Select **Yes** or **No** for the option **Configure Custom DNS Alias?** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by selecting **Next : Database >**. If you select **Yes**, you must choose either to configure a custom DNS alias based on an existing Azure DNS zone, or create an Azure DNS zone and a custom DNS alias. This can be done by selecting **Yes** or **No** for the option **Use an existing Azure DNS Zone**.
+If you select **Yes**, you must fill in the following table to map the services to load balancer ports.
+
+**Service name prefix** column:
+
+You can fill in any valid value in this column.
+
+**Target** and **Port** column:
+
+For the ports, the recommended values are the usual 7001 for the **admin-server** and 8001 for the **cluster-1**.
+
+When you are satisfied with your selections, select **Next** and open **DNS** blade.
+
+### DNS
+
+With the **DNS** blade, you can provision the Oracle WebLogic Server Administration Console using a custom DNS name.
+
+Select **Yes** or **No** for the option **Custom DNS Alias?** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by selecting **Next** to configure database. If you select **Yes**, you must choose either to configure a custom DNS alias based on an existing Azure DNS zone, or create an Azure DNS zone and a custom DNS alias. This can be done by selecting **Yes** or **No** for the option **Use an existing Azure DNS Zone**.
 
 {{% notice note %}}
 For more information about the DNS zones, see [Overview of DNS zones and records](https://docs.microsoft.com/azure/dns/dns-zones-records).
@@ -258,11 +268,11 @@ See the preceding table for the description of these fields.
 In the case of creating an Azure DNS zone and a custom DNS alias, you must perform the DNS domain delegation at your DNS registry post deployment. See [Delegation of DNS zones with Azure DNS](https://docs.microsoft.com/azure/dns/dns-domain-delegation).
 {{% /notice %}}
 
-When you are satisfied with your selections, select **Next : Database**.
+When you are satisfied with your selections, select **Next** and open **Database** blade.
 
 ### Database
 
-Use the Database blade to configure Oracle WebLogic Server to connect to an existing database. Select **Yes** or **No** for the option **Connect to Database?** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by clicking **Next : Review + create >**. If you select **Yes**, you must specify the details of your database by entering the values for the fields listed in the following table.
+Use the Database blade to configure Oracle WebLogic Server to connect to an existing database. Select **Yes** or **No** for the option **Connect to Database?** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by clicking **Next**. If you select **Yes**, you must specify the details of your database by entering the values for the fields listed in the following table.
 
 | Field | Description |
 |-------|-------------|
@@ -284,7 +294,44 @@ If you select **Other** as the database type, there are some additional values y
 | DataSource driver name | The fully qualified Java class name of the JDBC driver. |
 | Test table name | The name of the database table to use when testing physical database connections. This value depends on the specified database. Some suggested values include the following. {{< line_break >}}{{< line_break >}} • For Oracle, use `SQL ISVALID`. {{< line_break >}} • For PostgreSQL, SQL Server and MariaDB use `SQL SELECT 1`. {{< line_break >}} • For Informix use `SYSTABLES`.|
 
-When you are satisfied with your selections, select **Next : Review + create**.
+When you are satisfied with your selections, select **Next** and open **Autoscaling** blade.
+
+### Autoscaling
+
+Use the Autoscaling blade to configure metric that scales the WebLogic cluster. Select **Yes** or **No** for the option **Provision resources for horizontal autoscaling?** based on your preference. If you select **No**, you don't have to provide any details, and can proceed by clicking **Review + create**. If you select **Yes**, you must specify the details of your autoscaling option and autoscaling settings.
+
+You must select one of the following two options, each described in turn.
+
+* Kubernetes Metrics Server (simple autoscaling): this option configures and runs Kubernetes Horizontal Pod Autoscaler (HPA) to scale a WebLogic cluster, based on the CPU or memory utilization.
+* WebLogic Monitoring Exporter (advanced autoscaling): this option allows you to create Java metric aware KEDA scaling rules.
+
+#### Kubernetes Metrics Server (simple autoscaling)
+
+| Field | Description |
+|-------|-------------|
+| Select metric | There are two options:{{< line_break >}}{{< line_break >}} • Average CPU Utilization {{< line_break >}} • Average Memory Utilization |
+| Average CPU Utilization | Pick average CPU utilization in percent. The HPA autoscales WebLogic Server instances from a minimum of 1 cluster members up to maximum of cluster members, and the scale up or down action occur when the average CPU is consistently over the utilization. |
+| Average Memory Utilization | Pick average memory utilization in percent. The HPA autoscales WebLogic Server instances from a minimum of 1 cluster members up to maximum of cluster members, and the scale up or down action occur when the average memory is consistently over the utilization.|
+
+#### WebLogic Monitoring Exporter (advanced autoscaling)
+
+This option installs all the software necessary to allow you to create Java metric aware KEDA scaling rules. The offer provisions the following deployments. Right-click and select **Open Link in New Tab** to follow links:
+
+* [Install WebLogic Monitoring Exporter to scrape WebLogic Server metrics](https://aka.ms/wls-exporter).
+* [Install AKS Prometheus metrics addon](https://aka.ms/aks-enable-monitoring).
+* [Feed WebLogic Server metrics to Azure Monitor Managed Service for Prometheus](https://aka.ms/aks-prometheus-metrics-scrape-configuration).
+* [Integrate KEDA with AKS cluster](https://aka.ms/aks-integrate-keda).
+
+After the provisioning is completed, you can create KEDA scaling rules. A sample rule is provided in the deployment outputs. The following steps show how to see the sample rule.
+
+* View the resource group for this deployment in the Azure portal.
+* In the **Settings** section, select **Deployments**.
+* Select the oldest deployment. The name of the deployment looks similar to **oracle.20210620-wls-on-aks**.
+* Select **Outputs**.
+* The **shellCmdtoOutputKedaScalerSample** value is the base64 string of a scaler sample. Copy the value and run it in your terminal.
+* For guidance on how to complete the configuration, see [Tutorial: Migrate Oracle WebLogic Server to AKS with KEDA scaler based on Prometheus Metrics](https://aka.ms/wls-aks-keda-scaler).
+
+When you are satisfied with your selections, select **Review + create**.
 
 ### Review + create
 
@@ -313,7 +360,9 @@ After clicking **Create** to create this offer, you will go to the **Deployment 
 | `clusterExternalSecuredUrl` | This output is not always present:{{< line_break >}}1. You must configure [Networking](#networking) to enable the Azure Load Balancer service or Azure Application Gateway Ingress Controller for the WLS cluster.{{< line_break >}}2. The TLS/SSL certificate used is configured by filling out [TLS/SSL configuration](#tlsssl-configuration).{{< line_break >}}{{< line_break >}}This is a fully qualified, public link to the WLS cluster. You can access your application with `${clusterExternalUrl}<your-app-path>` from the public Internet.{{< line_break >}}Sample value: `https://contoso.azure.com/`. |
 | `clusterT3InternalUrl` | This output is not always present:{{< line_break >}}1. You must [create/update the WLS cluster with advanced configuration](https://oracle.github.io/weblogic-azure/aks/).{{< line_break >}}2. You must enable custom T3 channel by setting `enableClusterT3Tunneling=true`.{{< line_break >}}{{< line_break >}}This is a fully qualified, private link to custom T3 channel of the WLS cluster. |
 | `clusterT3ExternalEndpoint` | This output is not always present:{{< line_break >}}1. You must [create/update the WLS cluster with advanced configuration](https://oracle.github.io/weblogic-azure/aks/).{{< line_break >}}2. You must enable custom T3 channel by setting `enableClusterT3Tunneling=true`.{{< line_break >}}3. You must configure [Networking](#networking) to enable the Azure Load Balancer service for the WLS cluster.{{< line_break >}}{{< line_break >}}This is a fully qualified, public link to custom T3 channel of the WLS cluster.{{< line_break >}}Sample value:`http://20.4.56.3:8005/` |
+| `kedaScalerServerAddress` | This output is the server address of that saves the WLS metrics. KEDA is able to access and retrieve metric from the address.|
 | `shellCmdtoConnectAks` | AZ CLI command to connect to the AKS cluster.{{< line_break >}}Sample value: {{< line_break >}}`az account set{{< line_break >}} --subscription <id>;{{< line_break >}} az aks get-credentials --resource-group contoso-rg{{< line_break >}} --name contosoakscluster`|
+| `shellCmdtoOutputKedaScalerSample` | Sell command to display the the base64 string of a scaler sample.{{< line_break >}}Sample value: {{< line_break >}}`echo -e YXBpVm...XV0aAo= \| base64 -d > scaler.yaml` |
 | `shellCmdtoOutputWlsDomainYaml` | Shell command to display the base64 encoded string of the WLS domain resource definition.{{< line_break >}}Sample value: {{< line_break >}}`echo -e YXBpV...mVCg== \| base64 -d > domain.yaml` |
 | `shellCmdtoOutputWlsImageModelYaml` | Shell command to display the base64 encoded string of the WLS [image model]({{< relref "/managing-domains/model-in-image/model-files.md" >}}).{{< line_break >}}Sample value:{{< line_break >}}`echo -e IyBDb...3EnC \| base64 -d > model.yaml`|
 | `shellCmdtoOutputWlsImageProperties`|Shell command to display the base64 encoded string of the model properties.{{< line_break >}}Sample value:{{< line_break >}}`echo -e IyBDF...PTUK \| base64 -d > model.properties` |


### PR DESCRIPTION
This pull request modifies the `documentation/site/content/managing-domains/aks/_index.md` file to update the instructions for configuring Oracle WebLogic Server on Azure Kubernetes Service (AKS). The changes mainly involve updating the configuration steps, modifying the terminology used, and reordering some of the sections.

The most important changes include:

Updates to Configuration Steps:

* The instructions for the **Basics** configuration blade have been modified to simplify the process of moving to the next step. The user now simply clicks **Next** instead of **Next: Configure AKS cluster**.
* The **AKS** configuration blade now includes an **Advanced** section where users can specify additional optional configurations.
* The **TLS/SSL** configuration blade has been updated to provide clearer instructions for configuring Oracle WebLogic Server on a secure HTTPS port.
* The **Load balancing** blade has been updated to provide three options for load balancing: Application Gateway Ingress Controller, Standard Load Balancer service, and No Load Balancer.
* The **DNS** blade has been updated to simplify the process of provisioning the Oracle WebLogic Server Administration Console using a custom DNS name.

Terminology Changes:

* The **Configure AKS Cluster** blade has been renamed to **AKS**.
* The **Java EE Application** section has been renamed to **Application**.
* The **TLS/SSL configuration** blade has been renamed to **TLS/SSL**.
* The **Networking** blade has been renamed to **Load balancing**.
* The **DNS Configuration** blade has been renamed to **DNS**.

Section Reordering:

* The option to generate a self-signed frontend certificate in the **Application Gateway Ingress Controller** section has been moved to the beginning of the list of options.