### PR TITLE
cluster needs to be created before the domain

### DIFF
--- a/kubernetes/samples/quick-start/domain-resource.yaml
+++ b/kubernetes/samples/quick-start/domain-resource.yaml
@@ -1,6 +1,23 @@
 # Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+
+apiVersion: "weblogic.oracle/v1"
+kind: Cluster
+metadata:
+  name: sample-domain1-cluster-1
+  # Update this with the namespace your domain will run in:
+  namespace: sample-domain1-ns
+  labels:
+    # Update this with the `domainUID` of your domain:
+    weblogic.domainUID: sample-domain1
+
+spec:
+  replicas: 2
+  clusterName: cluster-1
+
+---
+
 apiVersion: "weblogic.oracle/v9"
 kind: Domain
 metadata:
@@ -130,18 +147,3 @@ spec:
     #secrets:
     #- sample-domain1-datasource-secret
 
----
-
-apiVersion: "weblogic.oracle/v1"
-kind: Cluster
-metadata:
-  name: sample-domain1-cluster-1
-  # Update this with the namespace your domain will run in:
-  namespace: sample-domain1-ns
-  labels:
-    # Update this with the `domainUID` of your domain:
-    weblogic.domainUID: sample-domain1
-
-spec:
-  replicas: 2
-  clusterName: cluster-1


### PR DESCRIPTION
When applying quick-start yaml, **domain** fails with below error until it gets resolved with next retry happens in 120 seconds.
The reason is that domain gets created before cluster. It must be the other way around.
`
% kubectl describe domain sample-domain1 -n sample-domain1-ns  
 
  Message:                 Cluster resource 'sample-domain1-cluster-1' not found in namespace 'sample-domain1-ns'. Will retry next at 2024-06-26T11:24:46.003016707Z and approximately every 120 seconds afterward until 2024-06-27T11:22:46.003016707Z if the failure is not resolved.

Events:
  Type     Reason   Age    From               Message
  ----     ------   ----   ----               -------
  Normal   Created  3m22s  weblogic.operator  Domain sample-domain1 was created.
  Warning  Failed   3m21s  weblogic.operator  Domain sample-domain1 failed due to 'Domain validation error': Cluster resource 'sample-domain1-cluster-1' not found in namespace 'sample-domain1-ns'. Update the domain resource to correct the validation error.
`